### PR TITLE
Remove osDiskName parameter from AzureDiskEncryption running VM templates

### DIFF
--- a/201-encrypt-create-new-vm-gallery-image/azuredeploy.json
+++ b/201-encrypt-create-new-vm-gallery-image/azuredeploy.json
@@ -208,9 +208,6 @@
                     },
                     "KeyEncryptionKeyURL": {
                         "value": "[parameters('KeyEncryptionKeyURL')]"
-                    },
-                    "osDiskName": {
-                        "value": "[variables('osDiskName')]"
                     }
                 }
             }

--- a/201-encrypt-running-windows-vm/README.md
+++ b/201-encrypt-running-windows-vm/README.md
@@ -1,6 +1,6 @@
 # Enable encryption on a running Windows VM. 
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSudhakaraReddyEvuri%2Fazure-quickstart-templates%2Fmaster%2F201-encrypt-running-windows-vm%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-quickstart-templates%2Fmaster%2F201-encrypt-running-windows-vm%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/201-encrypt-running-windows-vm/README.md
+++ b/201-encrypt-running-windows-vm/README.md
@@ -1,6 +1,6 @@
 # Enable encryption on a running Windows VM. 
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-quickstart-templates%2Fmaster%2F201-encrypt-running-windows-vm%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FSudhakaraReddyEvuri%2Fazure-quickstart-templates%2Fmaster%2F201-encrypt-running-windows-vm%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/201-encrypt-running-windows-vm/README.md
+++ b/201-encrypt-running-windows-vm/README.md
@@ -4,4 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-This template enables encryption on a running windows vm using AAD client secret.
+This template enables encryption on a running windows vm using AAD client secret. This template assumes that the VM is located in the same region as the resource group. If not, please edit the template to pass appropriate location for the VM sub-resources.

--- a/201-encrypt-running-windows-vm/azuredeploy.json
+++ b/201-encrypt-running-windows-vm/azuredeploy.json
@@ -46,12 +46,6 @@
                 "description": "Type of the volume OS or Data to perform encryption operation"
             }
         },
-        "osDiskName": {
-            "type": "string",
-            "metadata": {
-                "description": "name of the OS disk on which encryption needs to be enabled"
-            }
-        },
         "sequenceVersion": {
             "type": "string",
             "defaultValue": "1",
@@ -101,7 +95,6 @@
             "properties": {
                 "storageProfile": {
                     "osDisk": {
-                        "name": "[parameters('osDiskName')]",
                         "encryptionSettings": {
                             "diskEncryptionKey": {
                                 "sourceVault": {

--- a/201-encrypt-running-windows-vm/azuredeploy.parameters.json
+++ b/201-encrypt-running-windows-vm/azuredeploy.parameters.json
@@ -23,9 +23,6 @@
         "VolumeType": {
             "value": "All"
         },
-        "osDiskName": {
-            "value": "osDiskName"
-        },
         "sequenceVersion": {
             "value": "1"
         }


### PR DESCRIPTION
This PR contains below changes
1. Removed 'osDiskName' parameter as it's no longer needed to update VM's encryption settings. 
2. Updated Readme.md to mention that the resources and resource group needs to be in the same region. 