### PR TITLE
fix(arm-asm-s2s/azuredeploy) - descriptions need to be in metadata obj

### DIFF
--- a/arm-asm-s2s/azuredeploy.json
+++ b/arm-asm-s2s/azuredeploy.json
@@ -4,7 +4,9 @@
   "parameters": {
     "location": {
       "type": "String",
-      "description": "Region where the resources will be deployed",
+      "metadata": {
+        "description": "Region where the resources will be deployed"
+      },
       "defaultValue": "Central US",
       "allowedValues": [
         "North Central US",
@@ -15,7 +17,9 @@
     },
     "enableBgp": {
       "type": "String",
-      "description": "Enable or disable BGP",
+      "metadata": {
+        "description": "Enable or disable BGP"
+      },
       "defaultValue": "false",
       "allowedValues": [
         "false"
@@ -23,7 +27,9 @@
     },
     "gatewayType": {
       "type": "String",
-      "description": "VPN or ER",
+      "metadata": {
+        "description": "VPN or ER"
+      },
       "defaultValue": "Vpn",
       "allowedValues": [
         "Vpn",
@@ -32,7 +38,9 @@
     },
     "vpnType": {
       "type": "String",
-      "description": "Route based or policy based",
+      "metadata": {
+        "description": "Route based or policy based"
+      },
       "defaultValue": "RouteBased",
       "allowedValues": [
         "RouteBased",
@@ -41,64 +49,92 @@
     },
     "subscriptionId": {
       "type": "string",
-      "description": "Azure subscription id"
+      "metadata": {
+        "description": "Azure subscription id"
+      }
     },
     "localGatewayName": {
       "type": "string",
-      "description": "Name for gateway connected to other VNet/on-prem network"
+      "metadata": {
+        "description": "Name for gateway connected to other VNet/on-prem network"
+      }
     },
     "localGatewayIpAddress": {
       "type": "string",
-      "description": "Public IP address for the gateway to connect to (from other VNet/on-prem)"
+      "metadata": {
+        "description": "Public IP address for the gateway to connect to (from other VNet/on-prem)"
+      }
     },
     "localGatewayAddressPrefix": {
       "type": "string",
-      "description": "CIDR block for remote network"
+      "metadata": {
+        "description": "CIDR block for remote network"
+      }
     },
     "virtualNetworkName": {
       "type": "string",
-      "description": "Name for new virtual network"
+      "metadata": {
+        "description": "Name for new virtual network"
+      }
     },
     "addressPrefix": {
       "type": "string",
-      "description": "Name for new virtual network"
+      "metadata": {
+        "description": "Name for new virtual network"
+      }
     },
     "subnet1Name": {
       "type": "string",
-      "description": "Name for VM subnet in the new VNet",
-      "defaultValue": "Subnet1"
+      "defaultValue": "Subnet1",
+      "metadata": {
+        "description": "Name for VM subnet in the new VNet"
+      }
     },
     "gatewaySubnet": {
       "type": "string",
-      "description": "Name for gateway subnet in new VNet",
       "defaultValue": "GatewaySubnet",
+      "metadata": {
+        "description": "Name for gateway subnet in new VNet"
+      },
       "allowedValues": [
         "GatewaySubnet"
       ]
     },
     "subnet1Prefix": {
       "type": "string",
-      "description": "CIDR block for VM subnet"
+      "metadata": {
+        "description": "CIDR block for VM subnet"
+      }
     },
     "gatewaySubnetPrefix": {
       "type": "string",
-      "description": "CIDR block for gateway subnet"
+      "metadata": {
+        "description": "CIDR block for gateway subnet"
+      }
     },
     "gatewayPublicIPName": {
       "type": "string",
-      "description": "Name for public IP object used for the new gateway"
+      "metadata": {
+        "description": "Name for public IP object used for the new gateway"
+      }
     },
     "gatewayName": {
       "type": "string",
-      "description": "Name for the new gateway"
+      "metadata": {
+        "description": "Name for the new gateway"
+      }
     },
     "connectionName": {
       "type": "string",
-      "description": "Name for the new connection between the two VNets"
+      "metadata": {
+        "description": "Name for the new connection between the two VNets"
+      }
     },
     "sharedKey": {
       "type": "string",
-      "description": "Shared key for IPSec tunnel"
+      "metadata": {
+        "description": "Shared key for IPSec tunnel"
+      }
     }
   },
   "variables": {


### PR DESCRIPTION
As stated in Point 7 in [the contributing doc](https://github.com/Azure/azure-quickstart-templates/blob/master/CONTRIBUTING.md) all parameters must put the `description` field within the `metadata` object.