### PR TITLE
Stray commas were breaking JSON validation

### DIFF
--- a/101-application-gateway-public-ip-ssl-offload/azuredeploy.json
+++ b/101-application-gateway-public-ip-ssl-offload/azuredeploy.json
@@ -193,8 +193,8 @@
                     },
                     "backendHttpSettings": {
                         "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
-                    },
-                },
+                    }
+                }
             }]
         }
     }]


### PR DESCRIPTION
The template JSON was not valid due to stray commas