### PR TITLE
Make CI error output formatting nicer

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -361,7 +361,7 @@ describe('Template', function () {
               errorString += ' --template-file ' + test.args[0] + ' --parameters-file ' + test.args[1] + '\n';
               errorString += 'azure group deployment create --resource-group (your_group_name) ';
               errorString += ' --template-file ' + test.args[0] + ' --parameters-file ' + test.args[1];
-              assert(false, errorString + ' \n\nServer Error:' + JSON.stringify(err));
+              assert(false, errorString + ' \n\nServer Error:' + JSON.stringify(err, null, 4));
             });
         });
       });


### PR DESCRIPTION
Use `json.stringify` with a tab space of `4`