### PR TITLE
Bug fixes: Updated DSC typeHandlerVersion to 2.8 and update storageAc…

### DIFF
--- a/201-vm-domain-join/azuredeploy.json
+++ b/201-vm-domain-join/azuredeploy.json
@@ -232,7 +232,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
              "enabled": "true",
-             "storageUri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net')]"
+             "storageUri": "[concat('http://',parameters('storageAccount'),'.blob.core.windows.net')]"
           }
         }
       },
@@ -248,7 +248,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "1.9",
+            "typeHandlerVersion": "2.8",
             "settings": {
               "ModulesUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/active-directory-new-domain/CreateADPDC.ps1.zip",
               "ConfigurationFunction": "CreateADPDC.ps1\\CreateADPDC",
@@ -391,7 +391,7 @@
       "properties": {
         "publisher": "Microsoft.Powershell",
         "type": "DSC",
-        "typeHandlerVersion": "1.9",
+        "typeHandlerVersion": "2.8",
         "settings": {
           "ModulesUrl": "[concat(parameters('assetLocation'),'/Configuration.zip')]",
           "ConfigurationFunction": "Configuration.ps1\\DomainJoin",


### PR DESCRIPTION
- DSC typeHandlerVersion was set to 1.9 which is not available anymore. I updated this to 2.8 which is the latest version.
- storageAccount parameter was getting referenced as newStorageAccountName on line 235. I updated this to storageAccount.