### PR TITLE
Parametize storage type and more

### DIFF
--- a/mysql-ha-pxc/azuredeploy.json
+++ b/mysql-ha-pxc/azuredeploy.json
@@ -13,7 +13,7 @@
             "type": "string",
             "defaultValue": "Standard_LRS",
             "metadata": {
-                "description": "Storage account name for the cluster"
+                "description": "Storage account type for the cluster"
             }
         },
         "dnsName": {

--- a/mysql-ha-pxc/azuredeploy.json
+++ b/mysql-ha-pxc/azuredeploy.json
@@ -539,7 +539,7 @@
                 "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]",
                 "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccount'))]",
                 "[concat('Microsoft.Network/networkInterfaces/', variables('nicName2'))]",
-                "[concat('Microsoft.Compute/virtualMachines/', variables('vmName1'))]"
+                "[concat('Microsoft.Compute/virtualMachines/',variables('vmName1'),'/extensions/',variables('vmExtensionName'))]"
             ],
             "properties": {
                 "availabilitySet": {
@@ -625,7 +625,7 @@
                 "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]",
                 "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccount'))]",
                 "[concat('Microsoft.Network/networkInterfaces/', variables('nicName3'))]",
-                "[concat('Microsoft.Compute/virtualMachines/', variables('vmName1'))]"
+                "[concat('Microsoft.Compute/virtualMachines/',variables('vmName1'),'/extensions/',variables('vmExtensionName'))]"
             ],
             "properties": {
                 "availabilitySet": {

--- a/mysql-ha-pxc/azuredeploy.json
+++ b/mysql-ha-pxc/azuredeploy.json
@@ -9,6 +9,13 @@
                 "description": "Storage account name for the cluster"
             }
         },
+        "storageAccountType": {
+            "type": "string",
+            "defaultValue": "Standard_LRS",
+            "metadata": {
+                "description": "Storage account name for the cluster"
+            }
+        },
         "dnsName": {
             "type": "string",
             "defaultValue": "pxccs",
@@ -292,7 +299,7 @@
             "apiVersion": "2015-05-01-preview",
             "location": "[resourceGroup().location]",
             "properties": {
-                "accountType": "Standard_LRS"
+                "accountType": "[parameters('storageAccountType')]"
             }
         },
         {

--- a/mysql-ha-pxc/azurepxc.sh
+++ b/mysql-ha-pxc/azurepxc.sh
@@ -142,7 +142,7 @@ configure_disks() {
     fi
 
     echo "Creating filesystem on ${PARTITION}."
-    mkfs -t ext4 ${PARTITION}
+    mkfs -t ext4 lazy_itable_init=1 ${PARTITION}
     mkdir "${MOUNTPOINT}"
     read UUID FS_TYPE < <(blkid -u filesystem ${PARTITION}|awk -F "[= ]" '{print $3" "$5}'|tr -d "\"")
     add_to_fstab "${UUID}" "${MOUNTPOINT}"


### PR DESCRIPTION
1. Parametize storage account type so that it supports both standard and premium storage
2. Change secondary nodes to depend on the successful provision of the bootstrap node.  Previously dependency on custom script extension wasn't supported 
3. Enable quick format