### PR TITLE
correct the hyper link of "Deploy To Azure" button

### DIFF
--- a/create-hpc-cluster/README.md
+++ b/create-hpc-cluster/README.md
@@ -1,7 +1,7 @@
 # Create HPC Cluster
 
 # Using HPC published head node image
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsunbinzhu%2Fazure-quickstart-templates%2Fmaster%2Fcreate-hpc-cluster%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fcreate-hpc-cluster%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 


### PR DESCRIPTION
The hyper link of "Deploy to azure" button is points to sunbinzhu's
branch, correct it to Azure branch.