### PR TITLE
Create a VM with multiple NICs and RDP accessable

### DIFF
--- a/201-1-vm-loadbalancer-2-nics/README.md
+++ b/201-1-vm-loadbalancer-2-nics/README.md
@@ -1,0 +1,22 @@
+# Create a VM with multiple NICs and RDP accessable
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-1-vm-loadbalancer-2-nics%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+This template allows you to create a Virtual Machines with multiple (2) network interfaces (NICs), and RDP connectable with a configured load balancer and an inbound NAT rule. More NICs can easily  be added with this template. This template also deploys a Storage Account, Virtual Network, Public IP address, and 2 Network Interfaces (front-end and back-end).| Name   | Description    |
+|:--- |:---|
+| storageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
+| adminUsername  | Username for the Virtual Machines  |
+| adminPassword  | Password for the Virtual Machine  |
+| dnsNameForLBIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
+| subscriptionId  | Subscription ID where the template will be deployed |
+| vmSourceImageName  | Source Image Name for the VM. Example: b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-12_04_5-LTS-amd64-server-20140927-en-us-30GB |
+| region | location where the resources will be deployed |
+| vnetName | Name of Virtual Network |
+| vmSize | Size of the Virtual Machine |
+| vmNamePrefix | NamePrefix for Virtual Machines |
+| publicIPAddressName | Name of Public IP Address Name |
+| nicNamePrefix | NamePrefix for Network Interfaces |
+| lbName | Name for the load balancer |
+| backendPort | The Back End Port that needs to be opened on the Virtual Machine Instance. For example: 3389 for RDP, 22 for SSH etc., |

--- a/201-1-vm-loadbalancer-2-nics/azuredeploy.json
+++ b/201-1-vm-loadbalancer-2-nics/azuredeploy.json
@@ -1,0 +1,305 @@
+﻿{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "storageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of storage account"
+            }
+        },
+        "adminUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "Admin username"
+            }
+        },
+        "adminPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Admin password"
+            }
+        },
+        "dnsNameforLBIP": {
+            "type": "string",
+            "metadata": {
+                "description": "DNS for Load Balancer IP"
+            }
+        },
+        "vmNamePrefix": {
+            "type": "string",
+            "defaultValue": "myVM",
+            "metadata": {
+                "description": "Prefix to use for VM names"
+            }
+        },
+        "imagePublisher": {
+            "type": "string",
+            "defaultValue": "MicrosoftWindowsServer",
+            "metadata": {
+                "description": "Image Publisher"
+            }
+        },
+        "imageOffer": {
+            "type": "string",
+            "defaultValue": "WindowsServer",
+            "metadata": {
+                "description": "Image Offer"
+            }
+        },
+        "imageSKU": {
+            "type": "string",
+            "defaultValue": "2012-R2-Datacenter",
+            "metadata": {
+                "description": "Image SKU"
+            }
+        },
+        "lbName": {
+            "type": "string",
+            "defaultValue": "myLB",
+            "metadata": {
+                "description": "Load Balancer name"
+            }
+        },
+        "nic1NamePrefix": {
+            "type": "string",
+            "defaultValue": "nic1",
+            "metadata": {
+                "description": "Network Interface 1 name prefix"
+            }
+        },
+        "nic2NamePrefix": {
+            "type": "string",
+            "defaultValue": "nic2",
+            "metadata": {
+                "description": "Network Interface 2 name prefix"
+            }
+        },
+        "publicIPAddressName": {
+            "type": "string",
+            "defaultValue": "myPublicIP",
+            "metadata": {
+                "description": "Public IP Name"
+            }
+        },
+        "vnetName": {
+            "type": "string",
+            "defaultValue": "myVNET",
+            "metadata": {
+                "description": "VNET name"
+            }
+        },
+        "vmSize": {
+            "type": "string",
+            "defaultValue": "Standard_D1",
+            "metadata": {
+                "description": "Size of the VM"
+            }
+        }
+    },
+    "variables": {
+        "storageAccountType": "Standard_LRS",
+        "addressPrefix": "10.0.0.0/16",
+        "subnetName": "Subnet-1",
+        "subnetPrefix": "10.0.0.0/24",
+        "publicIPAddressType": "Dynamic",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
+        "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]",
+        "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
+        "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
+        "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/BackendPool1')]" 
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('storageAccountName')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[parameters('publicIPAddressName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[parameters('dnsNameforLBIP')]"
+                }
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[parameters('vnetName')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('addressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('subnetName')]",
+                        "properties": {
+                            "addressPrefix": "[variables('subnetPrefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[parameters('nic1NamePrefix')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]",
+                "[concat('Microsoft.Network/loadBalancers/', parameters('lbName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            },
+                            "loadBalancerBackendAddressPools": [
+                                {
+                                    "id": "[concat(variables('lbID'), '/backendAddressPools/BackendPool1')]"
+                                }
+                            ],
+                            "loadBalancerInboundNatRules": [
+                                {
+                                    "id": "[concat(variables('lbID'),'/inboundNatRules/RDP-VM0')]"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[parameters('nic2NamePrefix')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "name": "[parameters('lbName')]",
+            "type": "Microsoft.Network/loadBalancers",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
+            ],
+            "properties": {
+                "frontendIPConfigurations": [
+                    {
+                        "name": "LoadBalancerFrontEnd",
+                        "properties": {
+                            "publicIPAddress": {
+                                "id": "[variables('publicIPAddressID')]"
+                            }
+                        }
+                    }
+                ],
+                "backendAddressPools": [
+                    {
+                        "name": "BackendPool1"
+                    }
+                ],
+                "inboundNatRules": [
+                    {
+                        "name": "RDP-VM0",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[variables('frontEndIPConfigID')]"
+                            },
+                            "protocol": "tcp",
+                            "frontendPort": 50001,
+                            "backendPort": 3389,
+                            "enableFloatingIP": false
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[parameters('vmNamePrefix')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nic1NamePrefix'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('nic2NamePrefix'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[parameters('vmNamePrefix')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[parameters('imagePublisher')]",
+                        "offer": "[parameters('imageOffer')]",
+                        "sku": "[parameters('imageSKU')]",
+                        "version": "latest"
+                    },
+                    "osDisk": {
+                        "name": "osdisk",
+                        "vhd": {
+                            "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', '.vhd')]"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "properties": {
+                                "primary": true
+                            },
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',parameters('nic1NamePrefix'))]"
+                        },
+                        {
+                            "properties": {
+                                "primary": false
+                            },
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',parameters('nic2NamePrefix'))]"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/201-1-vm-loadbalancer-2-nics/metadata.json
+++ b/201-1-vm-loadbalancer-2-nics/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "1 VM with multiple NICs and RDP accessable",
+  "description": "This template allows you to create a Virtual Machines with multiple (2) network interfaces (NICs), and RDP connectable with a configured load balancer and an inbound NAT rule. More NICs can easily  be added with this template. This template also deploys a Storage Account, Virtual Network, Public IP address, and 2 Network Interfaces (front-end and back-end).",
+  "summary": "1 VM with multiple network interfaces and RDP accessable",
+  "githubUsername": "colincole",
+  "dateUpdated": "2015-05-26"
+}

--- a/201-1-vm-loadbalancer-2-nics/metadata.json
+++ b/201-1-vm-loadbalancer-2-nics/metadata.json
@@ -1,7 +1,7 @@
 {
-  "itemDisplayName": "1 VM with multiple NICs and RDP accessable",
+  "itemDisplayName": "Create a VM with multiple NICs and RDP accessable",
   "description": "This template allows you to create a Virtual Machines with multiple (2) network interfaces (NICs), and RDP connectable with a configured load balancer and an inbound NAT rule. More NICs can easily  be added with this template. This template also deploys a Storage Account, Virtual Network, Public IP address, and 2 Network Interfaces (front-end and back-end).",
-  "summary": "1 VM with multiple network interfaces and RDP accessable",
+  "summary": "Create a VM with multiple network interfaces and RDP accessable",
   "githubUsername": "colincole",
   "dateUpdated": "2015-05-26"
 }

--- a/201-1-vm-loadbalancer-2-nics/multi-nic-vm-iaasv2-final-1.ps1
+++ b/201-1-vm-loadbalancer-2-nics/multi-nic-vm-iaasv2-final-1.ps1
@@ -1,0 +1,75 @@
+﻿# PowerShell script to create the same two-NIC VM as the assoicated json template.
+# Author, Colin Cole, Microsoft
+
+Switch-AzureMode AzureResourceManager
+
+# Variables 
+$rgname = 'samplerg'
+$vnetName = $rgname + 'vnet' 
+$vnetAddressPrefix = '10.0.0.0/16'
+$subnetName = $rgname + 'subnet' 
+$subnetAddressPrefix = '10.0.1.0/24'
+$publicIpName = $rgname + 'pubip' 
+$lbName = $rgname + 'lb'
+$frontendName = $rgname + 'frontend'
+$backendAddressPoolName = $rgname + 'backend' 
+$inboundNatRuleName1 = $rgname + 'nat1' 
+$nicname1 = $rgname + 'nic1' 
+$nicname2 = $rgname + 'nic2' 
+$resourceTypeParent = "Microsoft.Network/loadBalancers" 
+$location = 'westus'
+$vmsize = 'Standard_D2';  # must be A2 or D2 or above for two nics
+$vmname = $rgname + 'vm';
+$stoname = $rgname.ToLower() + 'sto';
+$stotype = 'Standard_LRS'; 
+$osDiskName = 'osDisk';
+$osDiskVhdUri = "https://$stoname.blob.core.windows.net/vhds/os.vhd"; 
+$user = "ops";
+$password = 'pass@word2';
+ 
+# Create the resource group 
+New-AzureResourceGroup -Name $rgname -Location $location 
+          
+# Create the Virtual Network 
+$subnet = New-AzureVirtualNetworkSubnetConfig -Name $subnetName -AddressPrefix $subnetAddressPrefix 
+$vnet = New-AzurevirtualNetwork -Name $vnetName -ResourceGroupName $rgname -Location $location -AddressPrefix $vnetAddressPrefix -Subnet $subnet 
+          
+# Create the publicip 
+$publicip = New-AzurePublicIpAddress -ResourceGroupName $rgname -name $publicIpName -location $location -AllocationMethod Dynamic 
+  
+# Create LoadBalancer and open up a NAT rule
+$frontend = New-AzureLoadBalancerFrontendIpConfig -Name $frontendName -PublicIpAddress $publicip 
+$backendAddressPool = New-AzureLoadBalancerBackendAddressPoolConfig -Name $backendAddressPoolName 
+$inboundNatRule1 = New-AzureLoadBalancerInboundNatRuleConfig -Name $inboundNatRuleName1 -FrontendIPConfiguration $frontend -Protocol Tcp -FrontendPort 50001 -BackendPort 3389 -IdleTimeoutInMinutes 15 
+$lb = New-AzureLoadBalancer -Name $lbName -ResourceGroupName $rgname -Location $location -FrontendIpConfiguration $frontend -BackendAddressPool $backendAddressPool -InboundNatRule $inboundNatRule1 
+          
+# Create 2 network interfaces and accociate to loadbalancer to nic1  
+$nic1 = New-AzureNetworkInterface -Name $nicname1 -ResourceGroupName $rgname -Location $location -Subnet $vnet.Subnets[0] -LoadBalancerBackendAddressPool $lb.BackendAddressPools[0] -LoadBalancerInboundNatRule $lb.InboundNatRules[0] 
+$nic2 = New-AzureNetworkInterface -Name $nicname2 -ResourceGroupName $rgname -Location $location -SubnetId $vnet.Subnets[0].Id  
+
+# Associate the nic to the load balancer 
+$nic1.IpConfigurations[0].LoadBalancerBackendAddressPools.Add($lb.BackendAddressPools[0]); 
+$nic1.IpConfigurations[0].LoadBalancerInboundNatRules.Add($lb.InboundNatRules[0]); 
+
+# Configure VM and attach networking interfaces
+$vm = New-AzureVMConfig -VMName $vmname -VMSize $vmsize;
+$vm = Add-AzureVMNetworkInterface -VM $vm -Id $nic1.Id -Primary;
+$vm = Add-AzureVMNetworkInterface -VM $vm -Id $nic2.Id;
+
+# Setup storage account
+New-AzureStorageAccount -ResourceGroupName $rgname -Name $stoname -Location $location -Type $stotype;
+$stoaccount = Get-AzureStorageAccount -ResourceGroupName $rgname -Name $stoname;
+   
+# Add OS Disk
+$vm = Set-AzureVMOSDisk -VM $vm -Name $osDiskName -VhdUri $osDiskVhdUri -Caching 'ReadWrite' -CreateOption fromImage;
+    
+# Setup OS 
+$securePassword = ConvertTo-SecureString $password -AsPlainText -Force;
+$cred = New-Object System.Management.Automation.PSCredential ($user, $securePassword);   
+$vm = Set-AzureVMOperatingSystem -VM $vm -Windows -ComputerName $vmname -Credential $cred;
+
+# Setup Image
+$vm = Set-AzureVMSourceImage -VM $vm -PublisherName MicrosoftWindowsServer -Offer WindowsServer -Skus 2012-R2-Datacenter -Version "latest"
+    
+# Create Virtual Machine
+New-AzureVM -ResourceGroupName $rgname -Location $location -Name $vmname -VM $vm;

--- a/201-1-vm-loadbalancer-2-nics/multi-nic-vm-iaasv2.ps1
+++ b/201-1-vm-loadbalancer-2-nics/multi-nic-vm-iaasv2.ps1
@@ -1,0 +1,75 @@
+﻿# PowerShell script to create the same two-NIC VM as the assoicated json template.
+# Author, Colin Cole, Microsoft
+
+Switch-AzureMode AzureResourceManager
+
+# Variables 
+$rgname = 'samplerg'
+$vnetName = $rgname + 'vnet' 
+$vnetAddressPrefix = '10.0.0.0/16'
+$subnetName = $rgname + 'subnet' 
+$subnetAddressPrefix = '10.0.1.0/24'
+$publicIpName = $rgname + 'pubip' 
+$lbName = $rgname + 'lb'
+$frontendName = $rgname + 'frontend'
+$backendAddressPoolName = $rgname + 'backend' 
+$inboundNatRuleName1 = $rgname + 'nat1' 
+$nicname1 = $rgname + 'nic1' 
+$nicname2 = $rgname + 'nic2' 
+$resourceTypeParent = "Microsoft.Network/loadBalancers" 
+$location = 'westus'
+$vmsize = 'Standard_D2';  # must be A2 or D2 or above for two nics
+$vmname = $rgname + 'vm';
+$stoname = $rgname.ToLower() + 'sto';
+$stotype = 'Standard_LRS'; 
+$osDiskName = 'osDisk';
+$osDiskVhdUri = "https://$stoname.blob.core.windows.net/vhds/os.vhd"; 
+$user = "ops";
+$password = 'pass@word2';
+ 
+# Create the resource group 
+New-AzureResourceGroup -Name $rgname -Location $location 
+          
+# Create the Virtual Network 
+$subnet = New-AzureVirtualNetworkSubnetConfig -Name $subnetName -AddressPrefix $subnetAddressPrefix 
+$vnet = New-AzurevirtualNetwork -Name $vnetName -ResourceGroupName $rgname -Location $location -AddressPrefix $vnetAddressPrefix -Subnet $subnet 
+          
+# Create the publicip 
+$publicip = New-AzurePublicIpAddress -ResourceGroupName $rgname -name $publicIpName -location $location -AllocationMethod Dynamic 
+  
+# Create LoadBalancer and open up a NAT rule
+$frontend = New-AzureLoadBalancerFrontendIpConfig -Name $frontendName -PublicIpAddress $publicip 
+$backendAddressPool = New-AzureLoadBalancerBackendAddressPoolConfig -Name $backendAddressPoolName 
+$inboundNatRule1 = New-AzureLoadBalancerInboundNatRuleConfig -Name $inboundNatRuleName1 -FrontendIPConfiguration $frontend -Protocol Tcp -FrontendPort 50001 -BackendPort 3389 -IdleTimeoutInMinutes 15 
+$lb = New-AzureLoadBalancer -Name $lbName -ResourceGroupName $rgname -Location $location -FrontendIpConfiguration $frontend -BackendAddressPool $backendAddressPool -InboundNatRule $inboundNatRule1 
+          
+# Create 2 network interfaces and accociate to loadbalancer to nic1  
+$nic1 = New-AzureNetworkInterface -Name $nicname1 -ResourceGroupName $rgname -Location $location -Subnet $vnet.Subnets[0] -LoadBalancerBackendAddressPool $lb.BackendAddressPools[0] -LoadBalancerInboundNatRule $lb.InboundNatRules[0] 
+$nic2 = New-AzureNetworkInterface -Name $nicname2 -ResourceGroupName $rgname -Location $location -SubnetId $vnet.Subnets[0].Id  
+
+# Associate the nic to the load balancer 
+$nic1.IpConfigurations[0].LoadBalancerBackendAddressPools.Add($lb.BackendAddressPools[0]); 
+$nic1.IpConfigurations[0].LoadBalancerInboundNatRules.Add($lb.InboundNatRules[0]); 
+
+# Configure VM and attach networking interfaces
+$vm = New-AzureVMConfig -VMName $vmname -VMSize $vmsize;
+$vm = Add-AzureVMNetworkInterface -VM $vm -Id $nic1.Id -Primary;
+$vm = Add-AzureVMNetworkInterface -VM $vm -Id $nic2.Id;
+
+# Setup storage account
+New-AzureStorageAccount -ResourceGroupName $rgname -Name $stoname -Location $location -Type $stotype;
+$stoaccount = Get-AzureStorageAccount -ResourceGroupName $rgname -Name $stoname;
+   
+# Add OS Disk
+$vm = Set-AzureVMOSDisk -VM $vm -Name $osDiskName -VhdUri $osDiskVhdUri -Caching 'ReadWrite' -CreateOption fromImage;
+    
+# Setup OS 
+$securePassword = ConvertTo-SecureString $password -AsPlainText -Force;
+$cred = New-Object System.Management.Automation.PSCredential ($user, $securePassword);   
+$vm = Set-AzureVMOperatingSystem -VM $vm -Windows -ComputerName $vmname -Credential $cred;
+
+# Setup Image
+$vm = Set-AzureVMSourceImage -VM $vm -PublisherName MicrosoftWindowsServer -Offer WindowsServer -Skus 2012-R2-Datacenter -Version "latest"
+    
+# Create Virtual Machine
+New-AzureVM -ResourceGroupName $rgname -Location $location -Name $vmname -VM $vm;


### PR DESCRIPTION
This template allows you to create a Virtual Machines with multiple (2) network interfaces (NICs), and RDP connectable with a configured load balancer and an inbound NAT rule. More NICs can easily  be added with this template. This template also deploys a Storage Account, Virtual Network, Public IP address, and 2 Network Interfaces (front-end and back-end).