### PR TITLE
Fixing Slurm deployment error

### DIFF
--- a/slurm/azuredeploy.json
+++ b/slurm/azuredeploy.json
@@ -215,7 +215,7 @@
       "properties": {
         "publisher": "Microsoft.OSTCExtensions",
         "type": "CustomScriptForLinux",
-        "typeHandlerVersion": "1.1",
+        "typeHandlerVersion": "1.2",
         "settings": {
           "fileUris": [
             "[concat(variables('templateBaseUrl'), 'azuredeploy.sh')]"


### PR DESCRIPTION
The typeHandlerVersion was wrong. Changing allowed the template to
properly deploy SLURM to all the nodes.