### PR TITLE
Azure RM template for creating an Azure DevTest Lab with policies.

### DIFF
--- a/101-dtl-create-lab/Cmdlets.DevTestLab.ps1
+++ b/101-dtl-create-lab/Cmdlets.DevTestLab.ps1
@@ -880,12 +880,26 @@ function New-AzureDtlVirtualMachine
                 }
             }
 
-            # Pre-condition checks for sysprepped VHDs.
-            if ($true -eq $VMTemplate.Properties.SysPrep)
+            # Pre-condition checks for windows VHDs.
+            else 
             {
-                if ($false -eq ($PSBoundParameters.ContainsKey("UserName") -and $PSBoundParameters.ContainsKey("Password")))
+                # Pre-condition checks for sysprepped Windows VHDs.
+                if ($true -eq $VMTemplate.Properties.SysPrep)
                 {
-                    throw $("The specified VM template '" + $VMTemplate.Name + "' uses a sysprepped VHD. Please specify both the -UserName and -Password parameters to use this VM template.")
+                    if ($false -eq ($PSBoundParameters.ContainsKey("UserName") -and $PSBoundParameters.ContainsKey("Password")))
+                    {
+                        throw $("The specified VM template '" + $VMTemplate.Name + "' uses a sysprepped VHD. Please specify both the -UserName and -Password parameters to use this VM template.")
+                    }
+                }
+
+                # Pre-condition checks for non-sysprepped Windows VHDs.
+                # Note: For non-sysprepped windows VHDs we ignore the username and password and instead use the built-in account.
+                else
+                {
+                    if ($true -eq ($PSBoundParameters.ContainsKey("UserName") -and $PSBoundParameters.ContainsKey("Password")))
+                    {
+                        Write-Warning $("The specified VM template '" + $VMTemplate.Name + "' uses a non-sysprepped VHD with a built-in account. The specified userame and password will not be used.")
+                    }                    
                 }
             }
         }

--- a/101-dtl-create-lab/Cmdlets.DevTestLab.ps1
+++ b/101-dtl-create-lab/Cmdlets.DevTestLab.ps1
@@ -53,14 +53,11 @@ function GetLabFromVM_Private
         $VM
     )
 
-    $vmProperties = Get-AzureRmResource -ExpandProperties | Where {
-        $_.ResourceType -eq $EnvironmentResourceType -and 
-        $_.ResourceId -eq $VM.ResourceId
-    } | Select -Property "Properties"
+    $vm = GetResourceWithProperties_Private -Resource $VM
 
     Get-AzureRmResource | Where {
         $_.ResourceType -eq $LabResourceType -and 
-        $_.ResourceId -eq $vmProperties.Properties.LabId
+        $_.ResourceId -eq $vm.Properties.LabId
     }
 }
 

--- a/101-dtl-create-lab/Cmdlets.DevTestLab.ps1
+++ b/101-dtl-create-lab/Cmdlets.DevTestLab.ps1
@@ -55,7 +55,7 @@ function GetLabFromVM_Private
 
     $vm = GetResourceWithProperties_Private -Resource $VM
 
-    Get-AzureRmResource | Where {
+    Get-AzureRmResource | Where-Object {
         $_.ResourceType -eq $LabResourceType -and 
         $_.ResourceId -eq $vm.Properties.LabId
     }
@@ -205,7 +205,7 @@ function Get-AzureDtlLab
         {
             "ListByLabId"
             {
-                $output = Get-AzureRmResource | Where { 
+                $output = Get-AzureRmResource | Where-Object { 
                     $_.ResourceType -eq $LabResourceType -and 
                     $_.ResourceId -eq $LabId 
                 }
@@ -215,7 +215,7 @@ function Get-AzureDtlLab
             {
                 if ($PSBoundParameters.ContainsKey("LabResourceGroupName"))
                 {
-                    $output = Get-AzureRmResource | Where { 
+                    $output = Get-AzureRmResource | Where-Object { 
                         $_.ResourceType -eq $LabResourceType -and 
                         $_.ResourceName -eq $LabName -and 
                         $_.ResourceGroupName -eq $LabResourceGroupName 
@@ -223,7 +223,7 @@ function Get-AzureDtlLab
                 }
                 else
                 {
-                    $output = Get-AzureRmResource | Where { 
+                    $output = Get-AzureRmResource | Where-Object { 
                         $_.ResourceType -eq $LabResourceType -and 
                         $_.ResourceName -eq $LabName 
                     }     
@@ -232,7 +232,7 @@ function Get-AzureDtlLab
 
             "ListAllInResourceGroup"
             {
-                $output = Get-AzureRmResource | Where { 
+                $output = Get-AzureRmResource | Where-Object { 
                     $_.ResourceType -eq $LabResourceType -and 
                     $_.ResourceGroupName -eq $LabResourceGroupName 
                 }
@@ -240,7 +240,7 @@ function Get-AzureDtlLab
 
             "ListAllInLocation"
             {
-                $output = Get-AzureRmResource | Where { 
+                $output = Get-AzureRmResource | Where-Object { 
                     $_.ResourceType -eq $LabResourceType -and 
                     $_.Location -eq $LabLocation 
                 }
@@ -248,7 +248,7 @@ function Get-AzureDtlLab
 
             "ListAll" 
             {
-                $output = Get-AzureRmResource | Where { 
+                $output = Get-AzureRmResource | Where-Object { 
                     $_.ResourceType -eq $LabResourceType 
                 }
             }
@@ -349,7 +349,7 @@ function Get-AzureDtlVMTemplate
 
             "ListByVMTemplateName"
             {
-                $output = Get-AzureRmResource -ResourceName $Lab.ResourceName -ResourceGroupName $Lab.ResourceGroupName -ResourceType $VMTemplateResourceType -ApiVersion $RequiredApiVersion | Where {
+                $output = Get-AzureRmResource -ResourceName $Lab.ResourceName -ResourceGroupName $Lab.ResourceGroupName -ResourceType $VMTemplateResourceType -ApiVersion $RequiredApiVersion | Where-Object {
                     $_.Name -eq $VMTemplateName
                 }
             }
@@ -472,7 +472,7 @@ function Get-AzureDtlVirtualMachine
         {
             "ListByVMId"
             {
-                $output = Get-AzureRmResource | Where { 
+                $output = Get-AzureRmResource | Where-Object { 
                     $_.ResourceType -eq $EnvironmentResourceType -and 
                     $_.ResourceId -eq $VMId 
                 }
@@ -480,7 +480,7 @@ function Get-AzureDtlVirtualMachine
                     
             "ListByVMName"
             {
-                $output = Get-AzureRmResource | Where { 
+                $output = Get-AzureRmResource | Where-Object { 
                     $_.ResourceType -eq $EnvironmentResourceType -and 
                     $_.ResourceName -eq $VMName 
                 }                
@@ -490,7 +490,7 @@ function Get-AzureDtlVirtualMachine
             {
                 $fetchedLabObj = Get-AzureDtlLab -LabName $LabName 
 
-                if ($fetchedLabObj -ne $null -and $fetchedLabObj.Count -ne 0)
+                if ($null -ne $fetchedLabObj -and $fetchedLabObj.Count -ne 0)
                 {
                     if ($fetchedLabObj.Count > 1)
                     {
@@ -504,7 +504,7 @@ function Get-AzureDtlVirtualMachine
                         # Note: The -ErrorAction 'SilentlyContinue' ensures that we suppress irrelevant
                         # errors originating while expanding properties (especially in internal test and
                         # pre-production subscriptions).
-                        $output = Get-AzureRmResource -ExpandProperties -ErrorAction "SilentlyContinue" | Where { 
+                        $output = Get-AzureRmResource -ExpandProperties -ErrorAction "SilentlyContinue" | Where-Object { 
                             $_.ResourceType -eq $EnvironmentResourceType -and
                             $_.Properties.LabId -eq $fetchedLabObj.ResourceId
                         }
@@ -514,7 +514,7 @@ function Get-AzureDtlVirtualMachine
 
             "ListAllInResourceGroup"
             {
-                $output = Get-AzureRmResource | Where { 
+                $output = Get-AzureRmResource | Where-Object { 
                     $_.ResourceType -eq $EnvironmentResourceType -and 
                     $_.ResourceGroupName -eq $VMResourceGroupName 
                 }             
@@ -522,7 +522,7 @@ function Get-AzureDtlVirtualMachine
 
             "ListAllInLocation"
             {
-                $output = Get-AzureRmResource | Where { 
+                $output = Get-AzureRmResource | Where-Object { 
                     $_.ResourceType -eq $EnvironmentResourceType -and 
                     $_.Location -eq $VMLocation 
                 }
@@ -530,7 +530,7 @@ function Get-AzureDtlVirtualMachine
 
             "ListAll" 
             {
-                $output = Get-AzureRmResource | Where { 
+                $output = Get-AzureRmResource | Where-Object { 
                     $_.ResourceType -eq $EnvironmentResourceType 
                 }
             }
@@ -605,7 +605,7 @@ function New-AzureDtlLab
         }
 
         # Check if there are any existing labs with same name in the current subscription
-        $existingLabs = Get-AzureRmResource | Where { 
+        $existingLabs = Get-AzureRmResource | Where-Object { 
             $_.ResourceType -eq $LabResourceType -and 
             $_.ResourceName -eq $LabName -and 
             $_.SubscriptionId -eq (Get-AzureRmContext).Subscription.SubscriptionId

--- a/101-dtl-create-lab/Cmdlets.DevTestLab.ps1
+++ b/101-dtl-create-lab/Cmdlets.DevTestLab.ps1
@@ -1108,29 +1108,19 @@ function Remove-AzureDtlVirtualMachine
             # Get the same VM object, but with properties attached.
             $vm = GetResourceWithProperties_Private -Resource $vm
 
-            # Ensure that we're able to extract the FQDN of the VM.
-            if (($null -ne $vm) -and ($null -ne $vm.Properties) -and ($null -ne $vm.Properties.Vms) -and ($null -ne $vm.Properties.Vms[0]) -and ($null -ne $vm.Properties.Vms[0].Fqdn))
+            # Pop the confirmation dialog.
+            if ($PSCmdlet.ShouldProcess($vm.ResourceName, "delete VM"))
             {
-                # Pop the confirmation dialog.
-                if ($PSCmdlet.ShouldProcess($vm.ResourceName, "delete VM"))
+                Write-Warning $("Deleting VM '" + $vm.ResourceName + "' (Id = " + $vm.ResourceId + ") ...")
+                Write-Verbose $("Deleting VM '" + $vm.ResourceName + "' (Id = " + $vm.ResourceId + ") ...")
+
+                # Nuke the VM.
+                $result = Remove-AzureRmResource -ResourceId $vm.ResourceId -Force
+
+                if ($true -eq $result)
                 {
-                    Write-Warning $("Deleting VM '" + $vm.ResourceName + "' (FQDN = " + $vm.Properties.Vms[0].Fqdn + ") ...")
-                    Write-Verbose $("Deleting VM '" + $vm.ResourceName + "' (FQDN = " + $vm.Properties.Vms[0].Fqdn + ") ...")
-
-                    # Nuke the VM.
-                    $result = Remove-AzureRmResource -ResourceId $vm.ResourceId -Force
-
-                    if ($true -eq $result)
-                    {
-                        Write-Verbose $("Successfully deleted VM '" + $vm.ResourceName + "' (FQDN = " + $vm.Properties.Vms[0].Fqdn + ") ...")
-                    }
+                    Write-Verbose $("Successfully deleted VM '" + $vm.ResourceName + "' (Id = " + $vm.ResourceId + ") ...")
                 }
-            }
-
-            # Else display a non-terminating error and skip this VM.
-            else
-            {
-                Write-Error $("Unable to determine the FQDN of the VM '" + $VM.ResourceName + "'.")
             }
         }
     }

--- a/201-dtl-create-lab-with-policies/README.md
+++ b/201-dtl-create-lab-with-policies/README.md
@@ -1,0 +1,15 @@
+# Create a new DevTestLab instance
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-quickstart-templates%2Fmaster%2F201-dtl-create-lab-with-policies%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+<a href="http://armviz.io/#/?load=https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/201-dtl-create-lab-with-policies/azuredeploy.json" target="_blank">
+  <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+
+This template creates a new Azure DevTest Lab and allows you to set policies on it. The following policies can be set:
+- VM sizes allowed in the Lab.
+- Total number of VMs allowed in the Lab.
+- Maximum number of VMs allowed for each user.

--- a/201-dtl-create-lab-with-policies/azuredeploy.json
+++ b/201-dtl-create-lab-with-policies/azuredeploy.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newLabName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the new lab instance to be created."
+      }
+    },
+    "labVmShutDownTime": {
+      "type": "string",
+      "minLength": 5,
+      "maxLength": 5,
+      "metadata": {
+        "description": "The UTC time at which the Lab VMs will be automatically shutdown (E.g. 17:30, 20:00, 09:00)."
+      }
+    },
+    "maxAllowedVmsPerUser": {
+      "type": "int",
+      "minValue": 0,
+      "metadata": {
+        "description": "The maximum number of VMs allowed per user."
+      }
+    },
+    "maxAllowedVmsPerLab": {
+      "type": "int",
+      "minValue": 0,
+      "metadata": {
+        "description": "The maximum number of VMs allowed per lab."
+      }
+    },
+    "allowedVmSizes": {
+      "type": "string",
+      "defaultValue": "\"Standard_A5\", \"Standard_A3\", \"Standard_A2\"",
+      "metadata": {
+        "description": "A comma-separated list of VM sizes that are allowed in the lab."
+      }
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-21-preview",
+      "type": "Microsoft.DevTestLab/labs",
+      "name": "[trim(parameters('newLabName'))]",
+      "location": "[resourceGroup().location]",
+      "resources": [
+        {
+          "apiVersion": "2015-05-21-preview",
+          "name": "LabVmsShutdown",
+          "type": "schedules",
+          "dependsOn": [
+            "[resourceId('Microsoft.DevTestLab/labs', parameters('newLabName'))]"
+          ],
+          "properties": {
+            "status": "enabled",
+            "time": {
+              "hour": "[split(trim(parameters('labVmShutDownTime')), ':')[0]]",
+              "minute": "[split(trim(parameters('labVmShutDownTime')), ':')[1]]"
+            }
+          }
+        },
+        {
+          "apiVersion": "2015-05-21-preview",
+          "name": "MaxVmsAllowedPerUser",
+          "type": "policies",
+          "dependsOn": [
+            "[resourceId('Microsoft.DevTestLab/labs', parameters('newLabName'))]"
+          ],
+          "properties": {
+            "description": "",
+            "factName": "UserOwnedLabVmCount",
+            "threshold": "[string(parameters('maxAllowedVmsPerUser'))]",
+            "policyEvaluatorType": "MaxValuePolicy",
+            "status": "enabled"
+          }
+        },
+        {
+          "apiVersion": "2015-05-21-preview",
+          "name": "MaxVmsAllowedPerLab",
+          "type": "policies",
+          "dependsOn": [
+            "[resourceId('Microsoft.DevTestLab/labs', parameters('newLabName'))]"
+          ],
+          "properties": {
+            "description": "",
+            "factName": "LabVmCount",
+            "threshold": "[string(parameters('maxAllowedVmsPerLab'))]",
+            "policyEvaluatorType": "MaxValuePolicy",
+            "status": "enabled"
+          }
+        },
+        {
+          "apiVersion": "2015-05-21-preview",
+          "name": "AllowedVmSizesInLab",
+          "type": "policies",
+          "dependsOn": [
+            "[resourceId('Microsoft.DevTestLab/labs', parameters('newLabName'))]"
+          ],
+          "properties": {
+            "description": "",
+            "factName": "LabVmSize",
+            "threshold": "[concat('[', trim(parameters('allowedVmSizes')), ']')]",
+            "policyEvaluatorType": "AllowedValuesPolicy",
+            "status": "enabled"
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {
+    "labId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.DevTestLab/labs', parameters('newLabName'))]"
+    }
+  }
+}

--- a/201-dtl-create-lab-with-policies/azuredeploy.json
+++ b/201-dtl-create-lab-with-policies/azuredeploy.json
@@ -33,6 +33,7 @@
     "allowedVmSizes": {
       "type": "string",
       "defaultValue": "\"Standard_A5\", \"Standard_A3\", \"Standard_A2\"",
+      "minLength": 3,
       "metadata": {
         "description": "A comma-separated list of VM sizes that are allowed in the lab."
       }

--- a/201-dtl-create-lab-with-policies/azuredeploy.parameters.json
+++ b/201-dtl-create-lab-with-policies/azuredeploy.parameters.json
@@ -15,7 +15,7 @@
       "value": 2
     },
     "allowedVmSizes": {
-      "value": ""
+      "value": "Standard_A2"
     }
   }
 }

--- a/201-dtl-create-lab-with-policies/azuredeploy.parameters.json
+++ b/201-dtl-create-lab-with-policies/azuredeploy.parameters.json
@@ -15,7 +15,7 @@
       "value": 2
     },
     "allowedVmSizes": {
-      "value": "Standard_A2"
+      "value": "\"Standard_A2\", \"Standard_A4\""
     }
   }
 }

--- a/201-dtl-create-lab-with-policies/azuredeploy.parameters.json
+++ b/201-dtl-create-lab-with-policies/azuredeploy.parameters.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newLabName": {
+      "value": "MyLab1"
+    },
+    "labVmShutDownTime": {
+      "value": "21:00"
+    },
+    "maxAllowedVmsPerUser": {
+      "value": 10
+    },
+    "maxAllowedVmsPerLab": {
+      "value": 2
+    },
+    "allowedVmSizes": {
+      "value": ""
+    }
+  }
+}

--- a/201-dtl-create-lab-with-policies/metadata.json
+++ b/201-dtl-create-lab-with-policies/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Create a new lab with custom policy rules",
+  "description": "This template creates a new DevTest Lab and specifies custom policy rules (including the VM sizes allowed in the Lab, total number of VMs allowed in the Lab and the maximum number of VMs allowed for each user)",
+  "summary": "This template creates a new DevTest Lab instance and sets custom policy rules on it",
+  "githubUsername": "mithunshanbhag",
+  "dateUpdated": "2015-12-08"
+}

--- a/201-dtl-create-vmtemplate/azuredeploy.json
+++ b/201-dtl-create-vmtemplate/azuredeploy.json
@@ -38,8 +38,8 @@
       "name": "[variables('resourceName')]",
       "type": "Microsoft.DevTestLab/labs/vmtemplates",
       "properties": {
-        "createFromVmProperties": {
-          "sourceVmResourceId": "[parameters('existingVMResourceId')]"
+        "vm": {
+          "sourceVmId": "[parameters('existingVMResourceId')]"
         },
         "description": "[parameters('templateDescription')]",
         "imageType": "Custom",


### PR DESCRIPTION
Change Description: 

1: This Azure RM template allows the user to create an Azure DevTest Lab with the following policies set on it: 
  - VM sizes allowed in the Lab.
  - Total number of VMs allowed in the Lab.
  - Maximum number of VMs allowed for each user.

2: Updating an existing Azure RM template per changes in DevTest Lab RP. 

3: Minor bug-fixes & updates to the DTL PS cmdlets (wrapper around the DTL quickstart templates).