### PR TITLE
Renamed storageAccountName to storageAccountNamePrefix (Fix for Issue #895)

### DIFF
--- a/mongodb-high-availability/azuredeploy.json
+++ b/mongodb-high-availability/azuredeploy.json
@@ -14,7 +14,7 @@
         "description": "Administrator password used when provisioning virtual machines (which is also a password for the system administrator in MongoDB)"
       }
     },
-    "storageAccountName": {
+    "storageAccountNamePrefix": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
@@ -237,10 +237,10 @@
       "location": "[parameters('location')]"
     },
     "storageSettings": {
-      "vhdStorageAccountName": "[parameters('storageAccountName')]",
+      "vhdStorageAccountName": "[parameters('storageAccountNamePrefix')]",
       "vhdContainerName": "[variables('vmStorageAccountContainerName')]",
       "vmSeries": "[parameters('vmSeries')]",
-      "destinationVhdsContainer": "[concat('https://', parameters('storageAccountName'), variables('vmStorageAccountDomain'), '/', variables('vmStorageAccountContainerName'), '/')]",
+      "destinationVhdsContainer": "[concat('https://', parameters('storageAccountNamePrefix'), variables('vmStorageAccountDomain'), '/', variables('vmStorageAccountContainerName'), '/')]",
       "storageAccountCount": "[variables('clusterSpec').storageAccountCount]",
       "storageAccountType": "[parameters('storageAccountType')]"
     },

--- a/mongodb-high-availability/azuredeploy.parameters.json
+++ b/mongodb-high-availability/azuredeploy.parameters.json
@@ -8,7 +8,7 @@
     "adminPassword": {
       "value": ""
     },
-    "storageAccountName": {
+    "storageAccountNamePrefix": {
       "value": ""
     },
     "storageAccountType": {


### PR DESCRIPTION
Using `storageAccountName` as a parameter results in the following error "The `StorageAccountName` parameter is no longer used and will be removed in a future release. Also, the variable  `$storageAccountName` is empty causing deployment errors due to the account names being a concat of  `$storageAccountName`  & the iterator (basically tries to create a storage account name of  0 ,  1  etc.)