### PR TITLE
Add a template to deploy Concourse CI on Azure

### DIFF
--- a/concourse-ci/README.md
+++ b/concourse-ci/README.md
@@ -1,0 +1,68 @@
+# Setup Concourse CI
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fconcourse-ci%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+[Concourse](http://concourse.ci/) is a CI system composed of simple tools and ideas. It can express entire pipelines, integrating with arbitrary resources, or it can be used to execute one-off tasks, either locally or in another CI system.
+
+>**NOTE:** When you deploy this template, you should choose the right location which supports DS series VMs for better performance. If you don't want to use DS series VMs, you need to update `Standard_DS` to `Standard_D` in `concourse.yml` before deploying Concourse.
+
+## Steps
+
+### Deploy BOSH
+
+1. Configure `bosh.yml`
+
+  Update your service principal (`tenant_id`, `client_id` and `client_secret`) if you don't set them in the parameters of this template.
+
+2. Deploy
+
+  ```
+  ./deploy_bosh.sh
+  ```
+
+3. Get `director_uuid`
+
+  ```
+  bosh target 10.0.0.4 # username: admin, password: admin
+  bosh status --uuid
+  ```
+
+### Deploy Concourse CI
+
+You can click [**HERE**](http://concourse.ci/deploying-with-bosh.html) to learn more about how to deploy Concourse CI with BOSH.
+
+The following steps are just for your information:
+
+1. Upload the stemcell
+
+  Get the value of **resource_pools.name[vms].stemcell.url** in **bosh.yml**, then use it to replace **STEMCELL-FOR-AZURE-URL** in below command:
+
+  ```
+  bosh upload stemcell STEMCELL-FOR-AZURE-URL
+  ```
+
+2. Upload the releases
+
+  ```
+  bosh upload release https://github.com/concourse/concourse/releases/download/v0.68.0/concourse-0.68.0.tgz
+  bosh upload release https://github.com/concourse/concourse/releases/download/v0.68.0/garden-linux-0.328.0.tgz
+  ```
+ 
+3. Configure
+
+  Update `concourse.yml` where the value is `REPLACE_WITH_*`.
+
+4. Deploy
+
+  ```
+  bosh deployment concourse.yml
+  bosh deploy
+  ```
+
+  You can use the following command to check the deployment:
+
+  ```
+  bosh vms
+  ```

--- a/concourse-ci/azuredeploy.json
+++ b/concourse-ci/azuredeploy.json
@@ -1,0 +1,284 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "vnet",
+      "metadata": {
+        "description": "name of the virtual network"
+      }
+    },
+    "virtualNetworkAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "address prefix of the virtual network"
+      }
+    },
+    "subnetNameForBosh": {
+      "type": "string",
+      "defaultValue": "Bosh",
+      "metadata": {
+        "description": "name of the subnet for Bosh"
+      }
+    },
+    "subnetAddressPrefixForBosh": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/24",
+      "metadata": {
+        "description": "address prefix of the subnet for Bosh"
+      }
+    },
+    "subnetNameForConcourse": {
+      "type": "string",
+      "defaultValue": "Concourse",
+      "metadata": {
+        "description": "name of the subnet for Concourse"
+      }
+    },
+    "subnetAddressPrefixForConcourse": {
+      "type": "string",
+      "defaultValue": "10.0.16.0/24",
+      "metadata": {
+        "description": "address prefix of the subnet for Concourse"
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "name of the vm, will be used as DNS Name for the Public IP used to access the Virtual Machine"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D1",
+      "allowedValues": [
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_D1",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4"
+      ],
+      "metadata": {
+        "description": "Size of vm"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "User name for the Virtual Machine."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
+    },
+    "tenantID": {
+      "type": "string",
+      "defaultValue": "TENANT-ID",
+      "metadata": {
+        "description": "ID of the tenant."
+      }
+    },
+    "clientID": {
+      "type": "string",
+      "defaultValue": "CLIENT-ID",
+      "metadata": {
+        "description": "ID of the client"
+      }
+    },
+    "clientSecret": {
+      "type": "securestring",
+      "defaultValue": "CLIENT-SECRET",
+      "metadata": {
+        "description": "secret of the client"
+      }
+    }
+  },
+  "variables": {
+    "apiVersion": "2015-06-15",
+    "location": "[resourceGroup().location]",
+    "newStorageAccountName": "[concat('concourse', uniqueString(resourceGroup().id))]",
+    "storageAccountType": "Standard_RAGRS",
+    "vmStorageAccountContainerName": "vhds",
+    "storageid": "[resourceId('Microsoft.Storage/storageAccounts', variables('newStorageAccountName'))]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+    "subnetRefForBosh": "[concat(variables('vnetID'),'/subnets/', parameters('subnetNameForBosh'))]",
+    "nicName": "[parameters('vmName')]",
+    "devboxPrivateIPAddress": "10.0.0.100",
+    "devboxPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses', 'devbox')]",
+    "imagePublisher": "Canonical",
+    "imageOffer": "UbuntuServer",
+    "ubuntuOSVersion": "14.04.3-LTS",
+    "repository": "Azure",
+    "branch": "master",
+    "githubPath": "[concat('https://raw.githubusercontent.com/', variables('repository'), '/azure-quickstart-templates/', variables('branch'), '/concourse-ci/')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('newStorageAccountName')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "devbox",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[toLower(parameters('vmName'))]"
+        }
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "concourse",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "static"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('virtualNetworkAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnetNameForBosh')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetAddressPrefixForBosh')]"
+            }
+          },
+          {
+            "name": "[parameters('subnetNameForConcourse')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetAddressPrefixForConcourse')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', 'devbox')]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[variables('devboxPrivateIPAddress')]",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses','devbox')]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRefForBosh')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiversion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/',variables('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/',variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('ubuntuOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',parameters('vmName'),'-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmName'),'/initdevbox')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.2",
+        "settings": {
+          "fileUris": [
+            "[concat(variables('githubPath'),'launch_script.sh')]"
+          ],
+          "commandToExecute": "[concat('sh launch_script.sh',' ',variables('githubPath'))]",
+          "VNET-NAME": "[parameters('virtualNetworkName')]",
+          "SUBNET-NAME": "[parameters('subnetNameForBosh')]",
+          "SUBNET-NAME-FOR-CONCOURSE": "[parameters('subnetNameForConcourse')]",
+          "SUBSCRIPTION-ID": "[subscription().subscriptionId]",
+          "STORAGE-ACCOUNT-NAME": "[variables('newStorageAccountName')]",
+          "STORAGE-ACCESS-KEY": "[listKeys(variables('storageid'),variables('apiVersion')).key1]",
+          "RESOURCE-GROUP-NAME": "[resourceGroup().name]",
+          "TENANT-ID": "[parameters('tenantID')]",
+          "CLIENT-ID": "[parameters('clientID')]",
+          "CLIENT-SECRET": "[parameters('clientSecret')]",
+          "CONCOURSE-IP": "[reference('concourse').ipAddress]",
+          "username": "[parameters('adminUserName')]"
+        }
+      }
+    }
+  ]
+}

--- a/concourse-ci/azuredeploy.json
+++ b/concourse-ci/azuredeploy.json
@@ -2,48 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "virtualNetworkName": {
-      "type": "string",
-      "defaultValue": "vnet",
-      "metadata": {
-        "description": "name of the virtual network"
-      }
-    },
-    "virtualNetworkAddressPrefix": {
-      "type": "string",
-      "defaultValue": "10.0.0.0/16",
-      "metadata": {
-        "description": "address prefix of the virtual network"
-      }
-    },
-    "subnetNameForBosh": {
-      "type": "string",
-      "defaultValue": "Bosh",
-      "metadata": {
-        "description": "name of the subnet for Bosh"
-      }
-    },
-    "subnetAddressPrefixForBosh": {
-      "type": "string",
-      "defaultValue": "10.0.0.0/24",
-      "metadata": {
-        "description": "address prefix of the subnet for Bosh"
-      }
-    },
-    "subnetNameForConcourse": {
-      "type": "string",
-      "defaultValue": "Concourse",
-      "metadata": {
-        "description": "name of the subnet for Concourse"
-      }
-    },
-    "subnetAddressPrefixForConcourse": {
-      "type": "string",
-      "defaultValue": "10.0.16.0/24",
-      "metadata": {
-        "description": "address prefix of the subnet for Concourse"
-      }
-    },
     "vmName": {
       "type": "string",
       "metadata": {
@@ -108,8 +66,14 @@
     "storageAccountType": "Standard_RAGRS",
     "vmStorageAccountContainerName": "vhds",
     "storageid": "[resourceId('Microsoft.Storage/storageAccounts', variables('newStorageAccountName'))]",
-    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-    "subnetRefForBosh": "[concat(variables('vnetID'),'/subnets/', parameters('subnetNameForBosh'))]",
+    "virtualNetworkName": "vnet",
+    "virtualNetworkAddressPrefix": "10.0.0.0/16",
+    "subnetNameForBosh": "Bosh",
+    "subnetAddressPrefixForBosh": "10.0.0.0/24",
+    "subnetNameForConcourse": "Concourse",
+    "subnetAddressPrefixForConcourse": "10.0.16.0/24",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+    "subnetRefForBosh": "[concat(variables('vnetID'),'/subnets/', variables('subnetNameForBosh'))]",
     "nicName": "[parameters('vmName')]",
     "devboxPrivateIPAddress": "10.0.0.100",
     "devboxPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses', 'devbox')]",
@@ -154,25 +118,25 @@
     {
       "apiVersion": "[variables('apiVersion')]",
       "type": "Microsoft.Network/virtualNetworks",
-      "name": "[parameters('virtualNetworkName')]",
+      "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('virtualNetworkAddressPrefix')]"
+            "[variables('virtualNetworkAddressPrefix')]"
           ]
         },
         "subnets": [
           {
-            "name": "[parameters('subnetNameForBosh')]",
+            "name": "[variables('subnetNameForBosh')]",
             "properties": {
-              "addressPrefix": "[parameters('subnetAddressPrefixForBosh')]"
+              "addressPrefix": "[variables('subnetAddressPrefixForBosh')]"
             }
           },
           {
-            "name": "[parameters('subnetNameForConcourse')]",
+            "name": "[variables('subnetNameForConcourse')]",
             "properties": {
-              "addressPrefix": "[parameters('subnetAddressPrefixForConcourse')]"
+              "addressPrefix": "[variables('subnetAddressPrefixForConcourse')]"
             }
           }
         ]
@@ -185,7 +149,7 @@
       "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', 'devbox')]",
-        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "properties": {
         "ipConfigurations": [
@@ -265,9 +229,9 @@
             "[concat(variables('githubPath'),'launch_script.sh')]"
           ],
           "commandToExecute": "[concat('sh launch_script.sh',' ',variables('githubPath'))]",
-          "VNET-NAME": "[parameters('virtualNetworkName')]",
-          "SUBNET-NAME": "[parameters('subnetNameForBosh')]",
-          "SUBNET-NAME-FOR-CONCOURSE": "[parameters('subnetNameForConcourse')]",
+          "VNET-NAME": "[variables('virtualNetworkName')]",
+          "SUBNET-NAME": "[variables('subnetNameForBosh')]",
+          "SUBNET-NAME-FOR-CONCOURSE": "[variables('subnetNameForConcourse')]",
           "SUBSCRIPTION-ID": "[subscription().subscriptionId]",
           "STORAGE-ACCOUNT-NAME": "[variables('newStorageAccountName')]",
           "STORAGE-ACCESS-KEY": "[listKeys(variables('storageid'),variables('apiVersion')).key1]",

--- a/concourse-ci/azuredeploy.parameters.json
+++ b/concourse-ci/azuredeploy.parameters.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmName": {
+      "value": "#####"
+    },
+    "adminUsername": {
+      "value": "azureuser"
+    },
+    "adminPassword": {
+      "value": "jcN#ms,]&]~t38A"
+    }
+  }
+}

--- a/concourse-ci/bosh.yml
+++ b/concourse-ci/bosh.yml
@@ -1,0 +1,131 @@
+---
+name: bosh
+
+releases:
+- name: bosh
+  url: http://cloudfoundry.blob.core.windows.net/azureci/bosh-214+dev.1.tgz
+  sha1: c28477c7e08cce06add980bed0ab1ab113a7c825
+- name: bosh-azure-cpi
+  url: http://cloudfoundry.blob.core.windows.net/azureci/bosh-azure-cpi-0+dev.1.tgz
+  sha1: e8aea0783d0de2d38ddb0b671265bc9ea46629d7
+
+networks:
+- name: private
+  type: manual
+  subnets:
+  - range: 10.0.0.0/24
+    gateway: 10.0.0.1
+    dns: [8.8.8.8]
+    cloud_properties:
+      virtual_network_name: VNET-NAME # <--- Replace with virtual network name
+      subnet_name: SUBNET-NAME # <--- Replace with subnet name for BOSH VM
+
+resource_pools:
+- name: vms
+  network: private
+  stemcell:
+    url: http://cloudfoundry.blob.core.windows.net/azureci/stemcell-ubuntu.tgz
+    sha1: 4b221f753d662a7c3e472be140c88075902f2b68
+  cloud_properties:
+    instance_type: Standard_D1
+
+disk_pools:
+- name: disks
+  disk_size: 25_000
+
+jobs:
+- name: bosh
+  templates:
+  - {name: nats, release: bosh}
+  - {name: redis, release: bosh}
+  - {name: postgres, release: bosh}
+  - {name: blobstore, release: bosh}
+  - {name: director, release: bosh}
+  - {name: health_monitor, release: bosh}
+  - {name: registry, release: bosh}
+  - {name: cpi, release: bosh-azure-cpi}
+
+  instances: 1
+  resource_pool: vms
+  persistent_disk_pool: disks
+
+  networks:
+  - {name: private, static_ips: [10.0.0.4], default: [dns, gateway]}
+
+  properties:
+    nats:
+      address: 127.0.0.1
+      user: nats
+      password: nats-password
+
+    redis:
+      listen_addresss: 127.0.0.1
+      address: 127.0.0.1
+      password: redis-password
+
+    postgres: &db
+      host: 127.0.0.1
+      user: postgres
+      password: postgres-password
+      database: bosh
+      adapter: postgres
+
+    registry:
+      address: 10.0.0.4
+      host: 10.0.0.4
+      db: *db
+      http: {user: admin, password: admin, port: 25777}
+      username: admin
+      password: admin
+      port: 25777
+
+    blobstore:
+      address: 10.0.0.4
+      port: 25250
+      provider: dav
+      director: {user: director, password: director-password}
+      agent: {user: agent, password: agent-password}
+
+    director:
+      address: 127.0.0.1
+      name: bosh
+      db: *db
+      cpi_job: cpi
+      enable_snapshots: true
+
+    hm:
+      http: {user: hm, password: hm-password}
+      director_account: {user: admin, password: admin}
+
+    azure: &azure
+      environment: AzureCloud
+      subscription_id: SUBSCRIPTION-ID # <--- Replace with your subscription id
+      storage_account_name: STORAGE-ACCOUNT-NAME # <--- Replace with your storage account name
+      resource_group_name: RESOURCE-GROUP-NAME # <--- Replace with your resource group name
+      tenant_id: TENANT-ID # <--- Replace with your tenant id of the service principal
+      client_id: CLIENT-ID # <--- Replace with your client id of the service principal
+      client_secret: CLIENT-SECRET # <--- Replace with your client secret of the service principal
+      ssh_user: vcap
+      ssh_certificate: |
+        SSH-CERTIFICATE # <--- Replace with the content of your ssh certificate
+
+    agent: {mbus: "nats://nats:nats-password@10.0.0.4:4222"}
+
+    ntp: &ntp [0.north-america.pool.ntp.org]
+
+cloud_provider:
+  template: {name: cpi, release: bosh-azure-cpi}
+
+  ssh_tunnel:
+    host: 10.0.0.4
+    port: 22
+    user: vcap # The user must be as same as above ssh_user
+    private_key: ~/bosh # Path relative to this manifest file
+
+  mbus: https://mbus-user:mbus-password@10.0.0.4:6868
+
+  properties:
+    azure: *azure
+    agent: {mbus: "https://mbus-user:mbus-password@0.0.0.0:6868"}
+    blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
+    ntp: *ntp

--- a/concourse-ci/concourse.yml
+++ b/concourse-ci/concourse.yml
@@ -1,0 +1,157 @@
+---
+name: concourse
+
+# replace with bosh status --uuid
+director_uuid: REPLACE_WITH_UUID
+
+# pick a sane db name and password
+atc_db_name: &atc-db-name atc
+atc_db_role: &atc-db-role
+  name: atc
+  password: REPLACE_WITH_DB_PASSWORD
+
+networks:
+  - name: concourse
+    type: manual
+    subnets:
+      - range: 10.0.16.0/24
+        reserved: [10.0.16.2 - 10.0.16.3]
+        static:
+          - &discovery_static_ip 10.0.16.4
+          - &web_static_ip 10.0.16.5
+        dns: [8.8.8.8]
+        gateway: 10.0.16.1
+        cloud_properties:
+          virtual_network_name: VNET-NAME
+          subnet_name: SUBNET-NAME-FOR-CONCOURSE
+
+  - name: public
+    type: vip
+    cloud_properties:
+      tcp_endpoints:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+      - "22:22"
+
+releases:
+  - name: concourse
+    version: latest
+  - name: garden-linux
+    version: latest
+
+jobs:
+  - name: discovery
+    instances: 1
+    resource_pool: discovery
+    persistent_disk: 1024
+    templates:
+      - {release: concourse, name: consul-agent}
+    networks:
+      - name: concourse
+        static_ips: [*discovery_static_ip]
+    properties:
+      consul:
+        agent:
+          mode: server
+
+  - name: web
+    instances: 1
+    resource_pool: web
+    templates:
+      - {release: concourse, name: consul-agent}
+      - {release: concourse, name: tsa}
+      - {release: concourse, name: atc}
+    networks:
+      - name: concourse
+        static_ips: [*web_static_ip]
+        default: [dns, gateway]
+      - name: public
+        static_ips: [CONCOURSE-IP]
+    properties:
+      atc:
+        basic_auth_username: REPLACE_WITH_BASIC_AUTH_USERNAME
+        basic_auth_password: REPLACE_WITH_BASIC_AUTH_PASSWORD
+        postgresql:
+          database: *atc-db-name
+          role: *atc-db-role
+
+      consul:
+        agent:
+          servers: {lan: [*discovery_static_ip]}
+
+  - name: db
+    instances: 1
+    resource_pool: databases
+    persistent_disk: 10240
+    templates:
+      - {release: concourse, name: consul-agent}
+      - {release: concourse, name: postgresql}
+    networks: [{name: concourse}]
+    properties:
+      postgresql:
+        databases: [{name: *atc-db-name}]
+        roles: [*atc-db-role]
+
+      consul:
+        agent:
+          servers: {lan: [*discovery_static_ip]}
+
+  - name: worker
+    instances: 1
+    resource_pool: workers
+    templates:
+      - {release: concourse, name: consul-agent}
+      - {release: concourse, name: groundcrew}
+      - {release: concourse, name: baggageclaim}
+      - {release: garden-linux, name: garden}
+    networks: [{name: concourse}]
+    properties:
+      garden:
+        listen_network: tcp
+        listen_address: 0.0.0.0:7777
+
+      consul:
+        agent:
+          servers: {lan: [*discovery_static_ip]}
+
+resource_pools:
+  - name: web
+    network: concourse
+    stemcell: &stemcell
+      name: bosh-azure-hyperv-ubuntu-trusty-go_agent
+      version: '0000'
+    cloud_properties:
+      instance_type: Standard_DS2
+
+  - name: discovery
+    network: concourse
+    stemcell: *stemcell
+    cloud_properties:
+      instance_type: Standard_DS2
+
+  - name: databases
+    network: concourse
+    stemcell: *stemcell
+    cloud_properties:
+      instance_type: Standard_DS2
+
+  - name: workers
+    network: concourse
+    stemcell: *stemcell
+    cloud_properties:
+      instance_type: Standard_DS4
+
+compilation:
+  workers: 3
+  network: concourse
+  reuse_compilation_vms: true
+  cloud_properties:
+    instance_type: Standard_D1
+
+update:
+  canaries: 1
+  max_in_flight: 1
+  serial: false
+  canary_watch_time: 1000-60000
+  update_watch_time: 1000-60000

--- a/concourse-ci/create_cert.sh
+++ b/concourse-ci/create_cert.sh
@@ -1,0 +1,10 @@
+openssl genrsa -out bosh.key 2048 >/dev/null 2>&1
+openssl req -new -x509 -days 365 -key bosh.key -out bosh_cert.pem >/dev/null 2>&1 << EndOfMessage
+AU
+ZJU
+ZHCN
+Linux
+Soft
+SShKey
+test@abc.com
+EndOfMessage

--- a/concourse-ci/deploy_bosh.sh
+++ b/concourse-ci/deploy_bosh.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export BOSH_INIT_LOG_LEVEL='Debug'
+export BOSH_INIT_LOG_PATH='./run.log'
+bosh-init deploy bosh.yml

--- a/concourse-ci/init.sh
+++ b/concourse-ci/init.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Start to update package lists from repositories..."
+sudo apt-get update
+
+echo "Start to install prerequisites..."
+sudo apt-get install -y build-essential ruby2.0 ruby2.0-dev libxml2-dev libsqlite3-dev libxslt1-dev libpq-dev libmysqlclient-dev zlibc zlib1g-dev openssl libxslt-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev sqlite3 libffi-dev
+
+# Update Ruby 1.9 to 2.0
+sudo rm /usr/bin/ruby /usr/bin/gem /usr/bin/irb /usr/bin/rdoc /usr/bin/erb
+sudo ln -s /usr/bin/ruby2.0 /usr/bin/ruby
+sudo ln -s /usr/bin/gem2.0 /usr/bin/gem
+sudo ln -s /usr/bin/irb2.0 /usr/bin/irb
+sudo ln -s /usr/bin/rdoc2.0 /usr/bin/rdoc
+sudo ln -s /usr/bin/erb2.0 /usr/bin/erb
+sudo gem update --system
+sudo gem pristine --all
+
+echo "Start to install bosh_cli..."
+sudo gem install bosh_cli --no-ri --no-rdoc
+
+echo "Start to install bosh-init..."
+wget https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.80-linux-amd64
+chmod +x ./bosh-init-*
+sudo mv ./bosh-init-* /usr/local/bin/bosh-init
+
+echo "Finish"

--- a/concourse-ci/launch_script.sh
+++ b/concourse-ci/launch_script.sh
@@ -1,0 +1,8 @@
+for f in concourse.yml bosh.yml create_cert.sh setup_devbox.py init.sh deploy_bosh.sh
+do
+   wget $1/$f -O $f
+done
+
+\cp * ../../
+cd ../../
+python setup_devbox.py

--- a/concourse-ci/metadata.json
+++ b/concourse-ci/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Concourse CI",
+  "description": "Concourse is a CI system composed of simple tools and ideas. It can express entire pipelines, integrating with arbitrary resources, or it can be used to execute one-off tasks, either locally or in another CI system. This template can help to prepare neccessary Azure resources to setup such a CI system, and make the setup more simple.",
+  "summary": "This template helps you setup Concourse CI.",
+  "githubUsername": "bingosummer",
+  "dateUpdated": "2015-11-30"
+}

--- a/concourse-ci/setup_devbox.py
+++ b/concourse-ci/setup_devbox.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+import os
+import re
+import json
+import traceback
+from subprocess import call
+from Utils.WAAgentUtil import waagent
+import Utils.HandlerUtil as Util
+from azure.storage import BlobService
+from azure.storage import TableService
+
+call("mkdir -p ./bosh", shell=True)
+call("chmod +x deploy_bosh.sh", shell=True)
+call("cp deploy_bosh.sh ./bosh/", shell=True)
+
+# Get settings from CustomScriptForLinux extension configurations
+waagent.LoggerInit('/var/log/waagent.log', '/dev/stdout')
+hutil =  Util.HandlerUtility(waagent.Log, waagent.Error, "bosh-deploy-script")
+hutil.do_parse_context("enable")
+settings = hutil.get_public_settings()
+with open (os.path.join('bosh','settings'), "w") as tmpfile:
+    tmpfile.write(json.dumps(settings, indent=4, sort_keys=True))
+username = settings["username"]
+home_dir = os.path.join("/home", username)
+install_log = os.path.join(home_dir, "install.log")
+
+# Prepare the containers
+storage_account_name = settings["STORAGE-ACCOUNT-NAME"]
+storage_access_key = settings["STORAGE-ACCESS-KEY"]
+blob_service = BlobService(storage_account_name, storage_access_key)
+blob_service.create_container('bosh')
+blob_service.create_container('stemcell')
+
+# Generate the private key and certificate
+call("sh create_cert.sh", shell=True)
+call("cp bosh.key ./bosh/bosh", shell=True)
+with open ('bosh_cert.pem', 'r') as tmpfile:
+    ssh_cert = tmpfile.read()
+indentation = " " * 8
+ssh_cert=("\n"+indentation).join([line for line in ssh_cert.split('\n')])
+
+# Render the yml template for bosh-init
+bosh_template = 'bosh.yml'
+if os.path.exists(bosh_template):
+    with open (bosh_template, 'r') as tmpfile:
+        contents = tmpfile.read()
+    for k in ["RESOURCE-GROUP-NAME", "STORAGE-ACCESS-KEY", "STORAGE-ACCOUNT-NAME", "SUBNET-NAME", "SUBSCRIPTION-ID", "VNET-NAME", "TENANT-ID", "CLIENT-ID", "CLIENT-SECRET"]:
+        v = settings[k]
+        contents = re.compile(re.escape(k)).sub(v, contents)
+    contents = re.compile(re.escape("SSH-CERTIFICATE")).sub(ssh_cert, contents)
+    with open (os.path.join('bosh', bosh_template), 'w') as tmpfile:
+        tmpfile.write(contents)
+
+# Install bosh_cli and bosh-init
+#call("rm -r /tmp; mkdir /mnt/tmp; ln -s /mnt/tmp /tmp; chmod 777 /mnt/tmp; chmod 777 /tmp", shell=True)
+call("mkdir /mnt/bosh_install; cp init.sh /mnt/bosh_install; cd /mnt/bosh_install; chmod +x init.sh; ./init.sh >{0} 2>&1;".format(install_log), shell=True)
+
+# Render the yml template for concourse
+concourse_template = 'concourse.yml'
+if os.path.exists(concourse_template):
+    with open (concourse_template, 'r') as tmpfile:
+        contents = tmpfile.read()
+    for k in ["SUBNET-NAME-FOR-CONCOURSE", "VNET-NAME", "CONCOURSE-IP"]:
+        v = settings[k]
+        contents = re.compile(re.escape(k)).sub(v, contents)
+    with open (os.path.join('bosh', concourse_template), 'w') as tmpfile:
+        tmpfile.write(contents)
+
+# Copy all the files in ./bosh into the home directory
+call("cp -r ./bosh/* {0}".format(home_dir), shell=True)
+call("chown -R {0} {1}".format(username, home_dir), shell=True)
+call("chmod 400 {0}/bosh".format(home_dir), shell=True)


### PR DESCRIPTION
This template prepares Azure resources to deploy Concourse CI on Azure, including 1 storage account, 1 virtual network with 2 subnets, 2 public IPs and 1 VM.