### PR TITLE
Fix the issue that the storage account name is too long for some locations

### DIFF
--- a/create-hpc-cluster-linux-cn/azuredeploy.json
+++ b/create-hpc-cluster-linux-cn/azuredeploy.json
@@ -1,468 +1,519 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "clusterName": {
-            "type": "string",
-            "metadata": {
-                "description": "The unique HPC Pack cluster name. It is also used as the public DNS name prefix for the cluster, for example, the public DNS name is '&lt;clusterName&gt;.westus.cloudapp.azure.com' if the resource group location is 'West US'. It must contain between 3 and 15 characters with lowercase letters and numbers, and must start with a letter."
-            }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterName": {
+      "type": "string",
+      "metadata": {
+        "description": "The unique HPC Pack cluster name. It is also used as the public DNS name prefix for the cluster, for example, the public DNS name is '&lt;clusterName&gt;.westus.cloudapp.azure.com' if the resource group location is 'West US'. It must contain between 3 and 15 characters with lowercase letters and numbers, and must start with a letter."
+      }
+    },
+    "privateDomainName": {
+      "type": "string",
+      "defaultValue": "hpc.local",
+      "metadata": {
+        "description": "The fully qualified domain name (FQDN) for the private domain forest which will be created by this template, for example 'hpc.local'."
+      }
+    },
+    "headNodeVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_A4",
+      "allowedValues": [
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14"
+      ],
+      "metadata": {
+        "description": "The VM role size of the head node"
+      }
+    },
+    "computeNodeImage": {
+      "type": "string",
+      "defaultValue": "CentOS_7.0",
+      "allowedValues": [
+        "CentOS_6.6",
+        "CentOS_7.0",
+        "SLES_12",
+        "SLES_Premium_12",
+        "SLES_HPC_12",
+        "SLES_HPC_Premium_12",
+        "Ubuntu_14.04"
+      ],
+      "metadata": {
+        "description": "The Linux distro of the compute nodes"
+      }
+    },
+    "computeNodeNamePrefix": {
+      "type": "string",
+      "defaultValue": "IaaSLnxCN-",
+      "metadata": {
+        "description": "The name prefix of the compute nodes. It can contain letters, numbers and hyphens and must start with a letter, up to 13 characters. For example, if 'IaaSLnxCN-' is specified, the compute node names will be 'IaaSLnxCN-0', 'IaaSLnxCN-1', ..."
+      }
+    },
+    "computeNodeNumber": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "The number of the compute nodes"
+      }
+    },
+    "computeNodeVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_A3",
+      "allowedValues": [
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11",
+        "Standard_D1",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14"
+      ],
+      "metadata": {
+        "description": "The VM role size of the compute nodes"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The user name of the administrator"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password of the administrator"
+      }
+    },
+    "headNodePostConfigScript": {
+      "type": "string",
+      "defaultValue": " ",
+      "metadata": {
+        "description": "Optional, specify the script url and command line if you want to run your custom script on the head node after it is configured. The script url must be public available, and you can also specify arguments for the script, for example 'http://www.consto.com/mypostscript.ps1 -Arg1 arg1 -Arg2 arg2'."
+      }
+    }
+  },
+  "variables": {
+    "apiVersion": "2015-05-01-preview",
+    "storageAccountName": "[toLower(concat(parameters('clusterName'), 'sa'))]",
+    "cnStorageAccountPrefix": "[concat(variables('storageAccountName'), 'cn')]",
+    "cnStorageAccountNumber": "[add(div(parameters('computeNodeNumber'), 10), 1)]",
+    "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",
+    "virtualNetworkName": "[concat(parameters('clusterName'), 'VNet')]",
+    "addressPrefix": "10.0.0.0/16",
+    "subnet1Name": "Subnet-1",
+    "subnet1Prefix": "10.0.0.0/24",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
+    "publicIPAddressType": "Dynamic",
+    "publicIPAddressName": "[concat(parameters('clusterName'), '-PublicIP-VM')]",
+    "publicIPAddressNameHN": "[concat(variables('publicIPAddressName'),'-HN')]",
+    "availabilitySetName": "[concat(parameters('clusterName'), 'AVSet')]",
+    "dnsName": "[concat(parameters('clusterName'), 'ep')]",
+    "nicName": "[concat(parameters('clusterName'),'-nic')]",
+    "nicNameHN": "[concat(variables('nicName'),'-hn')]",
+    "vmSizeRDMAStates": {
+      "Standard_A1": "disabled",
+      "Standard_A2": "disabled",
+      "Standard_A3": "disabled",
+      "Standard_A4": "disabled",
+      "Standard_A5": "disabled",
+      "Standard_A6": "disabled",
+      "Standard_A7": "disabled",
+      "Standard_A8": "enabled",
+      "Standard_A9": "enabled",
+      "Standard_A10": "disabled",
+      "Standard_A11": "disabled",
+      "Standard_D1": "disabled",
+      "Standard_D2": "disabled",
+      "Standard_D3": "disabled",
+      "Standard_D4": "disabled",
+      "Standard_D11": "disabled",
+      "Standard_D12": "disabled",
+      "Standard_D13": "disabled",
+      "Standard_D14": "disabled"
+    },
+    "avSetJumpBox": {
+      "disabled-disabled": "disabled",
+      "disabled-enabled": "enabled",
+      "enabled-disabled": "enabled",
+      "enabled-enabled": "enabled"
+    },
+    "avSetState": "[variables('avSetJumpBox')[concat(variables('vmSizeRDMAStates')[parameters('headNodeVMSize')], '-', variables('vmSizeRDMAStates')[parameters('computeNodeVMSize')])]]",
+    "linuxImagePublishers": {
+      "CentOS_6.6": "OpenLogic",
+      "CentOS_7.0": "OpenLogic",
+      "SLES_12": "SUSE",
+      "SLES_Premium_12": "SUSE",
+      "SLES_HPC_12": "SUSE",
+      "SLES_HPC_Premium_12": "SUSE",
+      "Ubuntu_14.04": "Canonical"
+    },
+    "linuxImageOffers": {
+      "CentOS_6.6": "CentOS",
+      "CentOS_7.0": "CentOS",
+      "SLES_12": "SLES",
+      "SLES_Premium_12": "SLES-Priority",
+      "SLES_HPC_12": "SLES-HPC",
+      "SLES_HPC_Premium_12": "SLES-HPC-Priority",
+      "Ubuntu_14.04": "UbuntuServer"
+    },
+    "linuxImageSkus": {
+      "CentOS_6.6": "6.6",
+      "CentOS_7.0": "7.0",
+      "SLES_12": "12",
+      "SLES_Premium_12": "12",
+      "SLES_HPC_12": "12",
+      "SLES_HPC_Premium_12": "12",
+      "Ubuntu_14.04": "14.04.3-LTS"
+    },
+    "computeNodeImagePublisher": "[variables('linuxImagePublishers')[parameters('computeNodeImage')]]",
+    "computeNodeImageOffer": "[variables('linuxImageOffers')[parameters('computeNodeImage')]]",
+    "computeNodeImageSku": "[variables('linuxImageSkus')[parameters('computeNodeImage')]]",
+    "adminBase64Password": "[base64(parameters('adminPassword'))]",
+    "customScriptLocation": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/create-hpc-cluster/",
+    "iaasInfoArg": "[concat('-SubscriptionId ', subscription().subscriptionId, ' -VNet ', variables('virtualNetworkName'), ' -Subnet ', variables('subnet1Name'), ' -Location \"', resourceGroup().location, '\"')]",
+    "headNodeCommandStr": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File PrepareHN.ps1 -DomainFQDN ', parameters('privateDomainName'), ' -AdminUserName ', parameters('adminUsername'), ' -AdminBase64Password \"', variables('adminBase64Password'), '\" -PostConfigScript \"', parameters('headNodePostConfigScript'), '\" -UnsecureDNSUpdate ', variables('iaasInfoArg'))]",
+    "storageConnStrPrefix": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=')]",
+    "computeNodeCommandStr": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File PrepareCN.ps1 -DomainFQDN ', parameters('privateDomainName'), ' -ClusterName ', parameters('clusterName'),' -AdminUserName ', parameters('adminUsername'), ' -AdminBase64Password \"', variables('adminBase64Password'), '\"')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
         },
-        "privateDomainName": {
-            "type": "string",
-            "defaultValue": "hpc.local",
-            "metadata": {
-                "description": "The fully qualified domain name (FQDN) for the private domain forest which will be created by this template, for example 'hpc.local'."
-            }
+        "dhcpOptions": {
+          "dnsServers": [
+            "10.0.0.4",
+            "8.8.8.8"
+          ]
         },
-        "headNodeVMSize": {
-            "type": "string",
-            "defaultValue": "Standard_A4",
-            "allowedValues": [
-                "Standard_A3",
-                "Standard_A4",
-                "Standard_A5",
-                "Standard_A6",
-                "Standard_A7",
-                "Standard_A8",
-                "Standard_A9",
-                "Standard_A10",
-                "Standard_A11",
-                "Standard_D3",
-                "Standard_D4",
-                "Standard_D12",
-                "Standard_D13",
-                "Standard_D14"
-            ],
-            "metadata": {
-                "description": "The VM role size of the head node"
+        "subnets": [
+          {
+            "name": "[variables('subnet1Name')]",
+            "properties": {
+              "addressPrefix": "[variables('subnet1Prefix')]"
             }
-        },
-        "computeNodeImage": {
-            "type": "string",
-            "defaultValue": "CentOS_7.0",
-            "allowedValues": [
-                "CentOS_6.6",
-                "CentOS_7.0",
-                "SLES_12",
-                "SLES_Premium_12",
-                "SLES_HPC_12",
-                "SLES_HPC_Premium_12",
-                "Ubuntu_14.04"
-            ],
-            "metadata": {
-                "description": "The Linux distro of the compute nodes"
-            }
-        },
-        "computeNodeNamePrefix": {
-            "type": "string",
-            "defaultValue": "IaaSLnxCN-",
-            "metadata": {
-                "description": "The name prefix of the compute nodes. It can contain letters, numbers and hyphens and must start with a letter, up to 13 characters. For example, if 'IaaSLnxCN-' is specified, the compute node names will be 'IaaSLnxCN-0', 'IaaSLnxCN-1', ..."
-            }
-        },
-        "computeNodeNumber": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "The number of the compute nodes"
-            }
-        },
-        "computeNodeVMSize": {
-            "type": "string",
-            "defaultValue": "Standard_A3",
-            "allowedValues": [
-                "Standard_A1",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_A4",
-                "Standard_A5",
-                "Standard_A6",
-                "Standard_A7",
-                "Standard_A8",
-                "Standard_A9",
-                "Standard_A10",
-                "Standard_A11",
-                "Standard_D1",
-                "Standard_D2",
-                "Standard_D3",
-                "Standard_D4",
-                "Standard_D11",
-                "Standard_D12",
-                "Standard_D13",
-                "Standard_D14"
-            ],
-            "metadata": {
-                "description": "The VM role size of the compute nodes"
-            }
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "The user name of the administrator"
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "The password of the administrator"
-            }
-        },
-        "headNodePostConfigScript": {
-            "type": "string",
-            "defaultValue": " ",
-            "metadata": {
-                "description": "Optional, specify the script url and command line if you want to run your custom script on the head node after it is configured. The script url must be public available, and you can also specify arguments for the script, for example 'http://www.consto.com/mypostscript.ps1 -Arg1 arg1 -Arg2 arg2'."
-            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressNameHN')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('clusterName')]"
         }
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicNameHN')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressNameHN'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "IPConfig",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "10.0.0.4",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressNameHN'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
     },
 
-    "variables": {
-        "apiVersion": "2015-05-01-preview",    
-        "storageAccountName": "[toLower(concat(parameters('clusterName'), 'sa'))]",
-        "cnStorageAccountPrefix": "[concat(variables('storageAccountName'), 'cn')]",
-        "cnStorageAccountNumber": "[add(div(parameters('computeNodeNumber'), 10), 1)]",
-        "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",
-        "virtualNetworkName": "[concat(parameters('clusterName'), 'VNet')]",
-        "addressPrefix": "10.0.0.0/16",
-        "subnet1Name": "Subnet-1",
-        "subnet1Prefix": "10.0.0.0/24",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
-        "publicIPAddressType": "Dynamic",
-        "publicIPAddressName": "[concat(parameters('clusterName'), '-PublicIP-VM')]",
-        "publicIPAddressNameHN": "[concat(variables('publicIPAddressName'),'-HN')]",
-        "availabilitySetName": "[concat(parameters('clusterName'), 'AVSet')]",
-        "dnsName": "[concat(parameters('clusterName'), 'ep')]",
-        "nicName": "[concat(parameters('clusterName'),'-nic')]",
-        "nicNameHN": "[concat(variables('nicName'),'-hn')]",
-        "linuxImagePublishers": {
-            "CentOS_6.6": "OpenLogic",
-            "CentOS_7.0": "OpenLogic",
-            "SLES_12": "SUSE",
-            "SLES_Premium_12": "SUSE",
-            "SLES_HPC_12": "SUSE",
-            "SLES_HPC_Premium_12": "SUSE",
-            "Ubuntu_14.04": "Canonical"
+    {
+      "apiVersion": "2015-01-01",
+      "type": "Microsoft.Resources/deployments",
+      "name": "createAvailabilitySet",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('customScriptLocation'), 'availabilityset-', variables('avSetState'), '.json')]",
+          "contentVersion": "1.0.0.0"
         },
-        "linuxImageOffers": {
-            "CentOS_6.6": "CentOS",
-            "CentOS_7.0": "CentOS",
-            "SLES_12": "SLES",
-            "SLES_Premium_12": "SLES-Priority",
-            "SLES_HPC_12": "SLES-HPC",
-            "SLES_HPC_Premium_12": "SLES-HPC-Priority",
-            "Ubuntu_14.04": "UbuntuServer"
-        },
-        "linuxImageSkus": {
-            "CentOS_6.6": "6.6",
-            "CentOS_7.0": "7.0",
-            "SLES_12": "12",
-            "SLES_Premium_12": "12",
-            "SLES_HPC_12": "12",
-            "SLES_HPC_Premium_12": "12",
-            "Ubuntu_14.04": "14.04.3-LTS"
-        },
-        "computeNodeImagePublisher": "[variables('linuxImagePublishers')[parameters('computeNodeImage')]]",
-        "computeNodeImageOffer": "[variables('linuxImageOffers')[parameters('computeNodeImage')]]",
-        "computeNodeImageSku": "[variables('linuxImageSkus')[parameters('computeNodeImage')]]",
-        "adminBase64Password": "[base64(parameters('adminPassword'))]",
-        "customScriptLocation": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/create-hpc-cluster/",
-        "iaasInfoArg": "[concat('-SubscriptionId ', subscription().subscriptionId, ' -VNet ', variables('virtualNetworkName'), ' -Subnet ', variables('subnet1Name'), ' -Location \"', resourceGroup().location, '\"')]",
-        "headNodeCommandStr": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File PrepareHN.ps1 -DomainFQDN ', parameters('privateDomainName'), ' -AdminUserName ', parameters('adminUsername'), ' -AdminBase64Password \"', variables('adminBase64Password'), '\" -PostConfigScript \"', parameters('headNodePostConfigScript'), '\" -UnsecureDNSUpdate ', variables('iaasInfoArg'))]",
-        "storageConnStrPrefix": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=')]",
-        "computeNodeCommandStr": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File PrepareCN.ps1 -DomainFQDN ', parameters('privateDomainName'), ' -ClusterName ', parameters('clusterName'),' -AdminUserName ', parameters('adminUsername'), ' -AdminBase64Password \"', variables('adminBase64Password'), '\"')]"
+        "parameters": {
+          "apiVersion": {
+            "value": "[variables('apiVersion')]"
+          },
+          "availabilitySetName": {
+            "value": "[variables('availabilitySetName')]"
+          }
+        }
+      }
     },
 
-    "resources": [
-        {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('storageAccountName')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "accountType": "Standard_LRS"
-            }
+    {
+      "apiVersion": "2015-01-01",
+      "type": "Microsoft.Resources/deployments",
+      "name": "createHeadNode",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicNameHN'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "Microsoft.Resources/deployments/createAvailabilitySet"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('customScriptLocation'), 'headnode-rdma-', variables('vmSizeRDMAStates')[parameters('headNodeVMSize')], '.json')]",
+          "contentVersion": "1.0.0.0"
         },
-
-        {
-            "type": "Microsoft.Compute/availabilitySets",
-            "name": "[variables('availabilitySetName')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]"
-        },
-
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[variables('virtualNetworkName')]",
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('addressPrefix')]"
-                    ]
-                },
-                "dhcpOptions": {
-                    "dnsServers": [ "10.0.0.4", "8.8.8.8" ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('subnet1Name')]",
-                        "properties": {
-                            "addressPrefix": "[variables('subnet1Prefix')]"
-                        }
-                    }
-                ]
-            }
-        },
-
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[variables('publicIPAddressNameHN')]",
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-                "dnsSettings": {
-                    "domainNameLabel": "[parameters('clusterName')]"
-                }
-            }
-        },
-
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[variables('nicNameHN')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressNameHN'))]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "IPConfig",
-                        "properties": {
-                            "privateIPAllocationMethod": "Static",
-                            "privateIPAddress": "10.0.0.4",
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressNameHN'))]"
-                            },
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[parameters('clusterName')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/networkInterfaces/', variables('nicNameHN'))]",
-                "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]"
-            ],
-            "properties": {
-                "hardwareProfile": {
-                    "vmSize": "[parameters('headNodeVMSize')]"
-                },
-                "osProfile": {
-                    "computername": "[parameters('clusterName')]",
-                    "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "MicrosoftWindowsServerHPCPack",
-                        "offer": "WindowsServerHPCPack",
-                        "sku": "2012R2",
-                        "version": "latest"
-                    },
-                    "osDisk": {
-                        "name": "osdisk",
-                        "vhd": {
-                            "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/headnode/','osdisk.vhd')]"
-                        },
-                        "caching": "ReadOnly",
-                        "createOption": "FromImage"
-                    }
-                },
-
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicNameHN'))]"
-                        }
-                    ]
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(parameters('clusterName'),'/configureHeadNode')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('clusterName'))]"
-            ],
-            "properties": {
-                "publisher": "Microsoft.Compute",
-                "type": "CustomScriptExtension",
-                "typeHandlerVersion": "1.4",
-                "settings": {
-                    "fileUris": [
-                        "[concat(variables('customScriptLocation'), 'PrepareHN.ps1')]",
-                        "[concat(variables('customScriptLocation'), 'HPCHNPrepare.ps1')]",
-                        "[concat(variables('customScriptLocation'), 'HpcPrepareUtil.ps1')]"
-                    ],
-                    "commandToExecute": "[concat(variables('headNodeCommandStr'), ' -AzureStorageConnStr \"', variables('storageConnStrPrefix'), listKeys(variables('storageAccountId'), variables('apiVersion')).key1, '\" -PublicDnsName ', reference(variables('publicIPAddressNameHN')).dnsSettings.fqdn)]"
-                }
-            }
-        },
-
-        {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[concat(variables('cnStorageAccountPrefix'), copyIndex())]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "copy": {
-                "name": "CNStorageAccounts",
-                "count": "[variables('cnStorageAccountNumber')]"
-            },
-            "properties": {
-                "accountType": "Standard_LRS"
-            }
-        },
-        
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[concat(variables('nicName'), copyIndex())]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/networkInterfaces/', variables('nicNameHN'))]"
-            ],
-            "copy": {
-                "name": "CN",
-                "count": "[parameters('computeNodeNumber')]"
-            },
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "IPConfig",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[concat(parameters('computeNodeNamePrefix'), copyIndex())]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]",
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('clusterName'))]",
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('clusterName'), '/extensions/configureHeadNode')]",
-                "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex())]",
-                "[concat('Microsoft.Storage/storageAccounts/', variables('cnStorageAccountPrefix'), div(copyIndex(), 10))]"
-            ],
-            "copy": {
-                "name": "CN",
-                "count": "[parameters('computeNodeNumber')]"
-            },
-            "properties": {
-                "availabilitySet": {
-                    "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
-                },
-                "hardwareProfile": {
-                    "vmSize": "[parameters('computeNodeVMSize')]"
-                },
-                "osProfile": {
-                    "computername": "[concat(parameters('computeNodeNamePrefix'), copyIndex())]",
-                    "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]",
-                    "linuxConfiguration": {
-                        "disablePasswordAuthentication": "false"
-                    }
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "[variables('computeNodeImagePublisher')]",
-                        "offer": "[variables('computeNodeImageOffer')]",
-                        "sku": "[variables('computeNodeImageSku')]",
-                        "version": "latest"
-                    },
-                    "osDisk": {
-                        "name": "osdisk",
-                        "vhd": {
-                            "uri": "[concat('http://',variables('cnStorageAccountPrefix'),div(copyIndex(), 10),'.blob.core.windows.net/vhds',copyIndex(),'/','osdisk.vhd')]"
-                        },
-                        "caching": "ReadWrite",
-                        "createOption": "FromImage"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), copyIndex()))]"
-                        }
-                    ]
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(parameters('computeNodeNamePrefix'), copyIndex(), '/updateDNSRecord')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('computeNodeNamePrefix'), copyIndex())]"
-            ],
-            "copy": {
-                "name": "CN",
-                "count": "[parameters('computeNodeNumber')]"
-            },
-            "properties": {
-                "publisher": "Microsoft.OSTCExtensions",
-                "type": "CustomScriptForLinux",
-                "typeHandlerVersion": "1.3",
-                "settings": {
-                    "fileUris": [
-                        "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/create-hpc-cluster-linux-cn/updatednsrecord.sh"
-                    ],
-                    "commandToExecute": "[concat('bash updatednsrecord.sh ', parameters('privateDomainName'), ' ', reference(concat(variables('nicName'), copyIndex())).ipConfigurations[0].properties.privateIPAddress)]"
-                }
-            }            
-        },
-        {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(parameters('computeNodeNamePrefix'), copyIndex(), '/installHPCNodeAgent')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('computeNodeNamePrefix'), copyIndex(), '/extensions/updateDNSRecord')]"
-            ],
-            "copy": {
-                "name": "CN",
-                "count": "[parameters('computeNodeNumber')]"
-            },
-            "properties": {
-                "publisher": "Microsoft.HpcPack",
-                "type": "LinuxNodeAgent",
-                "typeHandlerVersion": "1.5",
-                "protectedSettings": {
-                    "ClusterName": "[concat(parameters('clusterName'), '.', parameters('privateDomainName'))]"
-                }
-            }
+        "parameters": {
+          "apiVersion": {
+            "value": "[variables('apiVersion')]"
+          },
+          "vmName": {
+            "value": "[parameters('clusterName')]"
+          },
+          "vmSize": {
+            "value": "[parameters('headNodeVMSize')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "nicName": {
+            "value": "[variables('nicNameHN')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "availabilitySetName": {
+            "value": "[variables('availabilitySetName')]"
+          }
         }
-    ]
+      }
+    },
+
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('clusterName'),'/configureHeadNode')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "Microsoft.Resources/deployments/createHeadNode"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Compute",
+        "type": "CustomScriptExtension",
+        "typeHandlerVersion": "1.4",
+        "settings": {
+          "fileUris": [
+            "[concat(variables('customScriptLocation'), 'PrepareHN.ps1')]",
+            "[concat(variables('customScriptLocation'), 'HPCHNPrepare.ps1')]",
+            "[concat(variables('customScriptLocation'), 'HpcPrepareUtil.ps1')]"
+          ],
+          "commandToExecute": "[concat(variables('headNodeCommandStr'), ' -AzureStorageConnStr \"', variables('storageConnStrPrefix'), listKeys(variables('storageAccountId'),variables('apiVersion')).key1, '\" -PublicDnsName ', reference(variables('publicIPAddressNameHN')).dnsSettings.fqdn)]"
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[concat(variables('cnStorageAccountPrefix'), copyIndex())]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "CNStorageAccounts",
+        "count": "[variables('cnStorageAccountNumber')]"
+      },
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('nicName'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicNameHN'))]"
+      ],
+      "copy": {
+        "name": "CN",
+        "count": "[parameters('computeNodeNumber')]"
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "IPConfig",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+
+    {
+      "apiVersion": "2015-01-01",
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat('create', parameters('computeNodeNamePrefix'), copyIndex())]",
+      "dependsOn": [
+        "Microsoft.Resources/deployments/createAvailabilitySet",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex())]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('cnStorageAccountPrefix'), div(copyIndex(), 10))]"
+      ],
+      "copy": {
+        "name": "CN",
+        "count": "[parameters('computeNodeNumber')]"
+      },
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('customScriptLocation'), 'linuxnode-rdma-', variables('vmSizeRDMAStates')[parameters('computeNodeVMSize')], '.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "apiVersion": {
+            "value": "[variables('apiVersion')]"
+          },
+          "vmName": {
+            "value": "[concat(parameters('computeNodeNamePrefix'), copyIndex())]"
+          },
+          "vmSize": {
+            "value": "[parameters('computeNodeVMSize')]"
+          },
+          "storageAccountName": {
+            "value": "[concat(variables('cnStorageAccountPrefix'), div(copyIndex(), 10))]"
+          },
+          "imgPublisher": {
+            "value": "[variables('computeNodeImagePublisher')]"
+          },
+          "imgOffer": {
+            "value": "[variables('computeNodeImageOffer')]"
+          },
+          "imgSku": {
+            "value": "[variables('computeNodeImageSku')]"
+          },
+          "imgVersion": {
+            "value": "latest"
+          },
+          "nicName": {
+            "value": "[concat(variables('nicName'), copyIndex())]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "availabilitySetName": {
+            "value": "[variables('availabilitySetName')]"
+          },
+          "customData": { 
+            "value": "[base64(concat('HPCClusterName=', parameters('clusterName'), '\r\nImageCategory=public\r\nImageName=', parameters('computeNodeImage'), '\r\nVMSize=', parameters('computeNodeVMSize')))]"
+          }
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('computeNodeNamePrefix'), copyIndex(), '/updateDNSRecord')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('clusterName'), '/extensions/configureHeadNode')]",
+        "[concat('Microsoft.Resources/deployments/create', parameters('computeNodeNamePrefix'), copyIndex())]"
+      ],
+      "copy": {
+        "name": "CN",
+        "count": "[parameters('computeNodeNumber')]"
+      },
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.3",
+        "settings": {
+          "fileUris": [
+            "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/create-hpc-cluster-linux-cn/updatednsrecord.sh"
+          ],
+          "commandToExecute": "[concat('bash updatednsrecord.sh ', parameters('privateDomainName'), ' ', reference(concat(variables('nicName'), copyIndex())).ipConfigurations[0].properties.privateIPAddress)]"
+        }
+      }
+    },
+
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('computeNodeNamePrefix'), copyIndex(), '/installHPCNodeAgent')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('computeNodeNamePrefix'), copyIndex(), '/extensions/updateDNSRecord')]"
+      ],
+      "copy": {
+        "name": "CN",
+        "count": "[parameters('computeNodeNumber')]"
+      },
+      "properties": {
+        "publisher": "Microsoft.HpcPack",
+        "type": "LinuxNodeAgent",
+        "typeHandlerVersion": "1.5",
+        "protectedSettings": {
+          "ClusterName": "[concat(parameters('clusterName'), '.', parameters('privateDomainName'))]"
+        }
+      }
+    }
+  ]
 }

--- a/create-hpc-cluster-linux-cn/azuredeploy.json
+++ b/create-hpc-cluster-linux-cn/azuredeploy.json
@@ -119,7 +119,7 @@
 
     "variables": {
         "apiVersion": "2015-05-01-preview",    
-        "storageAccountName": "[toLower(concat(parameters('clusterName'), replace(resourceGroup().location, ' ', ''), 'sa'))]",
+        "storageAccountName": "[toLower(concat(parameters('clusterName'), 'sa'))]",
         "cnStorageAccountPrefix": "[concat(variables('storageAccountName'), 'cn')]",
         "cnStorageAccountNumber": "[add(div(parameters('computeNodeNumber'), 10), 1)]",
         "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",

--- a/create-hpc-cluster/availabilityset-disabled.json
+++ b/create-hpc-cluster/availabilityset-disabled.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json# ",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "apiVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "The API version"
+      }
+    },  
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The availability set name"
+      }
+    }
+  },
+  "variables": {},
+  "resources": []
+}

--- a/create-hpc-cluster/availabilityset-enabled.json
+++ b/create-hpc-cluster/availabilityset-enabled.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json# ",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "apiVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "The API version"
+      }
+    },  
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The availability set name"
+      }
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[parameters('availabilitySetName')]",
+      "apiVersion": "[parameters('apiVersion')]",
+      "location": "[resourceGroup().location]"
+    }
+  ]
+}

--- a/create-hpc-cluster/azuredeploy.json
+++ b/create-hpc-cluster/azuredeploy.json
@@ -130,6 +130,34 @@
     "dnsName": "[concat(parameters('clusterName'), 'ep')]",
     "nicName": "[concat(parameters('clusterName'),'-nic')]",
     "nicNameHN": "[concat(variables('nicName'),'-hn')]",
+    "vmSizeRDMAStates": {
+      "Standard_A1": "disabled",
+      "Standard_A2": "disabled",
+      "Standard_A3": "disabled",
+      "Standard_A4": "disabled",
+      "Standard_A5": "disabled",
+      "Standard_A6": "disabled",
+      "Standard_A7": "disabled",
+      "Standard_A8": "enabled",
+      "Standard_A9": "enabled",
+      "Standard_A10": "disabled",
+      "Standard_A11": "disabled",
+      "Standard_D1": "disabled",
+      "Standard_D2": "disabled",
+      "Standard_D3": "disabled",
+      "Standard_D4": "disabled",
+      "Standard_D11": "disabled",
+      "Standard_D12": "disabled",
+      "Standard_D13": "disabled",
+      "Standard_D14": "disabled"
+    },
+    "avSetJumpBox": {
+      "disabled-disabled": "disabled",
+      "disabled-enabled": "enabled",
+      "enabled-disabled": "enabled",
+      "enabled-enabled": "enabled"
+    },
+    "avSetState": "[variables('avSetJumpBox')[concat(variables('vmSizeRDMAStates')[parameters('headNodeVMSize')], '-', variables('vmSizeRDMAStates')[parameters('computeNodeVMSize')])]]",
     "availableCNImageSkus": {
       "ComputeNode": "2012R2CN",
       "ComputeNodeWithExcel": "2012R2CNExcel"
@@ -151,12 +179,6 @@
       "properties": {
         "accountType": "Standard_LRS"
       }
-    },
-    {
-      "type": "Microsoft.Compute/availabilitySets",
-      "name": "[variables('availabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
-      "location": "[resourceGroup().location]"
     },
     {
       "apiVersion": "[variables('apiVersion')]",
@@ -223,60 +245,79 @@
         ]
       }
     },
+
     {
-      "apiVersion": "[variables('apiVersion')]",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[parameters('clusterName')]",
-      "location": "[resourceGroup().location]",
-      "dependsOn": [
-        "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]",
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicNameHN'))]",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]"
-      ],
+      "apiVersion": "2015-01-01",
+      "type": "Microsoft.Resources/deployments",
+      "name": "createAvailabilitySet",
       "properties": {
-        "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('customScriptLocation'), 'availabilityset-', variables('avSetState'), '.json')]",
+          "contentVersion": "1.0.0.0"
         },
-        "hardwareProfile": {
-          "vmSize": "[parameters('headNodeVMSize')]"
-        },
-        "osProfile": {
-          "computername": "[parameters('clusterName')]",
-          "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "publisher": "MicrosoftWindowsServerHPCPack",
-            "offer": "WindowsServerHPCPack",
-            "sku": "2012R2",
-            "version": "latest"
+        "parameters": {
+          "apiVersion": {
+            "value": "[variables('apiVersion')]"
           },
-          "osDisk": {
-            "name": "osdisk",
-            "vhd": {
-              "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/headnode/','osdisk.vhd')]"
-            },
-            "caching": "ReadOnly",
-            "createOption": "FromImage"
+          "availabilitySetName": {
+            "value": "[variables('availabilitySetName')]"
           }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicNameHN'))]"
-            }
-          ]
         }
       }
     },
+
+    {
+      "apiVersion": "2015-01-01",
+      "type": "Microsoft.Resources/deployments",
+      "name": "createHeadNode",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicNameHN'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "Microsoft.Resources/deployments/createAvailabilitySet"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('customScriptLocation'), 'headnode-rdma-', variables('vmSizeRDMAStates')[parameters('headNodeVMSize')], '.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "apiVersion": {
+            "value": "[variables('apiVersion')]"
+          },
+          "vmName": {
+            "value": "[parameters('clusterName')]"
+          },
+          "vmSize": {
+            "value": "[parameters('headNodeVMSize')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "nicName": {
+            "value": "[variables('nicNameHN')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "availabilitySetName": {
+            "value": "[variables('availabilitySetName')]"
+          }
+        }
+      }
+    },
+
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterName'),'/configureHeadNode')]",
       "apiVersion": "[variables('apiVersion')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
-        "[concat('Microsoft.Compute/virtualMachines/', parameters('clusterName'))]"
+        "Microsoft.Resources/deployments/createHeadNode"
       ],
       "properties": {
         "publisher": "Microsoft.Compute",
@@ -333,14 +374,13 @@
         ]
       }
     },
+
     {
-      "apiVersion": "[variables('apiVersion')]",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(parameters('computeNodeNamePrefix'), copyIndex())]",
-      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-01-01",
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat('create', parameters('computeNodeNamePrefix'), copyIndex())]",
       "dependsOn": [
-        "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]",
-        "[concat('Microsoft.Compute/virtualMachines/', parameters('clusterName'))]",
+        "Microsoft.Resources/deployments/createAvailabilitySet",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex())]",
         "[concat('Microsoft.Storage/storageAccounts/', variables('cnStorageAccountPrefix'), div(copyIndex(), 10))]"
       ],
@@ -349,43 +389,55 @@
         "count": "[parameters('computeNodeNumber')]"
       },
       "properties": {
-        "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('customScriptLocation'), 'windowsnode-rdma-', variables('vmSizeRDMAStates')[parameters('computeNodeVMSize')], '.json')]",
+          "contentVersion": "1.0.0.0"
         },
-        "hardwareProfile": {
-          "vmSize": "[parameters('computeNodeVMSize')]"
-        },
-        "osProfile": {
-          "computername": "[concat(parameters('computeNodeNamePrefix'), copyIndex())]",
-          "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]",
-          "customData": "[base64(concat('HPCClusterName=', parameters('clusterName'), '\r\nImageCategory=public\r\nImageName=WindowsServerHPCPack-', variables('computeNodeImageSku'), '\r\nVMSize=', parameters('computeNodeVMSize')))]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "publisher": "MicrosoftWindowsServerHPCPack",
-            "offer": "WindowsServerHPCPack",
-            "sku": "[variables('computeNodeImageSku')]",
-            "version": "latest"
+        "parameters": {
+          "apiVersion": {
+            "value": "[variables('apiVersion')]"
           },
-          "osDisk": {
-            "name": "osdisk",
-            "vhd": {
-              "uri": "[concat('http://',variables('cnStorageAccountPrefix'),div(copyIndex(), 10),'.blob.core.windows.net/vhds',copyIndex(),'/','osdisk.vhd')]"
-            },
-            "caching": "ReadWrite",
-            "createOption": "FromImage"
+          "vmName": {
+            "value": "[concat(parameters('computeNodeNamePrefix'), copyIndex())]"
+          },
+          "vmSize": {
+            "value": "[parameters('computeNodeVMSize')]"
+          },
+          "storageAccountName": {
+            "value": "[concat(variables('cnStorageAccountPrefix'), div(copyIndex(), 10))]"
+          },
+          "imgPublisher": {
+            "value": "MicrosoftWindowsServerHPCPack"
+          },
+          "imgOffer": {
+            "value": "WindowsServerHPCPack"
+          },
+          "imgSku": {
+            "value": "[variables('computeNodeImageSku')]"
+          },
+          "imgVersion": {
+            "value": "latest"
+          },
+          "nicName": {
+            "value": "[concat(variables('nicName'), copyIndex())]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "availabilitySetName": {
+            "value": "[variables('availabilitySetName')]"
+          },
+          "customData": { 
+            "value": "[base64(concat('HPCClusterName=', parameters('clusterName'), '\r\nImageCategory=public\r\nImageName=WindowsServerHPCPack-', variables('computeNodeImageSku'), '\r\nVMSize=', parameters('computeNodeVMSize')))]"
           }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), copyIndex()))]"
-            }
-          ]
         }
       }
     },
+
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('computeNodeNamePrefix'), copyIndex(), '/configureComputeNode')]",
@@ -393,7 +445,7 @@
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('clusterName'), '/extensions/configureHeadNode')]",
-        "[concat('Microsoft.Compute/virtualMachines/', parameters('computeNodeNamePrefix'), copyIndex())]"
+        "[concat('Microsoft.Resources/deployments/create', parameters('computeNodeNamePrefix'), copyIndex())]"
       ],
       "copy": {
         "name": "CN",

--- a/create-hpc-cluster/azuredeploy.json
+++ b/create-hpc-cluster/azuredeploy.json
@@ -113,7 +113,7 @@
   },
   "variables": {
     "apiVersion": "2015-05-01-preview",
-    "storageAccountName": "[toLower(concat(parameters('clusterName'), replace(resourceGroup().location, ' ', ''), 'sa'))]",
+    "storageAccountName": "[toLower(concat(parameters('clusterName'), 'sa'))]",
     "cnStorageAccountPrefix": "[concat(variables('storageAccountName'), 'cn')]",
     "cnStorageAccountNumber": "[add(div(parameters('computeNodeNumber'), 10), 1)]",
     "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",

--- a/create-hpc-cluster/headnode-rdma-disabled.json
+++ b/create-hpc-cluster/headnode-rdma-disabled.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "apiVersion": { 
+      "type": "string",
+      "metadata": {
+        "description": "The API version"
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM name"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM role size"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The storage account name to store the VHD of the VM"
+      }
+    },
+    "nicName": {
+      "type": "string",
+      "metadata": {
+        "description": "The network interface name"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The user name of the administrator"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password of the administrator"
+      }
+    },
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The availability set name"
+      }    
+    }
+  },
+
+  "resources": [
+    {
+      "apiVersion": "[parameters('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "MicrosoftWindowsServerHPCPack",
+            "offer": "WindowsServerHPCPack",
+            "sku": "2012R2",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-osdisk.vhd')]"
+            },
+            "caching": "ReadOnly",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/create-hpc-cluster/headnode-rdma-enabled.json
+++ b/create-hpc-cluster/headnode-rdma-enabled.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "apiVersion": { 
+      "type": "string",
+      "metadata": {
+        "description": "The API version"
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM name"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM role size"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The storage account name to store the VHD of the VM"
+      }
+    },
+    "nicName": {
+      "type": "string",
+      "metadata": {
+        "description": "The network interface name"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The user name of the administrator"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password of the administrator"
+      }
+    },
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The availability set name"
+      }    
+    }
+  },
+
+  "resources": [
+    {
+      "apiVersion": "[parameters('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "MicrosoftWindowsServerHPCPack",
+            "offer": "WindowsServerHPCPack",
+            "sku": "2012R2",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-osdisk.vhd')]"
+            },
+            "caching": "ReadOnly",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmName'),'/installRDMADriver')]",
+      "apiVersion": "[parameters('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.HpcCompute",
+        "type": "HpcVmDrivers",
+        "typeHandlerVersion": "1.1"
+      }
+    }
+  ]
+}

--- a/create-hpc-cluster/linuxnode-rdma-disabled.json
+++ b/create-hpc-cluster/linuxnode-rdma-disabled.json
@@ -1,0 +1,130 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "apiVersion": { 
+      "type": "string",
+      "metadata": {
+        "description": "The API version"
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM name"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM role size"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The storage account name to store the VHD of the VM"
+      }
+    },
+    "imgPublisher": {
+      "type": "string",
+      "metadata": {
+        "description": "The publisher of the VM image"
+      }
+    },
+    "imgOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "The offer of the VM image"
+      }
+    },
+    "imgSku": {
+      "type": "string",
+      "metadata": {
+        "description": "The sku of the VM image"
+      }
+    },
+    "imgVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "The version of the VM image"
+      }
+    },
+    "nicName": {
+      "type": "string",
+      "metadata": {
+        "description": "The network interface name"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The user name of the administrator"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password of the administrator"
+      }
+    },
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The availability set name"
+      }
+    },
+    "customData": { 
+      "type": "string",
+      "metadata": {
+        "description": "The custom data in base64 format"
+      }
+    }
+  },
+
+  "resources": [
+    {
+      "apiVersion": "[parameters('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "customData": "[parameters('customData')]",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": "false"
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imgPublisher')]",
+            "offer": "[parameters('imgOffer')]",
+            "sku": "[parameters('imgSku')]",
+            "version": "[parameters('imgVersion')]"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-osdisk.vhd')]"
+            },
+            "caching": "ReadOnly",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/create-hpc-cluster/linuxnode-rdma-enabled.json
+++ b/create-hpc-cluster/linuxnode-rdma-enabled.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "apiVersion": { 
+      "type": "string",
+      "metadata": {
+        "description": "The API version"
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM name"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM role size"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The storage account name to store the VHD of the VM"
+      }
+    },
+    "imgPublisher": {
+      "type": "string",
+      "metadata": {
+        "description": "The publisher of the VM image"
+      }
+    },
+    "imgOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "The offer of the VM image"
+      }
+    },
+    "imgSku": {
+      "type": "string",
+      "metadata": {
+        "description": "The sku of the VM image"
+      }
+    },
+    "imgVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "The version of the VM image"
+      }
+    },
+    "nicName": {
+      "type": "string",
+      "metadata": {
+        "description": "The network interface name"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The user name of the administrator"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password of the administrator"
+      }
+    },
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The availability set name"
+      }
+    },
+    "customData": { 
+      "type": "string",
+      "metadata": {
+        "description": "The custom data in base64 format"
+      }
+    }
+  },
+
+  "resources": [
+    {
+      "apiVersion": "[parameters('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "customData": "[parameters('customData')]",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": "false"
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imgPublisher')]",
+            "offer": "[parameters('imgOffer')]",
+            "sku": "[parameters('imgSku')]",
+            "version": "[parameters('imgVersion')]"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-osdisk.vhd')]"
+            },
+            "caching": "ReadOnly",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/create-hpc-cluster/windowsnode-rdma-disabled.json
+++ b/create-hpc-cluster/windowsnode-rdma-disabled.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "apiVersion": { 
+      "type": "string",
+      "metadata": {
+        "description": "The API version"
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM name"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM role size"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The storage account name to store the VHD of the VM"
+      }
+    },
+    "imgPublisher": {
+      "type": "string",
+      "metadata": {
+        "description": "The publisher of the VM image"
+      }
+    },
+    "imgOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "The offer of the VM image"
+      }
+    },
+    "imgSku": {
+      "type": "string",
+      "metadata": {
+        "description": "The sku of the VM image"
+      }
+    },
+    "imgVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "The version of the VM image"
+      }
+    },
+    "nicName": {
+      "type": "string",
+      "metadata": {
+        "description": "The network interface name"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The user name of the administrator"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password of the administrator"
+      }
+    },
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The availability set name"
+      }
+    },
+    "customData": { 
+      "type": "string",
+      "metadata": {
+        "description": "The custom data in base64 format"
+      }
+    }
+  },
+
+  "resources": [
+    {
+      "apiVersion": "[parameters('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "customData": "[parameters('customData')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imgPublisher')]",
+            "offer": "[parameters('imgOffer')]",
+            "sku": "[parameters('imgSku')]",
+            "version": "[parameters('imgVersion')]"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-osdisk.vhd')]"
+            },
+            "caching": "ReadOnly",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/create-hpc-cluster/windowsnode-rdma-enabled.json
+++ b/create-hpc-cluster/windowsnode-rdma-enabled.json
@@ -1,0 +1,144 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "apiVersion": { 
+      "type": "string",
+      "metadata": {
+        "description": "The API version"
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM name"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The VM role size"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The storage account name to store the VHD of the VM"
+      }
+    },
+    "imgPublisher": {
+      "type": "string",
+      "metadata": {
+        "description": "The publisher of the VM image"
+      }
+    },
+    "imgOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "The offer of the VM image"
+      }
+    },
+    "imgSku": {
+      "type": "string",
+      "metadata": {
+        "description": "The sku of the VM image"
+      }
+    },
+    "imgVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "The version of the VM image"
+      }
+    },
+    "nicName": {
+      "type": "string",
+      "metadata": {
+        "description": "The network interface name"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The user name of the administrator"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password of the administrator"
+      }
+    },
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The availability set name"
+      }
+    },
+    "customData": { 
+      "type": "string",
+      "metadata": {
+        "description": "The custom data in base64 format"
+      }
+    }
+  },
+
+  "resources": [
+    {
+      "apiVersion": "[parameters('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "customData": "[parameters('customData')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imgPublisher')]",
+            "offer": "[parameters('imgOffer')]",
+            "sku": "[parameters('imgSku')]",
+            "version": "[parameters('imgVersion')]"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-osdisk.vhd')]"
+            },
+            "caching": "ReadOnly",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmName'),'/installRDMADriver')]",
+      "apiVersion": "[parameters('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.HpcCompute",
+        "type": "HpcVmDrivers",
+        "typeHandlerVersion": "1.1"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fix the issue that the storage account name is too long for some
locations: Remove the location from the storage account name to reduce
the storage account name length.