### PR TITLE
SLURM cluster on SLES 12 HPC SKU

### DIFF
--- a/slurm-on-sles12-hpc/README.md
+++ b/slurm-on-sles12-hpc/README.md
@@ -2,7 +2,7 @@
 
 Deploys a SLURM cluster with head node and n worker nodes.
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsmith1511%2Fhpc%2Fmaster%2Fslurm-on-sles12%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fslurm-on-sles12-hpc%2Fazuredeploy.json" target="_blank">
    <img alt="Deploy to Azure" src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/slurm-on-sles12-hpc/README.md
+++ b/slurm-on-sles12-hpc/README.md
@@ -1,0 +1,84 @@
+# Azure SLES 12 HPC ARM Template
+
+Deploys a SLURM cluster with head node and n worker nodes.
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fsmith1511%2Fhpc%2Fmaster%2Fslurm-on-sles12%2Fazuredeploy.json" target="_blank">
+   <img alt="Deploy to Azure" src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+1. Fill in the 3 mandatory parameters - public DNS name, a storage account to hold VM image, and admin user password.
+
+2. Select an existing resource group or enter the name of a new resource group to create.
+
+3. Select the resource group location.
+
+4. Accept the terms and agreements.
+
+5. Click Create.
+
+## Accessing the cluster
+
+Simply SSH to the master node using the DNS name _**dnsName**_._**location**_.cloudapp.azure.com, for example, slurm12-hpc.westus.cloudapp.azure.com.
+
+```
+# ssh azureuser@slurm12-hpc.westus.cloudapp.azure.com
+```
+
+You can log into the head node using the admin user and password specified.  Once on the head node you can switch to the HPC user.  For security reasons the HPC user cannot login to the head node directly.
+
+## Running workloads
+
+### HPC User
+
+After SSHing to the head node you can switch to the HPC user specified on creation, the default username is 'hpc'.  
+
+This is a special user that should be used to run work and/or SLURM jobs.  The HPC user has public key authentication configured across the cluster and can login to any node without a password.  The HPC users home directory is a NFS share on the master and shared by all nodes.
+
+To switch to the HPC user.
+
+```
+azureuser@master:~> sudo su hpc
+azureuser's password:
+hpc@master:/home/azureuser>
+```
+
+### Shares
+
+The master node doubles as a NFS server for the worker nodes and exports two shares, one for the HPC user home directory and one for a data disk.
+
+The HPC users home directory is located in /share/home and is shared by all nodes across the cluster.
+
+The master also exports a generic data share under /share/data.  This share is mounted under the same location on all worker nodes.  This share is backed by 16 disks configured as a RAID-0 volume.  You can expect much better IO from this share and it should be used for any shared data across the cluster.
+
+### Running a SLURM job
+
+To verify that SLURM is configured and running as expected you can execute the following.
+
+```
+hpc@master:~> srun -N6 hostname
+worker4
+worker0
+worker2
+worker3
+worker5
+worker1
+hpc@master:~>
+```
+
+Replace '6' above with the number of worker nodes your cluster was configured with.  The output of the command should print out the hostname of each node.
+
+### VM Sizes
+
+#### Head Node
+
+The master/head node only supports VM sizes that support up to 16 disks being attached, hence >= A4.
+
+#### Worker Nodes
+
+Worker nodes support any VM size.
+
+### MPI
+
+To run MPI applications you'll need to use the A8/A9 instances which include InfiniBand and RDMA support.  We suggest using A8 for the head node and A9 instances for worker nodes.
+
+Currently RDMA only supports Intel MPI.  You can download the Intel pieces and get an evaluation license from https://software.intel.com/en-us/intel-mpi-library.

--- a/slurm-on-sles12-hpc/azuredeploy.json
+++ b/slurm-on-sles12-hpc/azuredeploy.json
@@ -157,7 +157,7 @@
     },
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('networkSettings').virtualNetworkName)]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('networkSettings').subnet.dse.name)]",
-    "templateBaseUrl": "https://raw.githubusercontent.com/smith1511/hpc/master/slurm-on-sles12/",
+    "templateBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/slurm-on-sles12-hpc/",
     "installationCLI": "[concat('bash azuredeploy.sh ', variables('masterVMName'), ' ', variables('workerVMName'), ' ', parameters('workerNodeCount'), ' ', parameters('hpcUserName'), ' ', variables('templateBaseUrl'))]",
     "storageAccountType": "Standard_LRS"
   },

--- a/slurm-on-sles12-hpc/azuredeploy.json
+++ b/slurm-on-sles12-hpc/azuredeploy.json
@@ -8,12 +8,6 @@
         "description": "Unique public dns name where the master node will be exposed"
       }
     },
-    "newStorageAccountName": {
-      "type": "string",
-      "metadata": {
-        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
-      }
-    },
     "adminUserName": {
       "type": "string",
       "defaultValue": "azureuser",
@@ -130,12 +124,14 @@
     "imagePublisher": "SUSE",
     "imageOffer": "SLES-HPC",
     "slesOSVersion": "12",
+    "newStorageAccountName": "[concat('st', uniqueString(resourceGroup().id))]",
     "vmStorageAccountContainerName": "vhd",
     "OSDiskName": "osdisk",
     "publicIPAddressType": "Dynamic",
     "publicIPAddressName": "publicips",
     "masterVMName": "master",
     "workerVMName": "worker",
+	"armApiVersion": "2015-06-15",
     "nicName": "nic",
     "networkSettings": {
       "virtualNetworkName": "virtualnetwork",
@@ -164,15 +160,15 @@
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[parameters('newStorageAccountName')]",
-      "apiVersion": "2015-05-01-preview",
+      "name": "[variables('newStorageAccountName')]",
+      "apiVersion": "[variables('armApiVersion')]",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "[variables('armApiVersion')]",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('networkSettings').virtualNetworkName]",
       "location": "[resourceGroup().location]",
@@ -194,7 +190,7 @@
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "[variables('armApiVersion')]",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -205,7 +201,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "[variables('armApiVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -232,12 +228,12 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "[variables('armApiVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('masterVMName')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],
       "properties": {
@@ -259,7 +255,7 @@
           "osDisk": {
             "name": "osdisk",
             "vhd": {
-              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),variables('masterVMName'),'.vhd')]"
+              "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),variables('masterVMName'),'.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"
@@ -270,7 +266,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 0,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk0.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk0.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -280,7 +276,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 1,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk1.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk1.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -290,7 +286,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 2,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk2.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk2.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -300,7 +296,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 3,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk3.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk3.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -310,7 +306,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 4,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk4.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk4.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -320,7 +316,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 5,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk5.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk5.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -330,7 +326,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 6,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk6.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk6.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -340,7 +336,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 7,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk7.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk7.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -350,7 +346,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 8,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk8.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk8.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -360,7 +356,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 9,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk9.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk9.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -370,7 +366,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 10,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk10.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk10.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -380,7 +376,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 11,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk11.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk11.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -390,7 +386,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 12,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk12.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk12.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -400,7 +396,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 13,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk13.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk13.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -410,7 +406,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 14,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk14.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk14.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -420,7 +416,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 15,
               "vhd": {
-                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk15.vhd')]"
+                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk15.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -437,7 +433,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "[variables('armApiVersion')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('masterVMName'), '/Installation')]",
       "location": "[resourceGroup().location]",
@@ -457,7 +453,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "[variables('armApiVersion')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('workerVMName'), copyindex(), '/Installation')]",
       "location": "[resourceGroup().location]",
@@ -482,7 +478,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "[variables('armApiVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), 'worker', copyindex())]",
       "location": "[resourceGroup().location]",
@@ -509,12 +505,12 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "[variables('armApiVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('workerVMName'), copyindex())]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), 'worker', copyindex())]"
       ],
       "copy": {
@@ -540,7 +536,7 @@
           "osDisk": {
             "name": "osdisk",
             "vhd": {
-              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),variables('workerVMName'),copyindex(),'.vhd')]"
+              "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),variables('workerVMName'),copyindex(),'.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"

--- a/slurm-on-sles12-hpc/azuredeploy.json
+++ b/slurm-on-sles12-hpc/azuredeploy.json
@@ -1,0 +1,559 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dnsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique public dns name where the master node will be exposed"
+      }
+    },
+    "newStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
+      }
+    },
+    "adminUserName": {
+      "type": "string",
+      "defaultValue": "azureuser",
+      "metadata": {
+        "description": "User name for the Virtual Machine. Pick a valid username otherwise there will be a BadRequest error."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin password. Pick a complex password with uppercase letters, lowercase letters, digits, and symbols. The password should not be longer than 16. Otherwise you'll get a BadRequest error."
+      }
+    },
+    "hpcUserName": {
+      "type": "string",
+      "defaultValue": "hpc",
+      "metadata": {
+        "description": "User for running HPC applications with shared home directory and SSH public key authentication setup.  This user cannot login from outside the cluster. Pick a valid username otherwise there will be a BadRequest error."
+      }
+    },
+    "headNodeSize": {
+      "type": "string",
+      "defaultValue": "Standard_A8",
+      "allowedValues": [
+        "Standard_A4",
+        "Standard_A7",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11",
+        "Standard_D4",
+		"Standard_D13",
+		"Standard_D14",
+        "Standard_DS4",
+		"Standard_DS13",
+		"Standard_DS14",
+		"Standard_G3",
+		"Standard_G4",
+		"Standard_G5",
+		"Standard_GS3",
+		"Standard_GS4",
+		"Standard_GS5"
+      ],
+      "metadata": {
+        "description": "Size of the head node."
+      }
+    },
+    "workerNodeSize": {
+      "type": "string",
+      "defaultValue": "Standard_A9",
+      "allowedValues": [
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11",
+		"Standard_D1",
+		"Standard_D2",
+		"Standard_D3",
+        "Standard_D4",
+		"Standard_D11",
+		"Standard_D12",
+		"Standard_D13",
+		"Standard_D14",
+		"Standard_DS1",
+		"Standard_DS2",
+		"Standard_DS3",
+		"Standard_DS4",
+		"Standard_D11",
+		"Standard_D12",
+		"Standard_D13",
+		"Standard_D14",
+		"Standard_DS11",
+		"Standard_DS12",
+		"Standard_DS13",
+		"Standard_DS14",
+		"Standard_G1",
+		"Standard_G2",
+		"Standard_G3",
+		"Standard_G4",
+		"Standard_G5",
+		"Standard_GS1",
+		"Standard_GS2",
+		"Standard_GS3",
+		"Standard_GS4",
+		"Standard_GS5"
+      ],
+      "metadata": {
+        "description": "Size of the worker nodes."
+      }
+    },
+    "workerNodeCount": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "This template creates N worker node. Use workerNodeCount to specify that N."
+      }
+    },
+    "dataDiskSize": {
+      "type": "int",
+      "defaultValue": 128,
+      "metadata": {
+        "description": "The size in GB of each data disk that is attached to the VM.  A RAID-0 volume is created with all data disks that is dataDiskSize * dataDiskCount in size."
+      }
+    }
+  },
+  "variables": {
+    "imagePublisher": "SUSE",
+    "imageOffer": "SLES-HPC",
+    "slesOSVersion": "12",
+    "vmStorageAccountContainerName": "vhd",
+    "OSDiskName": "osdisk",
+    "publicIPAddressType": "Dynamic",
+    "publicIPAddressName": "publicips",
+    "masterVMName": "master",
+    "workerVMName": "worker",
+    "nicName": "nic",
+    "networkSettings": {
+      "virtualNetworkName": "virtualnetwork",
+      "addressPrefix": "10.0.0.0/16",
+      "subnet": {
+        "dse": {
+          "name": "dse",
+          "prefix": "10.0.0.0/24",
+          "vnet": "virtualnetwork"
+        }
+      },
+      "statics": {
+        "workerRange": {
+          "base": "10.0.0.",
+          "start": 5
+        },
+        "master": "10.0.0.254"
+      }
+    },
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('networkSettings').virtualNetworkName)]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('networkSettings').subnet.dse.name)]",
+    "templateBaseUrl": "https://raw.githubusercontent.com/smith1511/hpc/master/slurm-on-sles12/",
+    "installationCLI": "[concat('bash azuredeploy.sh ', variables('masterVMName'), ' ', variables('workerVMName'), ' ', parameters('workerNodeCount'), ' ', parameters('hpcUserName'), ' ', variables('templateBaseUrl'))]",
+    "storageAccountType": "Standard_LRS"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('newStorageAccountName')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('networkSettings').virtualNetworkName]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('networkSettings').addressPrefix]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('networkSettings').subnet.dse.name]",
+            "properties": {
+              "addressPrefix": "[variables('networkSettings').subnet.dse.prefix]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2015-05-01-preview",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsName')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('networkSettings').virtualNetworkName)]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[variables('networkSettings').statics.master]",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('masterVMName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('headNodeSize')]"
+        },
+        "osProfile": {
+          "computername": "[variables('masterVMName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('slesOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),variables('masterVMName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          },
+          "dataDisks": [
+            {
+              "name": "datadisk0",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 0,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk0.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk1",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 1,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk1.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk2",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 2,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk2.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk3",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 3,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk3.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk4",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 4,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk4.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk5",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 5,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk5.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk6",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 6,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk6.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk7",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 7,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk7.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk8",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 8,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk8.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk9",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 9,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk9.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk10",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 10,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk10.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk11",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 11,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk11.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk12",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 12,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk12.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk13",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 13,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk13.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk14",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 14,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk14.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk15",
+              "diskSizeGB": "[parameters('dataDiskSize')]",
+              "lun": 15,
+              "vhd": {
+                "Uri":  "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk15.vhd')]"
+              },
+              "caching": "None",
+              "createOption": "Empty"
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('masterVMName'), '/Installation')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.3",
+        "settings": {
+          "fileUris": [
+            "[concat(variables('templateBaseUrl'), 'azuredeploy.sh')]"
+          ],
+          "commandToExecute": "[variables('installationCLI')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('workerVMName'), copyindex(), '/Installation')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+	    "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMName'),'/extensions/Installation')]",
+        "[concat('Microsoft.Compute/virtualMachines/', variables('workerVMName'), copyindex())]"
+      ],
+      "copy": {
+        "name": "foo",
+        "count": "[parameters('workerNodeCount')]"
+      },
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.3",
+        "settings": {
+          "fileUris": [
+            "[concat(variables('templateBaseUrl'), 'azuredeploy.sh')]"
+          ],
+          "commandToExecute": "[variables('installationCLI')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('nicName'), 'worker', copyindex())]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('networkSettings').virtualNetworkName)]"
+      ],
+      "copy": {
+        "name": "foo",
+        "count": "[parameters('workerNodeCount')]"
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[concat(variables('networkSettings').statics.workerRange.base, copyindex(variables('networkSettings').statics.workerRange.start))]",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(variables('workerVMName'), copyindex())]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), 'worker', copyindex())]"
+      ],
+      "copy": {
+        "name": "foo",
+        "count": "[parameters('workerNodeCount')]"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('workerNodeSize')]"
+        },
+        "osProfile": {
+          "computername": "[concat(variables('workerVMName'), copyindex())]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('slesOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),variables('workerVMName'),copyindex(),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), 'worker', copyindex()))]"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/slurm-on-sles12-hpc/azuredeploy.json
+++ b/slurm-on-sles12-hpc/azuredeploy.json
@@ -2,10 +2,10 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "dnsName": {
+    "dnsPrefix": {
       "type": "string",
       "metadata": {
-        "description": "Unique public dns name where the master node will be exposed"
+        "description": "Unique public dns prefix where the master node will be exposed"
       }
     },
     "adminUserName": {
@@ -196,7 +196,7 @@
       "properties": {
         "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
         "dnsSettings": {
-          "domainNameLabel": "[parameters('dnsName')]"
+          "domainNameLabel": "[parameters('dnsPrefix')]"
         }
       }
     },

--- a/slurm-on-sles12-hpc/azuredeploy.parameters.json
+++ b/slurm-on-sles12-hpc/azuredeploy.parameters.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dnsName": {
+      "value": "deishbai32"
+    },
+    "newStorageAccountName": {
+      "value": "slurmcluster"
+    },
+    "adminUserName": {
+      "value": "azureuser"
+    },
+    "adminPassword": {
+      "value": ""
+    },
+    "hpcUserName": {
+      "value": "hpc"
+    },
+    "headNodeSize": {
+      "value": "Standard_A8"
+    },
+    "workerNodeSize": {
+      "value": "Standard_A9"
+    },
+    "workerNodeCount": {
+      "value": 2
+    },
+  }
+}

--- a/slurm-on-sles12-hpc/azuredeploy.parameters.json
+++ b/slurm-on-sles12-hpc/azuredeploy.parameters.json
@@ -3,10 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "dnsName": {
-      "value": "deishbai32"
-    },
-    "newStorageAccountName": {
-      "value": "slurmcluster"
+      "value": ""
     },
     "adminUserName": {
       "value": "azureuser"
@@ -25,6 +22,6 @@
     },
     "workerNodeCount": {
       "value": 2
-    },
+    }
   }
 }

--- a/slurm-on-sles12-hpc/azuredeploy.parameters.json
+++ b/slurm-on-sles12-hpc/azuredeploy.parameters.json
@@ -2,7 +2,7 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "dnsName": {
+    "dnsPrefix": {
       "value": ""
     },
     "adminUserName": {

--- a/slurm-on-sles12-hpc/azuredeploy.sh
+++ b/slurm-on-sles12-hpc/azuredeploy.sh
@@ -1,0 +1,293 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+if [[ $(id -u) -ne 0 ]] ; then
+    echo "Must be run as root"
+    exit 1
+fi
+
+if [ $# != 5 ]; then
+    echo "Usage: $0 <MasterHostname> <WorkerHostnamePrefix> <WorkerNodeCount> <HPCUserName> <TemplateBaseUrl>"
+    exit 1
+fi
+
+# Set user args
+MASTER_HOSTNAME=$1
+WORKER_HOSTNAME_PREFIX=$2
+WORKER_COUNT=$3
+TEMPLATE_BASE_URL="$5"
+LAST_WORKER_INDEX=$(($WORKER_COUNT - 1))
+
+# Shares
+SHARE_HOME=/share/home
+SHARE_DATA=/share/data
+
+# Munged
+MUNGE_USER=munge
+MUNGE_GROUP=munge
+MUNGE_VERSION=0.5.11
+
+# SLURM
+SLURM_USER=slurm
+SLURM_UID=6006
+SLURM_GROUP=slurm
+SLURM_GID=6006
+SLURM_VERSION=15-08-1-1
+SLURM_CONF_DIR=$SHARE_DATA/conf
+
+# Hpc User
+HPC_USER=$4
+HPC_UID=7007
+HPC_GROUP=users
+
+
+# Returns 0 if this node is the master node.
+#
+is_master()
+{
+    hostname | grep "$MASTER_HOSTNAME"
+    return $?
+}
+
+# Add the SLES 12 SDK repository which includes all the
+# packages for compilers and headers.
+#
+add_sdk_repo()
+{
+    repoFile="/etc/zypp/repos.d/SMT-http_smt-azure_susecloud_net:SLE-SDK12-Pool.repo"
+	
+    if [ -e "$repoFile" ]; then
+        echo "SLES 12 SDK Repository already installed"
+        return 0
+    fi
+	
+	wget $TEMPLATE_BASE_URL/sles12sdk.repo
+	
+	cp sles12sdk.repo "$repoFile"
+
+    # init new repo
+    zypper -n search nfs > /dev/null 2>&1
+}
+
+# Installs all required packages.
+#
+install_pkgs()
+{
+    pkgs="libbz2-1 libz1 openssl libopenssl-devel gcc gcc-c++ nfs-client rpcbind"
+
+    if is_master; then
+        pkgs="$pkgs nfs-kernel-server"
+    fi
+
+    zypper -n install $pkgs
+}
+
+# Partitions all data disks attached to the VM and creates
+# a RAID-0 volume with them.
+#
+setup_data_disks()
+{
+    mountPoint="$1"
+	createdPartitions=""
+
+    # Loop through and partition disks until not found
+    for disk in sdc sdd sde sdf sdg sdh sdi sdj sdk sdl sdm sdn sdo sdp sdq sdr; do
+        fdisk -l /dev/$disk || break
+        fdisk /dev/$disk << EOF
+n
+p
+1
+
+
+t
+fd
+w
+EOF
+        createdPartitions="$createdPartitions /dev/${disk}1"
+	done
+
+    # Create RAID-0 volume
+    if [ -n "$createdPartitions" ]; then
+        devices=`echo $createdPartitions | wc -w`
+        mdadm --create /dev/md10 --level 0 --raid-devices $devices $createdPartitions
+	    mkfs -t ext4 /dev/md10
+	    echo "/dev/md10 $mountPoint ext4 defaults,nofail 0 2" >> /etc/fstab
+	    mount /dev/md10
+    fi
+}
+
+# Creates and exports two shares on the master nodes:
+#
+# /share/home (for HPC user)
+# /share/data
+#
+# These shares are mounted on all worker nodes.
+#
+setup_shares()
+{
+    mkdir -p $SHARE_HOME
+    mkdir -p $SHARE_DATA
+
+    if is_master; then
+	    setup_data_disks $SHARE_DATA
+        echo "$SHARE_HOME    *(rw,async)" >> /etc/exports
+        echo "$SHARE_DATA    *(rw,async)" >> /etc/exports
+        service nfsserver status && service nfsserver reload || service nfsserver start
+    else
+        echo "master:$SHARE_HOME $SHARE_HOME    nfs4    rw,auto,_netdev 0 0" >> /etc/fstab
+        echo "master:$SHARE_DATA $SHARE_DATA    nfs4    rw,auto,_netdev 0 0" >> /etc/fstab
+        mount -a
+        mount | grep "^master:$SHARE_HOME"
+        mount | grep "^master:$SHARE_DATA"
+    fi
+}
+
+# Downloads/builds/installs munged on the node.  
+# The munge key is generated on the master node and placed 
+# in the data share.  
+# Worker nodes copy the existing key from the data share.
+#
+install_munge()
+{
+    groupadd $MUNGE_GROUP
+
+    useradd -M -c "Munge service account" -g munge -s /usr/sbin/nologin munge
+
+    wget https://github.com/dun/munge/archive/munge-0.5.11.tar.gz
+
+    tar xvfz munge-$MUNGE_VERSION.tar.gz
+
+    cd munge-munge-$MUNGE_VERSION
+
+    mkdir -m 700 /etc/munge
+    mkdir -m 711 /var/lib/munge
+    mkdir -m 700 /var/log/munge
+    mkdir -m 755 /var/run/munge
+
+    ./configure -libdir=/usr/lib64 --prefix=/usr --sysconfdir=/etc --localstatedir=/var && make && make install
+
+    chown -R munge:munge /etc/munge /var/lib/munge /var/log/munge /var/run/munge
+
+    if is_master; then
+        dd if=/dev/urandom bs=1 count=1024 > /etc/munge/munge.key
+		mkdir -p $SLURM_CONF_DIR
+        cp /etc/munge/munge.key $SLURM_CONF_DIR
+    else
+        cp $SLURM_CONF_DIR/munge.key /etc/munge/munge.key
+    fi
+
+    chown munge:munge /etc/munge/munge.key
+    chmod 0400 /etc/munge/munge.key
+
+    /etc/init.d/munge start
+
+    cd ..
+}
+
+# Installs and configures slurm.conf on the node.
+# This is generated on the master node and placed in the data
+# share.  All nodes create a sym link to the SLURM conf
+# as all SLURM nodes must share a common config file.
+#
+install_slurm_config()
+{
+    if is_master; then
+
+        mkdir -p $SLURM_CONF_DIR
+
+	    wget "$TEMPLATE_BASE_URL/slurm.template.conf"
+
+		cat slurm.template.conf |
+		        sed 's/__MASTER__/'"$MASTER_HOSTNAME"'/g' |
+				sed 's/__WORKER_HOSTNAME_PREFIX__/'"$WORKER_HOSTNAME_PREFIX"'/g' |
+				sed 's/__LAST_WORKER_INDEX__/'"$LAST_WORKER_INDEX"'/g' > $SLURM_CONF_DIR/slurm.conf
+    fi
+
+    ln -s $SLURM_CONF_DIR/slurm.conf /etc/slurm/slurm.conf
+}
+
+# Downloads, builds and installs SLURM on the node.
+# Starts the SLURM control daemon on the master node and
+# the agent on worker nodes.
+#
+install_slurm()
+{
+    groupadd -g $SLURM_GID $SLURM_GROUP
+
+    useradd -M -u $SLURM_UID -c "SLURM service account" -g $SLURM_GROUP -s /usr/sbin/nologin $SLURM_USER
+
+    mkdir /etc/slurm /var/spool/slurmd /var/run/slurmd /var/run/slurmctld /var/log/slurmd /var/log/slurmctld
+
+    chown -R slurm:slurm /var/spool/slurmd /var/run/slurmd /var/run/slurmctld /var/log/slurmd /var/log/slurmctld
+
+    wget https://github.com/SchedMD/slurm/archive/slurm-$SLURM_VERSION.tar.gz
+
+    tar xvfz slurm-$SLURM_VERSION.tar.gz
+
+    cd slurm-slurm-$SLURM_VERSION
+	
+    ./configure -libdir=/usr/lib64 --prefix=/usr --sysconfdir=/etc/slurm && make && make install
+
+    install_slurm_config
+
+    if is_master; then
+        /usr/sbin/slurmctld -vvvv
+    else
+        /usr/sbin/slurmd -vvvv
+    fi
+
+    cd ..
+}
+
+# Adds a common HPC user to the node and configures public key SSh auth.
+# The HPC user has a shared home directory (NFS share on master) and access
+# to the data share.
+#
+setup_hpc_user()
+{
+    if is_master; then
+        useradd -c "HPC User" -g $HPC_GROUP -d $SHARE_HOME/$HPC_USER -s /bin/bash -m -u $HPC_UID $HPC_USER
+
+        # Configure public key auth for the HPC user
+        sudo -u $HPC_USER ssh-keygen -t rsa -f $SHARE_HOME/$HPC_USER/.ssh/id_rsa -q -P ""
+        cat $SHARE_HOME/$HPC_USER/.ssh/id_rsa.pub > $SHARE_HOME/$HPC_USER/.ssh/authorized_keys
+
+        echo "Host *" > $SHARE_HOME/$HPC_USER/.ssh/config
+        echo "    StrictHostKeyChecking no" >> $SHARE_HOME/$HPC_USER/.ssh/config
+        echo "    UserKnownHostsFile /dev/null" >> $SHARE_HOME/$HPC_USER/.ssh/config
+		echo "    PasswordAuthentication no" >> $SHARE_HOME/$HPC_USER/.ssh/config
+
+        chown $HPC_USER:$HPC_GROUP $SHARE_HOME/$HPC_USER/.ssh/authorized_keys
+        chown $HPC_USER:$HPC_GROUP $SHARE_HOME/$HPC_USER/.ssh/config
+        chown $HPC_USER:$HPC_GROUP $SHARE_DATA
+    else
+        useradd -c "HPC User" -g $HPC_GROUP -d $SHARE_HOME/$HPC_USER -s /bin/bash -u $HPC_UID $HPC_USER
+    fi
+
+    # Don't require password for HPC user sudo
+    echo "$HPC_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+}
+
+# Sets all common environment variables and system parameters.
+#
+setup_env()
+{
+    # Set unlimited mem lock
+    echo "$HPC_USER hard memlock unlimited" >> /etc/security/limits.conf
+	echo "$HPC_USER soft memlock unlimited" >> /etc/security/limits.conf
+
+	# Intel MPI config for IB
+    echo "# IB Config for MPI" > /etc/profile.d/hpc.sh
+	echo "export I_MPI_FABRICS=shm:dapl" >> /etc/profile.d/hpc.sh
+	echo "export I_MPI_DAPL_PROVIDER=ofa-v2-ib0" >> /etc/profile.d/hpc.sh
+	echo "export I_MPI_DYNAMIC_CONNECTION=0" >> /etc/profile.d/hpc.sh
+}
+
+add_sdk_repo
+install_pkgs
+setup_shares
+setup_hpc_user
+install_munge
+install_slurm
+setup_env

--- a/slurm-on-sles12-hpc/metadata.json
+++ b/slurm-on-sles12-hpc/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Create a SLURM cluster on SLES 12 HPC SKU",
+  "description": "Creates a SLURM HPC cluster running SLES 12.  This cluster is ready to run Intel MPI workloads when used with A8 or A9 VMs.",
+  "githubUsername": "smith1511",
+  "summary": "SLURM HPC cluster",
+  "dateUpdated": "2015-11-11"
+}

--- a/slurm-on-sles12-hpc/sles12sdk.repo
+++ b/slurm-on-sles12-hpc/sles12sdk.repo
@@ -1,0 +1,7 @@
+[SMT-http_smt-azure_susecloud_net:SLE-SDK12-Pool]
+name=SLE-SDK12-Pool
+enabled=1
+autorefresh=0
+baseurl=http://smt-azure.susecloud.net/repo/SUSE/Products/SLE-SDK/12/x86_64/product?credentials=SMT-http_smt-azure_susecloud_net
+type=rpm-md
+service=SMT-http_smt-azure_susecloud_net

--- a/slurm-on-sles12-hpc/slurm.template.conf
+++ b/slurm-on-sles12-hpc/slurm.template.conf
@@ -1,0 +1,24 @@
+ControlMachine=master
+MpiDefault=none
+ProctrackType=proctrack/pgid
+ReturnToService=1
+SlurmctldPidFile=/var/run/slurmctld/slurmctld.pid
+SlurmdPidFile=/var/run/slurmd/slurmd.pid
+SlurmdSpoolDir=/var/spool/slurmd
+SlurmUser=slurm
+StateSaveLocation=/var/spool/slurmd
+SwitchType=switch/none
+TaskPlugin=task/none
+FastSchedule=1
+SchedulerType=sched/backfill
+SelectType=select/cons_res
+SelectTypeParameters=CR_CPU
+AccountingStorageType=accounting_storage/none
+ClusterName=cluster
+JobAcctGatherType=jobacct_gather/none
+SlurmctldDebug=5
+SlurmctldLogFile=/var/log/slurmctld/slurmctld.log
+SlurmdDebug=5
+SlurmdLogFile=/var/log/slurmd/slurmd.log
+NodeName=__WORKER_HOSTNAME_PREFIX__[0-__LAST_WORKER_INDEX__] State=UNKNOWN
+PartitionName=debug Nodes=__WORKER_HOSTNAME_PREFIX__[0-__LAST_WORKER_INDEX__] Default=YES MaxTime=INFINITE State=UP


### PR DESCRIPTION
Creates a fully configured SLURM cluster based on the SLES 12 HPC SKU.  This cluster is ready to run Intel MPI workloads when deployed on A8/A9 instances.