### PR TITLE
Fix to RM template that creates a DevTestLab with policies

### DIFF
--- a/201-dtl-create-lab-with-policies/azuredeploy.json
+++ b/201-dtl-create-lab-with-policies/azuredeploy.json
@@ -63,8 +63,8 @@
         },
         {
           "apiVersion": "2015-05-21-preview",
-          "name": "MaxVmsAllowedPerUser",
-          "type": "policies",
+          "name": "default/MaxVmsAllowedPerUser",
+          "type": "policySets/policies",
           "dependsOn": [
             "[resourceId('Microsoft.DevTestLab/labs', parameters('newLabName'))]"
           ],
@@ -78,8 +78,8 @@
         },
         {
           "apiVersion": "2015-05-21-preview",
-          "name": "MaxVmsAllowedPerLab",
-          "type": "policies",
+          "name": "default/MaxVmsAllowedPerLab",
+          "type": "policySets/policies",
           "dependsOn": [
             "[resourceId('Microsoft.DevTestLab/labs', parameters('newLabName'))]"
           ],
@@ -93,8 +93,8 @@
         },
         {
           "apiVersion": "2015-05-21-preview",
-          "name": "AllowedVmSizesInLab",
-          "type": "policies",
+          "name": "default/AllowedVmSizesInLab",
+          "type": "policySets/policies",
           "dependsOn": [
             "[resourceId('Microsoft.DevTestLab/labs', parameters('newLabName'))]"
           ],


### PR DESCRIPTION
As per recent changes in the microsoft.DevTestLab Resource Provider, we're making a minor change to fix the RM template that creates a DevTestLab with custom policies.