### PR TITLE
Update azuredeploy.json

### DIFF
--- a/201-logic-app-custom-api/azuredeploy.json
+++ b/201-logic-app-custom-api/azuredeploy.json
@@ -86,6 +86,7 @@
         },
         {
             "type": "Microsoft.Web/sites",
+            "kind": "api",
             "apiVersion": "2015-08-01",
             "name": "[parameters('webAppName')]",
             "location": "[parameters('location')]",


### PR DESCRIPTION
Setting the kind to api.  Not a hard requirement but indicates the intent is an "api".  This makes Ibiza orient settings and quickstarts accordingly.