### PR TITLE
location variable now default to resourceGroup location instead of harcoded West US

### DIFF
--- a/101-vm-from-user-image/azuredeploy.json
+++ b/101-vm-from-user-image/azuredeploy.json
@@ -53,35 +53,10 @@
       "metadata": {
         "description": "This is the size of your VM"
       }
-    },
-    "location": {
-      "allowedValues": [
-        "Central US",
-        "East US",
-        "East US 2",
-        "East India",
-        "North Central US",
-        "South Central US",
-        "West US",
-        "West India",
-        "North Europe",
-        "West Europe",
-        "East Asia",
-        "South East Asia",
-        "Japan East",
-        "Japan West",
-        "Brazil South",
-        "Australia East",
-        "Australia Southeast"
-      ],
-      "defaultValue": "West US",
-      "metadata": {
-        "description": "This is location where resources are gonna be created."
-      },
-      "type": "string"
     }
   },
   "variables": {
+    "location": "[resourceGroup().location]",
     "publicIPAddressName": "myPublicIP",
     "vmName": "myVM",
     "virtualNetworkName": "myVNET",
@@ -100,7 +75,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "properties": {
         "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
         "dnsSettings": {
@@ -112,7 +87,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -133,7 +108,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -159,7 +134,7 @@
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],

--- a/101-vm-from-user-image/azuredeploy.json
+++ b/101-vm-from-user-image/azuredeploy.json
@@ -53,10 +53,35 @@
       "metadata": {
         "description": "This is the size of your VM"
       }
+    },
+    "location": {
+      "allowedValues": [
+        "Central US",
+        "East US",
+        "East US 2",
+        "East India",
+        "North Central US",
+        "South Central US",
+        "West US",
+        "West India",
+        "North Europe",
+        "West Europe",
+        "East Asia",
+        "South East Asia",
+        "Japan East",
+        "Japan West",
+        "Brazil South",
+        "Australia East",
+        "Australia Southeast"
+      ],
+      "defaultValue": "West US",
+      "metadata": {
+        "description": "This is location where resources are gonna be created."
+      },
+      "type": "string"
     }
   },
   "variables": {
-    "location": "West US",
     "publicIPAddressName": "myPublicIP",
     "vmName": "myVM",
     "virtualNetworkName": "myVNET",
@@ -68,14 +93,14 @@
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
     "userImageName": "[concat('http://',parameters('userImageStorageAccountName'),'.blob.core.windows.net/',parameters('userImageStorageContainerName'),'/',parameters('userImageVhdName'))]",
-    "osDiskVhdName": "[concat('http://',parameters('userImageStorageAccountName'),'.blob.core.windows.net/',parameters('userImageStorageContainerName'),'/',variables('vmName'),'osDisk.vhd')]"
+    "osDiskVhdName": "[concat('http://',parameters('userImageStorageAccountName'),'.blob.core.windows.net/vhds/',variables('vmName'),'osDisk.vhd')]"
   },
   "resources": [
     {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
-      "location": "[variables('location')]",
+      "location": "[parameters('location')]",
       "properties": {
         "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
         "dnsSettings": {
@@ -87,7 +112,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
-      "location": "[variables('location')]",
+      "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -108,7 +133,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
-      "location": "[variables('location')]",
+      "location": "[parameters('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -134,7 +159,7 @@
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
-      "location": "[variables('location')]",
+      "location": "[parameters('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],

--- a/101-vm-from-user-image/metadata.json
+++ b/101-vm-from-user-image/metadata.json
@@ -2,6 +2,6 @@
   "itemDisplayName": "Create a VM from User Image",
   "description": "This template allows you to create a Virtual Machines from a User image. This template also deploys a Virtual Network, Public IP addresses and a Network Interface.",
   "summary": "Create a Virtual Machine from a User Image",
-  "githubUsername": "mahthi",
-  "dateUpdated": "2015-04-24"
+  "githubUsername": "slapointe",
+  "dateUpdated": "2015-09-10"
 }


### PR DESCRIPTION
Template will now work for VMs and storage account outside of West US data center. The location variable now default to the resourceGroup location. The VM vhd destination container has been changed to "vhds" instead of the user image container.