### PR TITLE
VMSS templates - remove deployment().name

### DIFF
--- a/201-2-vms-loadbalancer-natrules/azuredeploy.json
+++ b/201-2-vms-loadbalancer-natrules/azuredeploy.json
@@ -106,7 +106,7 @@
     "lbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('lbName'))]",
     "numberOfInstances": 2,
     "frontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/loadBalancerFrontend')]",
-    "storageAccountName": "[uniqueString(resourceGroup().id, deployment().name)]"
+    "storageAccountName": "[uniqueString(resourceGroup().id)]"
   },
   "resources": [
     {

--- a/201-vmss-lapstack-autoscale/azuredeploy.json
+++ b/201-vmss-lapstack-autoscale/azuredeploy.json
@@ -76,11 +76,11 @@
     "saCount":5,
     "newStorageAccountSuffix":"[concat(parameters('vmssName'), 'sa')]",
     "uniqueStringArray":[
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '0')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '1')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '2')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '3')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '4')))]"
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '0')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '1')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '2')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '3')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '4')))]"
     ],
     "vhdContainerName":"[concat(parameters('vmssName'), 'vhd')]",
     "osDiskName":"[concat(parameters('vmssName'), 'osdisk')]",

--- a/201-vmss-linux-jumpbox/azuredeploy.json
+++ b/201-vmss-linux-jumpbox/azuredeploy.json
@@ -74,7 +74,7 @@
   "variables":{
     "apiVersion":"2015-06-15",
     "jumpBoxName":"[concat(parameters('vmssName'), 'jumpbox')]",
-    "jumpBoxSAName":"[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), 'jumpboxsa')), 'jb')]",
+    "jumpBoxSAName":"[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), 'jumpboxsa')), 'jb')]",
     "jumpBoxOSDiskName":"[concat(variables('jumpBoxName'), 'osdisk')]",
     "jumpBoxVHDContainerName":"[concat(variables('jumpBoxName'), 'vhd')]",
     "jumpBoxIPConfigName":"[concat(variables('jumpBoxName'), 'ipconfig')]",
@@ -84,11 +84,11 @@
     "namingInfix": "[toLower(parameters('vmssName'))]",
     "newStorageAccountSuffix":"[concat(variables('namingInfix'), 'sa')]",
     "uniqueStringArray":[
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '0')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '1')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '2')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '3')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '4')))]"
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '0')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '1')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '2')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '3')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '4')))]"
     ],
     "vhdContainerName":"[concat(variables('namingInfix'), 'vhd')]",
     "osDiskName":"[concat(variables('namingInfix'), 'osdisk')]",

--- a/201-vmss-linux-nat/azuredeploy.json
+++ b/201-vmss-linux-nat/azuredeploy.json
@@ -78,11 +78,11 @@
     "namingInfix": "[toLower(parameters('vmssName'))]",
     "newStorageAccountSuffix":"[concat(variables('namingInfix'), 'sa')]",
     "uniqueStringArray":[
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '0')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '1')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '2')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '3')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '4')))]"
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '0')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '1')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '2')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '3')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '4')))]"
     ],
     "vhdContainerName":"[concat(variables('namingInfix'), 'vhd')]",
     "osDiskName":"[concat(variables('namingInfix'), 'osdisk')]",

--- a/201-vmss-ubuntu-autoscale/azuredeploy.json
+++ b/201-vmss-ubuntu-autoscale/azuredeploy.json
@@ -76,11 +76,11 @@
     "saCount":5,
     "newStorageAccountSuffix":"[concat(parameters('vmssName'), 'sa')]",
     "uniqueStringArray":[
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '0')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '1')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '2')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '3')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '4')))]"
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '0')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '1')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '2')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '3')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '4')))]"
     ],
     "vhdContainerName":"[concat(parameters('vmssName'), 'vhd')]",
     "osDiskName":"[concat(parameters('vmssName'), 'osdisk')]",

--- a/201-vmss-windows-jumpbox/azuredeploy.json
+++ b/201-vmss-windows-jumpbox/azuredeploy.json
@@ -74,7 +74,7 @@
   "variables":{
     "apiVersion":"2015-06-15",
     "jumpBoxName":"[concat(parameters('vmssName'), 'jumpbox')]",
-    "jumpBoxSAName":"[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), 'jumpboxsa')), 'jb')]",
+    "jumpBoxSAName":"[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), 'jumpboxsa')), 'jb')]",
     "jumpBoxOSDiskName":"[concat(variables('jumpBoxName'), 'osdisk')]",
     "jumpBoxVHDContainerName":"[concat(variables('jumpBoxName'), 'vhd')]",
     "jumpBoxIPConfigName":"[concat(variables('jumpBoxName'), 'ipconfig')]",
@@ -84,11 +84,11 @@
     "namingInfix": "[toLower(parameters('vmssName'))]",
     "newStorageAccountSuffix":"[concat(variables('namingInfix'), 'sa')]",
     "uniqueStringArray":[
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '0')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '1')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '2')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '3')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '4')))]"
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '0')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '1')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '2')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '3')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '4')))]"
     ],
     "vhdContainerName":"[concat(variables('namingInfix'), 'vhd')]",
     "osDiskName":"[concat(variables('namingInfix'), 'osdisk')]",

--- a/201-vmss-windows-nat/azuredeploy.json
+++ b/201-vmss-windows-nat/azuredeploy.json
@@ -78,11 +78,11 @@
     "namingInfix": "[toLower(parameters('vmssName'))]",
     "newStorageAccountSuffix":"[concat(variables('namingInfix'), 'sa')]",
     "uniqueStringArray":[
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '0')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '1')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '2')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '3')))]",
-      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '4')))]"
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '0')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '1')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '2')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '3')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '4')))]"
     ],
     "vhdContainerName":"[concat(variables('namingInfix'), 'vhd')]",
     "osDiskName":"[concat(variables('namingInfix'), 'osdisk')]",


### PR DESCRIPTION
There were various usages of "deployment().name" in the VMSS templates. I spoke with @gbowerman and @gatneil about this as it can cause issues with templates that are re-deployed to build up environments and they agreed that removing it makes sense.