### PR TITLE
docker-swarm-cluster: Naming fixes

### DIFF
--- a/docker-swarm-cluster/README.md
+++ b/docker-swarm-cluster/README.md
@@ -4,9 +4,9 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-This template deploys a [Docker Swarm](http://docs.docker.com/swarm) cluster
-on Azure with multiple manager nodes and specified number of slave nodes in
-the location of the resource group.
+This template deploys a [Docker Swarm](http://docs.docker.com/swarm) cluster on
+Azure with 3 Swarm managers and specified number of Swarm nodes in the location
+of the resource group.
 
 If you are not familiar with Docker Swarm, please
 [read Swarm documentation](http://docs.docker.com/swarm).
@@ -25,15 +25,14 @@ an [Avabilability Set][av-set] to achieve the highest uptime.
 Each Swarm manager VM is of size `Standard_A0` as they are not running any
 workloads except the Swarm Manager and Consul containers. Manager node VMs have
 static private IP addresses `10.0.0.4`, `10.0.0.5` and `10.0.0.6` and they are
-in the same [Virtual Network][az-vnet] as slave nodes.
+in the same [Virtual Network][az-vnet] as Swarm nodes.
 
 #### How to SSH into Swarm Manager Nodes
 
- Swarm manager nodes (`swarm-master-*` VMs) do not
-have public IP addresses. However they are NAT'ted behind an Azure Load
-Balancer. You can SSH into them using the domain name (emitted in the template
-deployment output) or the Public IP address of `swarm-lb-masters` (can be found
-on the Azure Portal).
+Swarm manager nodes (`swarm-master-*` VMs) do not have public IP addresses.
+However they are NAT'ted behind an Azure Load Balancer. You can SSH into them
+using the domain name (emitted in the template deployment output) or the Public
+IP address of `swarm-lb-masters` (can be found on the Azure Portal).
 
 Port numbers of each master VM is described in the following table:
 
@@ -43,31 +42,33 @@ Port numbers of each master VM is described in the following table:
 | `swarm-master-1`  | `ssh <username>@<IP> -p 2201` |
 | `swarm-master-2`  | `ssh <username>@<IP> -p 2202` |
 
-#### Swarm Slave Nodes
+#### Swarm Worker Nodes
 
-You can configure `slaveCount` parameter to create as many instances you like.
-Each Swarm slave VM is of size `Standard_A2`.
+You can configure `nodeCount` parameter to create as many Swarm worker instances
+you like. Each Swarm worker VM is of size `Standard_A2`.
 
-Slave nodes do not have public IP addresses, and are accessible through Swarm
-manager VMs over SSH. In order to access a slave VM, you need to SSH into a
-master VM and use slave VMs private IP address to SSH from there (using the
-same SSH key you used for authenticating into master). Alternatively, you can
-establish an SSH Tunnel on your development machine and directly connect to
-the slave VM using its private IP address.
+Nodes in the Swarm cluster accepting Docker workloads do not have public IP
+addresses, and are accessible through Swarm manager VMs over SSH. In order to
+access a worker node, you need to SSH into a master VM and use worker node VMs
+private IP address to SSH from there (using the same SSH key you used for
+authenticating into master). Alternatively, you can establish an SSH Tunnel on
+your development machine and directly connect to the worker VM using its private
+IP address.
 
-Slave node VMs have private IP addresses `192.168.0.*` and are in the same
-[Virtual Network][az-vnet] with the manager nodes. Slave nodes are in an
-[Availability Set][av-set] to ensure highest uptime and fault domains.
+Virtual Machines of Swarm worker nodes have private IP addresses `192.168.0.*`
+and are in the same [Virtual Network][az-vnet] with the manager nodes. These
+nodes are in an [Availability Set][av-set] to ensure highest uptime and fault
+domains.
 
-Slave node VMs have are behind a load balancer (called `swarm-lb-slaves`). Any
-multi-instance services deployed across slave VMs can be served to the public
-internet by creating probes and load balancing rules on this Load Balancer
-resource. Load balancer's public DNS address is emitted as an output of the
-template deployment.
+The swarm worker VMs node VMs have are behind a load balancer
+(called `swarm-lb-nodes`). Any multi-instance services deployed across worker
+VMs can be served to the public internet by creating probes and load balancing
+rules on this Load Balancer resource. Load balancer's public DNS address is
+emitted as an output of the template deployment.
 
-#### How to SSH into Swarm Slave Nodes
+#### How to SSH into Swarm Worker Nodes
 
-Since Swarm slave VMs do not have public IP addresses, you first need to SSH
+Since Swarm worker nodes do not have public IP addresses, you first need to SSH
 into Swarm manager VMs (described above) to SSH into Swarm nodes.
 
 You just need to use `ssh -A` to SSH into one of the masters, and from that
@@ -79,8 +80,11 @@ $
 $ ssh -A <username>@<masters-IP> -p 2200
 azureuser@swarm-master-0 ~ $ ## <-- You are on Swarm master
 azureuser@swarm-master-0 ~ $ ssh <username>@swarm-node-3
-azureuser@swarm-node-3 ~ $ ## <-- You are now on a Swarm slave
+azureuser@swarm-node-3 ~ $ ## <-- You are now on a Swarm worker node
 ```
+
+The `-A` argument enables forwarding of authentication credentials so that just
+by authenticating to manager VM, you can access Swarm worker VMs from there.
 
 Swarm node hostnames are numbered starting from 0, such as: `swarm-node-0`,
 `swarm-node-1`, ..., `swarm-node-19` etc. You can see the VM names on the

--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -26,36 +26,36 @@
         "description": "Unique DNS Name prefix for the Swarm cluster."
       }
     },
-    "slaveCount": {
+    "nodeCount": {
       "type": "int",
       "defaultValue": 3,
       "metadata": {
-        "description": "Number of Swarm nodes"
+        "description": "Number of Swarm worker nodes in the cluster."
       }
     }
   },
   "variables": {
     "masterCount": 3,
     "vmNameMaster": "swarm-master-",
-    "vmNameSlave": "swarm-node-",
+    "vmNameNode": "swarm-node-",
     "vmSizeMaster": "Standard_A0",
-    "vmSizeSlave": "Standard_A2",
+    "vmSizeNode": "Standard_A2",
     "availabilitySetMasters": "swarm-masters-set",
-    "availabilitySetSlaves": "swarm-nodes-set",
+    "availabilitySetNodes": "swarm-nodes-set",
     "osImagePublisher": "CoreOS",
     "osImageOffer": "CoreOS",
     "osImageSKU": "Stable",
     "managementPublicIPAddrName": "swarm-lb-masters-ip",
-    "slavesPublicIPAddrName": "swarm-lb-slaves-ip",
+    "nodesPublicIPAddrName": "swarm-lb-nodes-ip",
     "virtualNetworkName": "swarm-vnet",
-    "subnetNameMaster": "subnet-masters",
-    "subnetNameSlave": "subnet-slave",
-    "addressPrefixMaster": "10.0.0.0/16",
-    "addressPrefixSlave": "192.168.0.0/16",
-    "subnetPrefixMaster": "10.0.0.0/24",
-    "subnetPrefixSlave": "192.168.0.0/24",
-    "subnetRefMaster": "[concat(resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName')),'/subnets/',variables('subnetNameMaster'))]",
-    "subnetRefSlave": "[concat(resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName')),'/subnets/',variables('subnetNameSlave'))]",
+    "subnetNameMasters": "subnet-masters",
+    "subnetNameNodes": "subnet-nodes",
+    "addressPrefixMasters": "10.0.0.0/16",
+    "addressPrefixNodes": "192.168.0.0/16",
+    "subnetPrefixMasters": "10.0.0.0/24",
+    "subnetPrefixNodes": "192.168.0.0/24",
+    "subnetRefMaster": "[concat(resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName')),'/subnets/',variables('subnetNameMasters'))]",
+    "subnetRefNodes": "[concat(resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName')),'/subnets/',variables('subnetNameNodes'))]",
     "nsgName": "swarm-nsg",
     "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
     "storageAccountType": "Standard_LRS",
@@ -64,10 +64,10 @@
     "mastersLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('mastersLbName'))]",
     "mastersLbIPConfigName": "MastersLBFrontEnd",
     "mastersLbIPConfigID": "[concat(variables('mastersLbID'),'/frontendIPConfigurations/', variables('mastersLbIPConfigName'))]",
-    "mastersLbBackendPoolName": "swarm-master-pool",
-    "slavesLbName": "swarm-lb-slaves",
-    "slavesLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('slavesLbName'))]",
-    "slavesLbBackendPoolName": "swarm-slave-pool",
+    "mastersLbBackendPoolName": "swarm-masters-pool",
+    "nodesLbName": "swarm-lb-nodes",
+    "nodesLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('nodesLbName'))]",
+    "nodesLbBackendPoolName": "swarm-nodes-pool",
     "sshKeyPath": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
     "consulServerArgs": [
       "-advertise 10.0.0.4 -bootstrap-expect 3 -retry-join 10.0.0.5 -retry-join 10.0.0.6",
@@ -94,7 +94,7 @@
     },
     {
       "type": "Microsoft.Compute/availabilitySets",
-      "name": "[variables('availabilitySetSlaves')]",
+      "name": "[variables('availabilitySetNodes')]",
       "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {}
@@ -114,7 +114,7 @@
     {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[variables('slavesPublicIPAddrName')]",
+      "name": "[variables('nodesPublicIPAddrName')]",
       "location": "[resourceGroup().location]",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
@@ -134,24 +134,24 @@
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[variables('addressPrefixMaster')]",
-            "[variables('addressPrefixSlave')]"
+            "[variables('addressPrefixMasters')]",
+            "[variables('addressPrefixNodes')]"
           ]
         },
         "subnets": [
           {
-            "name": "[variables('subnetNameMaster')]",
+            "name": "[variables('subnetNameMasters')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefixMaster')]",
+              "addressPrefix": "[variables('subnetPrefixMasters')]",
               "networkSecurityGroup": {
                 "id": "[variables('nsgID')]"
               }
             }
           },
           {
-            "name": "[variables('subnetNameSlave')]",
+            "name": "[variables('subnetNameNodes')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefixSlave')]",
+              "addressPrefix": "[variables('subnetPrefixNodes')]",
               "networkSecurityGroup": {
                 "id": "[variables('nsgID')]"
               }
@@ -288,11 +288,11 @@
     },
     {
       "apiVersion": "2015-05-01-preview",
-      "name": "[variables('slavesLbName')]",
+      "name": "[variables('nodesLbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('slavesPublicIPAddrName'))]"
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('nodesPublicIPAddrName'))]"
       ],
       "properties": {
         "frontendIPConfigurations": [
@@ -300,14 +300,14 @@
             "name": "LoadBalancerFrontEnd",
             "properties": {
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('slavesPublicIPAddrName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('nodesPublicIPAddrName'))]"
               }
             }
           }
         ],
         "backendAddressPools": [
           {
-            "name": "[variables('slavesLbBackendPoolName')]"
+            "name": "[variables('nodesLbBackendPoolName')]"
           }
         ]
       }
@@ -315,28 +315,28 @@
     {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(variables('vmNameSlave'),copyIndex(), '-nic')]",
+      "name": "[concat(variables('vmNameNode'),copyIndex(), '-nic')]",
       "location": "[resourceGroup().location]",
       "copy": {
-        "name": "nicLoopSlave",
-        "count": "[parameters('slaveCount')]"
+        "name": "nicLoopNode",
+        "count": "[parameters('nodeCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/loadBalancers/', variables('slavesLbName'))]",
+        "[concat('Microsoft.Network/loadBalancers/', variables('nodesLbName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "properties": {
         "ipConfigurations": [
           {
-            "name": "ipConfigSlave",
+            "name": "ipConfigNode",
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[variables('subnetRefSlave')]"
+                "id": "[variables('subnetRefNodes')]"
               },
               "loadBalancerBackendAddressPools": [
                 {
-                  "id": "[concat(variables('slavesLbID'), '/backendAddressPools/', variables('slavesLbBackendPoolName'))]"
+                  "id": "[concat(variables('nodesLbID'), '/backendAddressPools/', variables('nodesLbBackendPoolName'))]"
                 }
               ]
             }
@@ -408,25 +408,25 @@
     {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmNameSlave'), copyIndex())]",
+      "name": "[concat(variables('vmNameNode'), copyIndex())]",
       "location": "[resourceGroup().location]",
       "copy": {
-        "name": "vmLoopSlave",
-        "count": "[parameters('slaveCount')]"
+        "name": "vmLoopNode",
+        "count": "[parameters('nodeCount')]"
       },
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-        "[concat('Microsoft.Network/networkInterfaces/', variables('vmNameSlave'), copyIndex(), '-nic')]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('vmNameNode'), copyIndex(), '-nic')]"
       ],
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetSlaves'))]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets',variables('availabilitySetNodes'))]"
         },
         "hardwareProfile": {
-          "vmSize": "[variables('vmSizeSlave')]"
+          "vmSize": "[variables('vmSizeNode')]"
         },
         "osProfile": {
-          "computername": "[concat(variables('vmNameSlave'), copyIndex())]",
+          "computername": "[concat(variables('vmNameNode'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
@@ -448,9 +448,9 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "[concat(variables('vmNameSlave'), copyIndex(),'-osdisk')]",
+            "name": "[concat(variables('vmNameNode'), copyIndex(),'-osdisk')]",
             "vhd": {
-              "uri": "[concat('http://', parameters('newStorageAccountName'), '.blob.core.windows.net/', variables('vhdBlobContainer'), '/slave-', copyIndex(), '-osdisk.vhd')]"
+              "uri": "[concat('http://', parameters('newStorageAccountName'), '.blob.core.windows.net/', variables('vhdBlobContainer'), '/node-', copyIndex(), '-osdisk.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"
@@ -459,7 +459,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmNameSlave'), copyindex(), '-nic'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmNameNode'), copyindex(), '-nic'))]"
             }
           ]
         }
@@ -471,7 +471,7 @@
       "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "copy": {
-        "name": "extLoopMaster",
+        "name": "extensionLoopMaster",
         "count": "[variables('masterCount')]"
       },
       "dependsOn": [
@@ -520,15 +520,15 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('vmNameSlave'), copyIndex(), '/DockerExtension')]",
+      "name": "[concat(variables('vmNameNode'), copyIndex(), '/DockerExtension')]",
       "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "copy": {
-        "name": "extLoopSlave",
-        "count": "[parameters('slaveCount')]"
+        "name": "extensionLoopNode",
+        "count": "[parameters('nodeCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Compute/virtualMachines/', variables('vmNameSlave'), copyIndex())]"
+        "[concat('Microsoft.Compute/virtualMachines/', variables('vmNameNode'), copyIndex())]"
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
@@ -542,7 +542,7 @@
             "swarm": {
               "image": "swarm:0.4.0",
               "restart": "always",
-              "command": "[concat('join --advertise=', reference(concat(variables('vmNameSlave'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2375 consul://10.0.0.4:8500/nodes')]"
+              "command": "[concat('join --advertise=', reference(concat(variables('vmNameNode'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2375 consul://10.0.0.4:8500/nodes')]"
             }
           }
         }
@@ -558,6 +558,10 @@
       "type": "string",
       "value": "docker -H tcp://localhost:2375 info"
     },
+    "swarmNodesLoadBalancerAddress": {
+      "type": "string",
+      "value": "[reference(variables('nodesPublicIPAddrName')).dnsSettings.fqdn]"
+    },
     "sshMaster0": {
       "type": "string",
       "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -p 2200')]"
@@ -569,10 +573,6 @@
     "sshMaster2": {
       "type": "string",
       "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -p 2202')]"
-    },
-    "SwarmSlavesDNS": {
-      "type": "string",
-      "value": "[reference(variables('slavesPublicIPAddrName')).dnsSettings.fqdn]"
     }
   }
 }

--- a/docker-swarm-cluster/azuredeploy.parameters.json
+++ b/docker-swarm-cluster/azuredeploy.parameters.json
@@ -14,7 +14,7 @@
     "dnsName": {
       "value": "myswarm"
     },
-    "slaveCount": {
+    "nodeCount": {
       "value": 3
     }
   }

--- a/docker-swarm-cluster/metadata.json
+++ b/docker-swarm-cluster/metadata.json
@@ -1,7 +1,7 @@
 {
   "itemDisplayName": "Docker Swarm Cluster",
   "description": "This template creates a high-availability Docker Swarm cluster",
-  "summary": "This template deploys a Docker Swarm with multiple managers and specified number of slave nodes.",
+  "summary": "This template deploys a Docker Swarm with 3 masters and specified number of nodes.",
   "githubUsername": "ahmetalpbalkan",
   "dateUpdated": "2015-07-29"
 }


### PR DESCRIPTION
Mostly naming `slave` → `(worker) node`.

cc: @anhowe as fyi