### PR TITLE
Update README.md

### DIFF
--- a/101-internal-loadbalancer-create/README.md
+++ b/101-internal-loadbalancer-create/README.md
@@ -4,4 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-This template allows you to create a Load Balancer, Public IP address for the Load balancer, Virtual Network, Network Interface in the Virtual Network & a NAT Rule in the Load Balancer that is used by the Network Interface.
+This template allows you to create a Load Balancer with the front-end connected to a Virtual Network subnet, Virtual Network, Network Interface in the Virtual Network & a NAT Rule in the Load Balancer that is used by the Network Interface.


### PR DESCRIPTION
The description in the `README.md` doesn't match the template, or the folder name, because it mentions a Public IP Address resource for the Load Balancer front-end IP configuration.

- The word "public" doesn't appear anywhere inside the `azuredeploy.json` file
- The folder name clearly indicates that the front-end IP configuration of the Load Balancer should be "internal," meaning that its front-end IP configuration wouldn't have a Public IP Address resource bound to it.

Consequently, I am fixing the `README.md`.

Cheers,
Trevor Sullivan
Microsoft MVP: PowerShell