### PR TITLE
 Removing resource group name dependency

### DIFF
--- a/201-winrm-windows-vm/azuredeploy-parameters.json
+++ b/201-winrm-windows-vm/azuredeploy-parameters.json
@@ -2,6 +2,9 @@
     "newStorageAccountName" : {
         "value":""
     },
+    "dnsNameForPublicIP": {
+        "value": ""
+    },
     "adminUsername": {
         "value": ""
     },
@@ -18,9 +21,6 @@
       "value" : ""
     },
     "vaultName" : {
-      "value" : ""
-    },
-    "vaultResourceGroup" : {
       "value" : ""
     },
     "certificateUrl" : {

--- a/201-winrm-windows-vm/azuredeploy-parameters.json
+++ b/201-winrm-windows-vm/azuredeploy-parameters.json
@@ -23,6 +23,9 @@
     "vaultName" : {
       "value" : ""
     },
+    "vaultResourceGroup" : {
+      "value" : ""
+    },
     "certificateUrl" : {
       "value" : ""
     }

--- a/201-winrm-windows-vm/azuredeploy.json
+++ b/201-winrm-windows-vm/azuredeploy.json
@@ -71,6 +71,12 @@
         "description": "Name of the KeyVault"
       }
     },
+    "vaultResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "Resource Group of the KeyVault"
+      }
+    },
     "certificateUrl": {
       "type": "string",
       "metadata": {
@@ -170,7 +176,7 @@
         "adminPassword": "[parameters('adminPassword')]",
         "secrets": [{
           "sourceVault": {
-            "id": "[resourceId('Microsoft.KeyVault/vaults', parameters('vaultName'))]"
+            "id": "[resourceId(parameters('vaultResourceGroup'), 'Microsoft.KeyVault/vaults', parameters('vaultName'))]"
           },
           "vaultCertificates": [{
             "certificateUrl": "[parameters('certificateUrl')]",

--- a/201-winrm-windows-vm/azuredeploy.json
+++ b/201-winrm-windows-vm/azuredeploy.json
@@ -8,6 +8,12 @@
         "description": "This is the name of the storage account"
       }
     },
+    "dnsNameForPublicIP" : {
+            "type" : "string",
+            "metadata": {
+                "description": "DNS Name for the Public IP. Must be lowercase."
+            }
+    },
     "adminUserName": {
       "type": "string",
       "metadata": {
@@ -65,12 +71,6 @@
         "description": "Name of the KeyVault"
       }
     },
-    "vaultResourceGroup": {
-      "type": "string",
-      "metadata": {
-        "description": "Resource Group of the KeyVault"
-      }
-    },
     "certificateUrl": {
       "type": "string",
       "metadata": {
@@ -105,8 +105,11 @@
     "name": "[variables('publicIPAddressName')]",
     "location": "[parameters('location')]",
     "properties": {
-      "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
-    }
+      "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+      "dnsSettings": {
+                        "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+                     }
+                  }
   }, {
     "apiVersion": "2015-05-01-preview",
     "type": "Microsoft.Network/virtualNetworks",
@@ -167,7 +170,7 @@
         "adminPassword": "[parameters('adminPassword')]",
         "secrets": [{
           "sourceVault": {
-            "id": "[resourceId(parameters('vaultResourceGroup'), 'Microsoft.KeyVault/vaults', parameters('vaultName'))]"
+            "id": "[resourceId('Microsoft.KeyVault/vaults', parameters('vaultName'))]"
           },
           "vaultCertificates": [{
             "certificateUrl": "[parameters('certificateUrl')]",


### PR DESCRIPTION
1) Removing resource group name dependency in parameter file as this is not required
2) Adding DNS name as well for VM, without this you can't get right certificate as IP of the dynamic machine is not constant
