### PR TITLE
Fix typo (remove double quotes)

### DIFF
--- a/docker-simple-on-ubuntu/azuredeploy.parameters.json
+++ b/docker-simple-on-ubuntu/azuredeploy.parameters.json
@@ -6,7 +6,7 @@
             "value": "unqiueStorageAccount"
         },
         "adminUsername": {
-            "value": "userName""
+            "value": "userName"
         },
         "adminPassword": {
             "value": "password"


### PR DESCRIPTION
Remove a typo in the "adminUsername" property of the simple ubuntu parameters file. 

There were too many double quotes ;)