### PR TITLE
Update Minecraft install script

### DIFF
--- a/minecraft-on-ubuntu/azuredeploy.json
+++ b/minecraft-on-ubuntu/azuredeploy.json
@@ -2,19 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": {
-      "type": "string",
-      "allowedValues": [
-        "West US",
-        "East US",
-        "West Europe",
-        "East Asia",
-        "Southeast Asia"
-      ],
-      "metadata": {
-        "description": "Location of resources"
-      }
-    },
     "minecraftUser": {
       "type": "string",
       "metadata": {
@@ -143,14 +130,15 @@
     "vmSize": "Standard_A1",
     "virtualNetworkName": "minecraftvnet",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "location": "[resourceGroup().location]"
   },
   "resources": [
     {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
@@ -159,7 +147,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "properties": {
         "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
         "dnsSettings": {
@@ -171,7 +159,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -192,7 +180,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -218,7 +206,7 @@
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
@@ -261,7 +249,7 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
       "apiVersion": "2015-05-01-preview",
-      "location": "[parameters('location')]",
+      "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       ],
@@ -273,7 +261,7 @@
           "fileUris": [
             "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"
           ],
-          "commandToExecute": "[concat('sh install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'))]"
+          "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'))]"
         }
       }
     }

--- a/minecraft-on-ubuntu/azuredeploy.parameters.json
+++ b/minecraft-on-ubuntu/azuredeploy.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": {
-      "value": "West US"
-    },
     "minecraftUser": {
       "value": ""
     },

--- a/minecraft-on-ubuntu/install_minecraft.sh
+++ b/minecraft-on-ubuntu/install_minecraft.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Custom Minecraft server install script for Ubuntu 15.04
 # $1 = Minecraft user name
 # $2 = difficulty
@@ -9,6 +9,12 @@
 # $7 = spawn-monsters
 # $8 = generate-structures
 # $9 = level-seed
+
+# basic service and API settings
+minecraft_server_path=/srv/minecraft_server
+minecraft_user=minecraft
+minecraft_group=minecraft
+UUID_URL=https://api.mojang.com/users/profiles/minecraft/$1
 
 # add and update repos
 while ! echo y | apt-get install -y software-properties-common; do
@@ -35,11 +41,10 @@ while ! echo y | apt-get install -y oracle-java8-installer; do
 done
 
 # create user and install folder
-adduser --system --no-create-home --home /srv/minecraft-server minecraft
-addgroup --system minecraft
-adduser minecraft minecraft
-mkdir /srv/minecraft_server
-cd /srv/minecraft_server
+adduser --system --no-create-home --home /srv/minecraft-server $minecraft_user
+addgroup --system $minecraft_group
+mkdir $minecraft_server_path
+cd $minecraft_server_path
 
 # download the server jar
 while ! echo y | wget https://s3.amazonaws.com/Minecraft.Download/versions/1.8/minecraft_server.1.8.jar; do
@@ -48,7 +53,7 @@ while ! echo y | wget https://s3.amazonaws.com/Minecraft.Download/versions/1.8/m
 done
 
 # set permissions on install folder
-chown -R minecraft /srv/minecraft_server
+chown -R $minecraft_user $minecraft_server_path
 
 # adjust memory usage depending on VM size
 totalMem=$(free -m | awk '/Mem:/ { print $2 }')
@@ -59,42 +64,44 @@ else
 fi
 
 # create the uela file
-touch /srv/minecraft_server/eula.txt
-echo 'eula=true' >> /srv/minecraft_server/eula.txt
+touch $minecraft_server_path/eula.txt
+echo 'eula=true' >> $minecraft_server_path/eula.txt
 
 # create a service
 touch /etc/systemd/system/minecraft-server.service
-echo '[Unit]\nDescription=Minecraft Service\nAfter=rc-local.service\n' >> /etc/systemd/system/minecraft-server.service
-echo '[Service]\nWorkingDirectory=/srv/minecraft_server' >> /etc/systemd/system/minecraft-server.service
-printf 'ExecStart=/usr/bin/java -Xms%s -Xmx%s -jar /srv/minecraft_server/minecraft_server.1.8.jar nogui' $memoryAlloc $memoryAlloc  >> /etc/systemd/system/minecraft-server.service
-echo 'ExecReload=/bin/kill -HUP $MAINPID\nKillMode=process\nRestart=on-failure\n' >> /etc/systemd/system/minecraft-server.service
-echo '[Install]\nWantedBy=multi-user.target\nAlias=minecraft-server.service' >> /etc/systemd/system/minecraft-server.service
+printf '[Unit]\nDescription=Minecraft Service\nAfter=rc-local.service\n' >> /etc/systemd/system/minecraft-server.service
+printf '[Service]\nWorkingDirectory=%s\n' $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
+printf 'ExecStart=/usr/bin/java -Xms%s -Xmx%s -jar %s/minecraft_server.1.8.jar nogui\n' $memoryAlloc $memoryAlloc $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
+printf 'ExecReload=/bin/kill -HUP $MAINPID\nKillMode=process\nRestart=on-failure\n' >> /etc/systemd/system/minecraft-server.service
+printf '[Install]\nWantedBy=multi-user.target\nAlias=minecraft-server.service' >> /etc/systemd/system/minecraft-server.service
 
 # create and set permissions on user access JSON files
-touch /srv/minecraft_server/banned-players.json
-chown minecraft:minecraft /srv/minecraft_server/banned-players.json
-touch /srv/minecraft_server/banned-ips.json
-chown minecraft:minecraft /srv/minecraft_server/banned-ips.json
-touch /srv/minecraft_server/whitelist.json
-chown minecraft:minecraft /srv/minecraft_server/whitelist.json
+touch $minecraft_server_path/banned-players.json
+chown $minecraft_user:$minecraft_group $minecraft_server_path/banned-players.json
+touch $minecraft_server_path/banned-ips.json
+chown $minecraft_user:$minecraft_group $minecraft_server_path/banned-ips.json
+touch $minecraft_server_path/whitelist.json
+chown $minecraft_user:$minecraft_group $minecraft_server_path/whitelist.json
 
-# create a valid operators file using the ketrwu.de API
-touch /srv/minecraft_server/ops.json
-chown minecraft:minecraft /srv/minecraft_server/ops.json
-UUID="`wget -q  -O - http://api.ketrwu.de/$1/`"
-sh -c "echo '[\n {\n  \"uuid\":\"$UUID\",\n  \"name\":\"$1\",\n  \"level\":4\n }\n]' >> /srv/minecraft_server/ops.json"
+# create a valid operators file using the Mojang API
+touch $minecraft_server_path/ops.json
+mojang_output="`wget -qO- $UUID_URL`"
+rawUUID=${mojang_output:7:32}
+UUID=${rawUUID:0:8}-${rawUUID:8:4}-${rawUUID:12:4}-${rawUUID:16:4}-${rawUUID:20:12}
+printf '[\n {\n  \"uuid\":\"%s\",\n  \"name\":\"%s\",\n  \"level\":4\n }\n]' $UUID $1 >> $minecraft_server_path/ops.json
+chown $minecraft_user:$minecraft_group $minecraft_server_path/ops.json
 
 # set user preferences in server.properties
-touch /srv/minecraft_server/server.properties
-chown minecraft:minecraft /srv/minecraft_server/server.properties
-# echo 'max-tick-time=-1' >> /srv/minecraft_server/server.properties
-sh -c "echo 'difficulty=$2' >> /srv/minecraft_server/server.properties"
-sh -c "echo 'level-name=$3' >> /srv/minecraft_server/server.properties"
-sh -c "echo 'gamemode=$4' >> /srv/minecraft_server/server.properties"
-sh -c "echo 'white-list=$5' >> /srv/minecraft_server/server.properties"
-sh -c "echo 'enable-command-block=$6' >> /srv/minecraft_server/server.properties"
-sh -c "echo 'spawn-monsters=$7' >> /srv/minecraft_server/server.properties"
-sh -c "echo 'generate-structures=$8' >> /srv/minecraft_server/server.properties"
-sh -c "echo 'level-seed=$9' >> /srv/minecraft_server/server.properties"
+touch $minecraft_server_path/server.properties
+chown $minecraft_user:$minecraft_group $minecraft_server_path/server.properties
+# echo 'max-tick-time=-1' >> $minecraft_server_path/server.properties
+printf 'difficulty=%s\n' $2 >> $minecraft_server_path/server.properties
+printf 'level-name=%s\n' $3 >> $minecraft_server_path/server.properties
+printf 'gamemode=%s\n' $4 >> $minecraft_server_path/server.properties
+printf 'white-list=%s\n' $5 >> $minecraft_server_path/server.properties
+printf 'enable-command-block=%s\n' $6 >> $minecraft_server_path/server.properties
+printf 'spawn-monsters=%s\n' $7 >> $minecraft_server_path/server.properties
+printf 'generate-structures=%s\n' $8 >> $minecraft_server_path/server.properties
+printf 'level-seed=%s\n' $9 >> $minecraft_server_path/server.properties
 
 systemctl start minecraft-server

--- a/minecraft-on-ubuntu/metadata.json
+++ b/minecraft-on-ubuntu/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template deploys and sets up a customized Minecraft server on an Ubuntu Virtual Machine.",
   "summary": "Install Minecraft Server on an Ubuntu VM using the Linux Custom Script Extension",
   "githubUsername": "gbowerman",
-  "dateUpdated": "2015-07-05"
+  "dateUpdated": "2015-09-20"
 }


### PR DESCRIPTION
- Updated Minecraft installer to remove a 3rd party UUID service call which was flaky. This version calls the official Mojang API to generate UUIDs from usernames.
- Removed unnecessary "location" parameter (get it from Resource location instead).
- Switched script from sh to bash to make getting substrings easier.