### PR TITLE
Improved 101-vm-multiple-data-disk

### DIFF
--- a/101-vm-multiple-data-disk/CreateStoragePool.ps1
+++ b/101-vm-multiple-data-disk/CreateStoragePool.ps1
@@ -1,0 +1,15 @@
+$subsystem = Get-StorageSubSystem
+$subsystemname = $subsystem[0].FriendlyName
+
+$PhysicalDisks = (Get-PhysicalDisk -CanPool $True)
+
+New-StoragePool -FriendlyName DataPool_01 -StorageSubSystemFriendlyName $subsystemname -PhysicalDisks $PhysicalDisks
+
+$disk = New-VirtualDisk -StoragePoolFriendlyName DataPool_01 -FriendlyName DataDisk_01 -Size 2TB -ResiliencySettingName Parity -ProvisioningType Thin
+
+Initialize-Disk -VirtualDisk $disk
+
+$part = New-Partition -DiskId $disk.UniqueId -DriveLetter "G" -UseMaximumSize
+
+Format-Volume -DriveLetter $part.DriveLetter -NewFileSystemLabel "Data01" -Confirm:$false
+

--- a/101-vm-multiple-data-disk/README.md
+++ b/101-vm-multiple-data-disk/README.md
@@ -6,6 +6,8 @@
 
 This template allows you to create a Windows Virtual Machine from a specified image during the template deployment and install the VM Diagnostics Extension. It also attaches 4 empty data disks. Note that you can specify the size of each of the empty data disks. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.
 
+Addition: A storage pool is created and formatted from the four data disks using a custom script extension
+
 NOTE: The configuration of the VM diagnostics extension relies on a Base64 encoded string for the xmlConfig. This configures a basic set of counters, including CPU and Memory. 
 
 Below are the parameters that the template expects.

--- a/101-vm-multiple-data-disk/azuredeploy.json
+++ b/101-vm-multiple-data-disk/azuredeploy.json
@@ -1,15 +1,15 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
-    "parameters" : {
+    "parameters": {
         "newStorageAccountName": {
             "type": "string",
             "metadata": {
                 "description": "This is the name of the your storage account"
             }
         },
-        "dnsNameForPublicIP" : {
-            "type" : "string",
+        "dnsNameForPublicIP": {
+            "type": "string",
             "metadata": {
                 "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
             }
@@ -28,22 +28,29 @@
         },
         "vmSize": {
             "type": "string",
+            "defaultValue": "Standard_D2",
+            "allowedValues": [
+                "Standard_D1",
+                "Standard_D2",
+                "Standard_D3",
+                "Standard_D4"
+            ],
             "metadata": {
-                "description": "Size of VM"
+                "description": "Size of the VM"
             }
         },
-        "sizeOfEachDataDiskInGB" : {
-            "type" : "string",
+        "sizeOfEachDataDiskInGB": {
+            "type": "string",
             "metadata": {
                 "description": "Size of each data disk in GB"
             }
         }
     },
     "variables": {
-        "location": "West US",
-        "addressPrefix":"10.0.0.0/16",
+        "location": "[resourceGroup().location]",
+        "addressPrefix": "10.0.0.0/16",
         "subnet1Name": "Subnet-1",
-        "subnet1Prefix" : "10.0.0.0/24",
+        "subnet1Prefix": "10.0.0.0/24",
         "vmStorageAccountContainerName": "vhds",
         "imagePublisher": "MicrosoftWindowsServer",
         "imageOffer": "WindowsServer",
@@ -54,164 +61,185 @@
         "storageAccountType": "Standard_LRS",
         "virtualNetworkName": "myVNET",
         "vmName": "myVM",
-        "vnetID":"[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "nicName":"myNIC",
-        "subnet1Ref" : "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
-        "dataDisk1VhdName" : "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk1.vhd')]",
-        "dataDisk2VhdName" : "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk2.vhd')]",
-        "dataDisk3VhdName" : "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk3.vhd')]",
-        "dataDisk4VhdName" : "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk4.vhd')]"
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+        "nicName": "myNIC",
+        "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
+        "dataDisk1VhdName": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk1.vhd')]",
+        "dataDisk2VhdName": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk2.vhd')]",
+        "dataDisk3VhdName": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk3.vhd')]",
+        "dataDisk4VhdName": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk4.vhd')]",
+        "scriptURL": "https://skpublic.blob.core.windows.net/scripts/CreateStoragePool.ps1",
+        "scriptName": "CreateStoragePool.ps1" 
     },
     "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[parameters('newStorageAccountName')]",
-      "apiVersion": "2015-05-01-preview",
-      "location": "[variables('location')]",
-      "properties": {
-        "accountType": "[variables('storageAccountType')]"
-      }
-    },
-    {
-        "apiVersion": "2015-05-01-preview",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[variables('publicIPAddressName')]",
-        "location": "[variables('location')]",
-        "properties": {
-            "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-            "dnsSettings": {
-                "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('newStorageAccountName')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[variables('location')]",
+            "properties": {
+                "accountType": "[variables('storageAccountType')]"
             }
-        }
-    },
-    {
-      "apiVersion": "2015-05-01-preview",
-      "type": "Microsoft.Network/virtualNetworks",
-      "name": "[variables('virtualNetworkName')]",
-      "location": "[variables('location')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('addressPrefix')]"
-          ]
         },
-        "subnets": [
-          {
-            "name": "[variables('subnet1Name')]",
-            "properties" : {
-                "addressPrefix": "[variables('subnet1Prefix')]"
-            }
-          }
-        ]
-      }
-    },
-    {
-        "apiVersion": "2015-05-01-preview",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[variables('nicName')]",
-        "location": "[variables('location')]",
-        "dependsOn": [
-            "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-            "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-        ],
-        "properties": {
-            "ipConfigurations": [
-            {
-                "name": "ipconfig1",
-                "properties": {
-                    "privateIPAllocationMethod": "Dynamic",
-                    "publicIPAddress": {
-                        "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-                    },
-                    "subnet": {
-                        "id": "[variables('subnet1Ref')]"
-                    }
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('publicIPAddressName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+                "dnsSettings": {
+                    "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
                 }
             }
-            ]
-        }
-    },
-    {
-        "apiVersion": "2015-05-01-preview",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[variables('vmName')]",
-        "location": "[variables('location')]",
-        "dependsOn": [
-            "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-            "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-        ],
-        "properties": {
-            "hardwareProfile": {
-                "vmSize": "[parameters('vmSize')]"
-            },
-            "osProfile": {
-                "computername": "[variables('vmName')]",
-                "adminUsername": "[parameters('adminUsername')]",
-                "adminPassword": "[parameters('adminPassword')]"
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "[variables('imagePublisher')]",
-                    "offer": "[variables('imageOffer')]",
-                    "sku" : "[variables('imageSKU')]",
-                    "version":"[variables('imageVersion')]"
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[variables('virtualNetworkName')]",
+            "location": "[variables('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('addressPrefix')]"
+                    ]
                 },
-
-                "dataDisks" : [
+                "subnets": [
                     {
-                        "name" : "datadisk1",
-                        "diskSizeGB" : "[parameters('sizeOfEachDataDiskInGB')]",
-                        "lun" : 0,
-                        "vhd":{
-                            "Uri" : "[variables('dataDisk1VhdName')]"
-                        },
-                        "createOption":"Empty"
-                    },
-                    {
-                        "name" : "datadisk2",
-                        "diskSizeGB" : "[parameters('sizeOfEachDataDiskInGB')]",
-                        "lun" : 1,
-                        "vhd":{
-                            "Uri" : "[variables('dataDisk2VhdName')]"
-                        },
-                        "createOption":"Empty"
-                    },
-                    {
-                        "name" : "datadisk3",
-                        "diskSizeGB" : "[parameters('sizeOfEachDataDiskInGB')]",
-                        "lun" : 2,
-                        "vhd":{
-                            "Uri" : "[variables('dataDisk3VhdName')]"
-                        },
-                        "createOption":"Empty"
-                    },
-                    {
-                        "name" : "datadisk4",
-                        "diskSizeGB" : "[parameters('sizeOfEachDataDiskInGB')]",
-                        "lun" : 3,
-                        "vhd":{
-                            "Uri" : "[variables('dataDisk4VhdName')]"
-                        },
-                        "createOption":"Empty"
+                        "name": "[variables('subnet1Name')]",
+                        "properties": {
+                            "addressPrefix": "[variables('subnet1Prefix')]"
+                        }
                     }
-                ],
-                "osDisk" : {
-                    "name": "osdisk1",
-                    "vhd": {
-                       "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/','osdisk1.vhd')]"
-                    },
-                    "caching": "ReadWrite",
-                    "createOption": "FromImage"
-                }
-            },
-            "networkProfile": {
-                "networkInterfaces" : [
-                {
-                    "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-                }
                 ]
             }
-        }
-    }
-  ]
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnet1Ref')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[variables('vmName')]",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[variables('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('imagePublisher')]",
+                        "offer": "[variables('imageOffer')]",
+                        "sku": "[variables('imageSKU')]",
+                        "version": "[variables('imageVersion')]"
+                    },
+
+                    "dataDisks": [
+                        {
+                            "name": "datadisk1",
+                            "diskSizeGB": "[parameters('sizeOfEachDataDiskInGB')]",
+                            "lun": 0,
+                            "vhd": {
+                                "Uri": "[variables('dataDisk1VhdName')]"
+                            },
+                            "createOption": "Empty"
+                        },
+                        {
+                            "name": "datadisk2",
+                            "diskSizeGB": "[parameters('sizeOfEachDataDiskInGB')]",
+                            "lun": 1,
+                            "vhd": {
+                                "Uri": "[variables('dataDisk2VhdName')]"
+                            },
+                            "createOption": "Empty"
+                        },
+                        {
+                            "name": "datadisk3",
+                            "diskSizeGB": "[parameters('sizeOfEachDataDiskInGB')]",
+                            "lun": 2,
+                            "vhd": {
+                                "Uri": "[variables('dataDisk3VhdName')]"
+                            },
+                            "createOption": "Empty"
+                        },
+                        {
+                            "name": "datadisk4",
+                            "diskSizeGB": "[parameters('sizeOfEachDataDiskInGB')]",
+                            "lun": 3,
+                            "vhd": {
+                                "Uri": "[variables('dataDisk4VhdName')]"
+                            },
+                            "createOption": "Empty"
+                        }
+
+                    ],
+                    "osDisk": {
+                        "name": "osdisk1",
+                        "vhd": {
+                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/','osdisk1.vhd')]"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(variables('vmName'), '/CustomScriptExtension')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.Compute",
+                "type": "CustomScriptExtension",
+                "typeHandlerVersion": "1.2",
+                "settings": {
+                    "fileUris": [ "[variables('scriptURL')]" ],
+                    "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -file ',variables('scriptName'))]"
+                }
+            }
+        },
+    ]
 }

--- a/101-vm-multiple-data-disk/metadata.json
+++ b/101-vm-multiple-data-disk/metadata.json
@@ -2,6 +2,6 @@
   "itemDisplayName": "Create a VM from a Windows Image with 4 Empty Data Disks",
   "description": "This template allows you to create a Windows Virtual Machine from a specified image. It also attaches 4 empty data disks. Note that you can specify the size of the empty data disks.",
   "summary": "Create a VM from a Windows Image with 4 Empty Data Disks",
-  "githubUsername": "kenazk",
-  "dateUpdated": "2015-04-24"
+  "githubUsername": "sk-bln",
+  "dateUpdated": "2015-06-04"
 }

--- a/101-vm-multiple-data-disk/metadata.json
+++ b/101-vm-multiple-data-disk/metadata.json
@@ -2,6 +2,6 @@
   "itemDisplayName": "Create a VM from a Windows Image with 4 Empty Data Disks",
   "description": "This template allows you to create a Windows Virtual Machine from a specified image. It also attaches 4 empty data disks. Note that you can specify the size of the empty data disks.",
   "summary": "Create a VM from a Windows Image with 4 Empty Data Disks",
-  "githubUsername": "sk-bln",
+  "githubUsername": "kenazk",
   "dateUpdated": "2015-06-04"
 }


### PR DESCRIPTION
In my fork, I did the following changes to 101-vm-multiple-data-disk
- Added a selection of instance types (Standard_D1 to Standard_D4)
- Changed the location to the location of the created resource group
- Added a custom script extension to the VM that creates &formats a storage pool out of the four data disks

Regards
Steffen