### PR TITLE
SQL VM Provisioning in CSM v2 to support CSP subscriptions

### DIFF
--- a/sqlvm-provisioning-csp/Common.ps1
+++ b/sqlvm-provisioning-csp/Common.ps1
@@ -1,0 +1,30 @@
+﻿function SetupAzureResourceManagementSubscription
+{
+    #<#
+    #.Synopsis
+    #	The function signs to Azure and setup Azure subscription 
+    #       for ARM development by enabling ARM cmdlets. 
+    #.Description
+    #	The function should be called before executing any scripts. 
+    #       SubscriptionName is the name of the subscription to use. If the name has space
+    #       you need to srround it with white space. 
+    #.Parameter SubscriptionId
+    #       SubscriptionId is Azure subscription identifier of the subscription to use.
+    ##>
+    param
+    (
+      [Parameter(Mandatory)]
+      [string]$SubscriptionId
+    )
+
+    Add-AzureAccount
+
+    Write-Host 'Selecting Azure Subscription...' $SubscriptionId -foregroundcolor Yellow
+    Select-AzureSubscription -SubscriptionId $SubscriptionId
+
+
+    Write-Host 'Enabling Azure Resource Manager API...' -foregroundcolor Yellow
+    Switch-AzureMode AzureResourceManager
+    Write-Host 'Azure ARM API enabled.' -foregroundcolor Yellow
+}
+

--- a/sqlvm-provisioning-csp/CreateSQLVMExample.ps1
+++ b/sqlvm-provisioning-csp/CreateSQLVMExample.ps1
@@ -1,0 +1,20 @@
+﻿. "$PSScriptRoot\New-SqlServerVirtualMachine.ps1"
+
+
+$PlainPassword = "Pa55word1"
+$AdminPassword = $PlainPassword | ConvertTo-SecureString -AsPlainText -Force
+
+New-SqlServerVirtualMachine -SubscriptionId "e192531b-7c84-4681-aff9-644e1db18774" `
+                            -ResourceGroupName "ojtestvmcsmvrg" `
+                            -TemplatePath "SQLServerVMDeployment.json" `
+                            -VmName "ojtestvmcsmvt" `
+                            -VmSize "Standard_D4" `
+                            -VmLocation "westus" `
+                            -Username "zodaicman" `
+                            -Password $AdminPassword `
+                            -StorageName "ojtestvmcsmvstore" `
+                            -StorageType "Standard_GRS" `
+                            -VnetName "ojtestvmcsmvnet" `
+                            -NetworkAddressSpace "10.10.0.0/26" `
+                            -SubnetName "Subnet-1" `
+                            -SubnetAddressPrefix "10.10.0.0/28"

--- a/sqlvm-provisioning-csp/New-SqlServerVirtualMachine.ps1
+++ b/sqlvm-provisioning-csp/New-SqlServerVirtualMachine.ps1
@@ -1,0 +1,191 @@
+﻿function New-SqlServerVirtualMachine()
+{
+    #<#
+	#.Synopsis
+	#	   Deploy a new SQL VM Datawarehouse server on Azure cloud solution. 
+	#.Description
+    #      Create Azure resource group if not present and deploy a new cloud service and virtual machine. 
+    #      User can specify the SQL Server image name and SKU but the script will only create 
+    #      SQL Server IaaS VM. If you provide an image not published by SQL Server, the
+    #      deployment will fail. All virtual machines deployed are configured 
+    #      for remote desktop. 
+    #
+	#.Parameter SubscriptionId
+    #      SubscriptionId is the identifier of the subscription to use. 
+	#.Parameter ResourceGroupName
+	#      Azure resource group name. If this resource group exists, it will be used for the new VM deployment
+    #.Parameter TemplatePath
+    #      Virtual Machine CSM JSON file absolute path    
+    #.Parameter TemplateStorage
+    #      Azure stroage name to use for executing the template. This is a legacey parameter which Azure PowerShell SDK require but does not use.
+    #.Parameter VmName
+    #      Virtual Machine name. The name must be 15 character and all lowercase 
+    #.Parameter VmSize
+    #     Virtual Machine size. 
+    #.Parameter VmLocation
+    #     Virtual Machine deployment location 
+    #.Parameter Username
+    #     Virtual Machine username
+    #.Parameter Password
+    #     Virtual Machine password
+    #.Parameter StorageName
+    #     Virtual Machine service service name. If not is specified, then one will be create and the VM will be add to it. Otherwise, the provided service will be used
+    #.Parameter StorageType
+    #     Virtual Machine cloud storage type.
+    #.Parameter VnetName
+    #     Virtual Machine virtual network name 
+    #.Parameter NetworkAddressSpace
+    #     Virtual Machine virtual network address space 
+    #.Parameter SubnetName      
+    #     Virtual Machine virtual network subnet name 
+    #.Parameter SubnetAddressPrefix
+    #     Virtual Machine virtual network subnet address prefix
+	##>
+    param
+    (
+      [Parameter(Mandatory)]
+      [string]$SubscriptionId,
+
+      [Parameter(Mandatory)]
+      [string]$ResourceGroupName,
+
+      [Parameter(Mandatory)] 
+      [string]$TemplatePath ,
+
+      [Parameter(Mandatory)]
+      [string]$VmName,
+
+      [Parameter(Mandatory)]
+      [string]$VmSize,
+      
+      [Parameter(Mandatory)]
+      [string]$VmLocation,
+
+      [Parameter(Mandatory)]
+      [string]$Username,
+
+      [Parameter(Mandatory)]
+      [SecureString]$Password,
+
+      [Parameter(Mandatory)]
+      [string]$StorageName,
+
+      [Parameter(Mandatory)]
+      [string]$StorageType,
+
+      [Parameter(Mandatory)]
+      [string]$VnetName,
+
+      [string]$NetworkAddressSpace,
+
+      [Parameter(Mandatory)]
+      [string]$SubnetName,
+
+      [string]$SubnetAddressPrefix
+    )
+
+
+    Write-Host 'Selecting Azure Subscription...' -foregroundcolor Yellow
+
+    # include helper functions
+    . "$PSScriptRoot\Common.ps1"
+
+    # validate virtual machine name is less than or equal to 15 characters and all lowercase
+    if (($VmName.length -gt 15) -or ($VmName -cne $VmName.ToLower()))
+    {
+        Write-Output "The parameter 'ServiceName' should be 15 lowercase characters or less."
+        return;
+    }
+
+    # Update current subscription
+    Write-Host 'Selecting Azure Subscription...' $SubscriptionName -foregroundcolor Yellow
+    SetupAzureResourceManagementSubscription -SubscriptionId $SubscriptionId
+
+
+
+    # create the resource group if does not exists 
+    try
+    {
+        # create new resource group
+        Write-Host "Query resource group details '$ResourceGroupName' ..." -foregroundcolor Green
+
+
+        # if the resource group does not exist, then it will return a non-terminating error. We check the error to catch and create the resource in the finally. 
+        $error.Clear()
+
+        Get-AzureResourceGroup -Name $ResourceGroupName
+    }
+    catch
+    {
+        Write-Warning ("Azure resource group query operation failed. Error details:" + $_)
+    }
+    finally
+    {
+        if ($error[0])
+        {
+            # reset the error state
+            $error.Clear()
+
+            Write-Host "Create resource group '$ResourceGroupName' ..." -foregroundcolor Yellow
+
+            New-AzureResourceGroup  -Name $ResourceGroupName -Location $VmLocation
+
+            $error.Clear()
+            Get-AzureResourceGroup -Name $ResourceGroupName
+
+            if ($error[0])
+            {
+                Write-Host "Failed to create resource group '$ResourceGroupName'!" -foregroundcolor Red
+            }
+            else
+            {
+                Write-Host "Created resource group '$ResourceGroupName'" -foregroundcolor Green
+            }
+        }
+        else
+        {
+            Write-Host "Resource group '$ResourceGroupName' is already created!" -foregroundcolor Green
+        }
+    }
+
+    # execute the deployment template
+    try
+    {
+        $error.Clear()
+
+        New-AzureResourceGroupDeployment -ResourceGroupName $ResourceGroupName `
+                                         -TemplateFile $TemplatePath `
+                                         -vmName $VmName `
+                                         -vmSize $VmSize `
+                                         -sqlImageOffer "SQL2014-WS2012R2" `
+                                         -sqlImageSku "Enterprise" `
+                                         -sqlImageVersion "latest" `
+                                         -vmLocation $VmLocation `
+                                         -username $Username `
+                                         -password $Password `
+                                         -storageName $StorageName `
+                                         -storageType $StorageType `
+                                         -vnetName $VnetName `
+                                         -networkAddressSpace $NetworkAddressSpace `
+                                         -subnetName $SubnetName `
+                                         -subnetAddressPrefix $SubnetAddressPrefix `
+                                         -Verbose
+    }
+    catch
+    {
+        Write-Warning ("Azure SQL Server deployment failed!! Error details:" + $_)
+    }
+    finally
+    {
+        if ($error[0])
+        {
+            Write-Host "SQL Server deployment under resource group '$ResourceGroupName' failed!!" -foregroundcolor Red
+        }
+        else
+        {
+            Write-Host "*****************************************************************************" -foregroundcolor Green
+            Write-Host "Created SQL Server deployment under resource group '$ResourceGroupName'"       -foregroundcolor Green
+            Write-Host "*****************************************************************************" -foregroundcolor Green
+        }   
+    }
+}

--- a/sqlvm-provisioning-csp/Readme.md
+++ b/sqlvm-provisioning-csp/Readme.md
@@ -1,0 +1,150 @@
+# Create a SQL Server Virtual Machine on Azure CSP Subscription
+
+Microsoft Azure has a new subscription offering, CSP Subscriptions. Some aspects of SQL VM deployment are not yet supported in CSP subscriptions. This includes the SQL IaaS Agent Extension, which is required for features such as SQL Automated Backup and SQL Automated Patching.
+
+# Solution Overview
+
+Deploying via powershell or portal ui
+Requires the latest Azure PowerShell SDK http://azure.microsoft.com/en-us/downloads/
+
+Click the button below to deploy from the portal
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fsql-server-2014-alwayson-dsc%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+## Files Included
+
+This solution includes 3 files required for deployment and 1 example powershell script to help with executing the PowerShell cmdlet:
++   Common.ps1
+    A set of helper functions common in the implementation
++   New-SqlServerVirtualMachine.ps1
+    The PowerShell function that handles deployment of the template
++   SQLServerVMDeployment.json
+    ARM CSM v2 template to deploy SQL Server in an Azure VM
++   CreateSQLVMExample.ps1
+    Sample PowerShell script to help user execute the PowerShell cmdlet
+
+## Deploying from PowerShell 
+
+For details on how to install and configure Azure Powershell see [here].(https://azure.microsoft.com/en-us/documentation/articles/powershell-install-configure/)
+
+Before deploying via PowerShell there are a few steps you should follow:
++   Download the above files to the same location on your local machine
++   For each file, right click and open **Properties**, then deselect **Read-only** for each file. This will allow you to edit the files as needed.
++   Update the CreateSQLVMExample.ps1 file to fit your preferred input parameters
+
+Launch an Azure PowerShell console
+
+Log in to your Azure account
+
+```PowerShell
+
+Add-AzureAccount
+
+```
+
+Ensure that you are in Resource Manager Mode
+
+```PowerShell
+
+Switch-AzureMode AzureResourceManager
+
+```
+
+Change working folder to the folder containing these files.
+
+If you have updated the CreateSQLVMExample.ps1 file, run that file to deploy the template with your desired specifications.
+
+```PowerShell
+
+./CreateSQLVMExample.ps1
+
+```
+
+## Parameters
+
+|Name|Description                                        |
+|:----|:-------------------------------------------------|
+|SubscriptionId|Subscription ID of subscription used for deployment|
+|ResourceGroupName|Name of Resource Group which the resources will contained in|
+|TemplatePath|Path of the JSON template file in this repo|
+|VmName|Name of Virtual Machine|
+|VmSize|Size of Virtual Machine (https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-size-specs/)|
+|VmLocation|Region in which the VM will be provisioned|
+|Username|Virtual Machine admin user|
+|Password|Virtual Machine admin password|
+|StorageName|Name of Azure Storage Account|
+|StorageType|Type of Azure Storage Account <ul><li>Standard_LRS</li><li>Standard_GRS</li><li>Standard_RAGRS</li><li>Premium_LRS</li></ul>|
+|VnetName|Azure Virtual Network name|
+|NetworkAddressSpace|Virtual Network address space|
+|SubnetName|Virtual Network subnet name|
+|SubnetAddressPrefix|Virtual Network subnet address|
+
+## Additional Notes
+
++   Supported Images
+    All public SQL images are supported, both OS and Platform images.
++   Public DNS IP Address
+    A public DNS IP address is added to each VM created. The public DNS entry allows the remote desktop access.
++   Remote desktop
+    Remote desktop will be enabled by default on all new Virtual Machines created
++   Public Endpoint
+    The deployment does not create any public endpoint for any VM
++   Deploying on existing resources
+    Azure CSM v2 supports existing resources by simply referencing them. Submit a request to create a resource that already exists, will result in success request. Therefore, there is no special handling. For example, if you submit info for an existing VM, but change the storage account information, this will update the existing VM to use that storage account.
++   Data Disks
+    The template will not create data disks for OS images deployment. User can use the portal to add data disks after provisioning is complete. Platform images are created with preconfigured data disks.
++   Supported Deployment Locations
+    This is provided as a parameter the user can provide at deployment time
+
+## Supported Scenarios
+
++   New Virtual Machine Deployment Resources using OS Image
+    Im this scenario, the following resources are created:
+    +   Virtual Machine using OS image with no data disks
+    +   public DNS entry
+    +   Storage
+    +   Virtual Network
+    +   Subnet
++   Add Virtual Machine using OS image and existing storage
+    In this scenario, the following resources are created:
+    +   Virtual Machine using OS image with no data disks
+    +   Public DNS Entry
+    +   Virtual Network
+    +   Subnet
++   Add Virtual Machine using OS Image and existing VNET / Subnet 
+    In this scenario, the following resources are created:
+    +   Virtual Machine using OS image with no data disks
+    +   Public DNS Entry
+    +   Storage
++   Add Virtual Machine using OS Image to existing VNET / Subnet and Storage 
+    In this scenario, the following resources are created:
+    +   Virtual Machine using OS image with no data disks
+    +   Public DNS Entry
++   New Virtual Machine Deployment Resources using Platform Image
+    In this scenario, the following resources are created:
+    +   Virtual Machine using Platform image
+    +   Public DNS Entry
+    +   Storage
+    +   Virtual Network
+    +   Subnet
++   Add Virtual Machine using Platform Image and existing Storage 
+    In this scenario, the following resources are created:
+    +   Virtual Machine using Platform Image
+    +   Public DNS Entry
+    +   Virtual Network
+    +   Subnet
++   Add Virtual Machine using Platform Image and existing VNET / Subnet 
+    In this scenario, the following resources are created:
+    +   Virtual Machine using Platform image
+    +   Public DNS Entry
+    +   Storage
++   Add Virtual Machine using Platform Image to existing VNET / Subnet and Storage 
+    In this scenario, the following resources are created:
+    +   Virtual Machine using Platform image
+    +   Public DNS Entry
+
+
+
+

--- a/sqlvm-provisioning-csp/SQLServerVMDeployment.json
+++ b/sqlvm-provisioning-csp/SQLServerVMDeployment.json
@@ -4,14 +4,12 @@
     "parameters": {
         "vmName": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "SQL IaaS VM machine name"
             }
         },
         "vmSize": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "SQL IaaS VM size. Use Azure VM size name from MSDN"
             }
@@ -47,28 +45,24 @@
         },
         "vmLocation": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "SQL IaaS VM data center location. User Azure location from MDSN"
             }
         },
         "username": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "SQL IaaS VM local administrator username"
             }
         },
         "password": {
             "type": "securestring",
-            "defaultValue": "",
             "metadata": {
                 "description": "SQL IaaS VM local administrator password"
             }
         },
         "storageName": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "SQL IaaS VM data and OS disks storage service"
             }
@@ -87,7 +81,6 @@
         },
         "vnetName": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "SQL IaaS VM virtual network name"
             }
@@ -101,7 +94,6 @@
         },
         "subnetName": {
             "type": "string",
-            "defaultValue": "",
             "metadata": {
                 "description": "SQL IaaS VM virtual network subnet name"
             }

--- a/sqlvm-provisioning-csp/SQLServerVMDeployment.json
+++ b/sqlvm-provisioning-csp/SQLServerVMDeployment.json
@@ -1,0 +1,238 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "vmName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SQL IaaS VM machine name"
+            }
+        },
+        "vmSize": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SQL IaaS VM size. Use Azure VM size name from MSDN"
+            }
+        },
+        "sqlImageOffer": {
+            "type": "string",
+            "defaultValue": "SQL2014-WS2012R2",
+            "allowedValues": [
+                "SQL2014-WS2012R2"
+            ],
+            "metadata": {
+                "description": "SQL Server Gallery Image Offer"
+            }
+        },
+        "sqlImageSku": {
+            "type": "string",
+            "defaultValue": "Standard",
+            "allowedValues": [
+                "Enterprise",
+                "Standard",
+                "Web"
+            ],
+            "metadata": {
+                "description": "SQL Server Gallery Image SKU"
+            }
+        },
+        "sqlImageVersion": {
+            "type": "string",
+            "defaultValue": "latest",
+            "metadata": {
+                "description": "SQL Server Gallery Image Published Version"
+            }
+        },
+        "vmLocation": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SQL IaaS VM data center location. User Azure location from MDSN"
+            }
+        },
+        "username": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SQL IaaS VM local administrator username"
+            }
+        },
+        "password": {
+            "type": "securestring",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SQL IaaS VM local administrator password"
+            }
+        },
+        "storageName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SQL IaaS VM data and OS disks storage service"
+            }
+        },
+        "storageType": {
+            "type": "string",
+            "defaultValue": "Standard_LRS",
+            "allowedValues": [
+                "Standard_LRS",
+                "Standard_GRS",
+                "Standard_ZRS"
+            ],
+            "metadata": {
+                "description": "SQL IaaS VM data and OS disks storage type"
+            }
+        },
+        "vnetName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SQL IaaS VM virtual network name"
+            }
+        },
+        "networkAddressSpace": {
+            "type": "string",
+            "defaultValue": "10.10.0.0/26",
+            "metadata": {
+                "description": "SQL IaaS VM virtual network IPv4 address space"
+            }
+        },
+        "subnetName": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "SQL IaaS VM virtual network subnet name"
+            }
+        },
+        "subnetAddressPrefix": {
+            "type": "string",
+            "defaultValue": "10.10.0.0/28",
+            "metadata": {
+                "description": "SQL IaaS VM virtual network subnet IPv4 address prefix"
+            }
+        }
+    },
+    "variables": {
+        "vmnic": "[concat(parameters('vmName'), 'devnic')]",
+        "vmosdisk": "[concat(parameters('vmName'), 'osdisk')]",
+        "publicDnsName": "[concat(parameters('vmName'), 'dns')]",
+        "virtualNetworkID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vnetName'))]",
+        "vnetSubNetID": "[concat(variables('virtualNetworkID'),'/subnets/',parameters('subnetName'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('storageName')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[parameters('vmlocation')]",
+            "properties": {
+                "accountType": "[parameters('storageType')]"
+            }
+        },
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "2015-05-01-preview",
+            "name": "[variables('publicDnsName')]",
+            "location": "[parameters('vmLocation')]",
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic",
+                "dnsSettings": {
+                    "domainNameLabel": "[variables('publicDnsName')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks",
+            "apiVersion": "2015-05-01-preview",
+            "name": "[parameters('vnetName')]",
+            "location": "[parameters('vmLocation')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[parameters('networkAddressSpace')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[parameters('subnetName')]",
+                        "properties": {
+                            "addressPrefix": "[parameters('subnetAddressPrefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('vmnic')]",
+            "location": "[parameters('vmLocation')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicDnsName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "devipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicDnsName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('vnetSubNetID')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "apiVersion": "2015-05-01-preview",
+            "name": "[parameters('vmName')]",
+            "location": "[parameters('vmLocation')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('vmnic'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[parameters('vmName')]",
+                    "adminUserName": "[parameters('username')]",
+                    "adminPassword": "[parameters('password')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "MicrosoftSQLServer",
+                        "offer": "[parameters('sqlImageOffer')]",
+                        "sku": "[parameters('sqlImageSku')]",
+                        "version": "[parameters('sqlImageVersion')]"
+                    },
+                    "osDisk": {
+                        "name": "[variables('vmosdisk')]",
+                        "vhd": {
+                            "uri": "[concat('http://',parameters('storageName'),'.blob.core.windows.net/vhds/', variables('vmosdisk'),'.vhd')]"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmnic'))]"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
All required scripts to accomplish provisioning a SQL VM, similarly to normal VM provisioning in Portal but supporting CSP subscriptions. this is for CSM v2. Readme
contains all details required. template included, sample powershell
script included to help customer deploy. this feature is fully tested by
our team.