### PR TITLE
docker-swarm: separate nsg for nodes/masters

### DIFF
--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -39,8 +39,10 @@
     "subnetPrefixNodes": "192.168.0.0/24",
     "subnetRefMaster": "[concat(resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName')),'/subnets/',variables('subnetNameMasters'))]",
     "subnetRefNodes": "[concat(resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName')),'/subnets/',variables('subnetNameNodes'))]",
-    "nsgName": "swarm-nsg",
-    "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
+    "mastersNsgName": "swarm-masters-firewall",
+    "nodesNsgName": "swarm-nodes-firewall",
+    "mastersNsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('mastersNsgName'))]",
+    "nodesNsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nodesNsgName'))]",
     "newStorageAccountName": "[uniqueString(resourceGroup().id, deployment().name)]",
     "clusterFqdn": "[concat('swarm-',uniqueString(resourceGroup().id, deployment().name))]",
     "storageAccountType": "Standard_LRS",
@@ -114,7 +116,8 @@
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
-        "[variables('nsgID')]"
+        "[variables('mastersNsgID')]",
+        "[variables('nodesNsgID')]"
       ],
       "properties": {
         "addressSpace": {
@@ -129,7 +132,7 @@
             "properties": {
               "addressPrefix": "[variables('subnetPrefixMasters')]",
               "networkSecurityGroup": {
-                "id": "[variables('nsgID')]"
+                "id": "[variables('mastersNsgID')]"
               }
             }
           },
@@ -138,7 +141,7 @@
             "properties": {
               "addressPrefix": "[variables('subnetPrefixNodes')]",
               "networkSecurityGroup": {
-                "id": "[variables('nsgID')]"
+                "id": "[variables('nodesNsgID')]"
               }
             }
           }
@@ -148,21 +151,45 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('nsgName')]",
+      "name": "[variables('mastersNsgName')]",
       "location": "[resourceGroup().location]",
       "properties": {
         "securityRules": [
           {
             "name": "ssh",
             "properties": {
-              "description": "SSH",
+              "description": "",
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "22",
               "sourceAddressPrefix": "*",
               "destinationAddressPrefix": "*",
               "access": "Allow",
-              "priority": 200,
+              "priority": 1000,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('nodesNsgName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "AllowAny",
+            "properties": {
+              "description": "Swarm node ports need to be configured on the load balancer to be reachable",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1000,
               "direction": "Inbound"
             }
           }
@@ -229,7 +256,7 @@
         ],
         "backendAddressPools": [
           {
-          "name": "[variables('mastersLbBackendPoolName')]"
+            "name": "[variables('mastersLbBackendPoolName')]"
           }
         ]
       }
@@ -451,6 +478,7 @@
         "publisher": "Microsoft.Azure.Extensions",
         "type": "DockerExtension",
         "typeHandlerVersion": "1.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "compose": {
             "consul": {
@@ -504,6 +532,7 @@
         "publisher": "Microsoft.Azure.Extensions",
         "type": "DockerExtension",
         "typeHandlerVersion": "1.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "docker": {
             "port": "2375"


### PR DESCRIPTION
Separating firewall for nodes and masters as users need to add an
AllowAny (*->*) rule to make their containers accessible from
public Internet through Azure LB.

Also adding autoUpgradeMinorVersion to pick up DockerExtension v1.1+.

**Manually tested.**