### PR TITLE
Kibana+Elasticsearch in docker containers template

### DIFF
--- a/docker-kibana-elasticsearch/README.md
+++ b/docker-kibana-elasticsearch/README.md
@@ -1,0 +1,15 @@
+# Deployment of Kibana+Elasticsearch Containers with Docker Compose
+
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fymartel06%2Fazure-quickstart-templates%2Fmaster%2Fdocker-kibana-elasticsearch%2Fazuredeploy.json" target="_blank">
+	<img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+This template allows you to deploy an Ubuntu Server 15.04 VM with Docker (using the [Docker Extension][ext])
+and starts a Kibana container listening on port 5601 which uses Elasticsearch database running
+in a separate but linked Docker container, which are created using [Docker Compose][compose]
+capabilities of the [Azure Docker Extension][ext].
+
+
+[ext]: https://github.com/Azure/azure-docker-extension
+[compose]: https://docs.docker.com/compose

--- a/docker-kibana-elasticsearch/azuredeploy.json
+++ b/docker-kibana-elasticsearch/azuredeploy.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
+      }
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "The location where the Virtual Machine will be deployed."
+      },
+      "allowedValues": [
+        "West US",
+        "East US",
+        "Southeast Asia",
+        "East Asia",
+        "West Europe"
+      ]
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
+    },
+    "dnsNameForPublicIP": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+      }
+    }
+  },
+  "variables": {
+    "imagePublisher": "Canonical",
+    "imageOffer": "UbuntuServer",
+    "ubuntuOSVersion": "15.04",
+    "OSDiskName": "osdiskfordockersimple",
+    "nsgName": "myNSG",
+    "nicName": "myVMNic",
+    "extensionName": "DockerExtension",
+    "addressPrefix": "10.0.0.0/16",
+    "subnetName": "Subnet",
+    "subnetPrefix": "10.0.0.0/24",
+    "storageAccountType": "Standard_LRS",
+    "publicIPAddressName": "myPublicIP",
+    "publicIPAddressType": "Dynamic",
+    "vmStorageAccountContainerName": "vhds",
+    "vmName": "MyDockerVM",
+    "vmSize": "Standard_D1",
+    "virtualNetworkName": "MyVNET",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('newStorageAccountName')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[parameters('location')]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[variables('nsgID')]"
+      ],
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[variables('nsgID')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('nsgName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "http",
+            "properties": {
+              "description": "Allow HTTP",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "5601",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "ssh",
+            "properties": {
+              "description": "Allow SSH",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[variables('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('ubuntuOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk1",
+            "vhd": {
+              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmName'),'/', variables('extensionName'))]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "DockerExtension",
+        "typeHandlerVersion": "1.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "compose": {
+            "elasticsearch": {
+              "image": "elasticsearch",
+              "ports": [
+                "9200:9200"
+              ]
+            },
+            "kibana": {
+              "image": "kibana",
+              "ports": [
+                "5601:5601"
+              ],
+              "links": [
+                "elasticsearch:elasticsearch"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docker-kibana-elasticsearch/azuredeploy.parameters.json
+++ b/docker-kibana-elasticsearch/azuredeploy.parameters.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newStorageAccountName": {
+      "value": "unqiueStorageAccount"
+    },
+    "location": {
+      "value": "West US"
+    },
+    "adminUsername": {
+      "value": "userName"
+    },
+    "adminPassword": {
+      "value": "password"
+    },
+    "dnsNameForPublicIP": {
+      "value": "uniqueDNS"
+    }
+  }
+}

--- a/docker-kibana-elasticsearch/metadata.json
+++ b/docker-kibana-elasticsearch/metadata.json
@@ -1,5 +1,5 @@
 {
-  "itemDisplayName": "Deploy a Kiabana dashboard with Docker",
+  "itemDisplayName": "Deploy a Kibana dashboard with Docker",
   "description": "This template allows you to deploy an Ubuntu VM with Docker installed (using the Docker Extension) and Kibana/Elasticsearch containers created and configured to serve an analytic dashboard.",
   "summary": "Deploy a Kibana dashboard using Docker",
   "githubUsername": "ymartel06",

--- a/docker-kibana-elasticsearch/metadata.json
+++ b/docker-kibana-elasticsearch/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Deploy a Kiabana dashboard with Docker",
+  "description": "This template allows you to deploy an Ubuntu VM with Docker installed (using the Docker Extension) and Kibana/Elasticsearch containers created and configured to serve an analytic dashboard.",
+  "summary": "Deploy a Kibana dashboard using Docker",
+  "githubUsername": "ymartel06",
+  "dateUpdated": "2015-10-07"
+}


### PR DESCRIPTION
This template allows to deploy an Ubuntu Server 15.04 VM with Docker and starts a Kibana container listening on port 5601 which uses Elasticsearch database.