### PR TITLE
Adding ‘tolower’ function to public IP and storage account parameters…

### DIFF
--- a/mesos-swarm-marathon/azuredeploy.json
+++ b/mesos-swarm-marathon/azuredeploy.json
@@ -178,6 +178,7 @@
     }
   },
   "variables": {
+    "newStorageAccountNamePrefix": "[tolower(parameters('newStorageAccountNamePrefix'))]",
     "masterVMNamePrefix": "[concat(parameters('clusterPrefix'),'master')]",
     "agentVMNamePrefix": "[concat(parameters('clusterPrefix'),'agent')]",
     "jumpboxVMNamePrefix": "[concat(parameters('clusterPrefix'),'jumpbox')]",
@@ -209,7 +210,7 @@
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[concat(parameters('newStorageAccountNamePrefix'),'0')]",
+      "name": "[concat(variables('newStorageAccountNamePrefix'),'0')]",
       "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -286,7 +287,7 @@
       "type": "Microsoft.Resources/deployments",
       "name": "createMasterNodes",
       "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountNamePrefix'), '0')]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountNamePrefix'), '0')]",
         "[variables('vnetID')]"
       ],
       "properties": {
@@ -297,7 +298,7 @@
         },
         "parameters": {
           "newStorageAccountName": {
-            "value": "[concat(parameters('newStorageAccountNamePrefix'), '0')]"
+            "value": "[concat(variables('newStorageAccountNamePrefix'), '0')]"
           },
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
@@ -306,7 +307,7 @@
             "value": "[parameters('adminPassword')]"
           },
           "dnsNameForContainerServicePublicIP": {
-            "value": "[parameters('dnsNameForContainerServicePublicIP')]"
+            "value": "[tolower(parameters('dnsNameForContainerServicePublicIP'))]"
           },
           "masterVMSize": {
             "value": "[parameters('masterVMSize')]"
@@ -380,7 +381,7 @@
         },
         "parameters": {
           "newStorageAccountNamePrefix": {
-            "value": "[concat(parameters('newStorageAccountNamePrefix'))]"
+            "value": "[concat(variables('newStorageAccountNamePrefix'))]"
           },
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
@@ -464,7 +465,7 @@
         },
         "parameters": {
           "newStorageAccountName": {
-            "value": "[concat(parameters('newStorageAccountNamePrefix'), '0')]"
+            "value": "[concat(variables('newStorageAccountNamePrefix'), '0')]"
           },
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
@@ -473,7 +474,7 @@
             "value": "[parameters('adminPassword')]"
           },
           "dnsNameForJumpboxPublicIP": {
-            "value": "[parameters('dnsNameForJumpboxPublicIP')]"
+            "value": "[tolower(parameters('dnsNameForJumpboxPublicIP'))]"
           },
           "jumpboxVMSize": {
             "value": "[parameters('jumpboxVMSize')]"


### PR DESCRIPTION
Adding ‘tolower’ function to public IP and storage account parameters, this prevents deployment failure if the parameter values are entered in UCase.