### PR TITLE
High-availability Swarm cluster with Consul

### DIFF
--- a/docker-swarm-cluster/README.md
+++ b/docker-swarm-cluster/README.md
@@ -1,0 +1,102 @@
+# Docker Swarm Cluster
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdocker-swarm-cluster%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+*(Built by: [ahmetalpbalkan](https://github.com/ahmetalpbalkan), [garimakhulbe](https://github.com/garimakhulbe))*
+
+This template deploys a [Docker Swarm](http://docs.docker.com/swarm) cluster
+on Azure with multiple manager nodes and specified number of slave nodes in
+the location of the resource group.
+
+If you are not familiar with Docker Swarm, please
+[read Swarm documentation](http://docs.docker.com/swarm).
+
+## Parameters
+
+| Name   | Description |
+|:--- |:---|
+| `slaveCount`  | Number of the nodes in the Swarm node pool. |
+| `newStorageAccountName`  | Unique name for a new storage account where the VM disks will be stored. |
+| `adminUsername` | SSH user for the Virtual Machines.  |
+| `sshPublicKey` | SSH key for the Virtual Machines.  |
+| `dnsName` | Unique DNS Name for the Swarm Management endpoint and the load balancer for slave nodes. |
+| `dockerCa`  | Base64-encoded Docker CA certificate (`ca.pem`) for the Docker engines and Swarm managers. Leave empty to create an insecure Docker cluster. |
+| `dockerCert`  | Base64-encoded Docker TLS Certificate (`cert.pem`) for the Docker engines and Swarm managers. Leave empty to create an insecure Docker cluster. |
+| `dockerKey` | Base64-encoded Docker TLS Key (`key.pem`) for the Docker engines and Swarm managers. Leave empty to create an insecure Docker cluster. |
+
+## Cluster Properties
+
+#### Swarm Managers (High Availability Setup)
+
+The template provisions 3 Swarm manager VMs that use [Consul](https://consul.io/)
+for discovery and leader election. These VMs are in an [Avabilability Set][av-set]
+to achieve the highest uptime.
+
+Each manager VM has a public IP address. However, it's recommended to talk to the
+Swarm manager using the DNS adddress emitted in the deployment output rather than
+directly talking to each Swarm Manager. This DNS address is [load balanced][az-lb]
+among the Swarm managers (described later).
+
+Each Swarm manager VM is of size `Standard_A0` as they are not running any workloads
+except Swarm Manager and Consul. Manager node VMs have static private IP addresses
+`10.0.0.4`, `10.0.0.5` and `10.0.0.6` and they are in the same [Virtual Network][az-vnet] as slave nodes.
+
+#### Configuring Authentication
+
+It is highly recommended to provide `dockerCa`, `dockerCert`, `dockerKey` parameters
+in the template. Otherwise the created Docker Swarm cluster will be open to anyone
+in public Internet without any authentication.
+
+These certificates are used to configure each Docker Engine and Docker Swarm
+Manager endpoints using TLS authentication. Once the cluster is created, you
+can use the DNS address in the output as follows to talk to the Docker Swarm Managers:
+
+    docker -H tcp://<dnsName>-manage.cloudapp.azure.com:2376 --tls ps
+
+#### Swarm Slave Nodes
+
+You can configure `slaveCount` parameter to create as many instances you like.
+Each Swarm slave VM is of size `Standard_A2`.
+
+Slave nodes do not have public IP addresses, and are accessible through Swarm
+manager VMs over SSH. In order to access a slave VM, you need to SSH into a
+master VM and use slave VMs private IP address to SSH from there (using the
+same SSH key you used for authenticating into master). Alternatively, you can
+establish an SSH Tunnel on your development machine and directly connect to
+the slave VM using its private IP address.
+
+Slave node VMs have private IP addresses `192.168.0.*` and are in the same
+[Virtual Network][az-vnet] with the manager nodes. Slave nodes are in an
+[Availability Set][av-set] to ensure highest uptime and fault domains.
+
+Slave node VMs have are behind a load balancer (called `swarm-lb-slaves`). Any
+multi-instance services deployed across slave VMs can be served to the public
+internet by creating probes and load balancing rules on this Load Balancer
+resource. Load balancer's public DNS address is emitted as an output of the
+template deployment.
+
+## Output
+
+The template deployment will output two values:
+
+#### 1. `SwarmManagerDockerEndpoint`
+
+This is in `tcp://<hostname>:2376` format and can be directly used in Docker
+client to target managers of the Swarm cluster.
+
+#### 2. `SwarmSlavesDNS`
+
+This is a [Load Balancer][az-lb] endpoint for the slave nodes in the
+Swarm cluster and has no load balancing rules by default. As you deploy services
+to the cluster, you can create new Load Balancing Rules and Probes from Azure
+Portal.
+
+-----------------
+
+![Docker Swarm logo](https://github.com/docker/swarm/raw/master/logo.png?raw=true)
+
+[av-set]: https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-manage-availability/
+[az-lb]: https://azure.microsoft.com/en-us/documentation/articles/load-balancer-overview/
+[az-vnet]: http://azure.microsoft.com/en-us/documentation/services/virtual-network/

--- a/docker-swarm-cluster/azuredeploy-parameters.json
+++ b/docker-swarm-cluster/azuredeploy-parameters.json
@@ -1,0 +1,26 @@
+{
+  "newStorageAccountName": {
+    "value": "<<new storage account name>>"
+  },
+  "adminUsername": {
+    "value": "azureuser"
+  },
+  "sshPublicKey": {
+    "value": "<<paste your id_rsa.pub>>"
+  },
+  "dnsName": {
+    "value": "myswarm"
+  },
+  "slaveCount": {
+    "value": 3
+  },
+  "dockerCa": {
+    "value": "<<paste base64-encoded ca.pem>>"
+  },
+  "dockerCert": {
+    "value": "<<paste base64-encoded cert.pem>>"
+  },
+  "dockerKey": {
+    "value": "<<paste base64-encoded key.pem>>"
+  }
+}

--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -1,0 +1,616 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Storage Account where the Virtual Machines' disks will be stored."
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "User name for the Virtual Machines."
+      }
+    },
+    "sshPublicKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH RSA Public Key to access Swarm manager VMs"
+      }
+    },
+    "dnsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name prefix for the Swarm cluster."
+      }
+    },
+    "slaveCount": {
+      "type": "int",
+      "defaultValue": 3,
+      "metadata": {
+        "description": "Number of Swarm nodes"
+      }
+    },
+    "dockerCa": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Base64-encoded Docker TLS CA certificate (~/docker/ca.pem). Leave empty to create an insecure Docker cluster."
+      }
+    },
+    "dockerCert": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Base64-encoded Docker TLS Certificate (~/docker/cert.pem). Leave empty to create an insecure Docker cluster."
+      }
+    },
+    "dockerKey": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Base64-encoded Docker TLS Key (~/docker/ca.pem). Leave empty to create an insecure Docker cluster."
+      }
+    }
+  },
+  "variables": {
+    "masterCount": 3,
+    "vmNameMaster": "swarm-master-",
+    "vmNameSlave": "swarm-node-",
+    "vmSizeMaster": "Standard_A0",
+    "vmSizeSlave": "Standard_A2",
+    "availabilitySetMasters": "swarm-masters-set",
+    "availabilitySetSlaves": "swarm-nodes-set",
+    "osImagePublisher": "CoreOS",
+    "osImageOffer": "CoreOS",
+    "osImageSKU": "Stable",
+    "managementPublicIPAddrName": "swarm-lb-masters-ip",
+    "slavesPublicIPAddrName": "swarm-lb-slaves-ip",
+    "virtualNetworkName": "swarm-vnet",
+    "subnetNameMaster": "subnet-masters",
+    "subnetNameSlave": "subnet-slave",
+    "addressPrefixMaster": "10.0.0.0/16",
+    "addressPrefixSlave": "192.168.0.0/16",
+    "subnetPrefixMaster": "10.0.0.0/24",
+    "subnetPrefixSlave": "192.168.0.0/24",
+    "subnetRefMaster": "[concat(resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName')),'/subnets/',variables('subnetNameMaster'))]",
+    "subnetRefSlave": "[concat(resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName')),'/subnets/',variables('subnetNameSlave'))]",
+    "nsgName": "swarm-nsg",
+    "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
+    "storageAccountType": "Standard_LRS",
+    "vhdBlobContainer": "vhds",
+    "mastersLbName": "swarm-lb-masters",
+    "mastersLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('mastersLbName'))]",
+    "mastersLbBackendPoolName": "swarm-master-pool",
+    "slavesLbName": "swarm-lb-slaves",
+    "slavesLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('slavesLbName'))]",
+    "slavesLbBackendPoolName": "swarm-slave-pool",
+    "sshKeyPath": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+    "consulServerArgs": [
+      "-advertise 10.0.0.4 -bootstrap-expect 3",
+      "-advertise 10.0.0.5 -join 10.0.0.4 -join 10.0.0.6",
+      "-advertise 10.0.0.6 -join 10.0.0.4 -join 10.0.0.5"
+    ]
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('newStorageAccountName')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[variables('availabilitySetMasters')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[variables('availabilitySetSlaves')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {}
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('managementPublicIPAddrName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[concat(parameters('dnsName'), '-manage')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('slavesPublicIPAddrName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsName')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[variables('nsgID')]"
+      ],
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefixMaster')]",
+            "[variables('addressPrefixSlave')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetNameMaster')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefixMaster')]",
+              "networkSecurityGroup": {
+                "id": "[variables('nsgID')]"
+              }
+            }
+          },
+          {
+            "name": "[variables('subnetNameSlave')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefixSlave')]",
+              "networkSecurityGroup": {
+                "id": "[variables('nsgID')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('nsgName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "swarmManagementEndpoint",
+            "properties": {
+              "description": "Docker Swarm Manager",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "2376",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "ssh",
+            "properties": {
+              "description": "SSH",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 200,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(variables('vmNameMaster'), copyIndex(), '-ip')]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "ipLoopMaster",
+        "count": "[variables('masterCount')]"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('vmNameMaster'), copyIndex(), '-nic')]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "nicLoopMaster",
+        "count": "[variables('masterCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/loadBalancers/', variables('mastersLbName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/',concat(variables('vmNameMaster'), copyIndex(), '-ip'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipConfigMaster",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[concat('10.0.0.', copyIndex(4))]",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',concat(variables('vmNameMaster'), copyIndex(), '-ip'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRefMaster')]"
+              },
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "[concat(variables('mastersLbID'), '/backendAddressPools/', variables('mastersLbBackendPoolName'))]"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "name": "[variables('mastersLbName')]",
+      "type": "Microsoft.Network/loadBalancers",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('managementPublicIPAddrName'))]"
+      ],
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "LoadBalancerFrontEnd",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('managementPublicIPAddrName'))]"
+              }
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "[variables('mastersLbBackendPoolName')]"
+          }
+        ],
+        "probes": [
+          {
+            "name": "swarm-probe",
+            "properties": {
+              "protocol": "Tcp",
+              "port": 2376,
+              "intervalInSeconds": 10,
+              "numberOfProbes": 2
+            }
+          }
+        ],
+        "loadBalancingRules": [
+          {
+            "name": "SwarmManagerHTTP",
+            "properties": {
+              "protocol": "tcp",
+              "frontendPort": 2376,
+              "backendPort": 2376,
+              "enableFloatingIP": false,
+              "idleTimeoutInMinutes": 5,
+              "frontendIPConfiguration": {
+                "id": "[concat(variables('mastersLbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]"
+              },
+              "backendAddressPool": {
+                "id": "[concat(variables('mastersLbID'),'/backendAddressPools/', variables('mastersLbBackendPoolName'))]"
+              },
+              "probe": {
+                "id": "[concat(variables('mastersLbID'), '/probes/swarm-probe')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "name": "[variables('slavesLbName')]",
+      "type": "Microsoft.Network/loadBalancers",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('slavesPublicIPAddrName'))]"
+      ],
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "LoadBalancerFrontEnd",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('slavesPublicIPAddrName'))]"
+              }
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "[variables('slavesLbBackendPoolName')]"
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('vmNameSlave'),copyIndex(), '-nic')]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "nicLoopSlave",
+        "count": "[parameters('slaveCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/loadBalancers/', variables('slavesLbName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipConfigSlave",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRefSlave')]"
+              },
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "[concat(variables('slavesLbID'), '/backendAddressPools/', variables('slavesLbBackendPoolName'))]"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(variables('vmNameMaster'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "vmLoopMaster",
+        "count": "[variables('masterCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('vmNameMaster'), copyIndex(), '-nic')]",
+        "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetMasters'))]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetMasters'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSizeMaster')]"
+        },
+        "osProfile": {
+          "computername": "[concat(variables('vmNameMaster'), copyIndex())]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "linuxConfiguration":{
+            "disablePasswordAuthentication":"true",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "[variables('sshKeyPath')]",
+                  "keyData": "[parameters('sshPublicKey')]"
+                }
+              ]
+            }
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('osImagePublisher')]",
+            "offer": "[variables('osImageOffer')]",
+            "sku": "[variables('osImageSKU')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "[concat(variables('vmNameMaster'), copyIndex(),'-osdisk')]",
+            "vhd": {
+              "uri": "[concat('http://', parameters('newStorageAccountName'), '.blob.core.windows.net/', variables('vhdBlobContainer'), '/master-', copyIndex(), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmNameMaster'), copyIndex(), '-nic'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(variables('vmNameSlave'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "vmLoopSlave",
+        "count": "[parameters('slaveCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('vmNameSlave'), copyIndex(), '-nic')]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetSlaves'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSizeSlave')]"
+        },
+        "osProfile": {
+          "computername": "[concat(variables('vmNameSlave'), copyIndex())]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "linuxConfiguration":{
+            "disablePasswordAuthentication":"true",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "[variables('sshKeyPath')]",
+                  "keyData": "[parameters('sshPublicKey')]"
+                }
+              ]
+            }
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('osImagePublisher')]",
+            "offer": "[variables('osImageOffer')]",
+            "sku": "[variables('osImageSKU')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "[concat(variables('vmNameSlave'), copyIndex(),'-osdisk')]",
+            "vhd": {
+              "uri": "[concat('http://', parameters('newStorageAccountName'), '.blob.core.windows.net/', variables('vhdBlobContainer'), '/slave-', copyIndex(), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmNameSlave'), copyindex(), '-nic'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmNameMaster'), copyIndex(), '/DockerExtension')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "extLoopMaster",
+        "count": "[variables('masterCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('vmNameMaster'), copyIndex())]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "DockerExtension",
+        "typeHandlerVersion": "1.0",
+        "settings": {
+          "compose": {
+            "consul": {
+              "image": "progrium/consul",
+              "command": "[concat('-server -node master', copyIndex(), ' ', variables('consulServerArgs')[copyIndex()])]",
+              "ports": [
+                "8300:8300",
+                "8301:8301",
+                "8301:8301/udp",
+                "8302:8302",
+                "8302:8302/udp",
+                "8400:8400",
+                "8500:8500",
+                "53:53/udp"
+              ],
+              "volumes": [
+                "/data/consul:/data"
+              ],
+              "restart": "always"
+            },
+            "swarm": {
+              "image": "swarm",
+              "command": "[concat('--debug manage --tls --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/cert.pem --tlskey /etc/docker/key.pem --replication --advertise ', reference(concat(variables('vmNameMaster'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2376 consul://10.0.0.4:8500,10.0.0.5:8500,10.0.0.6:8500/nodes')]",
+              "ports": [
+                "2376:2375"
+              ],
+              "links": [
+                "consul"
+              ],
+              "volumes": [
+                "/etc/docker:/etc/docker"
+              ],
+              "restart": "always"
+            }
+          }
+        },
+        "protectedSettings": {
+          "certs": {
+            "ca": "[parameters('dockerCa')]",
+            "cert": "[parameters('dockerCert')]",
+            "key": "[parameters('dockerKey')]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmNameSlave'), copyIndex(), '/DockerExtension')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "extLoopSlave",
+        "count": "[parameters('slaveCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('vmNameSlave'), copyIndex())]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "DockerExtension",
+        "typeHandlerVersion": "1.0",
+        "settings": {
+          "docker": {
+            "port": "2375"
+          },
+          "compose": {
+            "swarm": {
+              "image": "swarm",
+              "restart": "always",
+              "command": "[concat('--debug join --advertise=', reference(concat(variables('vmNameSlave'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2375 consul://10.0.0.4:8500,10.0.0.5:8500,10.0.0.6:8500/nodes')]"
+            }
+          }
+        },
+        "protectedSettings": {
+          "certs": {
+            "ca": "[parameters('dockerCa')]",
+            "cert": "[parameters('dockerCert')]",
+            "key": "[parameters('dockerKey')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "SwarmManagerDockerEndpoint": {
+      "type": "string",
+      "value": "[concat('tcp://', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ':2376')]"
+    },
+    "SwarmSlavesDNS": {
+      "type": "string",
+      "value": "[reference(variables('slavesPublicIPAddrName'))]"
+    }
+  }
+}

--- a/docker-swarm-cluster/metadata.json
+++ b/docker-swarm-cluster/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Docker Swarm Cluster",
+  "description": "This template creates a high-availability Docker Swarm cluster",
+  "summary": "This template deploys a Docker Swarm with multiple managers and specified number of slave nodes.",
+  "githubUsername": "ahmetalpbalkan",
+  "dateUpdated": "2015-07-29"
+}


### PR DESCRIPTION
- Multiple swarm-master replicas setup (hardcoded: 3)
- Nodes and managers now use Consul for service discovery
  (removed Docker Hub token:// discovery)
- Statically allocated private IPs for masters
- Add TLS authentication to Swarm and Docker engines
- Masters and slave are now in an availability sets
- Use SSH key for authentication instead of password
- Slaves don't have public IPs, they are accessible via SSH tunneling
  through masters however they are load balanced publicly.
- Masters are behind a public Azure Load Balancer, clients should hit this
  Load Balancer's DNS address.
- Template output now conforms DOCKER_HOST URI format
- Only masters have a public IP address
- Update slave VM size from D1 to A2 (Docker use case generally does not use
  /mnt which D1 gets an SSD for. A2 has the same memory, 2-core CPU and
  twice more IOPS =4x500).
- Read 'location' from resource group instead of hardcoded value

Known issues
- `swarm-slaves-lb` is not getting an IP address allocated. Following up with
  networking team.

![Docker Swarm logo](https://github.com/docker/swarm/raw/master/logo.png?raw=true)