### PR TITLE
removed extra character

### DIFF
--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -233,7 +233,7 @@
             "type": "CustomScriptForLinux",
             "typeHandlerVersion": "1.2",
             "settings": {
-              "fileUris": "[[variables('ubuntuScripts')]",
+              "fileUris": "[variables('ubuntuScripts')]",
               "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -yn ', variables('esSettings').clusterName, ' -v ', variables('esSettings').version, ' -d ', variables('esSettings').discoveryHosts)]"
             }
           },


### PR DESCRIPTION
Removed an extra '[' character causing failure when attempting to provision a topology with client nodes