### PR TITLE
use secure string in password for client nodes

### DIFF
--- a/elasticsearch/client-nodes-resources.json
+++ b/elasticsearch/client-nodes-resources.json
@@ -9,7 +9,7 @@
       }
     },
     "adminPassword": {
-      "type": "string",
+      "type": "securestring",
       "metadata": {
         "description": "Admin password used when provisioning virtual machines"
       }


### PR DESCRIPTION
The client nodes were not using securestring for the admin password.
