### PR TITLE
updated diskraid example and shared disk provisioning utility script

### DIFF
--- a/diskraid-ubuntu-vm/azuredeploy.json
+++ b/diskraid-ubuntu-vm/azuredeploy.json
@@ -92,7 +92,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[parameters('location')]",
@@ -116,16 +116,16 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "properties": {
         "accountType": "Standard_LRS"
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
@@ -146,7 +146,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "publicIp",
       "location": "[parameters('location')]",
@@ -158,7 +158,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "nic",
       "location": "[parameters('location')]",
@@ -188,7 +188,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "myvm",
       "location": "[parameters('location')]",
@@ -250,27 +250,29 @@
             }
           ]
         }
-      }
-    },
-    {
-      "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat('myvm', '/azureVmUtils')]",
-      "apiVersion": "2015-05-01-preview",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Compute/virtualMachines/', 'myvm')]"
-      ],
-      "properties": {
-        "publisher": "Microsoft.OSTCExtensions",
-        "type": "CustomScriptForLinux",
-        "typeHandlerVersion": "1.2",
-        "settings": {
-          "fileUris": [
-            "[variables('scriptUrl')]"
+      },
+      "resources": [
+        {
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "[concat('myvm', '/azureVmUtils')]",
+          "apiVersion": "2015-06-15",
+          "location": "[parameters('location')]",
+          "dependsOn": [
+            "[concat('Microsoft.Compute/virtualMachines/', 'myvm')]"
           ],
-          "commandToExecute": "bash vm-disk-utils-0.1.sh -s"
+          "properties": {
+            "publisher": "Microsoft.OSTCExtensions",
+            "type": "CustomScriptForLinux",
+            "typeHandlerVersion": "1.2",
+            "settings": {
+              "fileUris": [
+                "[variables('scriptUrl')]"
+              ],
+              "commandToExecute": "bash vm-disk-utils-0.1.sh -s"
+            }
+          }
         }
-      }
+      ]
     }
   ]
 }

--- a/diskraid-ubuntu-vm/metadata.json
+++ b/diskraid-ubuntu-vm/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template creates a virtual machine with multiple disks attached.  A script partitions and formats the disks in raid0 array.",
   "summary": "Create Ubuntu vm with multiple data disks formatted as raid0 disk array",
   "githubUsername": "trentmswanson",
-  "dateUpdated": "2015-04-08"
+  "dateUpdated": "2015-10-01"
 }

--- a/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
+++ b/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
@@ -300,7 +300,8 @@ create_striped_volume()
 check_mdadm() {
     dpkg -s mdadm >/dev/null 2>&1
     if [ ${?} -ne 0 ]; then
-        DEBIAN_FRONTEND=noninteractive apt-get -y install mdadm
+        apt-get -y update
+        DEBIAN_FRONTEND=noninteractive apt-get -y install mdadm --fix-missing
     fi
 }
 


### PR DESCRIPTION
When using -s option to stripe the data disks we install mdadm.
* run `apt-get update` prior to mdadm install
* As requested I have included `--fix-missing` as a potential fix for issue #647

The ubuntu diskraid example has also been updated to the recent Compute/Network apiVersion.
