### PR TITLE
Add "nodiscard" to mkfs command in vm-disk-utils-0.1.sh

### DIFF
--- a/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
+++ b/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
@@ -288,7 +288,7 @@ create_striped_volume()
 	PARTITIONSNUM=${#PARTITIONS[@]}
 	STRIPEWIDTH=$((${STRIDE} * ${PARTITIONSNUM}))
 
-	mkfs.ext4 -b 4096 -E stride=${STRIDE},stripe-width=${STRIPEWIDTH} "${MDDEVICE}"
+	mkfs.ext4 -b 4096 -E stride=${STRIDE},stripe-width=${STRIPEWIDTH},nodiscard "${MDDEVICE}"
 
 	read UUID FS_TYPE < <(blkid -u filesystem ${MDDEVICE}|awk -F "[= ]" '{print $3" "$5}'|tr -d "\"")
 


### PR DESCRIPTION
Hi! I have added -E nodiscard to the mkfs options, which speeds up disk initialization noticeably.
c.f. http://manpages.ubuntu.com/manpages/utopic/en/man8/mkfs.ext4.8.html