### PR TITLE
CreateUiDefinition Fix for Thinkbox Deadline

### DIFF
--- a/thinkbox-deadline/createUiDefinition.json
+++ b/thinkbox-deadline/createUiDefinition.json
@@ -31,24 +31,39 @@
         "steps": 
         [
             {
-                "name": "configuration",
-                "label": "Additional Configuration",
+                "name": "infrastructureConfig",
+                "label": "Infrastructure settings",
                 "subLabel": 
                 {
-                    "preValidation": "Configure additional settings",
+                    "preValidation": "Configure the infrastructure settings",
                     "postValidation": "Done"
                 },
-                "bladeTitle": "Infrastructure Settings",
+                "bladeTitle": "Infrastructure settings",
                 "elements":
                 [
                     {
+                        "name": "clusterName",
+                        "type": "Microsoft.Common.TextBox",
+                        "label": "Cluster Prefix",
+                        "defaultValue": "dl",
+                        "toolTip": "Prefix for everything this template creates.",
+                        "constraints": 
+                        {
+                            "required": true,
+                            "regex": "^[a-z0-9]{1,30}$",
+                            "validationMessage": "Only lowercase alphanumeric characters are allowed, and the value must be 1-30 characters long."
+                        },
+                        "options": {}
+                    },
+                    {
                         "name": "slaveCount",
                         "type": "Microsoft.Common.DropDown",
+                        "label": "Number of Slave VMs",
                         "defaultValue": "2",
-                        "toolTip": "Number of Slave Instances to start.",
-                        "constraints":
+                        "toolTip": "",
+                        "constraints": 
                         {
-                            "allowedValues":
+                            "allowedValues": 
                             [
                                 {
                                     "label": "2",
@@ -72,35 +87,43 @@
                     {
                         "name": "storageAccount",
                         "type": "Microsoft.Storage.StorageAccountSelector",
-                        "label": "Storage Account",
-                        "defaultValue":
+                        "label": "Storage account",
+                        "defaultValue": 
                         {
                             "type": "Standard_LRS"
                         }
                     },
                     {
-                        "name": "dnsName",
+                        "name": "publicDnsName",
                         "type": "Microsoft.Common.TextBox",
-                        "label": "DNS Name",
-                        "toolTip": "The DNS name for the virtual network.",
-                        "constraints":
+                        "label": "Public DNS Name",
+                        "defaultValue": "",
+                        "toolTip": "",
+                        "constraints": 
                         {
-                            "required": true
-                        }
+                            "required": true,
+                            "regex": "^[a-z0-9]{1,30}$",
+                            "validationMessage": "Only lowercase alphanumeric characters are allowed, and the value must be 1-30 characters long."
+                        },
+                        "options": {}
                     },
                     {
-                        "name": "repositorySize",
+                        "name": "repositoryVMSize",
                         "type": "Microsoft.Compute.SizeSelector",
-                        "label": "Repository VM Size",
-                        "toolTip": "The size of the virtual machine that contains the repository.",
-                        "recommendedSizes":
-                        [
+                        "label": "Repository Virtual machine size",
+                        "toolTip": "The size of the virtual machine for the repository and mongo database.",
+                        "recommendedSizes": [
                             "Standard_D1",
                             "Standard_D2",
                             "Standard_D3"
                         ],
                         "constraints": {
                             "allowedSizes": [
+                              "Standard_A1",
+                              "Standard_A2",
+                              "Standard_A3",
+                              "Standard_A4",
+                              "Standard_A11",
                               "Standard_D1",
                               "Standard_D2",
                               "Standard_D3",
@@ -112,27 +135,30 @@
                             ]
                         },
                         "osPlatform": "Windows",
-                        "imageReference":
-                        {
-                            "publisher": "thinkboxsoftware",
+                        "imageReference": {
+                            "publisher": "thinkbox",
                             "offer": "deadline7-2",
                             "sku": "deadline-repository-7-2"
                         },
                         "count": 1
                     },
                     {
-                        "name": "slaveSize",
+                        "name": "slaveVMSize",
                         "type": "Microsoft.Compute.SizeSelector",
-                        "label": "Slave VM Size",
-                        "toolTip": "The size of the virtual machines that have the slave on them.",
-                        "recommendedSizes":
-                        [
-                            "Standard_D1",
-                            "Standard_D2",
-                            "Standard_D3"
+                        "label": "Slave Virtual machine size",
+                        "toolTip": "The size of the virtual machine for the slaves.",
+                        "recommendedSizes": [
+                            "Standard_A1",
+                            "Standard_A2",
+                            "Standard_A3"
                         ],
                         "constraints": {
                             "allowedSizes": [
+                              "Standard_A1",
+                              "Standard_A2",
+                              "Standard_A3",
+                              "Standard_A4",
+                              "Standard_A11",
                               "Standard_D1",
                               "Standard_D2",
                               "Standard_D3",
@@ -144,13 +170,12 @@
                             ]
                         },
                         "osPlatform": "Windows",
-                        "imageReference":
-                        {
-                            "publisher": "thinkboxsoftware",
+                        "imageReference": {
+                            "publisher": "thinkbox",
                             "offer": "deadline7-2",
                             "sku": "deadline-slave-7-2"
                         },
-                        "count": "[steps('configuration').slaveCount]"
+                        "count": "[steps('infrastructureConfig').slaveCount]"
                     }
                 ]
             }
@@ -158,13 +183,14 @@
         "outputs": 
         {
             "location": "[location()]",
-            "adminUsername": "[steps('basic').adminUsername]",
-            "adminPassword": "[steps('basic').adminPassword]",
-            "numberOfSlaves": "[steps('configuration').slaveCount]",
-            "publicDnsName": "[steps('configuration').dnsName]",
-            "newStorageAccount": "[steps('configuration').storageAccount.name]",
-            "repositorySize": "[steps('configuration').repositorySize",
-            "slaveSize": "[steps('configuration').slaveSize"
+            "adminUsername": "[steps('infrastructureConfig').adminUsername]",
+            "adminPassword": "[steps('infrastructureConfig').adminPassword]",
+            "newStorageAccount": "[steps('infrastructureConfig').storageAccount.name]",
+            "publicDnsName": "[steps('infrastructureConfig').publicDnsName]",
+            "clusterName": "[steps('infrastructureConfig').clusterName]",
+            "repositoryVMSize": "[steps('infrastructureConfig').repositoryVMSize]",
+            "slaveVMSize": "[steps('infrastructureConfig').slaveVMSize]",
+            "numberOfSlaves": "[steps('infrastructureConfig').slaveCount]"
         }
     }
 }


### PR DESCRIPTION
Did a lot of work on the createUiDefinition.json file for the thinkbox multi-vm template. 

This line is odd: "adminUsername": "[steps('infrastructureConfig').adminUsername]". I get an error I change it to steps('basic') but the summary page looks fine with infrastrucutreConfig.   


Seems to work with
https://portal.azure.com/?clientOptimizations=false#blade/Microsoft_Azure_Compute/CreateMultiVmWizardBlade/internal_bladeCallId/anything/internal_bladeCallerParams/{"initialData":{},"providerConfig":{"createUiDefinition":"https%3A%2F%2Fdeadline.blob.core.windows.net%2Fscripts%2FcreateUiDefinition.json"}}