### PR TITLE
Fix for #428 VM extension error when deploying CentOS-2nics-lb-cluster template

### DIFF
--- a/CentOS-2nics-lb-cluster/azuredeploy.json
+++ b/CentOS-2nics-lb-cluster/azuredeploy.json
@@ -72,7 +72,7 @@
     "imagePublisher": "OpenLogic",
     "imageOffer": "CentOS",
     "imageSKU": "6.5",
-    "customScriptFilePath": "https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/Centos-2nics-lb-cluster/deploy.sh",
+    "customScriptFilePath": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/CentOS-2nics-lb-cluster/deploy.sh",
     "customScriptCommandToExecute": "bash deploy.sh",
     "publicIPAddressName": "myPublicIP",
     "virtualNetworkName": "myVNET",


### PR DESCRIPTION
Added correct Uri for the script. Fixes #428 