### PR TITLE
Add SSH rsa public key parameter for all linux vms, and docker to linux jumpbox

### DIFF
--- a/mesos-swarm-marathon/agent-0.json
+++ b/mesos-swarm-marathon/agent-0.json
@@ -115,6 +115,24 @@
       "metadata": {
         "description": "Flag for enabling the Chronos framework."
       }
+    },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
+      }
+    },
+    "omsStorageAccount": {
+      "type": "string",
+      "metadata": {
+        "description": "The storage account for OMS log data."
+      }
+    },
+    "omsStorageAccountKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The storage account primary or secondary key for OMS log data."
+      }
     }
   },
   "variables": {},

--- a/mesos-swarm-marathon/agent-gt0.json
+++ b/mesos-swarm-marathon/agent-gt0.json
@@ -116,6 +116,12 @@
         "description": "Flag for enabling the Chronos framework."
       }
     },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
+      }
+    },
     "omsStorageAccount": {
       "type": "string",
       "metadata": {
@@ -260,7 +266,7 @@
         "typeHandlerVersion": "1.3",
         "settings": {
           "fileUris": [],
-          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('masterCount'), ' slaveconfiguration ', parameters('masterVMNamePrefix'), ' ', parameters('swarmEnabled'), ' ', parameters('marathonEnabled'), ' ', parameters('chronosEnabled'), ' ', parameters('omsStorageAccount'), ' ', parameters('omsStorageAccountKey'), variables('wgetCommandPostfix'))]"
+          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('masterCount'), ' slaveconfiguration ', parameters('masterVMNamePrefix'), ' ', parameters('swarmEnabled'), ' ', parameters('marathonEnabled'), ' ', parameters('chronosEnabled'), ' ', parameters('omsStorageAccount'), ' ', parameters('omsStorageAccountKey'), ' ', parameters('adminUsername'), ' \"', parameters('sshRSAPublicKey'), '\" ', variables('wgetCommandPostfix'))]"
         }
       }
     }

--- a/mesos-swarm-marathon/azuredeploy.json
+++ b/mesos-swarm-marathon/azuredeploy.json
@@ -168,6 +168,13 @@
       "metadata": {
         "description": "Flag for enabling the Chronos framework."
       }
+    },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "defaultValue": "disabled",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
+      }
     }
   },
   "variables": {
@@ -346,6 +353,9 @@
           "chronosEnabled": {
             "value": "[parameters('chronosEnabled')]"
           },
+          "sshRSAPublicKey": {
+            "value": "[parameters('sshRSAPublicKey')]"
+          },
           "omsStorageAccount": {
             "value": "[variables('omsStorageAccount')]"
           },
@@ -426,6 +436,9 @@
           "chronosEnabled": {
             "value": "[parameters('chronosEnabled')]"
           },
+          "sshRSAPublicKey": {
+            "value": "[parameters('sshRSAPublicKey')]"
+          },
           "omsStorageAccount": {
             "value": "[variables('omsStorageAccount')]"
           },
@@ -482,6 +495,9 @@
           },
           "masterVMNamePrefix": {
             "value": "[variables('masterVMNamePrefix')]"
+          },
+          "sshRSAPublicKey": {
+            "value": "[parameters('sshRSAPublicKey')]"
           }
         }
       }

--- a/mesos-swarm-marathon/azuredeploy.parameters.json
+++ b/mesos-swarm-marathon/azuredeploy.parameters.json
@@ -46,5 +46,8 @@
   },
   "chronosEnabled": {
     "value": "true"
+  },
+  "sshRSAPublicKey": {
+    "value": "disabled"
   }
 }

--- a/mesos-swarm-marathon/configure-ubuntu.sh
+++ b/mesos-swarm-marathon/configure-ubuntu.sh
@@ -11,11 +11,33 @@ ps axjf
 #############
 
 AZUREUSER=$1
+SSHKEY=$2
 HOMEDIR="/home/$AZUREUSER"
 VMNAME=`hostname`
 echo "User: $AZUREUSER"
 echo "User home dir: $HOMEDIR"
 echo "vmname: $VMNAME"
+
+###################
+# setup ssh access
+###################
+
+SSHDIR=$HOMEDIR/.ssh
+AUTHFILE=$SSHDIR/authorized_keys
+if [ `echo $SSHKEY | sed 's/^\(ssh-rsa \).*/\1/'` == "ssh-rsa" ] ; then
+  if [ ! -d $SSHDIR ] ; then
+    sudo -i -u $AZUREUSER mkdir $SSHDIR
+    sudo -i -u $AZUREUSER chmod 700 $SSHDIR
+  fi
+
+  if [ ! -e $AUTHFILE ] ; then
+    sudo -i -u $AZUREUSER touch $AUTHFILE
+    sudo -i -u $AZUREUSER chmod 600 $AUTHFILE
+  fi
+  echo $SSHKEY | sudo -i -u $AZUREUSER tee -a $AUTHFILE
+else
+  echo "no valid key data"
+fi
 
 ###################
 # Common Functions
@@ -64,6 +86,43 @@ ensureAzureNetwork()
   fi
 }
 ensureAzureNetwork
+
+################
+# Install Docker
+################
+
+echo "Installing and configuring docker and swarm"
+
+time wget -qO- https://get.docker.com | sh
+
+# Start Docker and listen on :2375 (no auth, but in vnet)
+echo 'DOCKER_OPTS="-H unix:///var/run/docker.sock -H 0.0.0.0:2375"' | sudo tee /etc/default/docker
+# the following insecure registry is for OMS
+echo 'DOCKER_OPTS="$DOCKER_OPTS --insecure-registry 137.135.93.9"' | sudo tee -a /etc/default/docker
+sudo service docker restart
+
+ensureDocker()
+{
+  # ensure that docker is healthy
+  dockerHealthy=1
+  for i in {1..3}; do
+    sudo docker info
+    if [ $? -eq 0 ]
+    then
+      # hostname has been found continue
+      dockerHealthy=0
+      echo "Docker is healthy"
+      sudo docker ps -a
+      break
+    fi
+    sleep 10
+  done
+  if [ $dockerHealthy -ne 0 ]
+  then
+    echo "Docker is not healthy"
+  fi
+}
+ensureDocker
 
 ###################################################
 # Update Ubuntu and install all necessary binaries

--- a/mesos-swarm-marathon/jumpbox-linux.json
+++ b/mesos-swarm-marathon/jumpbox-linux.json
@@ -67,6 +67,12 @@
       "metadata": {
         "description": "The vm name prefix of the master"
       }
+    },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
+      }
     }
   },
   "variables": {
@@ -173,7 +179,7 @@
         "type": "CustomScriptForLinux",
         "typeHandlerVersion": "1.3",
         "settings": {
-          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('adminUsername'), variables('wgetCommandPostfix'))]"
+          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('adminUsername'), ' \"', parameters('sshRSAPublicKey'), '\" ', variables('wgetCommandPostfix'))]"
         }
       }
     }

--- a/mesos-swarm-marathon/jumpbox-none.json
+++ b/mesos-swarm-marathon/jumpbox-none.json
@@ -67,6 +67,12 @@
       "metadata": {
         "description": "The vm name prefix of the master"
       }
+    },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure the machines"
+      }
     }
   },
   "variables": {},

--- a/mesos-swarm-marathon/master.json
+++ b/mesos-swarm-marathon/master.json
@@ -116,6 +116,12 @@
         "description": "Flag for enabling the Chronos framework."
       }
     },
+    "sshRSAPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH rsa public key string.  Use 'disabled' to not configure access with SSH rsa public key."
+      }
+    },
     "omsStorageAccount": {
       "type": "string",
       "metadata": {
@@ -355,7 +361,7 @@
         "typeHandlerVersion": "1.3",
         "settings": {
           "fileUris": [],
-          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('masterCount'), ' ', parameters('masterConfiguration'), ' ', parameters('masterVMNamePrefix'), ' ', parameters('swarmEnabled'), ' ', parameters('marathonEnabled'), ' ', parameters('chronosEnabled'), ' ', parameters('omsStorageAccount'), ' ', parameters('omsStorageAccountKey'), variables('wgetCommandPostfix'))]"
+          "commandToExecute": "[concat(variables('commandPrefix'), variables('wgetCommandPrefix'), parameters('masterCount'), ' ', parameters('masterConfiguration'), ' ', parameters('masterVMNamePrefix'), ' ', parameters('swarmEnabled'), ' ', parameters('marathonEnabled'), ' ', parameters('chronosEnabled'), ' ', parameters('omsStorageAccount'), ' ', parameters('omsStorageAccountKey'), ' ', parameters('adminUsername'), ' \"', parameters('sshRSAPublicKey'), '\" ', variables('wgetCommandPostfix'))]"
         }
       }
     }


### PR DESCRIPTION
- enable the user to specify an ssh public key through the parameter.  The reason this is done through the script is to provide the user the option, and the normal method highlighted in https://github.com/anhowe/scratch/tree/master/linuxvm does not provide this option.
- add docker to linux jumpbox

@ahmetalpbalkan, @rgardler