### PR TITLE
adding 101-simple-ubuntu-vm create to match the 101-simple-windows-vm template

### DIFF
--- a/101-simple-ubuntu-vm/README.md
+++ b/101-simple-ubuntu-vm/README.md
@@ -1,12 +1,12 @@
-# Very simple deployment of an Windows VM
+# Very simple deployment of an Ubuntu Server VM
 
 <a href="https://deploy.azure.com/?repository=https://github.com/Azure/azure-quickstart-templates/tree/master/101-simple-windows-vm" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-Built by: [coreysa](https://github.com/coreysa)
+Built by: [squillace](https://github.com/squillace)
 
-This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy in West US on a D1 VM Size.
+This template allows you to deploy a simple Ubuntu Server 14.10 VM using a few different options for the Ubuntu Server version, using the latest patched version. This will deploy in West US on a D1 VM Size.
 
 Below are the parameters that the template expects: 
 
@@ -16,4 +16,4 @@ Below are the parameters that the template expects:
 | adminUsername  | Username for the Virtual Machine  |
 | adminPassword  | Password for the Virtual Machine  |
 | dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| windowsOSVersion  | The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview |
+| ubuntuSkuVersion  | The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview |

--- a/101-simple-ubuntu-vm/README.md
+++ b/101-simple-ubuntu-vm/README.md
@@ -1,0 +1,19 @@
+# Very simple deployment of an Windows VM
+
+<a href="https://deploy.azure.com/?repository=https://github.com/Azure/azure-quickstart-templates/tree/master/101-simple-windows-vm" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+Built by: [coreysa](https://github.com/coreysa)
+
+This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy in West US on a D1 VM Size.
+
+Below are the parameters that the template expects: 
+
+| Name   | Description    |
+|:--- |:---|
+| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
+| adminUsername  | Username for the Virtual Machine  |
+| adminPassword  | Password for the Virtual Machine  |
+| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
+| windowsOSVersion  | The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview |

--- a/101-simple-ubuntu-vm/azuredeploy.json
+++ b/101-simple-ubuntu-vm/azuredeploy.json
@@ -1,0 +1,169 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01-preview/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "newStorageAccountName": {
+            "type": "string",
+            "metadata": {
+                "Description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
+            }
+        },
+        "adminUsername": {
+            "type": "string",
+            "metadata": {
+               "Description": "Username for the Virtual Machine."
+            }
+        },
+        "adminPassword": {
+            "type": "securestring",
+            "metadata": {
+                "Description": "Password for the Virtual Machine."
+            }
+        },
+        "dnsNameForPublicIP": {
+            "type": "string",
+            "metadata": {
+                  "Description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+            }
+        },
+        "UbuntuSkuVersion": {
+            "type": "string",
+            "defaultValue": "14.10",
+            "metadata": {
+                "Description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview."
+            }
+        } 
+    },
+    "variables": {
+        "location": "West US",
+        "imagePublisher": "Canonical", 
+        "imageOffer": "UbuntuServer", 
+        "OSDiskName": "osdiskforlinuxsimple",
+        "nicName": "myVMNic",
+        "addressPrefix": "10.0.0.0/16", 
+        "subnetName": "Subnet",
+        "subnetPrefix": "10.0.0.0/24",
+        "storageAccountType": "Standard_LRS",
+        "publicIPAddressName": "myPublicIP",
+        "publicIPAddressType": "Dynamic",
+        "vmStorageAccountContainerName": "vhds",
+        "vmName": "MyUbuntuVM",
+        "vmSize": "Standard_D1",
+        "virtualNetworkName": "MyVNET",        
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
+    },    
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('newStorageAccountName')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[variables('location')]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('publicIPAddressName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+                }
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[variables('virtualNetworkName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('addressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('subnetName')]",
+                        "properties": {
+                            "addressPrefix": "[variables('subnetPrefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[variables('vmName')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[variables('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[variables('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('imagePublisher')]",
+                        "offer": "[variables('imageOffer')]",
+                        "sku" : "[parameters('UbuntuSkuVersion')]",
+                        "version":"latest"
+                    },
+                   "osDisk" : {
+                        "name": "osdisk",
+                        "vhd": {
+                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+} 

--- a/101-simple-ubuntu-vm/azuredeploy.json
+++ b/101-simple-ubuntu-vm/azuredeploy.json
@@ -30,7 +30,7 @@
             "type": "string",
             "defaultValue": "14.10",
             "metadata": {
-                "Description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview."
+                "Description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
             }
         } 
     },

--- a/101-simple-ubuntu-vm/azuredeploy.parameters.json
+++ b/101-simple-ubuntu-vm/azuredeploy.parameters.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01-preview/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "newStorageAccountName": {
+            "value": "unqiueStorageAccount"
+        },
+        "adminUsername": {
+            "value": "userName""
+        },
+        "adminPassword": {
+            "value": "password"
+        },
+        "vmDnsName": {
+            "value": "uniqueDNS"
+        }
+   }
+}

--- a/101-simple-ubuntu-vm/metadata.json
+++ b/101-simple-ubuntu-vm/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Deploy a simple Ubuntu VM in West US",
+  "description": "This template allows you to deploy a simple Ubuntu Server 14.10 using the latest patched version. This will deploy in West US on a D1 VM Size.",
+  "summary": "This template takes a minimum amount of parameters and deploys an Ubuntu Server VM, using the latest patched version.",
+  "githubUsername": "squillace",
+  "dateUpdated": "2015-04-26"
+}


### PR DESCRIPTION
Does not allow you to switch skus, but works fine. Please confirm deployment works with both PS and azure-cli.

azure group deployment create --template-uri https://raw.githubusercontent.com/squillace/azure-quickstart-templates/master/101-simple-ubuntu-vm/azuredeploy.json --resource-group fun --name firstdeployment 
info:    Executing command group deployment create
info:    Supply values for the following parameters
newStorageAccountName: funster
adminUsername: xxx
adminPassword: xxxxxxx
dnsNameForPublicIP: funster
+ Initializing template configurations and parameters                          
+ Creating a deployment                                                        
info:    Created template deployment "firstdeployment"
+ Registering providers                                                        
info:    Registering provider microsoft.storage
info:    Registering provider microsoft.network
info:    Registering provider microsoft.compute
+ Waiting for deployment to complete                                           
data:    DeploymentName     : firstdeployment
data:    ResourceGroupName  : fun
data:    ProvisioningState  : Succeeded
data:    Timestamp          : 2015-04-27T02:25:59.9727261Z
data:    Mode               : Incremental
data:    TemplateLink       : https://raw.githubusercontent.com/squillace/azure-quickstart-templates/master/101-simple-ubuntu-vm/azuredeploy.json
data:    ContentVersion     : 1.0.0.0
data:    Name                   Type          Value    
data:    ---------------------  ------------  ---------
data:    newStorageAccountName  String        funster  
data:    adminUsername          String        ops      
data:    adminPassword          SecureString  undefined
data:    dnsNameForPublicIP     String        funster  
data:    ubuntuSkuVersion       String        14.10    
info:    group deployment create command OK
