### PR TITLE
update version and simplify load balancer config

### DIFF
--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -235,11 +235,11 @@
     "lbBackendPoolsRemoved": {
       "backendPools": []
     },
-    "dataLBSettingOptinos": [
+    "dataLBSettingOptions": [
       "[variables('lbBackEndPoolsAdded')]",
       "[variables('lbBackendPoolsRemoved')]"
     ],
-    "dataLBSettings": "[variables('dataLBSettingOptinos')[mod(add(parameters('vmClientNodeCount'),2),add(parameters('vmClientNodeCount'),1))]]",
+    "dataLBSettings": "[variables('dataLBSettingOptions')[mod(add(parameters('vmClientNodeCount'),2),add(parameters('vmClientNodeCount'),1))]]",
     "jumpboxTemplateYes": "jumpbox-resources.json",
     "jumpboxTemplateNo": "empty-resources.json",
     "jumpboxTemplateUrl": "[concat(variables('templateBaseUrl'), variables(concat('jumpboxTemplate',parameters('jumpbox'))))]",

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -79,9 +79,15 @@
       "defaultValue": 0,
       "allowedValues": [
         0,
+        1,
+        2,
         3,
+        4,
         5,
-        7
+        6,
+        7,
+        8,
+        9
       ],
       "metadata": {
         "description": "Number of Elasticsearch client nodes to provision (Setting this to zero puts the data nodes on the load balancer)"
@@ -214,13 +220,11 @@
     },
     "sharedTemplateUrl": "[concat(variables('templateBaseUrl'), 'shared-resources.json')]",
     "masterTemplateUrl": "[concat(variables('templateBaseUrl'), 'master-nodes-resources.json')]",
-    "clientTemplates": {
-      "n0": "empty-resources.json",
-      "n3": "client-nodes-resources.json",
-      "n5": "client-nodes-resources.json",
-      "n7": "client-nodes-resources.json"
-    },
-    "clientTemplateUrl": "[concat(variables('templateBaseUrl'), variables('clientTemplates')[concat('n',parameters('vmClientNodeCount'))])]",
+    "clientTemplates": [
+      "empty-resources.json",
+      "client-nodes-resources.json"
+    ],
+    "clientTemplateUrl": "[concat(variables('templateBaseUrl'), variables('clientTemplates')[mod(add(parameters('vmClientNodeCount'),2),add(parameters('vmClientNodeCount'),1))])]",
     "lbBackEndPoolsAdded": {
       "backendPools": [
         {
@@ -231,11 +235,11 @@
     "lbBackendPoolsRemoved": {
       "backendPools": []
     },
-    "dataLBSettings0": "[variables('lbBackEndPoolsAdded')]",
-    "dataLBSettings3": "[variables('lbBackendPoolsRemoved')]",
-    "dataLBSettings5": "[variables('lbBackendPoolsRemoved')]",
-    "dataLBSettings7": "[variables('lbBackendPoolsRemoved')]",
-    "dataLBSettings": "[variables(concat('dataLBSettings', parameters('vmClientNodeCount')))]",
+    "dataLBSettingOptinos": [
+      "[variables('lbBackEndPoolsAdded')]",
+      "[variables('lbBackendPoolsRemoved')]"
+    ],
+    "dataLBSettings": "[variables('dataLBSettingOptinos')[mod(add(parameters('vmClientNodeCount'),2),add(parameters('vmClientNodeCount'),1))]]",
     "jumpboxTemplateYes": "jumpbox-resources.json",
     "jumpboxTemplateNo": "empty-resources.json",
     "jumpboxTemplateUrl": "[concat(variables('templateBaseUrl'), variables(concat('jumpboxTemplate',parameters('jumpbox'))))]",

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -139,12 +139,11 @@
     },
     "esVersion": {
       "type": "string",
-      "defaultValue": "2.0.0",
+      "defaultValue": "2.0.1",
       "allowedValues": [
-        "2.0.0",
-        "1.7.3",
-        "1.6.2",
-        "1.5.2"
+        "2.1.0",
+        "2.0.1",
+        "1.7.3"
       ],
       "metadata": {
         "description": "Elasticsearch version to install"


### PR DESCRIPTION
Updated the version
* bumped 2.0.0 to 2.0.1
* added 2.1.0
* removed 1.5/1.6 since 1.7.3 should be used in favor of those on Azure

refactored and cleaned up the client node template/load-balancer configuration
