### PR TITLE
Update the "See the starter template here" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The metadata.json file will be validated using these rules
 
 ## Starter template
 
-A starter template is provided [here](https://github.com/Azure/azure-quickstart-templates/tree/master/100-starter-template-with-validation) for you to follow
+A starter template is provided [here](https://github.com/Azure/azure-quickstart-templates/tree/master/100-STARTER-TEMPLATE-with-VALIDATION) for you to follow
 
 ## Common errors from acomghbot
 


### PR DESCRIPTION
Seems the link was 
https://github.com/Azure/azure-quickstart-templates/tree/master/100-starter-template-with-validation   (404)
changed for
https://github.com/Azure/azure-quickstart-templates/tree/master/100-STARTER-TEMPLATE-with-VALIDATION