### PR TITLE
Promote "VNet name" and "storage account name/type" as parameters

### DIFF
--- a/create-hpc-cluster-linux-cn/azuredeploy.json
+++ b/create-hpc-cluster-linux-cn/azuredeploy.json
@@ -8,11 +8,35 @@
         "description": "The unique HPC Pack cluster name. It is also used as the public DNS name prefix for the cluster, for example, the public DNS name is '&lt;clusterName&gt;.westus.cloudapp.azure.com' if the resource group location is 'West US'. It must contain between 3 and 15 characters with lowercase letters and numbers, and must start with a letter."
       }
     },
+    "virtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the virtual network to be created."
+      }
+    },
     "privateDomainName": {
       "type": "string",
       "defaultValue": "hpc.local",
       "metadata": {
         "description": "The fully qualified domain name (FQDN) for the private domain forest which will be created by this template, for example 'hpc.local'."
+      }
+    },
+    "storageAccountNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The name prefix of the new storage accounts created to store the VMs disks. One storage account dedicated for head node, and one storage account every 10 compute nodes. For example, if 'mystorage' is specified, and there are 22 compute nodes, then 'mystoragehn' for head node, 'mystorage00', 'mystorage01' and 'mystorage02' for compute nodes."
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_RAGRS"
+      ],
+      "metadata": {
+        "description": "The type of the Storage Account created"
       }
     },
     "headNodeVMSize": {
@@ -58,7 +82,7 @@
       "type": "string",
       "defaultValue": "IaaSLnxCN-",
       "metadata": {
-        "description": "The name prefix of the compute nodes. It can contain letters, numbers and hyphens and must start with a letter, up to 13 characters. For example, if 'IaaSLnxCN-' is specified, the compute node names will be 'IaaSLnxCN-0', 'IaaSLnxCN-1', ..."
+        "description": "The name prefix of the compute nodes. It can contain letters, numbers and hyphens and must start with a letter, up to 12 characters. For example, if 'IaaSLnxCN-' is specified, the compute node names will be 'IaaSLnxCN-000', 'IaaSLnxCN-001', ..."
       }
     },
     "computeNodeNumber": {
@@ -119,15 +143,14 @@
   "variables": {
     "apiVersion": "2015-05-01-preview",
     "location": "[resourceGroup().location]",
-    "storageAccountName": "[toLower(concat(parameters('clusterName'), 'sa'))]",
-    "cnStorageAccountPrefix": "[concat(variables('storageAccountName'), 'cn')]",
-    "cnStorageAccountNumber": "[add(div(parameters('computeNodeNumber'), 10), 1)]",
-    "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",
-    "virtualNetworkName": "[concat(parameters('clusterName'), 'VNet')]",
+    "nbrCNPerStorageAccount": 10,
+    "cnStorageAccountNumber": "[add(div(parameters('computeNodeNumber'), variables('nbrCNPerStorageAccount')), 1)]",
+    "hnStorageAccountName": "[concat(parameters('storageAccountNamePrefix'), 'hn')]",
+    "hnStorageAccountId": "[resourceId('Microsoft.Storage/storageAccounts',variables('hnStorageAccountName'))]",
     "addressPrefix": "10.0.0.0/16",
     "subnet1Name": "Subnet-1",
     "subnet1Prefix": "10.0.0.0/24",
-    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
     "publicIPAddressType": "Dynamic",
     "publicIPAddressName": "[concat(parameters('clusterName'), '-PublicIP-VM')]",
@@ -196,25 +219,24 @@
     "computeNodeImageSku": "[variables('linuxImageSkus')[parameters('computeNodeImage')]]",
     "adminBase64Password": "[base64(parameters('adminPassword'))]",
     "customScriptLocation": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/create-hpc-cluster/",
-    "iaasInfoArg": "[concat('-SubscriptionId ', subscription().subscriptionId, ' -VNet ', variables('virtualNetworkName'), ' -Subnet ', variables('subnet1Name'), ' -Location \"', resourceGroup().location, '\"')]",
+    "iaasInfoArg": "[concat('-SubscriptionId ', subscription().subscriptionId, ' -VNet ', parameters('virtualNetworkName'), ' -Subnet ', variables('subnet1Name'), ' -Location \"', variables('location'), '\"')]",
     "headNodeCommandStr": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File PrepareHN.ps1 -DomainFQDN ', parameters('privateDomainName'), ' -AdminUserName ', parameters('adminUsername'), ' -AdminBase64Password \"', variables('adminBase64Password'), '\" -CNSize ', parameters('computeNodeVMSize'), ' -PostConfigScript \"', parameters('headNodePostConfigScript'), '\" -UnsecureDNSUpdate ', variables('iaasInfoArg'))]",
-    "storageConnStrPrefix": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=')]",
-    "computeNodeCommandStr": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File PrepareCN.ps1 -DomainFQDN ', parameters('privateDomainName'), ' -ClusterName ', parameters('clusterName'),' -AdminUserName ', parameters('adminUsername'), ' -AdminBase64Password \"', variables('adminBase64Password'), '\"')]"
+    "hnStorageConnStrPrefix": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('hnStorageAccountName'), ';AccountKey=')]"
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountName')]",
+      "name": "[variables('hnStorageAccountName')]",
       "apiVersion": "[variables('apiVersion')]",
       "location": "[variables('location')]",
       "properties": {
-        "accountType": "Standard_LRS"
+        "accountType": "[parameters('storageAccountType')]"
       }
     },
     {
       "apiVersion": "[variables('apiVersion')]",
       "type": "Microsoft.Network/virtualNetworks",
-      "name": "[variables('virtualNetworkName')]",
+      "name": "[parameters('virtualNetworkName')]",
       "location": "[variables('location')]",
       "properties": {
         "addressSpace": {
@@ -298,7 +320,7 @@
       "name": "createHeadNode",
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicNameHN'))]",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('hnStorageAccountName'))]",
         "Microsoft.Resources/deployments/createAvailabilitySet"
       ],
       "properties": {
@@ -318,7 +340,7 @@
             "value": "[parameters('headNodeVMSize')]"
           },
           "storageAccountName": {
-            "value": "[variables('storageAccountName')]"
+            "value": "[variables('hnStorageAccountName')]"
           },
           "nicName": {
             "value": "[variables('nicNameHN')]"
@@ -357,7 +379,7 @@
         },
         "parameters": {
           "virtualNetworkName": {
-            "value": "[variables('virtualNetworkName')]"
+            "value": "[parameters('virtualNetworkName')]"
           },
           "virtualNetworkAddressRange": {
             "value": "[variables('addressPrefix')]"
@@ -396,35 +418,36 @@
             "[concat(variables('customScriptLocation'), 'HPCHNPrepare.ps1')]",
             "[concat(variables('customScriptLocation'), 'HpcPrepareUtil.ps1')]"
           ],
-          "commandToExecute": "[concat(variables('headNodeCommandStr'), ' -AzureStorageConnStr \"', variables('storageConnStrPrefix'), listKeys(variables('storageAccountId'),variables('apiVersion')).key1, '\" -PublicDnsName ', reference(variables('publicIPAddressNameHN')).dnsSettings.fqdn)]"
+          "commandToExecute": "[concat(variables('headNodeCommandStr'), ' -AzureStorageConnStr \"', variables('hnStorageConnStrPrefix'), listKeys(variables('hnStorageAccountId'),variables('apiVersion')).key1, '\" -PublicDnsName ', reference(variables('publicIPAddressNameHN')).dnsSettings.fqdn)]"
         }
       }
     },
 
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[concat(variables('cnStorageAccountPrefix'), copyIndex())]",
+      "name": "[concat(parameters('storageAccountNamePrefix'), padLeft(string(copyIndex()), 2, '0'))]",
       "apiVersion": "[variables('apiVersion')]",
       "location": "[variables('location')]",
       "dependsOn": [
         "Microsoft.Resources/deployments/updateVNetDNS"
       ],
       "copy": {
-        "name": "CNStorageAccounts",
+        "name": "hpcStorageAccounts",
         "count": "[variables('cnStorageAccountNumber')]"
       },
       "properties": {
-        "accountType": "Standard_LRS"
+        "accountType": "[parameters('storageAccountType')]"
       }
     },
 
     {
       "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
-      "name": "[concat('create', parameters('computeNodeNamePrefix'), copyIndex())]",
+      "name": "[concat('create', parameters('computeNodeNamePrefix'), padLeft(string(copyIndex()), 3, '0'))]",
       "dependsOn": [
         "Microsoft.Resources/deployments/createAvailabilitySet",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('cnStorageAccountPrefix'), div(copyIndex(), 10))]"
+        "Microsoft.Resources/deployments/updateVNetDNS",
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountNamePrefix'), padLeft(string(mod(copyIndex(), variables('cnStorageAccountNumber'))), 2, '0'))]"
       ],
       "copy": {
         "name": "CN",
@@ -444,19 +467,19 @@
             "value": "[variables('location')]"
           },
           "nicName": {
-            "value": "[concat(variables('nicName'), copyIndex())]"
+            "value": "[concat(variables('nicName'), padLeft(string(copyIndex()), 3, '0'))]"
           },
-          "subnetId": { 
+          "subnetId": {
             "value": "[variables('subnetRef')]"
           },
           "vmName": {
-            "value": "[concat(parameters('computeNodeNamePrefix'), copyIndex())]"
+            "value": "[concat(parameters('computeNodeNamePrefix'), padLeft(string(copyIndex()), 3, '0'))]"
           },
           "vmSize": {
             "value": "[parameters('computeNodeVMSize')]"
           },
           "storageAccountName": {
-            "value": "[concat(variables('cnStorageAccountPrefix'), div(copyIndex(), 10))]"
+            "value": "[concat(parameters('storageAccountNamePrefix'), padLeft(string(mod(copyIndex(), variables('cnStorageAccountNumber'))), 2, '0'))]"
           },
           "imgPublisher": {
             "value": "[variables('computeNodeImagePublisher')]"
@@ -479,7 +502,7 @@
           "availabilitySetName": {
             "value": "[variables('availabilitySetName')]"
           },
-          "customData": { 
+          "customData": {
             "value": "[base64(concat('HPCClusterName=', parameters('clusterName'), '\r\nImageCategory=public\r\nImageName=', parameters('computeNodeImage'), '\r\nVMSize=', parameters('computeNodeVMSize')))]"
           },
           "scriptBaseUri": {

--- a/create-hpc-cluster-linux-cn/azuredeploy.parameters.json
+++ b/create-hpc-cluster-linux-cn/azuredeploy.parameters.json
@@ -5,18 +5,27 @@
     "clusterName": {
       "value": "myhpccluster01"
     },
+    "virtualNetworkName": {
+      "value": "hpcvnet"
+    },
     "privateDomainName": {
-      "value": "hpc.local"    
+      "value": "hpc.local"
+    },
+    "storageAccountNamePrefix": {
+      "value": "hpcstorage"
+    },
+    "storageAccountType": {
+      "value": "Standard_LRS"
     },
     "headNodeVMSize": {
       "value": "Standard_A4"
     },
     "computeNodeImage": {
-      "value": "CentOS_7.0",
+      "value": "CentOS_7.0"
     },
     "computeNodeNamePrefix": {
-      "value": "IaaSLnxCN-",
-    }, 
+      "value": "IaaSLnxCN-"
+    },
     "computeNodeNumber": {
       "value": 2
     },
@@ -29,5 +38,5 @@
     "adminPassword": {
       "value": "Pa$$word123"
     }
-  }    
+  }
 }

--- a/create-hpc-cluster/azuredeploy.json
+++ b/create-hpc-cluster/azuredeploy.json
@@ -8,11 +8,35 @@
         "description": "The unique HPC Pack cluster name. It is also used as the public DNS name prefix for the cluster, for example, the public DNS name is '&lt;clusterName&gt;.westus.cloudapp.azure.com' if the resource group location is 'West US'. It must contain between 3 and 15 characters with lowercase letters and numbers, and must start with a letter."
       }
     },
+    "virtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the virtual network to be created."
+      }
+    },
     "privateDomainName": {
       "type": "string",
       "defaultValue": "hpc.local",
       "metadata": {
         "description": "The fully qualified domain name (FQDN) for the private domain forest which will be created by this template, for example 'hpc.local'."
+      }
+    },
+    "storageAccountNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The name prefix of the new storage accounts created to store the VMs disks. One storage account dedicated for head node, and one storage account every 10 compute nodes. For example, if 'mystorage' is specified, and there are 22 compute nodes, then 'mystoragehn' for head node, 'mystorage00', 'mystorage01' and 'mystorage02' for compute nodes."
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_RAGRS"
+      ],
+      "metadata": {
+        "description": "The type of the Storage Account created"
       }
     },
     "headNodeVMSize": {
@@ -53,7 +77,7 @@
       "type": "string",
       "defaultValue": "IaaSCN-",
       "metadata": {
-        "description": "The name prefix of the compute nodes. It can contain letters, numbers and hyphens and must start with a letter, up to 13 characters. For example, if 'IaaSCN-' is specified, the compute node names will be 'IaaSCN-0', 'IaaSCN-1', ..."
+        "description": "The name prefix of the compute nodes. It can contain letters, numbers and hyphens and must start with a letter, up to 12 characters. For example, if 'IaaSCN-' is specified, the compute node names will be 'IaaSCN-000', 'IaaSCN-001', ..."
       }
     },
     "computeNodeNumber": {
@@ -114,15 +138,14 @@
   "variables": {
     "apiVersion": "2015-05-01-preview",
     "location": "[resourceGroup().location]",
-    "storageAccountName": "[toLower(concat(parameters('clusterName'), 'sa'))]",
-    "cnStorageAccountPrefix": "[concat(variables('storageAccountName'), 'cn')]",
-    "cnStorageAccountNumber": "[add(div(parameters('computeNodeNumber'), 10), 1)]",
-    "storageAccountId": "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",
-    "virtualNetworkName": "[concat(parameters('clusterName'), 'VNet')]",
+    "nbrCNPerStorageAccount": 10,
+    "cnStorageAccountNumber": "[add(div(parameters('computeNodeNumber'), variables('nbrCNPerStorageAccount')), 1)]",
+    "hnStorageAccountName": "[concat(parameters('storageAccountNamePrefix'), 'hn')]",
+    "hnStorageAccountId": "[resourceId('Microsoft.Storage/storageAccounts',variables('hnStorageAccountName'))]",
     "addressPrefix": "10.0.0.0/16",
     "subnet1Name": "Subnet-1",
     "subnet1Prefix": "10.0.0.0/24",
-    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
     "publicIPAddressType": "Dynamic",
     "publicIPAddressName": "[concat(parameters('clusterName'), '-PublicIP-VM')]",
@@ -166,24 +189,24 @@
     "computeNodeImageSku": "[variables('availableCNImageSkus')[parameters('computeNodeImage')]]",
     "adminBase64Password": "[base64(parameters('adminPassword'))]",
     "customScriptLocation": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/create-hpc-cluster/",
-    "iaasInfoArg": "[concat('-SubscriptionId ', subscription().subscriptionId, ' -VNet ', variables('virtualNetworkName'), ' -Subnet ', variables('subnet1Name'), ' -Location \"', variables('location'), '\"')]",
+    "iaasInfoArg": "[concat('-SubscriptionId ', subscription().subscriptionId, ' -VNet ', parameters('virtualNetworkName'), ' -Subnet ', variables('subnet1Name'), ' -Location \"', variables('location'), '\"')]",
     "headNodeCommandStr": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File PrepareHN.ps1 -DomainFQDN ', parameters('privateDomainName'), ' -AdminUserName ', parameters('adminUsername'), ' -AdminBase64Password \"', variables('adminBase64Password'), '\" -CNSize ', parameters('computeNodeVMSize'), ' -PostConfigScript \"', parameters('headNodePostConfigScript'), '\" ', variables('iaasInfoArg'))]",
-    "storageConnStrPrefix": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=')]"
+    "hnStorageConnStrPrefix": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('hnStorageAccountName'), ';AccountKey=')]"
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountName')]",
+      "name": "[variables('hnStorageAccountName')]",
       "apiVersion": "[variables('apiVersion')]",
       "location": "[variables('location')]",
       "properties": {
-        "accountType": "Standard_LRS"
+        "accountType": "[parameters('storageAccountType')]"
       }
     },
     {
       "apiVersion": "[variables('apiVersion')]",
       "type": "Microsoft.Network/virtualNetworks",
-      "name": "[variables('virtualNetworkName')]",
+      "name": "[parameters('virtualNetworkName')]",
       "location": "[variables('location')]",
       "properties": {
         "addressSpace": {
@@ -267,7 +290,7 @@
       "name": "createHeadNode",
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicNameHN'))]",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('hnStorageAccountName'))]",
         "Microsoft.Resources/deployments/createAvailabilitySet"
       ],
       "properties": {
@@ -287,7 +310,7 @@
             "value": "[parameters('headNodeVMSize')]"
           },
           "storageAccountName": {
-            "value": "[variables('storageAccountName')]"
+            "value": "[variables('hnStorageAccountName')]"
           },
           "nicName": {
             "value": "[variables('nicNameHN')]"
@@ -326,7 +349,7 @@
         },
         "parameters": {
           "virtualNetworkName": {
-            "value": "[variables('virtualNetworkName')]"
+            "value": "[parameters('virtualNetworkName')]"
           },
           "virtualNetworkAddressRange": {
             "value": "[variables('addressPrefix')]"
@@ -365,35 +388,36 @@
             "[concat(variables('customScriptLocation'), 'HPCHNPrepare.ps1')]",
             "[concat(variables('customScriptLocation'), 'HpcPrepareUtil.ps1')]"
           ],
-          "commandToExecute": "[concat(variables('headNodeCommandStr'), ' -AzureStorageConnStr \"', variables('storageConnStrPrefix'), listKeys(variables('storageAccountId'),variables('apiVersion')).key1, '\" -PublicDnsName ', reference(variables('publicIPAddressNameHN')).dnsSettings.fqdn)]"
+          "commandToExecute": "[concat(variables('headNodeCommandStr'), ' -AzureStorageConnStr \"', variables('hnStorageConnStrPrefix'), listKeys(variables('hnStorageAccountId'),variables('apiVersion')).key1, '\" -PublicDnsName ', reference(variables('publicIPAddressNameHN')).dnsSettings.fqdn)]"
         }
       }
     },
 
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[concat(variables('cnStorageAccountPrefix'), copyIndex())]",
+      "name": "[concat(parameters('storageAccountNamePrefix'), padLeft(string(copyIndex()), 2, '0'))]",
       "apiVersion": "[variables('apiVersion')]",
       "location": "[variables('location')]",
       "dependsOn": [
         "Microsoft.Resources/deployments/updateVNetDNS"
       ],
       "copy": {
-        "name": "CNStorageAccounts",
+        "name": "hpcStorageAccounts",
         "count": "[variables('cnStorageAccountNumber')]"
       },
       "properties": {
-        "accountType": "Standard_LRS"
+        "accountType": "[parameters('storageAccountType')]"
       }
     },
 
     {
       "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
-      "name": "[concat('create', parameters('computeNodeNamePrefix'), copyIndex())]",
+      "name": "[concat('create', parameters('computeNodeNamePrefix'), padLeft(string(copyIndex()), 3, '0'))]",
       "dependsOn": [
         "Microsoft.Resources/deployments/createAvailabilitySet",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('cnStorageAccountPrefix'), div(copyIndex(), 10))]"
+        "Microsoft.Resources/deployments/updateVNetDNS",
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountNamePrefix'), padLeft(string(mod(copyIndex(), variables('cnStorageAccountNumber'))), 2, '0'))]"
       ],
       "copy": {
         "name": "CN",
@@ -413,19 +437,19 @@
             "value": "[variables('location')]"
           },
           "nicName": {
-            "value": "[concat(variables('nicName'), copyIndex())]"
+            "value": "[concat(variables('nicName'), padLeft(string(copyIndex()), 3, '0'))]"
           },
-          "subnetId": { 
+          "subnetId": {
             "value": "[variables('subnetRef')]"
           },
           "vmName": {
-            "value": "[concat(parameters('computeNodeNamePrefix'), copyIndex())]"
+            "value": "[concat(parameters('computeNodeNamePrefix'), padLeft(string(copyIndex()), 3, '0'))]"
           },
           "vmSize": {
             "value": "[parameters('computeNodeVMSize')]"
           },
           "storageAccountName": {
-            "value": "[concat(variables('cnStorageAccountPrefix'), div(copyIndex(), 10))]"
+            "value": "[concat(parameters('storageAccountNamePrefix'), padLeft(string(mod(copyIndex(), variables('cnStorageAccountNumber'))), 2, '0'))]"
           },
           "imgPublisher": {
             "value": "MicrosoftWindowsServerHPCPack"

--- a/create-hpc-cluster/azuredeploy.parameters.json
+++ b/create-hpc-cluster/azuredeploy.parameters.json
@@ -5,18 +5,27 @@
     "clusterName": {
       "value": "myhpccluster01"
     },
+    "virtualNetworkName": {
+      "value": "hpcvnet"
+    },
     "privateDomainName": {
-      "value": "hpc.local"    
+      "value": "hpc.local"
+    },
+    "storageAccountNamePrefix": {
+      "value": "hpcstorage"
+    },
+    "storageAccountType": {
+      "value": "Standard_LRS"
     },
     "headNodeVMSize": {
       "value": "Standard_A4"
     },
     "computeNodeImage": {
-      "value": "ComputeNode",
+      "value": "ComputeNode"
     },
     "computeNodeNamePrefix": {
-      "value": "IaaSCN-",
-    }, 
+      "value": "IaaSCN-"
+    },
     "computeNodeNumber": {
       "value": 2
     },


### PR DESCRIPTION
Let the user to specify "VNet name" and "storage account name/type" as parameters. Previously they are pre-defined in the template as variables.