### PR TITLE
[Part 1] Enforcing consistent Readme format

### DIFF
--- a/101-create-applicationgateway-publicip/README.md
+++ b/101-create-applicationgateway-publicip/README.md
@@ -3,15 +3,3 @@
 Built by: [puneetsaraswat](https://github.com/puneetsaraswat)
 
 This template creates an Application Gateway, Public IP address for the Application Gateway, and the Virtual Network in which Application Gateway is deployed. Also configures Application Gateway for Http Load balancing with Two backend servers.
-
-Below are the parameters that the template expects
-
-| Name                      | Description                                               |
-|:-------------------------:|:---------------------------------------------------------:|
-| location                  | Azure region where the resource will be deployed to       |
-| addressPrefix             | Prefix for the address in CIDR format                     |
-| subnetPrefix              | Prefix for the subnet in CIDR format                      |
-| skuName                   | Sku Name                                                  |
-| capacity                  | Number of instances                                       |
-| backendIpAddress1         | IP Address for Backend Server 1                           |
-| backendIpAddress2         | IP Address for Backend Server 2                           |

--- a/101-create-internal-loadbalancer/README.md
+++ b/101-create-internal-loadbalancer/README.md
@@ -4,18 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-
-Built by: [kenazk](https://github.com/kenazk)
-
 This template allows you to create a Load Balancer, Public IP address for the Load balancer, Virtual Network, Network Interface in the Virtual Network & a NAT Rule in the Load Balancer that is used by the Network Interface.
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| location  | Azure region where the resource will be deployed to  |
-| addressPrefix | Prefix for the address in CIDR format |
-| subnetPrefix | Prefix for the subnet in CIDR format |
-
-
-

--- a/101-create-key-vault/README.md
+++ b/101-create-key-vault/README.md
@@ -4,6 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-This template creates a Key Vault. For more information, go to:
-
-http://azure.microsoft.com/en-us/documentation/services/key-vault/
+This template creates a Key Vault. For more information, go to: http://azure.microsoft.com/en-us/documentation/services/key-vault/

--- a/101-create-security-group/README.md
+++ b/101-create-security-group/README.md
@@ -4,7 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-This template creates a subnet, a Network Security Group and attaches it to the subnet in the VNET. For more information on how to configure the Network Security Group, go here:
-
-https://msdn.microsoft.com/en-us/library/azure/dn848316.aspx
-
+This template creates a subnet, a Network Security Group and attaches it to the subnet in the VNET. For more information on how to configure the Network Security Group, go here: https://msdn.microsoft.com/en-us/library/azure/dn848316.aspx

--- a/101-loadbalancer-with-nat-rule/README.md
+++ b/101-loadbalancer-with-nat-rule/README.md
@@ -5,13 +5,3 @@
 </a>
 
 This template allows you to create a Load Balancer, Public IP address for the Load balancer, Virtual Network, Network Interface in the Virtual Network & a NAT Rule in the Load Balancer that is used by the Network Interface.
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| dnsNameforLBIP  | Unique DNS Name for the Load Balancer  |
-| location  | Azure region where the resource will be deployed to  |
-| addressPrefix  | Address Prefix for the Virtual Network specified in the CIDR format  |
-| subnetPrefix | Prefix for the Subnet specified in CIDR format |
-| publicIPAddressType | Address Type of the Public IP Address - Dynamic or Static |

--- a/101-networkinterface-with-publicip-vnet/README.md
+++ b/101-networkinterface-with-publicip-vnet/README.md
@@ -5,14 +5,3 @@
 </a>
 
 This template allows you to create a Network Inerface in a Virtual Network referencing a Public IP Address.
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| dnsNameforPublicIP  | Unique DNS Name for the Public IP Address |
-| location  | Azure region where the resource will be deployed to  |
-| addressPrefix  | Address Prefix for the Virtual Network specified in the CIDR format  |
-| subnetPrefix | Prefix for the Subnet specified in CIDR format |
-| publicIPAddressType | Address Type of the Public IP Address - Dynamic or Static |
-

--- a/101-public-ip-dns-name/README.md
+++ b/101-public-ip-dns-name/README.md
@@ -7,11 +7,3 @@
 This template allows you to create a public IP with DNS Name during the template deployment. This is a template snippet. For a more complete network definition, see this template:
 
 https://github.com/Azure/azure-quickstart-templates/tree/master/101-loadbalancer-with-nat-rule
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| location | location where the resources will be deployed |
-

--- a/101-simple-linux-vm/README.md
+++ b/101-simple-linux-vm/README.md
@@ -4,17 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a><a  target="_blank">
 
-
-Built by: [coreysa](https://github.com/coreysa)
-
 This template allows you to deploy a simple Linux VM using a few different options for the Ubuntu Linux version, using the latest patched version. This will deploy in West US on a D1 VM Size.
-
-Below are the parameters that the template expects:
-
-| Name   | Description    |
-|:--- |:---|
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machine  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| ubuntuOSVersion  | The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version. Allowed values: 12.04.5-LTS, 14.04.2-LTS, 15.04 |

--- a/101-simple-windows-vm-data-disk/README.md
+++ b/101-simple-windows-vm-data-disk/README.md
@@ -1,20 +1,7 @@
-# Very simple deployment of an Windows VM with a single empty Data Disk 
+# Very simple deployment of an Windows VM with a single empty Data Disk
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-simple-windows-vm-data-disk%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-Built by: [kenazk](https://github.com/kenazk)
-
-This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy in West US on a D1 VM Size and attach an empty data disk to it. 
-
-Below are the parameters that the template expects: 
-
-| Name   | Description    |
-|:--- |:---|
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machine  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| windowsOSVersion  | The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview |
-| sizeOfDiskInGB | The size of disk in GB | 
+This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy in West US on a D1 VM Size and attach an empty data disk to it.

--- a/101-simple-windows-vm/README.md
+++ b/101-simple-windows-vm/README.md
@@ -4,16 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-Built by: [coreysa](https://github.com/coreysa)
-
 This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy in West US on a D1 VM Size.
-
-Below are the parameters that the template expects: 
-
-| Name   | Description    |
-|:--- |:---|
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machine  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| windowsOSVersion  | The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview |

--- a/101-tags-vm/README.md
+++ b/101-tags-vm/README.md
@@ -4,16 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-Built by: [mmccrory](https://github.com/mmccrory)
-
-This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy in West US on a D1 VM Size. This will include tags on the Virtual Machine, Storage Account, Public IP Address, Virtual Network, and Network Interface. 
-
-Below are the parameters that the template expects: 
-
-| Name   | Description    |
-|:--- |:---|
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machine  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| windowsOSVersion  | The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview |
+This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy in West US on a D1 VM Size. This will include tags on the Virtual Machine, Storage Account, Public IP Address, Virtual Network, and Network Interface.

--- a/101-two-subnets/README.md
+++ b/101-two-subnets/README.md
@@ -5,15 +5,3 @@
 </a>
 
 This template allows you to create a Virtual Network with two subnets.
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| location | Region where the resources will be deployed |
-| vnetName | Name for the new virtual network |
-| addressPrefix | Address prefix for the Virtual Network specified in CIDR format |
-| subnet1Name | Name for first subnet |
-| subnet1Prefix | Prefix for the Subnet-1 specified in CIDR format |
-| subnet2Name | Name for second subnet |
-| subnet2Prefix | Prefix for the Subnet-2 specified in CIDR format |

--- a/101-virtual-network/README.md
+++ b/101-virtual-network/README.md
@@ -5,11 +5,3 @@
 </a>
 
 This template allows you to create a Virtual Network with a single subnet
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| location | Region where the resources will be deployed |
-| addressPrefix | Address prefix for the Virtual Network specified in CIDR format |
-| subnetPrefix | Prefix for the Subnet-1 specified in CIDR format |

--- a/101-vm-customdata/README.md
+++ b/101-vm-customdata/README.md
@@ -5,19 +5,3 @@
 </a>
 
 This template allows you to create a Virtual Machine with Custom Data. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machines  |
-| adminPassword  | Password for the Virtual Machine  |
-| customData  | Specifies a base-64 encoded string of custom data. The base-64 encoded string is decoded to a binary array that is saved as a file on the Virtual Machine. The maximum length of the binary array is 65535 bytes. In Linux VMs, The base-64 encoded string is located in the ovf-env.xml file on the ISO of the Virtual Machine. The file is copied to /var/lib/waagent/ovf-env.xml by the Azure Linux Agent. The agent will also place the base-64 encoded data in /var/lib/waagent/CustomData during provisioning. In Windows VMs, the file is saved to %SYSTEMDRIVE%\AzureData\CustomData.bin. If the file exists, it is overwritten. The security on directory is set to System:Full Control and Administrators:Full Control. |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| subscriptionId  | Subscription ID where the template will be deployed |
-| location | location where the resources will be deployed |
-| vmSize | Size of the Virtual Machine |
-| ubuntuOSVersion | The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview.|
-
-

--- a/101-vm-multiple-data-disk/README.md
+++ b/101-vm-multiple-data-disk/README.md
@@ -7,13 +7,3 @@
 This template allows you to create a Windows Virtual Machine from a specified image during the template deployment and install the VM Diagnostics Extension. It also attaches 4 empty data disks. Note that you can specify the size of each of the empty data disks. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.
 
 NOTE: The configuration of the VM diagnostics extension relies on a Base64 encoded string for the xmlConfig. This configures a basic set of counters, including CPU and Memory. 
-
-Below are the parameters that the template expects.
-
-| Name   | Description    |
-|:--- |:---|
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machines  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| sizeOfEachDataDiskInGB | Size of each data disk in GB |

--- a/101-vm-simple-linux-vm-data-disk/README.md
+++ b/101-vm-simple-linux-vm-data-disk/README.md
@@ -5,13 +5,3 @@
 </a>
 
 This template allows you to create a Linux Virtual Machine from a specified image during the template deployment. It also attaches an empty data disk. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.
-
-Below are the parameters that the template expects.
-
-| Name   | Description    |
-|:--- |:---|
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machines  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| vmSize | Size of the Virtual Machine |

--- a/101-vm-with-rdp-port/Readme.md
+++ b/101-vm-with-rdp-port/Readme.md
@@ -14,21 +14,3 @@ This template deploys the following resources:
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-vm-with-rdp-port%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-
-Template parameters:
-
-| Name   | Description    |
-|:--- |:---|
-| location  | Location where to deploy the resources |
-| publicDnsName | The DNS prefix for the public IP address |
-| storageAccount | Name of the storage account to create |
-| vmName | The name of the VM |
-| imagePublisher | The name of the pulisher of the OS Image |
-| imageOffer | The Image Offer |
-| imageSKU | The Image SKU |
-| adminUsername | Admin username |
-| adminPassword | Admin password |
-| rdpPort | Public port number for RDP |
-
-
-

--- a/101-webapp-with-golang/README.md
+++ b/101-webapp-with-golang/README.md
@@ -5,13 +5,3 @@
 </a>
 
 This template creates a web app on azure with GoLang site extension, allowing you to run web applications developed on GoLang on Azure. Template was authored by Wade Wegner Of Microsoft. For more information about GoLang site extension see http://www.wadewegner.com/2015/01/creating-a-go-site-extension-and-resource-template-for-azure/
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| siteName  | Name of the Web App. |
-| hostingPlanName  | Name for hosting plan  |
-| siteLocation  | Site Location   |
-| sku  | SKU ("Free", "Shared", "Basic", "Standard") |
-| workerSize | Worker Size( 0=Small, 1=Medium, 2=Large ) |

--- a/201-1-vm-loadbalancer-2-nics/README.md
+++ b/201-1-vm-loadbalancer-2-nics/README.md
@@ -8,20 +8,3 @@
 </a>
 
 This template allows you to create a Virtual Machines with multiple (2) network interfaces (NICs), and RDP connectable with a configured load balancer and an inbound NAT rule. More NICs can easily  be added with this template. This template also deploys a Storage Account, Virtual Network, Public IP address, and 2 Network Interfaces (front-end and back-end).
-
-| Name   | Description    |
-|:--- |:---|
-| storageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machines  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForLBIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| subscriptionId  | Subscription ID where the template will be deployed |
-| vmSourceImageName  | Source Image Name for the VM. Example: b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-12_04_5-LTS-amd64-server-20140927-en-us-30GB |
-| region | location where the resources will be deployed |
-| vnetName | Name of Virtual Network |
-| vmSize | Size of the Virtual Machine |
-| vmNamePrefix | NamePrefix for Virtual Machines |
-| publicIPAddressName | Name of Public IP Address Name |
-| nicNamePrefix | NamePrefix for Network Interfaces |
-| lbName | Name for the load balancer |
-| backendPort | The Back End Port that needs to be opened on the Virtual Machine Instance. For example: 3389 for RDP, 22 for SSH etc., |

--- a/201-2-vms-internal-load-balancer/README.md
+++ b/201-2-vms-internal-load-balancer/README.md
@@ -18,6 +18,3 @@ The Azure Load Balancer is assigned a static IP in the Virtual Network and is  c
 - Modify the 2VMsinVnetWithILB-parameters file to update your subscriptionId and change naming convention
 
 - Deploy: New-AzureResourceGroupDeployment –Name IPDep1 -ResourceGroupName ILB-DemoRG -TemplateFile 2VMsinVnetWithILB.json -TemplateParameterFile 2VMsinVnetWithILB-parameters.json
-
-
-

--- a/201-2-vms-loadbalancer-lbrules/README.md
+++ b/201-2-vms-loadbalancer-lbrules/README.md
@@ -7,22 +7,3 @@
 This template allows you to create 2 Virtual Machines under a Load balancer and configure a load balancing rule on Port 80. This template also deploys a Storage Account, Virtual Network, Public IP address, Availability Set and Network Interfaces.
 
 In this template, we use the resource loops capability to create the network interfaces and virtual machines
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| storageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machines  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForLBIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| subscriptionId  | Subscription ID where the template will be deployed |
-| vmSourceImageName  | Source Image Name for the VM. Example: b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-12_04_5-LTS-amd64-server-20140927-en-us-30GB |
-| region | location where the resources will be deployed |
-| vnetName | Name of Virtual Network |
-| vmSize | Size of the Virtual Machine |
-| vmNamePrefix | NamePrefix for Virtual Machines |
-| publicIPAddressName | Name of Public IP Address Name |
-| nicNamePrefix | NamePrefix for Network Interfaces |
-| lbName | Name for the load balancer |
-| backendPort | The Back End Port that needs to be opened on the Virtual Machine Instance. For example: 3389 for RDP, 22 for SSH etc., |

--- a/201-2-vms-loadbalancer-natrules/README.md
+++ b/201-2-vms-loadbalancer-natrules/README.md
@@ -7,22 +7,3 @@
 This template allows you to create 2 Virtual Machines in an Availability Set and configure NAT rules through the load balancer. This template also deploys a Storage Account, Virtual Network, Public IP address and Network Interfaces.
 
 In this template, we use the resource loops capability to create the network interfaces and virtual machines
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| storageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machines  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForLBIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| subscriptionId  | Subscription ID where the template will be deployed |
-| vmSourceImageName  | Source Image Name for the VM. Example: b39f27a8b8c64d52b05eac6a62ebad85__Ubuntu-12_04_5-LTS-amd64-server-20140927-en-us-30GB |
-| region | location where the resources will be deployed |
-| vnetName | Name of Virtual Network |
-| vmSize | Size of the Virtual Machine |
-| vmNamePrefix | NamePrefix for Virtual Machines |
-| publicIPAddressName | Name of Public IP Address Name |
-| nicNamePrefix | NamePrefix for Network Interfaces |
-| lbName | Name for the load balancer |
-| backendPort | The Back End Port that needs to be opened on the Virtual Machine Instance. For example: 3389 for RDP, 22 for SSH etc., |

--- a/201-dependency-between-scripts-using-extensions/README.md
+++ b/201-dependency-between-scripts-using-extensions/README.md
@@ -5,13 +5,3 @@
 </a>
 
 This template deploys Configures and Installs Mongo DB on a Ubuntu Virtual Machine in two separate scripts. This template is a good example that showcases how to express dependencies between two scripts running on the same virtual machine. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machines  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| vmSize | Size of the Virtual Machine |

--- a/201-premium-storage-windows-vm/README.md
+++ b/201-premium-storage-windows-vm/README.md
@@ -4,17 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-Built by: [kenazk](https://github.com/kenazk)
-
 This template allows you to deploy a Premium Windows VM using a few different options for the Windows version, using the latest patched version.
-
-Below are the parameters that the template expects: 
-
-| Name   | Description    |
-|:--- |:---|
-| location | Location to deploy to | 
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| adminUsername  | Username for the Virtual Machine  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| windowsOSVersion  | The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview |

--- a/201-site-to-site-vpn/README.md
+++ b/201-site-to-site-vpn/README.md
@@ -9,30 +9,3 @@ This template will create a Virtual Network, a subnet for the network, a Virtual
 Please note that you must have a Public IP for your other network's VPN gateway and cannot be behind an NAT.
 
 Although only the parameters in [azuredeploy-parameters.json](./azure-deploy-parameters.json) are necessary, you can override the defaults of any of the template parameters below:
-
-| Name   | Description    |
-|:--- |:---|
-| location | Region where the resources will be deployed |
-| vpnType | Route based, or policy based |
-| subscriptionId | Subscription ID |
-| localGatewayName | Name for gateway connected to other Network |
-| localGatewayIpAddress | Public IP address of other network Gateway |
-| localAddressPrefix | CIDR block of other network address space |
-| virtualNetworkName | Name for new virtual network |
-| azureVNetAddressPrefix | CIDR block for new Azure VNet |
-| subnetName | Name for Azure VM subnet |
-| subnetPrefix | CIDR block for Azure VM subnet |
-| gatewaySubnet | Name for gatway subnet |
-| gatewaySubnetPrefix | CIDR block for Azure gateway subnet |
-| gatewayPublicIPName | Name for public IP resource for the Azure gateway |
-| gatewayName | Name for the gateway connected to the new VNet |
-| connectionName | Name for the new connection between Azure VNet and other network |
-| vmName | Virtual Machine Name |
-| vmSize | Shared key for IPSec connection |
-| adminUsername | Username for test Virtual Machine |
-| adminPassword | Password for test Virtual Machine |
-| imagePublisher | VM Image publisher |
-| imageOffer | VM Image offer |
-| imageSKU | VM Image SKU |
-| newStorageAccountName | Storage Account Name for VM Disk |
-| storageAccountType | Storage Account Type for VM Disk |

--- a/201-vm-domain-join/Readme.md
+++ b/201-vm-domain-join/Readme.md
@@ -1,6 +1,6 @@
 # Domain join sample
 
-This template demonstrates domain join to a private AD domain up in cloud. 
+This template demonstrates domain join to a private AD domain up in cloud.
 It creates one DC VM, one other VM and joins it to the domain.
 
 This template deploys the following resources:
@@ -12,19 +12,3 @@ Click the button below to deploy
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-vm-domain-join%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-
-Template parameters:
-
-| Name   | Description    |
-|:--- |:---|
-| publicDnsName | The DNS prefix for the public IP address |
-| storageAccount | Name of the storage account to create    |
-| windowsOSVersion| Windows OS version for the VM, allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter. |
-| vmSize | The size of the virtual machines (default: Standard_A2) |
-| domainName | Domain name (e.g. 'contoso.com') |
-| adminUsername | Domain admin username |
-| adminPassword | Domain admin password |
-| assetLocation | The location of resources such as templates and DSC modules that the script is dependent |
-
-
-

--- a/201-vmaccess-on-ubuntu/README.md
+++ b/201-vmaccess-on-ubuntu/README.md
@@ -4,8 +4,6 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-Built by: [Bin Xia](https://github.com/bingosummer)
-
 This template uses the Azure Linux [VMAccess extension](https://github.com/Azure/azure-linux-extensions/tree/master/VMAccess) to deploy an Linux VM. Azure Linux VMAccess extension provides several ways to allow owner of the VM to get the SSH access back.
 
 What you can do using the VMAccess extension:
@@ -14,23 +12,6 @@ What you can do using the VMAccess extension:
 2. Modify the password or public key of the existing user.
 3. Remove the existing user.
 4. Reset the ssh configuration.
-
-Below are the parameters that the template expects
-
-| Name   | Description    |
-|:--- |:---|
-| adminUsername  | Username for the Virtual Machine  |
-| adminPassword  | Password for the Virtual Machine  |
-| location | The location where the Virtual Machine will be deployed |
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed |
-| ubuntuOSVersion  | The Ubuntu version for deploying the VMAccess extension |
-| vmName | Name of the Virtual Machine |
-| vmSize | Size of the Virtual Machine |
-| userName | The user name whose password you want to change |
-| password | The new password |
-| sshKey | The new public key |
-| resetSSH | Whether to reset ssh |
-| userNameToRemove | The user name you want to remove |
 
 How to deploy
 
@@ -43,5 +24,3 @@ Azure CLI or Powershell is recommended to deploy the template.
 2. Using Powershell
 
   https://azure.microsoft.com/en-us/documentation/articles/powershell-azure-resource-manager/
-
-

--- a/201-windows-vm-diagnostics-extension/README.md
+++ b/201-windows-vm-diagnostics-extension/README.md
@@ -4,18 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-Built by: [kenazk](https://github.com/kenazk)
-
-This template allows you to deploy a Premium Windows VM using a few different options for the Windows version, using the latest patched version. In addition, it will provision the Diagnostics Extension on your behlf in a new, non-Premium Storage Account. 
-
-Below are the parameters that the template expects: 
-
-| Name   | Description    |
-|:--- |:---|
-| location | Location to deploy to | 
-| newStorageAccountName  | Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. |
-| vmDiagnosticsStorageAccountName | Unique DNS name for the Storage Account where the Virtual Machine's diagnostics are placed. | 
-| adminUsername  | Username for the Virtual Machine  |
-| adminPassword  | Password for the Virtual Machine  |
-| dnsNameForPublicIP  | Unique DNS Name for the Public IP used to access the Virtual Machine. |
-| windowsOSVersion  | The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter, Windows-Server-Technical-Preview |
+This template allows you to deploy a Premium Windows VM using a few different options for the Windows version, using the latest patched version. In addition, it will provision the Diagnostics Extension on your behlf in a new, non-Premium Storage Account.


### PR DESCRIPTION
This enforces consistent readme file formats across templates to prepare the readme's for rendering on Azure.com. This removes the table of parameters and "built by". 