### PR TITLE
Added stride and stripe-width RAID parameters for ext4 FS.

### DIFF
--- a/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
+++ b/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
@@ -284,7 +284,11 @@ create_striped_volume()
 	[ -d "${MOUNTPOINT}" ] || mkdir -p "${MOUNTPOINT}"
 
 	#Make a file system on the new device
-	mkfs -t ext4 "${MDDEVICE}"
+	STRIDE=128 #(512kB stripe size) / (4kB block size)
+	PARTITIONSNUM=${#PARTITIONS[@]}
+	STRIPEWIDTH=$((${STRIDE} * ${PARTITIONSNUM}))
+
+	mkfs.ext4 -b 4096 -E stride=${STRIDE},stripe-width=${STRIPEWIDTH} "${MDDEVICE}"
 
 	read UUID FS_TYPE < <(blkid -u filesystem ${MDDEVICE}|awk -F "[= ]" '{print $3" "$5}'|tr -d "\"")
 


### PR DESCRIPTION
stride=stride-size: Configure  the  filesystem  for  a  RAID  array with stride-size filesystem blocks. This is the number of blocks  read or written to disk before moving to the next disk, which is sometimes  referred  to  as  the chunk   size.   This  mostly  affects  placement  of filesystem metadata like bitmaps at mke2fs  time  to avoid  placing them on a single disk, which can hurt performance.  It may  also  be  used  by  the  block
allocator.

stripe-width=stripe-width: Configure  the  filesystem  for  a  RAID  array with stripe-width filesystem blocks per stripe.  This  is typically  stride-size * N, where N is the number of data-bearing disks in the  RAID  (e.g.  for  RAID  5 there is one parity disk, so N will be the number of disks in the array minus 1).  This allows the  block allocator to prevent read-modify-write of the parity in a RAID  stripe  if  possible  when  the  data  is written.

As default using mdadm, the stripe size is 512kB. Default block size for ext4 (and forced with mkfs.ext command in script) is 4kB. Stride = stripe size/block size. Stripe-width = stride * number of partitions used to build RAID0.