### PR TITLE
better handling of special chars in password

### DIFF
--- a/mysql-replication/azuredeploy.json
+++ b/mysql-replication/azuredeploy.json
@@ -29,19 +29,19 @@
         "mysqlRootPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "mysql root user password"
+                "description": "mysql root user password single quote not allowed"
             }
         },
         "mysqlReplicationPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "mysql replication user password"
+                "description": "mysql replication user password single quote not allowed"
             }
         },
         "mysqlProbePassword": {
             "type": "securestring",
             "metadata": {
-                "description": "mysql probe password"
+                "description": "mysql probe password single quote not allowed"
             }
         },
         "vmSize": {
@@ -216,6 +216,7 @@
         "vhdContainer": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/vhds/')]",
         "customScriptFilePath": "[concat(parameters('artifactsPath'), '/azuremysql.sh')]",
         "mysqlConfigFilePath": "[concat(parameters('artifactsPath'), '/my.cnf.template')]",
+        "singleQuote": "'",
 
         "sa": "[parameters('dbSubnetStartAddress')]",
         "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
@@ -407,7 +408,7 @@
                     "fileUris": [
                         "[variables('customScriptFilePath')]"
                     ],
-                    "commandToExecute": "[concat(parameters('customScriptCommandToExecute'), ' ', copyIndex(1), ' ', variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255), ' ', variables('mysqlConfigFilePath'), ' ', parameters('mysqlReplicationPassword'), ' ', parameters('mysqlRootPassword'), ' ', parameters('mysqlProbePassword'), ' ', parameters('dbSubnetStartAddress'))]"
+                    "commandToExecute": "[concat(parameters('customScriptCommandToExecute'), ' ', copyIndex(1), ' ', variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255), ' ', variables('mysqlConfigFilePath'), ' ', variables('singleQuote'), parameters('mysqlReplicationPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlRootPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlProbePassword'), variables('singleQuote'), ' ', parameters('dbSubnetStartAddress'))]"
                 },
                 "protectedSettings": {
                     "Items": {

--- a/mysql-replication/azuremysql.sh
+++ b/mysql-replication/azuremysql.sh
@@ -235,7 +235,7 @@ fi
  
 MYSQL_HOST="${NODEADDRESS}"
 MYSQL_USERNAME="probeuser"
-MYSQL_PASSWORD="${PROBEPWD}"
+MYSQL_PASSWORD='${PROBEPWD}'
 
 ERROR_MSG=\`/usr/bin/mysqladmin --host=\${MYSQL_HOST} --port=3306 --user=\${MYSQL_USERNAME} --password=\${MYSQL_PASSWORD} status 2>/dev/null\`
 #ERROR_MSG=\`/usr/bin/mysql --host=\${MYSQL_HOST} --port=3306 --user=\${MYSQL_USERNAME} --password=\${MYSQL_PASSWORD} -e "show databases;" 2>/dev/null\`

--- a/wordpress-mysql-replication/azuredeploy.json
+++ b/wordpress-mysql-replication/azuredeploy.json
@@ -97,7 +97,7 @@
         "location": {
             "type": "string",
             "metadata": {
-                "description": "Location where the MySQL cluster will be deployed to"
+                "description": "Location where the MySQL cluster will be deployed to must not contain space"
             }
         },
         "publicIPName": { 

--- a/wordpress-mysql-replication/createUiDefinition.json
+++ b/wordpress-mysql-replication/createUiDefinition.json
@@ -240,8 +240,8 @@
                         "toolTip": "",
                         "constraints": {
                             "required": true,
-                            "regex": "",
-                            "validationMessage": ""
+                            "regex": "^[^'\\\\]{6,72}$",
+                            "validationMessage": "The password must be between 6 and 72 characters long, and cannot contain the single quote (apostrophe) character."
                         },
                         "options": {
                             "hideConfirmation": false


### PR DESCRIPTION
Passwords that contains " $ ! # may break bash script.  Updated with more robust handling of these cases.  The only char not allowed in password is single quote. 