### PR TITLE
Changed PowerShell DSC extension versions from 1.0-2.3 to v2.8 

### DIFF
--- a/201-vm-domain-join/azuredeploy.json
+++ b/201-vm-domain-join/azuredeploy.json
@@ -248,7 +248,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "1.9",
+            "typeHandlerVersion": "2.8",
             "settings": {
               "ModulesUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/active-directory-new-domain/CreateADPDC.ps1.zip",
               "ConfigurationFunction": "CreateADPDC.ps1\\CreateADPDC",
@@ -391,7 +391,7 @@
       "properties": {
         "publisher": "Microsoft.Powershell",
         "type": "DSC",
-        "typeHandlerVersion": "1.9",
+        "typeHandlerVersion": "2.8",
         "settings": {
           "ModulesUrl": "[concat(parameters('assetLocation'),'/Configuration.zip')]",
           "ConfigurationFunction": "Configuration.ps1\\DomainJoin",

--- a/active-directory-new-domain-ha-2-dc/azuredeploy.json
+++ b/active-directory-new-domain-ha-2-dc/azuredeploy.json
@@ -500,7 +500,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "1.7",
+            "typeHandlerVersion": "2.8",
             "settings": {
               "ModulesUrl": "[variables('adPDCModulesURL')]",
               "ConfigurationFunction": "[variables('adPDCConfigurationFunction')]",
@@ -682,7 +682,7 @@
       "properties": {
         "publisher": "Microsoft.Powershell",
         "type": "DSC",
-        "typeHandlerVersion": "1.7",
+        "typeHandlerVersion": "2.8",
         "settings": {
           "ModulesUrl": "[variables('adBDCModulesURL')]",
           "ConfigurationFunction": "[variables('adBDCConfigurationFunction')]",

--- a/active-directory-new-domain/azuredeploy.json
+++ b/active-directory-new-domain/azuredeploy.json
@@ -417,7 +417,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "1.7",
+            "typeHandlerVersion": "2.8",
             "settings": {
               "ModulesUrl": "[variables('adModulesURL')]",
               "ConfigurationFunction": "[variables('adConfigurationFunction')]",

--- a/active-directory-new-domain/azuredeploy.parameters.json
+++ b/active-directory-new-domain/azuredeploy.parameters.json
@@ -18,7 +18,7 @@
       "value": "somePass"
     },
     "adVMSize": {
-      "value": "Standard_A2"
+      "value": "Standard_D2"
     },
     "domainName": {
       "value": "testName"

--- a/dsc-extension-iis-server-windows-vm/azuredeploy.json
+++ b/dsc-extension-iis-server-windows-vm/azuredeploy.json
@@ -214,7 +214,7 @@
       "properties": {
         "publisher": "Microsoft.Powershell",
         "type": "DSC",
-        "typeHandlerVersion": "1.9",
+        "typeHandlerVersion": "2.8",
         "settings": {
           "ModulesUrl": "[parameters('modulesUrl')]",
           "SasToken": "",

--- a/dsc-extension-iis-server-windows-vm/azuredeploy.parameters.json
+++ b/dsc-extension-iis-server-windows-vm/azuredeploy.parameters.json
@@ -3,13 +3,13 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "newStorageAccountName": {
-      "value": ""
+      "value": "uniqueAccount"
     },
     "location": {
       "value": "West US"
     },
     "vmName": {
-      "value": ""
+      "value": "iisservervm"
     },
     "vmSize": {
       "value": "Standard_A2"

--- a/dsc-pullserver-to-win-server/azuredeploy.json
+++ b/dsc-pullserver-to-win-server/azuredeploy.json
@@ -232,7 +232,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "1.9",
+            "typeHandlerVersion": "2.8",
             "settings": {
               "modulesUrl": "[variables('deployDSCPullServerConfigurationFile')]",
               "configurationFunction": "[variables('deployDSCPullServerConfigurationFunction')]",

--- a/rds-deployment/azuredeploy.json
+++ b/rds-deployment/azuredeploy.json
@@ -269,7 +269,7 @@
                     "properties": {
                         "publisher": "Microsoft.Powershell",
                         "type": "DSC",
-                        "typeHandlerVersion": "1.10",
+                        "typeHandlerVersion": "2.8",
                         "settings": {
                             "ModulesUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/active-directory-new-domain/CreateADPDC.ps1.zip",
                             "ConfigurationFunction": "CreateADPDC.ps1\\CreateADPDC",
@@ -469,7 +469,7 @@
                     "properties": {
                         "publisher": "Microsoft.Powershell",
                         "type": "DSC",
-                        "typeHandlerVersion": "2.1",
+                        "typeHandlerVersion": "2.8",
                         "settings": {
                             "ModulesUrl": "[concat(parameters('assetLocation'),'/Configuration.zip')]",
                             "ConfigurationFunction": "Configuration.ps1\\Gateway",
@@ -550,7 +550,7 @@
                     "properties": {
                         "publisher": "Microsoft.Powershell",
                         "type": "DSC",
-                        "typeHandlerVersion": "2.1",
+                        "typeHandlerVersion": "2.8",
                         "settings": {
                             "ModulesUrl": "[concat(parameters('assetLocation'),'/Configuration.zip')]",
                             "ConfigurationFunction": "Configuration.ps1\\SessionHost",
@@ -632,7 +632,7 @@
             "properties": {
                 "publisher": "Microsoft.Powershell",
                 "type": "DSC",
-                "typeHandlerVersion": "2.1",
+                "typeHandlerVersion": "2.8",
                 "settings": {
                     "ModulesUrl": "[concat(parameters('assetLocation'),'/Configuration.zip')]",
                     "ConfigurationFunction": "Configuration.ps1\\RDSDeployment",

--- a/vm-d14-high-iops-32-data-disks/azuredeploy.json
+++ b/vm-d14-high-iops-32-data-disks/azuredeploy.json
@@ -517,7 +517,7 @@
       "properties": {
         "publisher": "Microsoft.Powershell",
         "type": "DSC",
-        "typeHandlerVersion": "1.9",
+        "typeHandlerVersion": "2.8",
         "settings": {
           "ModulesUrl": "[parameters('modulesUrl')]",
           "SasToken": "",

--- a/web-app-dsc-vm/azuredeploy.json
+++ b/web-app-dsc-vm/azuredeploy.json
@@ -311,7 +311,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "1.7",
+            "typeHandlerVersion": "2.8",
             "settings": {
               "modulesUrl": "[parameters('modulesUrl')]",
               "sasToken": "[parameters('sasToken')]",


### PR DESCRIPTION
This is to prevent templates deployment failure because these versions have been removed 3 days ago.

http://blogs.msdn.com/b/powershell/archive/2015/10/26/azure-dsc-extension-versions-1-0-2-3-no-longer-available.aspx