### PR TITLE
docker-swarm-cluster: NAT rules for masters

### DIFF
--- a/docker-swarm-cluster/README.md
+++ b/docker-swarm-cluster/README.md
@@ -34,14 +34,22 @@ The template provisions 3 Swarm manager VMs that use [Consul](https://consul.io/
 for discovery and leader election. These VMs are in an [Avabilability Set][av-set]
 to achieve the highest uptime.
 
-Each manager VM has a public IP address. However, it's recommended to talk to the
-Swarm manager using the DNS adddress emitted in the deployment output rather than
-directly talking to each Swarm Manager. This DNS address is [load balanced][az-lb]
-among the Swarm managers (described later).
-
 Each Swarm manager VM is of size `Standard_A0` as they are not running any workloads
-except Swarm Manager and Consul. Manager node VMs have static private IP addresses
+except the Swarm Manager and Consul containers. Manager node VMs have static private IP addresses
 `10.0.0.4`, `10.0.0.5` and `10.0.0.6` and they are in the same [Virtual Network][az-vnet] as slave nodes.
+
+**Accessing manager VMs:** Swarm manager nodes (`swarm-master-*` VMs) do not have
+public IP addresses. However they are NAT'ted behind an Azure Load Balancer. You
+can SSH into them using the domain name (emitted in the template deployment output) or
+the Public IP address of `swarm-lb-masters` (can be found on the Azure Portal).
+
+Port numbers of each master VM is described in the following table:
+
+| VM   | SSH command |
+|:--- |:---|
+| `swarm-master-0`  | `ssh <username>@<IP> -p 2200` |
+| `swarm-master-1`  | `ssh <username>@<IP> -p 2201` |
+| `swarm-master-2`  | `ssh <username>@<IP> -p 2202` |
 
 #### Configuring Authentication
 

--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -83,6 +83,8 @@
     "vhdBlobContainer": "vhds",
     "mastersLbName": "swarm-lb-masters",
     "mastersLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('mastersLbName'))]",
+    "mastersLbIPConfigName": "MastersLBFrontEnd",
+    "mastersLbIPConfigID": "[concat(variables('mastersLbID'),'/frontendIPConfigurations/', variables('mastersLbIPConfigName'))]",
     "mastersLbBackendPoolName": "swarm-master-pool",
     "slavesLbName": "swarm-lb-slaves",
     "slavesLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('slavesLbName'))]",
@@ -219,19 +221,6 @@
     },
     {
       "apiVersion": "2015-05-01-preview",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[concat(variables('vmNameMaster'), copyIndex(), '-ip')]",
-      "location": "[resourceGroup().location]",
-      "copy": {
-        "name": "ipLoopMaster",
-        "count": "[variables('masterCount')]"
-      },
-      "properties": {
-        "publicIPAllocationMethod": "Dynamic"
-      }
-    },
-    {
-      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('vmNameMaster'), copyIndex(), '-nic')]",
       "location": "[resourceGroup().location]",
@@ -241,8 +230,7 @@
       },
       "dependsOn": [
         "[concat('Microsoft.Network/loadBalancers/', variables('mastersLbName'))]",
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
-        "[concat('Microsoft.Network/publicIPAddresses/',concat(variables('vmNameMaster'), copyIndex(), '-ip'))]"
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "properties": {
         "ipConfigurations": [
@@ -251,15 +239,17 @@
             "properties": {
               "privateIPAllocationMethod": "Static",
               "privateIPAddress": "[concat('10.0.0.', copyIndex(4))]",
-              "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses',concat(variables('vmNameMaster'), copyIndex(), '-ip'))]"
-              },
               "subnet": {
                 "id": "[variables('subnetRefMaster')]"
               },
               "loadBalancerBackendAddressPools": [
                 {
                   "id": "[concat(variables('mastersLbID'), '/backendAddressPools/', variables('mastersLbBackendPoolName'))]"
+                }
+              ],
+              "loadBalancerInboundNatRules": [
+                {
+                  "id": "[concat(variables('mastersLbID'),'/inboundNatRules/SSH-',variables('vmNameMaster'),copyindex())]"
                 }
               ]
             }
@@ -278,7 +268,7 @@
       "properties": {
         "frontendIPConfigurations": [
           {
-            "name": "LoadBalancerFrontEnd",
+            "name": "[variables('mastersLbIPConfigName')]",
             "properties": {
               "publicIPAddress": {
                 "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('managementPublicIPAddrName'))]"
@@ -312,7 +302,7 @@
               "enableFloatingIP": false,
               "idleTimeoutInMinutes": 5,
               "frontendIPConfiguration": {
-                "id": "[concat(variables('mastersLbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]"
+                "id": "[variables('mastersLbIPConfigID')]"
               },
               "backendAddressPool": {
                 "id": "[concat(variables('mastersLbID'),'/backendAddressPools/', variables('mastersLbBackendPoolName'))]"
@@ -320,6 +310,44 @@
               "probe": {
                 "id": "[concat(variables('mastersLbID'), '/probes/swarm-probe')]"
               }
+            }
+          }
+        ],
+        "inboundNatRules": [
+          {
+            "name": "[concat('SSH-',variables('vmNameMaster'), '0')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('mastersLbIPConfigID')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": 2200,
+              "backendPort": 22,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat('SSH-',variables('vmNameMaster'), '1')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('mastersLbIPConfigID')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": 2201,
+              "backendPort": 22,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat('SSH-',variables('vmNameMaster'), '2')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('mastersLbIPConfigID')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": 2202,
+              "backendPort": 22,
+              "enableFloatingIP": false
             }
           }
         ]


### PR DESCRIPTION
No need for having a public IP for each `swarm-master-N`
VM; instead NATted them behind Azure LB on ports
2200, 2201, 2202. Updated docs to reflect this.

