### PR TITLE
docker-swarm: Hard-code admin username

### DIFF
--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -2,12 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "adminUsername": {
-      "type": "string",
-      "metadata": {
-        "description": "SSH user for the Virtual Machines."
-      }
-    },
     "sshPublicKey": {
       "type": "securestring",
       "metadata": {
@@ -24,6 +18,7 @@
   },
   "variables": {
     "masterCount": 3,
+    "adminUsername": "azureuser",
     "vmNameMaster": "swarm-master-",
     "vmNameNode": "swarm-node-",
     "vmSizeMaster": "Standard_A0",
@@ -58,7 +53,7 @@
     "nodesLbName": "swarm-lb-nodes",
     "nodesLbID": "[resourceId('Microsoft.Network/loadBalancers',variables('nodesLbName'))]",
     "nodesLbBackendPoolName": "swarm-nodes-pool",
-    "sshKeyPath": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+    "sshKeyPath": "[concat('/home/', variables('adminUsername'), '/.ssh/authorized_keys')]",
     "consulServerArgs": [
       "-advertise 10.0.0.4 -bootstrap-expect 3 -retry-join 10.0.0.5 -retry-join 10.0.0.6",
       "-advertise 10.0.0.5 -retry-join 10.0.0.4 -retry-join 10.0.0.6",
@@ -342,7 +337,7 @@
         },
         "osProfile": {
           "computerName": "[concat(variables('vmNameMaster'), copyIndex())]",
-          "adminUsername": "[parameters('adminUsername')]",
+          "adminUsername": "[variables('adminUsername')]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
             "ssh": {
@@ -402,7 +397,7 @@
         },
         "osProfile": {
           "computerName": "[concat(variables('vmNameNode'), copyIndex())]",
-          "adminUsername": "[parameters('adminUsername')]",
+          "adminUsername": "[variables('adminUsername')]",
           "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
             "ssh": {
@@ -527,7 +522,7 @@
   "outputs": {
     "sshTunnelCmd": {
       "type": "string",
-      "value": "[concat('ssh -L 2375:swarm-master-0:2375 -N ', parameters('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -p 2200')]"
+      "value": "[concat('ssh -L 2375:swarm-master-0:2375 -N ', variables('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -p 2200')]"
     },
     "dockerCmd": {
       "type": "string",
@@ -539,15 +534,15 @@
     },
     "sshMaster0": {
       "type": "string",
-      "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -A -p 2200')]"
+      "value": "[concat('ssh ', variables('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -A -p 2200')]"
     },
     "sshMaster1": {
       "type": "string",
-      "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -A -p 2201')]"
+      "value": "[concat('ssh ', variables('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -A -p 2201')]"
     },
     "sshMaster2": {
       "type": "string",
-      "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -A -p 2202')]"
+      "value": "[concat('ssh ', variables('adminUsername'), '@', reference(variables('managementPublicIPAddrName')).dnsSettings.fqdn, ' -A -p 2202')]"
     }
   }
 }

--- a/docker-swarm-cluster/azuredeploy.parameters.json
+++ b/docker-swarm-cluster/azuredeploy.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "adminUsername": {
-      "value": "azureuser"
-    },
     "sshPublicKey": {
       "value": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDAVUjb+H+bQgargG0Ew42/KjjIrJ4Vqwp8X3PKDCS7udZE8rTKx0ah8EfsVcSpzgHMOg2Dx/EBjF5/fE3QUwd8GCe1pNi875/Cf2CEfuQNhoxs+zXTdrVnaa6AnZszFHnPSS7QMhWA8lhjF4N2GCRQDDd3e45qNMc4TsNLz4dS90SNwNVbCyQnme46NTS5Fk2AbiJ5YqWF1UhEpUAdsWFsCRVQAHjH3Y57b2jk3RJJ9UFYQ5Trlow4ocOYEfsUGmr3yNFiIxlZC/sfx6WKoBxCOJhv/NJr0ow65zp/TC85IeDK5h8Jedd5UT2umdZDp4dbGhW0Aus2Md8yWE80/M9f replace_this_with_your@id_rsa.pub"
     },


### PR DESCRIPTION
One more step towards minimalism in the Docker Swarm template.
Having a default username does not impose any significant security
risks yet simplifies the process even better.

Usernames such as "admin" are not allowed in Azure, however portal
does not do any validations about that. So that still leaves a room
for user mistake which actually is our mistake.

The actual value is still in one place in case someone wants to replace
and roll their own username.

cc: @anhowe 