### PR TITLE
Install Scrapy in a single ubuntu machine using Custom Script Linux Extension

### DIFF
--- a/scrapy-on-ubuntu/README.md
+++ b/scrapy-on-ubuntu/README.md
@@ -1,6 +1,6 @@
 # Install Scrapy on a Ubuntu Virtual Machine using Custom Script Linux Extension
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbingosummer%2Fazure-quickstart-templates%2Fmaster%2Fscrapy-on-ubuntu%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fscrapy-on-ubuntu%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/scrapy-on-ubuntu/README.md
+++ b/scrapy-on-ubuntu/README.md
@@ -1,0 +1,27 @@
+# Install Scrapy on a Ubuntu Virtual Machine using Custom Script Linux Extension
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fbingosummer%2Fazure-quickstart-templates%2Fmaster%2Fscrapy-on-ubuntu%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+This template deploys Scrapy on a Ubuntu Virtual Machine. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.
+
+Below are the parameters that the template expects
+
+| Name   | Description    |
+|:--- |:---|
+| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
+| adminUsername  | Username for the Virtual Machines  |
+| adminPassword  | Password for the Virtual Machine  |
+| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
+| imagePublisher  | Image Publisher  |
+| imageOffer  | Image Offer  |
+| imageSKU  | Image SKU  |
+| location | location where the resources will be deployed |
+| virtualNetworkName | Name of Virtual Network |
+| vmSize | Size of the Virtual Machine |
+| vmName | Name of Virtual Machine |
+| publicIPAddressName | Name of Public IP Address Name |
+| nicName | Name of Network Interface |
+| spiderName | Name of the spider |
+| spiderUri | Name of the uri |

--- a/scrapy-on-ubuntu/azuredeploy-parameters.json
+++ b/scrapy-on-ubuntu/azuredeploy-parameters.json
@@ -1,0 +1,47 @@
+﻿{
+    "newStorageAccountName" : {
+        "value":"azureuserscrapy"
+    },
+    "adminUsername": {
+        "value": "azureuser"
+    },
+    "adminPassword": {
+        "value": "User@123"
+    },
+    "dnsNameForPublicIP": {
+        "value": "azureuserdns"
+    },
+    "imagePublisher":{
+        "value" : "Canonical"
+    },
+    "imageOffer": {
+        "value": "UbuntuServer"
+    },
+    "imageSKU": {
+        "value": "14.04.2-LTS"
+    },
+    "location": {
+        "value": "West US"
+    },
+    "virtualNetworkName": {
+        "value": "auzreusernetwork"
+    },
+    "vmSize": {
+        "value": "Standard_A0"
+    },
+    "vmName" : {
+      "value" : "azureuservm"
+    },
+    "publicIPAddressName" : {
+      "value" : "azureuserpublicip"
+    },
+    "nicName" : {
+      "value" : "azureusernic"
+    },
+    "spiderName" : {
+      "value" : "myspider.py"
+    },
+    "spiderUri" : {
+      "value" : "https://raw.githubusercontent.com/bingosummer/azure-quickstart-templates/master/scrapy-on-ubuntu/myspider.py"
+    }
+}

--- a/scrapy-on-ubuntu/azuredeploy-parameters.json
+++ b/scrapy-on-ubuntu/azuredeploy-parameters.json
@@ -42,6 +42,6 @@
       "value" : "myspider.py"
     },
     "spiderUri" : {
-      "value" : "https://raw.githubusercontent.com/bingosummer/azure-quickstart-templates/master/scrapy-on-ubuntu/myspider.py"
+      "value" : "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/scrapy-on-ubuntu/myspider.py"
     }
 }

--- a/scrapy-on-ubuntu/azuredeploy.json
+++ b/scrapy-on-ubuntu/azuredeploy.json
@@ -58,7 +58,7 @@
             "type": "string",
             "defaultValue": "Standard_A0",
             "metadata": {
-              "Description": "Size of Virtual Machin"
+              "description": "Size of the Virtual Machine"
             }
         },
         "publicIPAddressName": {
@@ -76,27 +76,27 @@
         "virtualNetworkName":{
             "type" : "string",
             "metadata": {
-              "Description": "Name of Virtual Network"
+              "description": "Name of Virtual Network"
             }
         },
         "nicName":{
             "type" : "string",
             "metadata": {
-              "Description": "Name of Network Interface"
+              "description": "Name of Network Interface"
             }
         },
         "spiderName":{
             "type" : "string",
             "defaultValue":"myspider.py",
             "metadata": {
-              "Description": "Name of the spider"
+              "description": "Name of the spider"
             }
         },
         "spiderUri":{
             "type" : "string",
             "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/scrapy-on-ubuntu/myspider.py",
             "metadata": {
-              "Description": "Uri of the spider source"
+              "description": "Uri of the spider source"
             }
         }
 
@@ -109,10 +109,8 @@
         "subnetPrefix": "10.0.0.0/24",
         "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-        "imagePublisher": "Canonical",
-        "imageOffer": "UbuntuServer",
         "vmStorageAccountContainerName": "vhds",
-        "OSDiskName": "osdiskfordockersimple"
+        "OSDiskName": "osdiskforscrapy"
     },
     "resources": [
         {
@@ -203,8 +201,8 @@
                 },
                 "storageProfile": {
                     "imageReference": {
-                        "publisher": "[variables('imagePublisher')]",
-                        "offer": "[variables('imageOffer')]",
+                        "publisher": "[parameters('imagePublisher')]",
+                        "offer": "[parameters('imageOffer')]",
                         "sku" : "[parameters('imageSKU')]",
                         "version":"latest"
                     },

--- a/scrapy-on-ubuntu/azuredeploy.json
+++ b/scrapy-on-ubuntu/azuredeploy.json
@@ -1,0 +1,251 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters" : {
+        "newStorageAccountName": {
+            "type": "string",
+            "metadata": {
+              "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed"
+            }
+        },
+        "dnsNameForPublicIP" : {
+            "type" : "string",
+            "metadata": {
+              "description": "This is the dns name of the public IP"
+            }
+        },
+        "adminUserName": {
+            "type": "string",
+            "metadata": {
+              "description": "Username for the Virtual Machines"
+            }
+        },
+        "adminPassword": {
+            "type": "securestring",
+            "metadata": {
+              "description": "Password for the Virtual Machine"
+            }
+        },
+        "imagePublisher": {
+            "type": "string",
+            "defaultValue": "Canonical",
+            "metadata": {
+                 "description": "Image Publisher"
+            }
+        },
+        "imageOffer": {
+            "type": "string",
+            "defaultValue": "UbuntuServer",
+            "metadata": {
+                "description": "Image Offer"
+            }
+        },
+        "imageSKU": {
+            "type": "string",
+            "defaultValue": "14.04.2-LTS",
+            "metadata": {
+                "description": "Image SKU"
+            }
+        },
+        "location": {
+            "type": "String",
+            "defaultValue" : "West US",
+            "metadata": {
+              "description": "location where the resources will be deployed"
+            }
+        },
+        "vmSize": {
+            "type": "string",
+            "defaultValue": "Standard_A0",
+            "metadata": {
+              "Description": "Size of Virtual Machin"
+            }
+        },
+        "publicIPAddressName": {
+            "type": "string",
+            "metadata": {
+              "description": "Name of Public IP Address Name"
+            }
+        },
+        "vmName": {
+            "type": "string",
+            "metadata": {
+              "description": "Name of Virtual Machine"
+            }
+        },
+        "virtualNetworkName":{
+            "type" : "string",
+            "metadata": {
+              "Description": "Name of Virtual Network"
+            }
+        },
+        "nicName":{
+            "type" : "string",
+            "metadata": {
+              "Description": "Name of Network Interface"
+            }
+        },
+        "spiderName":{
+            "type" : "string",
+            "defaultValue":"myspider.py",
+            "metadata": {
+              "Description": "Name of the spider"
+            }
+        },
+        "spiderUri":{
+            "type" : "string",
+            "defaultValue": "https://raw.githubusercontent.com/bingosummer/azure-quickstart-templates/master/scrapy-on-ubuntu/myspider.py",
+            "metadata": {
+              "Description": "Uri of the spider source"
+            }
+        }
+
+    },
+    "variables": {
+        "storageAccountType": "Standard_LRS",
+        "publicIPAddressType": "Dynamic",
+        "addressPrefix":"10.0.0.0/16",
+        "subnetName": "Subnet",
+        "subnetPrefix": "10.0.0.0/24",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+        "imagePublisher": "Canonical",
+        "imageOffer": "UbuntuServer",
+        "vmStorageAccountContainerName": "vhds",
+        "OSDiskName": "osdiskfordockersimple"
+    },
+    "resources": [
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('newStorageAccountName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[parameters('publicIPAddressName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+                }
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[parameters('virtualNetworkName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                         "[variables('addressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('subnetName')]",
+                        "properties" : {
+                            "addressPrefix": "[variables('subnetPrefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[parameters('nicName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[parameters('vmName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[parameters('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('imagePublisher')]",
+                        "offer": "[variables('imageOffer')]",
+                        "sku" : "[parameters('imageSKU')]",
+                        "version":"latest"
+                    },
+                    "osDisk" : {
+                        "name": "osdisk1",
+                        "vhd": {
+                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',parameters('nicName'))]"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(parameters('vmName'),'/installscrapy')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.OSTCExtensions",
+                "type": "CustomScriptForLinux",
+                "typeHandlerVersion": "1.2",
+                "settings": {
+                    "fileUris": [
+                        "https://raw.githubusercontent.com/bingosummer/azure-quickstart-templates/master/scrapy-on-ubuntu/scrapy-install-ubuntu.sh",
+                        "[parameters('spiderUri')]"
+                    ],
+                    "commandToExecute": "[concat('sh scrapy-install-ubuntu.sh ', parameters('spiderName'))]"
+                }
+            }
+        }
+    ]
+}

--- a/scrapy-on-ubuntu/azuredeploy.json
+++ b/scrapy-on-ubuntu/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json",
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
     "contentVersion": "1.0.0.0",
     "parameters" : {
         "newStorageAccountName": {
@@ -94,7 +94,7 @@
         },
         "spiderUri":{
             "type" : "string",
-            "defaultValue": "https://raw.githubusercontent.com/bingosummer/azure-quickstart-templates/master/scrapy-on-ubuntu/myspider.py",
+            "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/scrapy-on-ubuntu/myspider.py",
             "metadata": {
               "Description": "Uri of the spider source"
             }
@@ -240,7 +240,7 @@
                 "typeHandlerVersion": "1.2",
                 "settings": {
                     "fileUris": [
-                        "https://raw.githubusercontent.com/bingosummer/azure-quickstart-templates/master/scrapy-on-ubuntu/scrapy-install-ubuntu.sh",
+                        "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/scrapy-on-ubuntu/scrapy-install-ubuntu.sh",
                         "[parameters('spiderUri')]"
                     ],
                     "commandToExecute": "[concat('sh scrapy-install-ubuntu.sh ', parameters('spiderName'))]"

--- a/scrapy-on-ubuntu/metadata.json
+++ b/scrapy-on-ubuntu/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Install Scrapy on Ubuntu using Custom Script Linux Extension",
+  "description": "This template deploys Scrapy on an Ubuntu Virtual Machine. The user can upload a spider to start to crawl. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.",
+  "summary": "Install Scrapy on an Ubuntu VM using Custom Script Linux Extension",
+  "githubUsername": "bingosummer",
+  "dateUpdated": "2015-04-24"
+}

--- a/scrapy-on-ubuntu/myspider.py
+++ b/scrapy-on-ubuntu/myspider.py
@@ -1,0 +1,10 @@
+from scrapy import Spider, Item, Field
+
+class Post(Item):
+    title = Field()
+
+class BlogSpider(Spider):
+    name, start_urls = 'blogspider', ['http://blog.scrapinghub.com']
+
+    def parse(self, response):
+        return [Post(title=e.extract()) for e in response.css("h2 a::text")]

--- a/scrapy-on-ubuntu/scrapy-install-ubuntu.sh
+++ b/scrapy-on-ubuntu/scrapy-install-ubuntu.sh
@@ -1,0 +1,4 @@
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 627220E7
+echo 'deb http://archive.scrapy.org/ubuntu scrapy main' | sudo tee /etc/apt/sources.list.d/scrapy.list
+sudo apt-get update && sudo apt-get -y install scrapy-0.24
+scrapy runspider $1


### PR DESCRIPTION
This template deploys Scrapy on an Ubuntu Virtual Machine. The user can upload a spider to start to crawl. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.