### PR TITLE
feat(site-to-site-vpn) - Site to Site VPN Connection

### DIFF
--- a/201-site-to-site-vpn/README.md
+++ b/201-site-to-site-vpn/README.md
@@ -1,0 +1,38 @@
+# Site to Site VPN Connection
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-site-to-site-vpn%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+This template will create a Virtual Network, a subnet for the network, a Virtual Netowork Gateway and Connection to your network outside of Azure (defined as your `local` network). This could be anything such as your on-premises network and can even be used with other cloud networks such as [AWS Virtual Private Cloud](https://github.com/sedouard/aws-vpc-to-azure-vnet). It also provisions an Ubuntu instance attached to the Azure Virtual Network so that you can test connectivity.
+
+Please note that you must have a Public IP for your other network's VPN gateway and cannot be behind an NAT.
+
+Although only the parameters in [azuredeploy-parameters.json](./azure-deploy-parameters.json) are necessary, you can override the defaults of any of the template parameters below:
+
+| Name   | Description    |
+|:--- |:---|
+| location | Region where the resources will be deployed |
+| vpnType | Route based, or policy based |
+| subscriptionId | Subscription ID |
+| localGatewayName | Name for gateway connected to other Network |
+| localGatewayIpAddress | Public IP address of other network Gateway |
+| localAddressPrefix | CIDR block of other network address space |
+| virtualNetworkName | Name for new virtual network |
+| azureVNetAddressPrefix | CIDR block for new Azure VNet |
+| subnetName | Name for Azure VM subnet |
+| subnetPrefix | CIDR block for Azure VM subnet |
+| gatewaySubnet | Name for gatway subnet |
+| gatewaySubnetPrefix | CIDR block for Azure gateway subnet |
+| gatewayPublicIPName | Name for public IP resource for the Azure gateway |
+| gatewayName | Name for the gateway connected to the new VNet |
+| connectionName | Name for the new connection between Azure VNet and other network |
+| vmName | Virtual Machine Name |
+| vmSize | Shared key for IPSec connection |
+| adminUsername | Username for test Virtual Machine |
+| adminPassword | Password for test Virtual Machine |
+| imagePublisher | VM Image publisher |
+| imageOffer | VM Image offer |
+| imageSKU | VM Image SKU |
+| newStorageAccountName | Storage Account Name for VM Disk |
+| storageAccountType | Storage Account Type for VM Disk |

--- a/201-site-to-site-vpn/azuredeploy-parameters.json
+++ b/201-site-to-site-vpn/azuredeploy-parameters.json
@@ -1,0 +1,32 @@
+{
+  "location": {
+    "value": "West US"
+  },
+  "adminUsername": {
+    "value": "ubuntu"
+  },
+  "localGatewayIpAddress": {
+    "value": "52.25.48.88"
+  },
+  "localAddressPrefix": {
+    "value": "10.0.0.0/24"
+  },
+  "azureVNetAddressPrefix": {
+    "value": "10.3.0.0/16"
+  },
+  "subnetPrefix": {
+    "value": "10.3.0.0/24"
+  },
+  "gatewaySubnetPrefix": {
+    "value": "10.3.200.0/29"
+  },
+  "adminPassword": {
+    "value": "azure@1234"
+  },
+  "newStorageAccountName": {
+    "value": "sedouardvpcdemo"
+  },
+  "sharedKey": {
+    "value": "abc123"
+  }
+}

--- a/201-site-to-site-vpn/azuredeploy.json
+++ b/201-site-to-site-vpn/azuredeploy.json
@@ -1,0 +1,383 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "type": "String",
+            "metadata": {
+                "description": "Region where the resources will be deployed"
+            },
+            "allowedValues": [
+                "East US",
+                "East US 2",
+                "East Asia",
+                "West US",
+                "West Europe",
+                "Southeast Asia",
+                "South Central US",
+                "East US 2",
+                "Japan East",
+                "Japan West",
+                "Central US"
+            ]
+        },
+        "vpnType": {
+            "type": "String",
+            "metadata": {
+                "description": "Route based or policy based"
+            },
+            "defaultValue": "RouteBased",
+            "allowedValues": [
+                "RouteBased",
+                "PolicyBased"
+            ]
+        },
+        "localGatewayName": {
+            "type": "string",
+            "defaultValue": "localGateway",
+            "metadata": {
+                "description": "Aribtary name for gateway resource representing "
+            }
+        },
+        "localGatewayIpAddress": {
+            "type": "string",
+            "metadata": {
+                "description": "Public IP of your StrongSwan Instance"
+            }
+        },
+        "localAddressPrefix": {
+            "type": "string",
+            "metadata": {
+                "description": "CIDR block representing the address space of the other network's Subnet"
+            }
+        },
+        "virtualNetworkName": {
+            "type": "string",
+            "defaultValue": "azureVnet",
+            "metadata": {
+                "description": "Arbitrary name for the Azure Virtual Network"
+            }
+        },
+        "azureVNetAddressPrefix": {
+            "type": "string",
+            "defaultValue": "10.3.0.0/16",
+            "metadata": {
+                "description": "CIDR block representing the address space of the Azure VNet"
+            }
+        },
+        "subnetName": {
+            "type": "string",
+            "defaultValue": "Subnet1",
+            "metadata": {
+                "description": "Aribtrary name for the Azure Subnet"
+            }
+        },
+        "subnetPrefix": {
+            "type": "string",
+            "metadata": {
+                "description": "CIDR block for VM subnet, subset of azureVNetAddressPrefix address space"
+            }
+        },
+        "gatewaySubnetPrefix": {
+            "type": "string",
+            "defaultValue": "10.3.200.0/29",
+            "metadata": {
+                "description": "CIDR block for gateway subnet, subsset of azureVNetAddressPrefix address space"
+            }
+        },
+        "gatewayPublicIPName": {
+            "type": "string",
+            "defaultValue": "azureGatewayIP",
+            "metadata": {
+                "description": "Aribtary name for public IP resource used for the new azure gateway"
+            }
+        },
+        "gatewayName": {
+            "type": "string",
+            "defaultValue": "azureGateway",
+            "metadata": {
+                "description": "Arbitrary name for the new gateway"
+            }
+        },
+        "connectionName": {
+            "type": "string",
+            "defaultValue": "Azure2Other",
+            "metadata": {
+                "description": "Arbitrary name for the new connection between Azure VNet and other network"
+            }
+        },
+        "sharedKey": {
+            "type": "string",
+            "metadata": {
+                "description": "Shared key (PSK) for IPSec tunnel"
+            }
+        },
+        "vmName": {
+            "type": "string",
+            "defaultValue": "node-1",
+            "metadata": {
+                "description": "Name of the sample VM to create"
+            }
+        },
+        "vmSize": {
+            "type": "string",
+            "defaultValue": "Standard_A1",
+            "allowedValues": [
+                "Standard_A1",
+                "Standard_A2",
+                "Standard_A3",
+                "Standard_A6",
+                "Standard_A7",
+                "Standard_A8",
+                "Standard_A9",
+                "Standard_A10",
+                "Standard_A11",
+                "Standard_D2",
+                "Standard_D3",
+                "Standard_D4",
+                "Standard_D11",
+                "Standard_D12",
+                "Standard_D13",
+                "Standard_D14"
+            ],
+            "metadata": {
+                "description": "Size of the Virtual Machine."
+            }
+        },
+        "adminUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "Username for sample VM"
+            }
+        },
+        "adminPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "User password for sample VM"
+            }
+        },
+        "newStorageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Stoarge Account Name for VM Disk"
+            }
+        },
+        "storageAccountType": {
+            "type": "string",
+            "allowedValues": [
+                "Standard_LRS",
+                "Standard_GRS",
+                "Standard_RAGRS",
+                "Premium_LRS"
+            ],
+            "metadata": {
+                "description": "The type of the Storage Account created"
+            },
+            "defaultValue": "Standard_LRS"
+        }
+    },
+    "variables": {
+        "imagePublisher": "Canonical",
+        "imageOffer": "UbuntuServer",
+        "imageSKU": "14.04.2-LTS",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+        "gatewaySubnetRef": "[concat(variables('vnetID'),'/subnets/','GatewaySubnet')]",
+        "subnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetName'))]",
+        "nicName": "[concat(parameters('vmName'), '-nic')]",
+        "vmStorageAccountContainerName": "vhds",
+        "OSDiskName": "osDisk",
+        "vmPublicIPName": "[concat(parameters('vmName'), '-publicIP')]",
+        "api-version": "2015-06-15",
+        "storage-api-version": "2015-05-01-preview"
+    },
+    "resources": [
+        {
+            "apiVersion": "[variables('api-version')]",
+            "type": "Microsoft.Network/localNetworkGateways",
+            "name": "[parameters('localGatewayName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "localNetworkAddressSpace": {
+                    "addressPrefixes": [
+                        "[parameters('localAddressPrefix')]"
+                    ]
+                },
+                "gatewayIpAddress": "[parameters('localGatewayIpAddress')]"
+            }
+        },
+        {
+            "apiVersion": "[variables('api-version')]",
+            "name": "[parameters('connectionName')]",
+            "type": "Microsoft.Network/connections",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]",
+                "[concat('Microsoft.Network/localNetworkGateways/', parameters('localGatewayName'))]"
+            ],
+            "properties": {
+                "virtualNetworkGateway1": {
+                    "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]"
+                },
+                "localNetworkGateway2": {
+                    "id": "[resourceId('Microsoft.Network/localNetworkGateways', parameters('localGatewayName'))]"
+                },
+                "connectionType": "IPsec",
+                "routingWeight": 10,
+                "sharedKey": "[parameters('sharedKey')]"
+            }
+        },
+        {
+            "apiVersion": "[variables('api-version')]",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[parameters('virtualNetworkName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[parameters('azureVNetAddressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[parameters('subnetName')]",
+                        "properties": {
+                            "addressPrefix": "[parameters('subnetPrefix')]"
+                        }
+                    },
+                    {
+                        "name": "GatewaySubnet",
+                        "properties": {
+                            "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "[variables('api-version')]",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[parameters('gatewayPublicIPName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic"
+            }
+        },
+        {
+            "apiVersion": "[variables('api-version')]",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('vmPublicIPName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic"
+            }
+        },
+        {
+            "apiVersion": "[variables('storage-api-version')]",
+            "name": "[parameters('newStorageAccountName')]",
+            "location": "[parameters('location')]",
+            "type": "Microsoft.Storage/storageAccounts",
+            "properties": {
+                "accountType": "[parameters('storageAccountType')]"
+            }
+        },
+        {
+            "apiVersion": "[variables('api-version')]",
+            "type": "Microsoft.Network/virtualNetworkGateways",
+            "name": "[parameters('gatewayName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('gatewaySubnetRef')]"
+                            },
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
+                            }
+                        },
+                        "name": "vnetGatewayConfig"
+                    }
+                ],
+                "gatewayType": "Vpn",
+                "vpnType": "[parameters('vpnType')]",
+                "enableBgp": "false"
+            }
+        },
+        {
+            "apiVersion": "[variables('api-version')]",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', variables('vmPublicIPName'))]",
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]",
+                "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('vmPublicIPName'))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnetRef')]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "[variables('api-version')]",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[parameters('vmName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                    "computername": "[parameters('vmName')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('imagePublisher')]",
+                        "offer": "[variables('imageOffer')]",
+                        "sku": "[variables('imageSKU')]",
+                        "version": "latest"
+                    },
+                    "osDisk": {
+                        "name": "osdisk1",
+                        "vhd": {
+                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/201-site-to-site-vpn/metadata.json
+++ b/201-site-to-site-vpn/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Create a Site-to-Site VPN Connection",
+  "description": "This template allows you to create a Site-to-Site VPN Connection using Virtual Network Gateways",
+  "summary": "Create a Site-to-Site VPN Connection to any on premesis or other cloud networks such as AWS Virtual Private Cloud",
+  "githubUsername": "sedouard",
+  "dateUpdated": "2015-08-17"
+}


### PR DESCRIPTION
I was messing around with cross-cloud integration with AWS and came up with this template which should be reusable for any IPSec Site-to-Site VPN connection. I found that [this virtual network gateway example](https://github.com/Azure/azure-quickstart-templates/tree/master/arm-asm-s2s) was lacking in completeness.

This one does:
- Creates a VNet, Subnet, VNetGateway & VNetConnection
- Provisions a test Ubuntu instance
- Tested to work with AWS VPC

The thing I'm not really certain on is which api version I should use. The current versions I'm using seems to work but I could use some guidance here.
