### PR TITLE
docker-swarm: Remove dnsName parameter, auto-generate

### DIFF
--- a/docker-swarm-cluster/README.md
+++ b/docker-swarm-cluster/README.md
@@ -49,9 +49,9 @@ Port numbers of each master VM is described in the following table:
 
 | VM   | SSH command |
 |:--- |:---|
-| `swarm-master-0`  | `ssh <username>@<IP> -p 2200` |
-| `swarm-master-1`  | `ssh <username>@<IP> -p 2201` |
-| `swarm-master-2`  | `ssh <username>@<IP> -p 2202` |
+| `swarm-master-0`  | `ssh <username>@<addr> -p 2200` |
+| `swarm-master-1`  | `ssh <username>@<addr> -p 2201` |
+| `swarm-master-2`  | `ssh <username>@<addr> -p 2202` |
 
 #### Swarm Worker Nodes
 
@@ -120,7 +120,7 @@ If the template successfully deploys, it will have output values
 The `sshTunnelCmd` command will help you create a SSH tunnel to Docker Swarm
 Manager from your machine (this command will keep running with no output):
 
-    $ ssh -L 2375:swarm-master-0:2375 -N core@<<DNSNAME>>-manage.westus.cloudapp.azure.com -p 2200
+    $ ssh -L 2375:swarm-master-0:2375 -N core@swarm-<<DNSNAME>>-manage.westus.cloudapp.azure.com -p 2200
 
 After this you can use `dockerCmd` command that points to localhost, just as
 Swarm managers were running on your development machine:

--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -14,12 +14,6 @@
         "description": "SSH public key for the Virtual Machines."
       }
     },
-    "dnsName": {
-      "type": "string",
-      "metadata": {
-        "description": "Unique DNS Name prefix for the Swarm cluster."
-      }
-    },
     "nodeCount": {
       "type": "int",
       "defaultValue": 3,
@@ -53,6 +47,7 @@
     "nsgName": "swarm-nsg",
     "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
     "newStorageAccountName": "[uniqueString(resourceGroup().id, deployment().name)]",
+    "clusterFqdn": "[concat('swarm-',uniqueString(resourceGroup().id, deployment().name))]",
     "storageAccountType": "Standard_LRS",
     "vhdBlobContainer": "vhds",
     "mastersLbName": "swarm-lb-masters",
@@ -102,7 +97,7 @@
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
-          "domainNameLabel": "[concat(parameters('dnsName'), '-manage')]"
+          "domainNameLabel": "[concat(variables('clusterFqdn'), '-manage')]"
         }
       }
     },
@@ -114,7 +109,7 @@
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
-          "domainNameLabel": "[parameters('dnsName')]"
+          "domainNameLabel": "[variables('clusterFqdn')]"
         }
       }
     },

--- a/docker-swarm-cluster/azuredeploy.parameters.json
+++ b/docker-swarm-cluster/azuredeploy.parameters.json
@@ -8,9 +8,6 @@
     "sshPublicKey": {
       "value": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAVUjb+H+bQgargG0Ew42/KjjIrJ4Vqwp8X3PKDCS7udZE8rTKx0ah8EfsVcSpzgHMOg2Dx/EBjF5/fE3QUwd8GCe1pNi875/Cf2CEfuQNhoxs+zXTdrVnaa6AnZszFHnPSS7QMhWA8lhjF4N2GCRQDDd3e45qNMc4TsNLz4dS90SNwNVbCyQnme46NTS5Fk2AbiJ5YqWF1UhEpUAdsWFsCRVQAHjH3Y57b2jk3RJJ9UFYQ5Trlow4ocOYEfsUGmr3yNFiIxlZC/sfx6WKoBxCOJhv/NJr0ow65zp/TC85IeDK5h8Jedd5UT2umdZDp4dbGhW0Aus2Md8yWE80/M9f replace_this_with_your@id_rsa.pub"
     },
-    "dnsName": {
-      "value": "swarm-#####"
-    },
     "nodeCount": {
       "value": 3
     }


### PR DESCRIPTION
Looks like we can even get rid of user-provided DNS names and
use `uniqueString` to generate that consistently from resource
group and deployment name.

This now produces DNS names such as
`swarm-fgd27vb3n5gn6.westus.cloudapp.azure.com` but nobody really
runs a public website like that anyway, so I think it's fine.

It also saves the user from another confusing parameter that has strict
validation checks.

cc: @rgardler @anhowe