### PR TITLE
Update ConfigureWinRM.ps1

### DIFF
--- a/201-vm-winrm-windows/ConfigureWinRM.ps1
+++ b/201-vm-winrm-windows/ConfigureWinRM.ps1
@@ -8,7 +8,8 @@
 
 param
 (
-    [string] $hostname
+    [Parameter(Mandatory = $true)]
+    [string] $HostName
 )
 
 #################################################################################################################################
@@ -32,7 +33,7 @@ function Delete-WinRMListener
 
 function Configure-WinRMHttpsListener
 {
-    param([string] $hostname,
+    param([string] $HostName,
           [string] $port)
 
     # Delete the WinRM Https listener if it is already configured
@@ -73,7 +74,7 @@ function Add-FirewallException
 $winrmHttpsPort=5986
 
 # Configure https listener
-Configure-WinRMHttpsListener $hostname $port
+Configure-WinRMHttpsListener $HostName $port
 
 # Add firewall exception
 Add-FirewallException -port $winrmHttpsPort


### PR DESCRIPTION
This script is designed to require a value for the `hostname` input parameter. However, the parameter was not marked as mandatory. This pull request adds the [Parameter()] attribute, and designates the `-HostName` parameter as mandatory. It also fixes the casing of the parameter name.

Cheers,
Trevor Sullivan
Microsoft MVP: PowerShell