### PR TITLE
201-cdn-with-storage-account JSON not valid

### DIFF
--- a/201-cdn-with-storage-account/azuredeploy.json
+++ b/201-cdn-with-storage-account/azuredeploy.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "variables": {
     "cdnApiVersion":"2015-06-01",
-    "storageApiVersion":"2015-06-15",
+    "storageApiVersion":"2015-06-15"
   },
   "parameters": {
     "storageAccountName": {


### PR DESCRIPTION
The template included an additional comma. This prevented the template from working with the Template Deployment blade on the Preview Portal.