### PR TITLE
docker-swarm-cluster: Bump swarm image version

### DIFF
--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -541,7 +541,7 @@
               "restart": "always"
             },
             "swarm": {
-              "image": "swarm:0.3.0",
+              "image": "swarm:0.4.0",
               "command": "[concat('--debug manage --tls --tlscacert /etc/docker/ca.pem --tlscert /etc/docker/cert.pem --tlskey /etc/docker/key.pem --replication --advertise ', reference(concat(variables('vmNameMaster'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2376 consul://10.0.0.4:8500/nodes')]",
               "ports": [
                 "2376:2375"
@@ -587,7 +587,7 @@
           },
           "compose": {
             "swarm": {
-              "image": "swarm:0.3.0",
+              "image": "swarm:0.4.0",
               "restart": "always",
               "command": "[concat('join --advertise=', reference(concat(variables('vmNameSlave'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2375 consul://10.0.0.4:8500/nodes')]"
             }


### PR DESCRIPTION
This changes the Swarm template to use swarm-0.4.0 which fixes
a leader election fault tolerance bug and makes this template
pretty much ready for a release.

cc: @singhkay PTAL. It'd be nice if we can get it in as soon as possible.