### PR TITLE
Describe valid chars for newStorageAccountName

### DIFF
--- a/CentOS-2nics-lb-cluster/azuredeploy.json
+++ b/CentOS-2nics-lb-cluster/azuredeploy.json
@@ -17,7 +17,7 @@
         "newStorageAccountName": {
             "type": "string",
             "metadata": {
-                "description": "Unique storage account name"
+                "description": "Unique storage account name. Must be between 3 and 24 characters in length and use numbers and lower-case letters only."
             }
         },
         "numberOfInstances": {

--- a/CentOS-2nics-lb-cluster/metadata.json
+++ b/CentOS-2nics-lb-cluster/metadata.json
@@ -2,6 +2,6 @@
   "itemDisplayName": "Deploys a N-node CentOS Cluster",
   "description": "This template deploys a 2-10 node CentOS cluster with 2 networks.",
   "summary": "This template deploys a 2-10 node CentOS cluster with a private and a public network, a load-balancer and a custom script that configures the networks on the CentOS nodes.",
-  "githubUsername": "gmarchet",
+  "githubUsername": "aculich",
   "dateUpdated": "2015-05-22"
 }


### PR DESCRIPTION
According to an `AccountNameInvalid` error message I received in the
Azure portal, a "Storage account name must be between 3 and 24
characters in length and use numbers and lower-case letters only."

It would be even more helpful if the templates were validated before
allowing them to be submitted, but at least including this in the
description might help a bit.