### PR TITLE
docker-swarm-cluster: Use -retry-join for consul, remove DNS port

### DIFF
--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -92,8 +92,8 @@
     "sshKeyPath": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
     "consulServerArgs": [
       "-advertise 10.0.0.4 -bootstrap-expect 3",
-      "-advertise 10.0.0.5 -join 10.0.0.4 -join 10.0.0.6",
-      "-advertise 10.0.0.6 -join 10.0.0.4 -join 10.0.0.5"
+      "-advertise 10.0.0.5 -retry-join 10.0.0.4 -retry-join 10.0.0.6",
+      "-advertise 10.0.0.6 -retry-join 10.0.0.4 -retry-join 10.0.0.5"
     ]
   },
   "resources": [
@@ -560,8 +560,7 @@
                 "8302:8302",
                 "8302:8302/udp",
                 "8400:8400",
-                "8500:8500",
-                "53:53/udp"
+                "8500:8500"
               ],
               "volumes": [
                 "/data/consul:/data"


### PR DESCRIPTION
This solves the consul's reaching to quorum problems in case of non-deterministic order consul agents start such as the parallel VM deployment.

Also removing consul DNS port mapping (:53/udp) as it's not used for service discovery in this set up.