### PR TITLE
Update azuredeploy.json

### DIFF
--- a/101-vm-sshkey/azuredeploy.json
+++ b/101-vm-sshkey/azuredeploy.json
@@ -14,12 +14,6 @@
                 "description": "User name for the Virtual Machine."
             }
         },
-        "adminPassword": {
-            "type": "string",
-            "metadata": {
-                "description": "Password for the Virtual Machine."
-            }
-        },
         "sshKeyData": {
             "type": "string",
             "metadata": {
@@ -157,7 +151,6 @@
             "osProfile": {
                 "computername": "[parameters('vmName')]",
                 "adminUsername": "[parameters('adminUsername')]",
-                "adminPassword": "[parameters('adminPassword')]",
                 "linuxConfiguration": {
                     "disablePasswordAuthentication": "true",
                     "ssh": {


### PR DESCRIPTION
@singhkay This modification removes the ability to even specify a password, so that no one misunderstands. It works perfectly using the following url:

`https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsquillace%2Fazure-quickstart-templates%2Fmaster%2F101-vm-sshkey%2Fazuredeploy.json`

but does not work in the azure cli due to some sort of bug. The current one does not, either, so there's no regression, so far as I can see. We're on that.