### PR TITLE
Fixed AppService typo in the provider name

### DIFF
--- a/201-logic-app-api-app-create/azuredeploy.json
+++ b/201-logic-app-api-app-create/azuredeploy.json
@@ -318,7 +318,7 @@
               "inputs": {
                 "apiVersion": "2015-01-14",
                 "host": {
-                  "id": "[concat(resourceGroup().id, '/providers/Microsoft.AppServices/apiApps/',parameters('apiAppName'))]",
+                  "id": "[concat(resourceGroup().id, '/providers/Microsoft.AppService/apiApps/',parameters('apiAppName'))]",
                   "gateway": "[concat('https://', reference(resourceId('Microsoft.Web/sites', parameters('gatewayName'))).hostNames[0])]"
                 },
                 "operation": "Values_Get",


### PR DESCRIPTION
Noticed a typo in the template that gets pulled into Azure SDK in Visual Studio. Blocks the template from working when executing it against ARM. 