### PR TITLE
fix not installing elastic search as data node on data nodes VMs

### DIFF
--- a/elasticsearch/data-nodes-16disk-resources.json
+++ b/elasticsearch/data-nodes-16disk-resources.json
@@ -349,7 +349,7 @@
         "typeHandlerVersion": "1.2",
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]",
-          "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -yn ', parameters('esSettings').clusterName, ' -v ', parameters('esSettings').version, ' -d ', parameters('esSettings').discoveryHosts)]"
+          "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -zn ', parameters('esSettings').clusterName, ' -v ', parameters('esSettings').version, ' -d ', parameters('esSettings').discoveryHosts)]"
         }
       }
     }

--- a/elasticsearch/data-nodes-2disk-resources.json
+++ b/elasticsearch/data-nodes-2disk-resources.json
@@ -209,7 +209,7 @@
         "typeHandlerVersion": "1.2",
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]",
-          "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -yn ', parameters('esSettings').clusterName, ' -v ', parameters('esSettings').version, ' -d ', parameters('esSettings').discoveryHosts)]"
+          "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -zn ', parameters('esSettings').clusterName, ' -v ', parameters('esSettings').version, ' -d ', parameters('esSettings').discoveryHosts)]"
         }
       }
     }

--- a/elasticsearch/data-nodes-4disk-resources.json
+++ b/elasticsearch/data-nodes-4disk-resources.json
@@ -229,7 +229,7 @@
         "typeHandlerVersion": "1.2",
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]",
-          "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -yn ', parameters('esSettings').clusterName, ' -v ', parameters('esSettings').version, ' -d ', parameters('esSettings').discoveryHosts)]"
+          "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -zn ', parameters('esSettings').clusterName, ' -v ', parameters('esSettings').version, ' -d ', parameters('esSettings').discoveryHosts)]"
         }
       }
     }

--- a/elasticsearch/data-nodes-8disk-resources.json
+++ b/elasticsearch/data-nodes-8disk-resources.json
@@ -269,7 +269,7 @@
         "typeHandlerVersion": "1.2",
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]",
-          "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -yn ', parameters('esSettings').clusterName, ' -v ', parameters('esSettings').version, ' -d ', parameters('esSettings').discoveryHosts)]"
+          "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -zn ', parameters('esSettings').clusterName, ' -v ', parameters('esSettings').version, ' -d ', parameters('esSettings').discoveryHosts)]"
         }
       }
     }

--- a/elasticsearch/elasticsearch-ubuntu-install.sh
+++ b/elasticsearch/elasticsearch-ubuntu-install.sh
@@ -108,7 +108,7 @@ while getopts :n:d:v:l:xyzsh optname; do
     y) #client node
       CLIENT_ONLY_NODE=1
       ;;
-    z) #client node
+    z) #data node
       DATA_NODE=1
       ;;
     s) #use OS striped disk volumes


### PR DESCRIPTION
probably copy-paste error
changed the elasticsearch-ubuntu-install.sh parameter from -y to -z