### PR TITLE
Vsoagent fix 260 max path

### DIFF
--- a/visual-studio-vsobuildagent-vm/InstallVSOAgent.ps1
+++ b/visual-studio-vsobuildagent-vm/InstallVSOAgent.ps1
@@ -17,11 +17,17 @@ Write-Verbose "Entering InstallVSOAgent.ps1" -verbose
 $currentLocation = Split-Path -parent $MyInvocation.MyCommand.Definition
 Write-Verbose "Current folder: $currentLocation" -verbose
 
+#Create a temporary directory where to download from VSTS the agent package (agent.zip) and then launch the configuration.
+$agentTempFolderName = Join-Path $env:temp ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Force -Path $agentTempFolderName
+Write-Verbose "Temporary Agent download folder: $agentTempFolderName" -verbose
+
 $serverUrl = "https://$VSOAccount.visualstudio.com"
 Write-Verbose "Server URL: $serverUrl" -verbose
 
 $VSOAgentURL = "$serverUrl/_apis/distributedtask/packages/agent"
 Write-Verbose "VSO Agent URL: $VSOAgentURL" -verbose
+
 
 $retryCount = 3
 $retries = 1
@@ -35,7 +41,7 @@ do
     $basicAuth = [System.Convert]::ToBase64String($basicAuth)
     $headers = @{Authorization=("Basic {0}" -f $basicAuth)}
 
-    Invoke-WebRequest -Uri $VSOAgentURL -headers $headers -Method Get -OutFile "$currentLocation\agent.zip"
+    Invoke-WebRequest -Uri $VSOAgentURL -headers $headers -Method Get -OutFile "$agentTempFolderName\agent.zip"
     Write-Verbose "Downloaded agent successfully on attempt $retries" -verbose
     break
   }
@@ -49,33 +55,48 @@ do
 } 
 while ($retries -le $retryCount)
 
+
+# Construct the agent folder under the main (hardcoded) C: drive.
+$agentInstallationPath = Join-Path "C:" $AgentName 
+# Create the directory for this agent.
+New-Item -ItemType Directory -Force -Path $agentInstallationPath 
+
+# Create a folder for the build work
+New-Item -ItemType Directory -Force -Path (Join-Path $agentInstallationPath $WorkFolder)
+
+
 Write-Verbose "Extracting the zip file for the agent" -verbose
-(new-object -com shell.application).namespace($currentLocation).CopyHere((new-object -com shell.application).namespace("$currentLocation\agent.zip").Items(),16)
+$destShellFolder = (new-object -com shell.application).namespace("$agentInstallationPath")
+$destShellFolder.CopyHere((new-object -com shell.application).namespace("$agentTempFolderName\agent.zip").Items(),16)
 
 # Removing the ZoneIdentifier from files downloaded from the internet so the plugins can be loaded
 # Don't recurse down _work or _diag, those files are not blocked and cause the process to take much longer
 Write-Verbose "Unblocking files" -verbose
-Get-ChildItem -Path $currentLocation | Unblock-File | out-null
-Get-ChildItem -Recurse -Path $currentLocation\Agent | Unblock-File | out-null
+Get-ChildItem -Path $agentInstallationPath | Unblock-File | out-null
+Get-ChildItem -Recurse -Path $agentInstallationPath\Agent | Unblock-File | out-null
 
-$agentLocation = [System.IO.Path]::Combine($currentLocation, 'Agent', 'vsoAgent.exe')
-Write-Verbose "Agent Location = $agentLocation" -Verbose
-if (![System.IO.File]::Exists($agentLocation))
+# Retrieve the path to the vsoAgent.exe file.
+$agentExePath = [System.IO.Path]::Combine($agentInstallationPath, 'Agent', 'vsoAgent.exe')
+Write-Verbose "Agent Location = $agentExePath" -Verbose
+if (![System.IO.File]::Exists($agentExePath))
 {
-    Write-Error "File not found: $agentLocation" -Verbose
+    Write-Error "File not found: $agentExePath" -Verbose
     return
 }
 
-# Call the agent with the configure command and all the options (this creates the settings file) without prompting the user or blocking the cmd execution
+# Call the agent with the configure command and all the options (this creates the settings file) without prompting
+# the user or blocking the cmd execution
+
 Write-Verbose "Configuring agent" -Verbose
 
-$WorkFolder = "c:\work"
 
-# Create a folder for the build work
-New-Item -ItemType Directory -Force -Path $WorkFolder
-
+# Set the current directory to the agent dedicated one previously created.
+Push-Location -Path $agentInstallationPath
 # The actual install of the agent. Using NetworkService as default service logon account, and some other values that could be turned into paramenters if needed 
-&start cmd.exe "/k $agentLocation /configure /RunningAsService /login:$VSOUser,$VSOPass /serverUrl:$serverUrl ""/WindowsServiceLogonAccount:NT AUTHORITY\NetworkService"" /WindowsServiceLogonPassword /WindowsServiceDisplayName:VsoBuildAgent /name:$AgentName /PoolName:$PoolName /WorkFolder:$WorkFolder /StartMode:Automatic /force /NoPrompt &exit"
+&start cmd.exe "/k $agentExePath /configure /RunningAsService /login:$VSOUser,$VSOPass /serverUrl:$serverUrl ""/WindowsServiceLogonAccount:NT AUTHORITY\NetworkService"" /WindowsServiceLogonPassword /WindowsServiceDisplayName:VsoBuildAgent /name:$AgentName /PoolName:$PoolName /WorkFolder:$WorkFolder /StartMode:Automatic /force /NoPrompt &exit"
+# Restore original current directory.
+Pop-Location
+
 
 Write-Verbose "Agent install output: $LASTEXITCODE" -Verbose
 

--- a/visual-studio-vsobuildagent-vm/README.md
+++ b/visual-studio-vsobuildagent-vm/README.md
@@ -7,4 +7,12 @@
 This template is based on the <a href="https://github.com/Azure/azure-quickstart-templates/tree/master/visual-studio-dev-vm">Visual Studio Dev VM</a> template created by [dtzar](https://github.com/dtzar).  It creates the VM in a new vnet, storage account, nic, and public ip with the new compute stack then installs the Visual Studio Online build agent.
 By default, it will deploy Visual Studio 2015 with Azure SDK 2.7 on Windows Server 2012 with a DS2 size on top of a new premium storage account.
 
-This template requires you to set up and pass in <a href="https://www.visualstudio.com/integrate/get-started/auth/overview">Alternate Authentication Credentials</a> from Visual Studio Online, your Visual Studio Online account name, and Pool name. You can revoke or change the credentials in Visual Studio Online after the VM has been created.
+This template requires you to pass in your Visual Studio Online account name, and Pool name. You can revoke or change the credentials in Visual Studio Online after the VM has been created.
+
+
+## Authentication
+In order to authenticate your agent as a member of Agent Pool Administrators group, you must use one of the following methods:
+* set up and use a <a href="https://www.visualstudio.com/en-us/get-started/setup/use-personal-access-tokens-to-authenticate">Personal Access Token</a>, set VSOPass to the token value, the VSOUser parameter can be anything.
+* set up and pass in <a href="https://www.visualstudio.com/integrate/get-started/auth/overview">Alternate Authentication Credentials</a> from Visual Studio Online. 
+
+In both cases you can revoke or change the credentials in Visual Studio Online after the VM has been created.


### PR DESCRIPTION
the current (875f3d1) script InstallVSOAgent.ps1 does fail with error "File path not found error" since it is going to extract the agent.zip archive into the path C:\Packages\Plugins\Microsoft.Compute.CustomScriptExtension\1.4\Downloads\0
which already wastes 75 characters, and the agent.zip file contains some paths longer than 185 characters. The deployment template always failed at attaching the agent to the VSTS account.

With this fix, the 260 char path limitation is worked around, and the agent is up and attached to the VSTS account as the deployment finishes.