### PR TITLE
Simpler parameters options and used uniqueString function

### DIFF
--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -26,7 +26,8 @@
         "North Central US",
         "East Asia",
         "Southeast Asia",
-        "West Europe"
+        "West Europe",
+        "North Europe"
       ],
       "defaultValue": "ResourceGroup",
       "metadata": {
@@ -179,7 +180,8 @@
         "North Central US":"[parameters('location')]",
         "East Asia":"[parameters('location')]",
         "Southeast Asia":"[parameters('location')]",
-        "West Europe":"[parameters('location')]"
+        "West Europe":"[parameters('location')]",
+        "North Europe":"[parameters('location')]"
     },
     "location":"[variables('locationMap')[parameters('location')]]",
     "templateBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch/",

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -20,12 +20,6 @@
         "description": "Load balancer subdomain name"
       }
     },
-    "storageAccountPrefix": {
-      "type": "string",
-      "metadata": {
-        "description": "Unique namespace for the Storage Account where the Virtual Machine's disks will be placed"
-      }
-    },
     "location": {
       "type": "string",
       "allowedValues": [
@@ -43,9 +37,16 @@
         "description": "Location where resources will be provisioned"
       }
     },
+    "storageAccountPrefix": {
+      "type": "string",
+      "defaultValue": "elastic",
+      "metadata": {
+        "description": "Storage account prefix used when creating the storage accounts used for storing virtual machine disks (must be lowercase charactors or numbers and max length of 7)"
+      }
+    },
     "virtualNetworkName": {
       "type": "string",
-      "defaultValue": "myVNET",
+      "defaultValue": "esvnet",
       "metadata": {
         "description": "Virtual Network"
       }
@@ -173,6 +174,8 @@
   },
   "variables": {
     "templateBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch/",
+    "storageAccountPrefix": "[toLower(parameters('storageAccountPrefix'))]",
+    "storageAccountNameShared": "[concat(variables('storageAccountPrefix'), 's', uniqueString(resourceGroup().id, deployment().name)]",
     "masterNodesIpPrefix": "10.0.0.1",
     "networkSettings": {
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
@@ -441,7 +444,7 @@
       "count":"[div(sub(add(parameters('vmDataNodeCount'), variables('nodesPerStorageAccount')), 1), variables('nodesPerStorageAccount'))]",
       "mapping":"[variables('storageBinPackMap')]",
       "accountType":"[variables('dataSkuSettings')[parameters('vmSizeDataNodes')].storageAccountType]",
-      "prefix":"[parameters('storageAccountPrefix')]"
+      "prefix":"[concat(variables('storageAccountPrefix'), 'd', uniqueString(resourceGroup().id, deployment().name)]"
     },
     "dataTemplateUrl": "[concat(variables('templateBaseUrl'), 'data-nodes-', string(variables('dataSkuSettings')[parameters('vmSizeDataNodes')].dataDisks), 'disk-resources.json')]"
   },
@@ -461,7 +464,7 @@
         },
         "parameters": {
           "storageAccountName": {
-            "value": "[concat(parameters('storageAccountPrefix'),'shared')]"
+            "value": "[variables('storageAccountNameShared')]"
           },
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
@@ -505,7 +508,7 @@
             "value": "[variables('networkSettings')]"
           },
           "storageAccountName": {
-            "value": "[concat(parameters('storageAccountPrefix'),'shared')]"
+            "value": "[variables('storageAccountNameShared')]"
           },
           "loadBalancerType": {
             "value": "[parameters('loadBalancerType')]"
@@ -540,7 +543,7 @@
             "value": "[parameters('adminPassword')]"
           },
           "storageAccountName": {
-            "value": "[concat(parameters('storageAccountPrefix'),'shared')]"
+            "value": "[variables('storageAccountNameShared')]"
           },
           "location": {
             "value": "[parameters('location')]"
@@ -625,7 +628,7 @@
         },
         "parameters": {
           "storageAccountName": {
-            "value": "[concat(parameters('storageAccountPrefix'),'shared')]"
+            "value": "[variables('storageAccountNameShared')]"
           },
           "adminUsername": {
             "value": "[parameters('adminUsername')]"

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -14,12 +14,6 @@
         "description": "Admin SSH key used when provisioning virtual machines"
       }
     },
-    "dnsNameforLBIP": {
-      "type": "string",
-      "metadata": {
-        "description": "Load balancer subdomain name"
-      }
-    },
     "location": {
       "type": "string",
       "allowedValues": [

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -11,12 +11,13 @@
     "adminPassword": {
       "type": "securestring",
       "metadata": {
-        "description": "Admin SSH key used when provisioning virtual machines"
+        "description": "Admin password used when provisioning virtual machines"
       }
     },
     "location": {
       "type": "string",
       "allowedValues": [
+        "ResourceGroup",
         "West US",
         "East US",
         "East US 2",
@@ -27,8 +28,9 @@
         "Southeast Asia",
         "West Europe"
       ],
+      "defaultValue": "ResourceGroup",
       "metadata": {
-        "description": "Location where resources will be provisioned"
+        "description": "Location where resources will be provisioned.  A value of 'ResourceGroup' will deploy the resource to the same location of the resource group the resources are provisioned into"
       }
     },
     "storageAccountPrefix": {
@@ -167,9 +169,22 @@
     }
   },
   "variables": {
+    "locationMap": {
+        "ResourceGroup":"[resourceGroup().location]",
+        "West US":"[parameters('location')]",
+        "East US":"[parameters('location')]",
+        "East US 2":"[parameters('location')]",
+        "Central US":"[parameters('location')]",
+        "South Central US":"[parameters('location')]",
+        "North Central US":"[parameters('location')]",
+        "East Asia":"[parameters('location')]",
+        "Southeast Asia":"[parameters('location')]",
+        "West Europe":"[parameters('location')]"
+    },
+    "location":"[variables('locationMap')[parameters('location')]]",
     "templateBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch/",
     "storageAccountPrefix": "[toLower(parameters('storageAccountPrefix'))]",
-    "storageAccountNameShared": "[concat(variables('storageAccountPrefix'), 's', uniqueString(resourceGroup().id, deployment().name)]",
+    "storageAccountNameShared": "[concat(variables('storageAccountPrefix'), 's', uniqueString(resourceGroup().id, deployment().name))]",
     "masterNodesIpPrefix": "10.0.0.1",
     "networkSettings": {
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
@@ -438,7 +453,7 @@
       "count":"[div(sub(add(parameters('vmDataNodeCount'), variables('nodesPerStorageAccount')), 1), variables('nodesPerStorageAccount'))]",
       "mapping":"[variables('storageBinPackMap')]",
       "accountType":"[variables('dataSkuSettings')[parameters('vmSizeDataNodes')].storageAccountType]",
-      "prefix":"[concat(variables('storageAccountPrefix'), 'd', uniqueString(resourceGroup().id, deployment().name)]"
+      "prefix":"[concat(variables('storageAccountPrefix'), 'd', uniqueString(resourceGroup().id, deployment().name))]"
     },
     "dataTemplateUrl": "[concat(variables('templateBaseUrl'), 'data-nodes-', string(variables('dataSkuSettings')[parameters('vmSizeDataNodes')].dataDisks), 'disk-resources.json')]"
   },
@@ -470,7 +485,7 @@
             "value": "[variables('masterNodesIpPrefix')]"
           },
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[variables('location')]"
           },
           "vmSize": {
             "value": "[parameters('vmSizeMasterNodes')]"
@@ -496,7 +511,7 @@
         },
         "parameters": {
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[variables('location')]"
           },
           "networkSettings": {
             "value": "[variables('networkSettings')]"
@@ -509,9 +524,6 @@
           },
           "ilbIpAddress": {
             "value": "10.0.0.100"
-          },
-          "dnsName": {
-            "value": "[parameters('dnsNameforLBIP')]"
           }
         }
       }
@@ -540,7 +552,7 @@
             "value": "[variables('storageAccountNameShared')]"
           },
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[variables('location')]"
           },
           "subnet": {
             "value": "[variables('networkSettings').subnet.data]"
@@ -581,7 +593,7 @@
             "value": "[parameters('adminPassword')]"
           },
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[variables('location')]"
           },
           "storageSettings": {
             "value": "[variables('dataNodeStorageSettings')]"
@@ -631,7 +643,7 @@
             "value": "[parameters('adminPassword')]"
           },
           "location": {
-            "value": "[parameters('location')]"
+            "value": "[variables('location')]"
           },
           "subnet": {
             "value": "[variables('networkSettings').subnet.data]"

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -34,13 +34,6 @@
         "description": "Location where resources will be provisioned.  A value of 'ResourceGroup' will deploy the resource to the same location of the resource group the resources are provisioned into"
       }
     },
-    "storageAccountPrefix": {
-      "type": "string",
-      "defaultValue": "elastic",
-      "metadata": {
-        "description": "Storage account prefix used when creating the storage accounts used for storing virtual machine disks (must be lowercase charactors or numbers and max length of 7)"
-      }
-    },
     "virtualNetworkName": {
       "type": "string",
       "defaultValue": "esvnet",
@@ -185,7 +178,7 @@
     },
     "location":"[variables('locationMap')[parameters('location')]]",
     "templateBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch/",
-    "storageAccountPrefix": "[toLower(parameters('storageAccountPrefix'))]",
+    "storageAccountPrefix": "elastic",
     "storageAccountNameShared": "[concat(variables('storageAccountPrefix'), 's', uniqueString(resourceGroup().id, deployment().name))]",
     "masterNodesIpPrefix": "10.0.0.1",
     "networkSettings": {

--- a/elasticsearch/azuredeploy.parameters.json
+++ b/elasticsearch/azuredeploy.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "dnsNameforLBIP": {
-      "value": "uniquedns"
-    },
     "storageAccountPrefix": {
       "value": "es"
     },

--- a/elasticsearch/azuredeploy.parameters.json
+++ b/elasticsearch/azuredeploy.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "storageAccountPrefix": {
-      "value": "elastic"
-    },
     "adminUsername": {
       "value": "changeme"
     },

--- a/elasticsearch/azuredeploy.parameters.json
+++ b/elasticsearch/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "storageAccountPrefix": {
-      "value": "es"
+      "value": "elastic"
     },
     "adminUsername": {
       "value": "changeme"
@@ -13,9 +13,6 @@
     },
     "vmDataNodeCount": {
       "value": 3
-    },
-    "location": {
-      "value": "West US"
     },
     "virtualNetworkName": {
       "value": "esvnet"

--- a/elasticsearch/data-nodes-0disk-resources.json
+++ b/elasticsearch/data-nodes-0disk-resources.json
@@ -75,7 +75,7 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix, 'd')]",
+    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
     "vmName": "[concat(parameters('namespace'), 'vm')]"
   },
   "resources": [

--- a/elasticsearch/data-nodes-16disk-resources.json
+++ b/elasticsearch/data-nodes-16disk-resources.json
@@ -75,7 +75,7 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix, 'd')]",
+    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
     "vmName": "[concat(parameters('namespace'), 'vm')]"
   },
   "resources": [

--- a/elasticsearch/data-nodes-2disk-resources.json
+++ b/elasticsearch/data-nodes-2disk-resources.json
@@ -75,7 +75,7 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix, 'd')]",
+    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
     "vmName": "[concat(parameters('namespace'), 'vm')]"
   },
   "resources": [

--- a/elasticsearch/data-nodes-4disk-resources.json
+++ b/elasticsearch/data-nodes-4disk-resources.json
@@ -75,7 +75,7 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix, 'd')]",
+    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
     "vmName": "[concat(parameters('namespace'), 'vm')]"
   },
   "resources": [

--- a/elasticsearch/data-nodes-8disk-resources.json
+++ b/elasticsearch/data-nodes-8disk-resources.json
@@ -75,7 +75,7 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix, 'd')]",
+    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
     "vmName": "[concat(parameters('namespace'), 'vm')]"
   },
   "resources": [

--- a/elasticsearch/shared-resources.json
+++ b/elasticsearch/shared-resources.json
@@ -31,12 +31,6 @@
         "description": "Storage account used for share virtual machine images"
       }
     },
-    "dnsName": {
-      "type": "string",
-      "metadata": {
-        "description": "A shared storage account for images"
-      }
-    },
     "ilbIpAddress": {
       "type": "string",
       "metadata": {
@@ -85,10 +79,7 @@
       "name": "publicIp",
       "location": "[parameters('location')]",
       "properties": {
-        "publicIPAllocationMethod": "Dynamic",
-        "dnsSettings": {
-          "domainNameLabel": "[parameters('dnsName')]"
-        }
+        "publicIPAllocationMethod": "Dynamic"
       }
     },
     {

--- a/elasticsearch/test/shared-resources.json
+++ b/elasticsearch/test/shared-resources.json
@@ -31,12 +31,6 @@
         "description": "Storage account used for share virtual machine images"
       }
     },
-    "dnsName": {
-      "type": "string",
-      "metadata": {
-        "description": "A shared storage account for images"
-      }
-    },
     "ilbIpAddress": {
       "type": "string",
       "metadata": {
@@ -62,10 +56,6 @@
     "storageAccountName": {
       "type": "string",
       "value": "[parameters('storageAccountName')]"
-    },
-    "dnsName": {
-      "type": "string",
-      "value": "[parameters('dnsName')]"
     },
     "ilbIpAddress": {
       "type": "string",

--- a/elasticsearch/tmpl/data-nodes.yml
+++ b/elasticsearch/tmpl/data-nodes.yml
@@ -51,7 +51,7 @@ parameters:
 variables:
   vmStorageAccountContainerName: vhd
   subnetRef: "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]"
-  storageAccountName: "[concat(parameters('storageSettings').prefix, 'd')]"
+  storageAccountName: "[concat(parameters('storageSettings').prefix)]"
   vmName: "[concat(parameters('namespace'), 'vm')]"
 resources:
 - type: Microsoft.Storage/storageAccounts


### PR DESCRIPTION
A bit of minor cleanup

1. Removed DNS configuration (not that useful for this template)
2. Use uniqueString() when creating storage account namespaces
3. Default location to 'ResourceGroup' allow for explicit override
4. Updated the test mock templates to match the parameter changes
