### PR TITLE
Multiple small tweaks

### DIFF
--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -36,7 +36,7 @@
     },
     "virtualNetworkName": {
       "type": "string",
-      "defaultValue": "esvnet",
+      "defaultValue": "es-vnet",
       "metadata": {
         "description": "Virtual Network"
       }
@@ -95,14 +95,44 @@
     },
     "vmSizeClientNodes": {
       "type": "string",
-      "defaultValue": "Standard_A1",
+      "defaultValue": "Standard_D2",
+      "allowedValues": [
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_DS2",
+        "Standard_DS3",
+        "Standard_DS4",
+        "Standard_DS13"
+      ],
       "metadata": {
         "description": "Size of the Elasticsearch cluster client nodes"
       }
     },
     "vmSizeMasterNodes": {
       "type": "string",
-      "defaultValue": "Standard_A0",
+      "defaultValue": "Standard_D2",
+      "allowedValues": [
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_DS2",
+        "Standard_DS3",
+        "Standard_DS4",
+        "Standard_DS13"
+      ],
       "metadata": {
         "description": "Size of the Elasticsearch master nodes"
       }
@@ -111,15 +141,15 @@
       "type": "string",
       "defaultValue": "Standard_D2",
       "allowedValues": [
-        "Standard_D1",
         "Standard_D2",
         "Standard_D3",
         "Standard_D4",
         "Standard_A2",
         "Standard_A3",
         "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
         "Standard_A7",
-        "Standard_DS1",
         "Standard_DS2",
         "Standard_DS3",
         "Standard_DS4",
@@ -194,8 +224,8 @@
         "North Europe":"[parameters('location')]"
     },
     "location":"[variables('locationMap')[parameters('location')]]",
-    "storageAccountPrefix": "elastic",
-    "storageAccountNameShared": "[concat(variables('storageAccountPrefix'), 's', uniqueString(resourceGroup().id, deployment().name))]",
+    "storageAccountPrefix": "[concat(substring(uniqueString(resourceGroup().id, parameters('esClusterName')), 0, 6), substring(parameters('esClusterName'), 0, 3))]",
+    "storageAccountNameShared": "[concat(variables('storageAccountPrefix'), 'sh')]",
     "masterNodesIpPrefix": "10.0.0.1",
     "networkSettings": {
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
@@ -209,6 +239,11 @@
         "data": {
           "name": "data",
           "prefix": "10.0.1.0/24",
+          "vnet": "[parameters('virtualNetworkName')]"
+        },
+        "other": {
+          "name": "other",
+          "prefix": "10.0.2.0/24",
           "vnet": "[parameters('virtualNetworkName')]"
         }
       }
@@ -228,7 +263,7 @@
     "lbBackEndPoolsAdded": {
       "backendPools": [
         {
-          "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/backendAddressPools/LBBE')]"
+          "id": "[concat(resourceId('Microsoft.Network/loadBalancers','es-load-balancer'),'/backendAddressPools/LBBE')]"
         }
       ]
     },
@@ -489,7 +524,7 @@
       "count":"[div(sub(add(parameters('vmDataNodeCount'), variables('nodesPerStorageAccount')), 1), variables('nodesPerStorageAccount'))]",
       "mapping":"[variables('storageBinPackMap')]",
       "accountType":"[variables('dataSkuSettings')[parameters('vmSizeDataNodes')].storageAccountType]",
-      "prefix":"[concat(variables('storageAccountPrefix'), 'd', uniqueString(resourceGroup().id, deployment().name))]"
+      "prefix":"[concat(variables('storageAccountPrefix'), 'da')]"
     },
     "dataTemplateUrl": "[concat(variables('templateBaseUrl'), 'data-nodes-', string(variables('dataSkuSettings')[parameters('vmSizeDataNodes')].dataDisks), 'disk-resources.json')]"
   },
@@ -531,6 +566,9 @@
           },
           "osSettings": {
             "value": "[variables('osSettings')]"
+          },
+          "namespace": {
+            "value": "[concat(parameters('esClusterName'), '-master')]"
           }
         }
       }
@@ -559,7 +597,7 @@
             "value": "[parameters('loadBalancerType')]"
           },
           "ilbIpAddress": {
-            "value": "10.0.0.100"
+            "value": "10.0.2.100"
           }
         }
       }
@@ -591,7 +629,7 @@
             "value": "[variables('location')]"
           },
           "subnet": {
-            "value": "[variables('networkSettings').subnet.data]"
+            "value": "[variables('networkSettings').subnet.other]"
           },
           "vmSize": {
             "value": "[parameters('vmSizeClientNodes')]"
@@ -604,6 +642,9 @@
           },
           "lbBackendPools": {
             "value": "[variables('lbBackEndPoolsAdded')]"
+          },
+          "namespace": {
+            "value": "[concat(parameters('esClusterName'), '-client')]"
           }
         }
       }
@@ -644,7 +685,7 @@
             "value": "[parameters('vmDataNodeCount')]"
           },
           "namespace": {
-            "value": "esdata"
+            "value": "[concat(parameters('esClusterName'), '-data')]"
           },
           "osSettings": {
             "value": "[variables('osSettings')]"
@@ -682,10 +723,13 @@
             "value": "[variables('location')]"
           },
           "subnet": {
-            "value": "[variables('networkSettings').subnet.data]"
+            "value": "[variables('networkSettings').subnet.other]"
           },
           "osSettings": {
             "value": "[variables('osSettings')]"
+          },
+          "namespace": {
+            "value": "[concat(parameters('esClusterName'), '-jumpbox')]"
           }
         }
       }
@@ -717,10 +761,13 @@
             "value": "[variables('location')]"
           },
           "subnet": {
-            "value": "[variables('networkSettings').subnet.data]"
+            "value": "[variables('networkSettings').subnet.other]"
           },
           "osSettings": {
             "value": "[variables('ubuntuSettings')]"
+          },
+          "namespace": {
+            "value": "[concat(parameters('esClusterName'), '-kibana')]"
           }
         }
       }

--- a/elasticsearch/azuredeploy.parameters.json
+++ b/elasticsearch/azuredeploy.parameters.json
@@ -12,22 +12,22 @@
       "value": 3
     },
     "virtualNetworkName": {
-      "value": "esvnet"
+      "value": "es-vnet"
     },
     "esClusterName": {
-      "value": "elasticsearch"
+      "value": "cluster-name"
     },
     "loadBalancerType": {
       "value": "internal"
     },
     "vmSizeDataNodes": {
-      "value": "Standard_D1"
+      "value": "Standard_D4"
     },
     "vmClientNodeCount": {
-      "value": 0
+      "value": 1
     },
     "marvel": {
-      "value": "no"
+      "value": "yes"
     },
     "kibana": {
       "value": "yes"

--- a/elasticsearch/client-nodes-resources.json
+++ b/elasticsearch/client-nodes-resources.json
@@ -56,20 +56,26 @@
       "metadata": {
         "description": "loadBalancerBackendAddressPools config object"
       }
+    },
+    "namespace": {
+      "type": "string",
+      "metadata": {
+        "description": "Namespace for resources created by this template"
+      }
     }
   },
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
     "storageAccountName": "[parameters('storageAccountName')]",
-    "vmName": "clientVm",
-    "nicName": "clientNic"
+    "vmName": "[concat(parameters('namespace'), '-vm')]",
+    "nicName": "[concat(parameters('namespace'), '-nic')]"
   },
   "resources": [
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
-      "name": "elasticsearchClient",
+      "name": "es-client-set",
       "location": "[parameters('location')]",
       "properties": {}
     },
@@ -100,7 +106,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat('clientVm', copyindex())]",
+      "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "clientVmLoop",
@@ -108,17 +114,17 @@
       },
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyindex())]",
-        "[concat('Microsoft.Compute/availabilitySets/', 'elasticsearchClient')]"
+        "[concat('Microsoft.Compute/availabilitySets/', 'es-client-set')]"
       ],
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'elasticsearchClient')]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'es-client-set')]"
         },
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat('esClient', copyIndex())]",
+          "computerName": "[concat(variables('vmName'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -144,11 +150,11 @@
       "resources": [
         {
           "type": "Microsoft.Compute/virtualMachines/extensions",
-          "name": "[concat('clientVm', copyindex(), '/installelasticsearch')]",
+          "name": "[concat(variables('vmName'), copyindex(), '/installelasticsearch')]",
           "apiVersion": "2015-06-15",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', 'clientVm', copyindex())]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyindex())]"
           ],
           "properties": "[parameters('osSettings').extentionSettings.client]"
         }   

--- a/elasticsearch/data-nodes-0disk-resources.json
+++ b/elasticsearch/data-nodes-0disk-resources.json
@@ -75,8 +75,8 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
-    "vmName": "[concat(parameters('namespace'), 'vm')]"
+    "storageAccountName": "[parameters('storageSettings').prefix]",
+    "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
     {
@@ -95,7 +95,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
-      "name": "[concat(parameters('namespace'), '-set')]",
+      "name": "es-data-set",
       "location": "[parameters('location')]",
       "properties": {
         "platformUpdateDomainCount": 20,
@@ -105,7 +105,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(parameters('namespace'), 'nic', copyindex())]",
+      "name": "[concat(parameters('namespace'), '-nic', copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'),'nicLoop')]",
@@ -129,25 +129,25 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(parameters('namespace'), 'vm', copyindex())]",
+      "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'), 'virtualMachineLoop')]",
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), 'nic', copyindex())]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
       ],
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), '-set'))]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
         },
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat(parameters('namespace'), 'vm', copyIndex())]",
+          "computername": "[concat(variables('vmName'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -165,7 +165,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'nic', copyindex()))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'-nic', copyindex()))]"
             }
           ]
         }
@@ -173,11 +173,11 @@
       "resources": [
         {
           "type": "Microsoft.Compute/virtualMachines/extensions",
-          "name": "[concat(parameters('namespace'),'vm', copyindex(), '/installelasticsearch')]",
+          "name": "[concat(variables('vmName'), copyindex(), '/installelasticsearch')]",
           "apiVersion": "2015-06-15",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), 'vm', copyindex())]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyindex())]"
           ],
           "properties": "[parameters('osSettings').extentionSettings.data]"
         }

--- a/elasticsearch/data-nodes-16disk-resources.json
+++ b/elasticsearch/data-nodes-16disk-resources.json
@@ -75,8 +75,8 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
-    "vmName": "[concat(parameters('namespace'), 'vm')]"
+    "storageAccountName": "[parameters('storageSettings').prefix]",
+    "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
     {
@@ -95,7 +95,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
-      "name": "[concat(parameters('namespace'), '-set')]",
+      "name": "es-data-set",
       "location": "[parameters('location')]",
       "properties": {
         "platformUpdateDomainCount": 20,
@@ -105,7 +105,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(parameters('namespace'), 'nic', copyindex())]",
+      "name": "[concat(parameters('namespace'), '-nic', copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'),'nicLoop')]",
@@ -129,25 +129,25 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(parameters('namespace'), 'vm', copyindex())]",
+      "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'), 'virtualMachineLoop')]",
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), 'nic', copyindex())]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
       ],
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), '-set'))]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
         },
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat(parameters('namespace'), 'vm', copyIndex())]",
+          "computername": "[concat(variables('vmName'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -327,7 +327,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'nic', copyindex()))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'-nic', copyindex()))]"
             }
           ]
         }
@@ -335,11 +335,11 @@
       "resources": [
         {
           "type": "Microsoft.Compute/virtualMachines/extensions",
-          "name": "[concat(parameters('namespace'),'vm', copyindex(), '/installelasticsearch')]",
+          "name": "[concat(variables('vmName'), copyindex(), '/installelasticsearch')]",
           "apiVersion": "2015-06-15",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), 'vm', copyindex())]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyindex())]"
           ],
           "properties": "[parameters('osSettings').extentionSettings.data]"
         }

--- a/elasticsearch/data-nodes-2disk-resources.json
+++ b/elasticsearch/data-nodes-2disk-resources.json
@@ -75,8 +75,8 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
-    "vmName": "[concat(parameters('namespace'), 'vm')]"
+    "storageAccountName": "[parameters('storageSettings').prefix]",
+    "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
     {
@@ -95,7 +95,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
-      "name": "[concat(parameters('namespace'), '-set')]",
+      "name": "es-data-set",
       "location": "[parameters('location')]",
       "properties": {
         "platformUpdateDomainCount": 20,
@@ -105,7 +105,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(parameters('namespace'), 'nic', copyindex())]",
+      "name": "[concat(parameters('namespace'), '-nic', copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'),'nicLoop')]",
@@ -129,25 +129,25 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(parameters('namespace'), 'vm', copyindex())]",
+      "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'), 'virtualMachineLoop')]",
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), 'nic', copyindex())]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
       ],
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), '-set'))]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
         },
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat(parameters('namespace'), 'vm', copyIndex())]",
+          "computername": "[concat(variables('vmName'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -187,7 +187,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'nic', copyindex()))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'-nic', copyindex()))]"
             }
           ]
         }
@@ -195,11 +195,11 @@
       "resources": [
         {
           "type": "Microsoft.Compute/virtualMachines/extensions",
-          "name": "[concat(parameters('namespace'),'vm', copyindex(), '/installelasticsearch')]",
+          "name": "[concat(variables('vmName'), copyindex(), '/installelasticsearch')]",
           "apiVersion": "2015-06-15",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), 'vm', copyindex())]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyindex())]"
           ],
           "properties": "[parameters('osSettings').extentionSettings.data]"
         }

--- a/elasticsearch/data-nodes-4disk-resources.json
+++ b/elasticsearch/data-nodes-4disk-resources.json
@@ -75,8 +75,8 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
-    "vmName": "[concat(parameters('namespace'), 'vm')]"
+    "storageAccountName": "[parameters('storageSettings').prefix]",
+    "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
     {
@@ -95,7 +95,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
-      "name": "[concat(parameters('namespace'), '-set')]",
+      "name": "es-data-set",
       "location": "[parameters('location')]",
       "properties": {
         "platformUpdateDomainCount": 20,
@@ -105,7 +105,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(parameters('namespace'), 'nic', copyindex())]",
+      "name": "[concat(parameters('namespace'), '-nic', copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'),'nicLoop')]",
@@ -129,25 +129,25 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(parameters('namespace'), 'vm', copyindex())]",
+      "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'), 'virtualMachineLoop')]",
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), 'nic', copyindex())]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
       ],
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), '-set'))]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
         },
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat(parameters('namespace'), 'vm', copyIndex())]",
+          "computername": "[concat(variables('vmName'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -207,7 +207,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'nic', copyindex()))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'-nic', copyindex()))]"
             }
           ]
         }
@@ -215,11 +215,11 @@
       "resources": [
         {
           "type": "Microsoft.Compute/virtualMachines/extensions",
-          "name": "[concat(parameters('namespace'),'vm', copyindex(), '/installelasticsearch')]",
+          "name": "[concat(variables('vmName'), copyindex(), '/installelasticsearch')]",
           "apiVersion": "2015-06-15",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), 'vm', copyindex())]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyindex())]"
           ],
           "properties": "[parameters('osSettings').extentionSettings.data]"
         }

--- a/elasticsearch/data-nodes-8disk-resources.json
+++ b/elasticsearch/data-nodes-8disk-resources.json
@@ -75,8 +75,8 @@
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(parameters('storageSettings').prefix)]",
-    "vmName": "[concat(parameters('namespace'), 'vm')]"
+    "storageAccountName": "[parameters('storageSettings').prefix]",
+    "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
     {
@@ -95,7 +95,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
-      "name": "[concat(parameters('namespace'), '-set')]",
+      "name": "es-data-set",
       "location": "[parameters('location')]",
       "properties": {
         "platformUpdateDomainCount": 20,
@@ -105,7 +105,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(parameters('namespace'), 'nic', copyindex())]",
+      "name": "[concat(parameters('namespace'), '-nic', copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'),'nicLoop')]",
@@ -129,25 +129,25 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(parameters('namespace'), 'vm', copyindex())]",
+      "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "[concat(parameters('namespace'), 'virtualMachineLoop')]",
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), 'nic', copyindex())]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
       ],
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), '-set'))]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
         },
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat(parameters('namespace'), 'vm', copyIndex())]",
+          "computername": "[concat(variables('vmName'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -247,7 +247,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'nic', copyindex()))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'-nic', copyindex()))]"
             }
           ]
         }
@@ -255,11 +255,11 @@
       "resources": [
         {
           "type": "Microsoft.Compute/virtualMachines/extensions",
-          "name": "[concat(parameters('namespace'),'vm', copyindex(), '/installelasticsearch')]",
+          "name": "[concat(variables('vmName'), copyindex(), '/installelasticsearch')]",
           "apiVersion": "2015-06-15",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), 'vm', copyindex())]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyindex())]"
           ],
           "properties": "[parameters('osSettings').extentionSettings.data]"
         }

--- a/elasticsearch/elasticsearch-ubuntu-install.sh
+++ b/elasticsearch/elasticsearch-ubuntu-install.sh
@@ -63,9 +63,9 @@ then
   echo "${HOSTNAME}found in /etc/hosts"
 else
   echo "${HOSTNAME} not found in /etc/hosts"
-  # Append it to the hsots file if not there
+  # Append it to the hosts file if not there
   echo "127.0.0.1 ${HOSTNAME}" >> /etc/hosts
-  log "hostname ${HOSTNAME} added to /etchosts"
+  log "hostname ${HOSTNAME} added to /etc/hosts"
 fi
 
 #Script Parameters
@@ -290,6 +290,7 @@ echo "vm.max_map_count = 262144" >> /etc/sysctl.conf
 #Update HEAP Size in this configuration or in upstart service
 #Set Elasticsearch heap size to 50% of system memory
 #TODO: Move this to an init.d script so we can handle instance size increases
+#TODO: Client nodes should use 75% of the heap
 ES_HEAP=`free -m |grep Mem | awk '{if ($2/2 >31744)  print 31744;else print $2/2;}'`
 log "Configure elasticsearch heap size - $ES_HEAP"
 echo "ES_HEAP_SIZE=${ES_HEAP}m" >> /etc/default/elasticsearch

--- a/elasticsearch/elasticsearch-windows-install.ps1
+++ b/elasticsearch/elasticsearch-windows-install.ps1
@@ -205,7 +205,7 @@ function Download-ElasticSearch
     )
 	# download ElasticSearch from a given source URL to destination folder
 	try{
-			$source = if ($elasticVersion -match '2.0.0') {"https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/$elasticVersion/elasticsearch-$elasticVersion.zip"} else { "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$elasticVersion.zip" }
+			$source = if ($elasticVersion -match '2.') {"https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/$elasticVersion/elasticsearch-$elasticVersion.zip"} else { "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-$elasticVersion.zip" }
 			$destination = "$targetDrive`:\Downloads\ElasticSearch\Elastic-Search.zip"
             
             # create folder if doesn't exists and suppress the output
@@ -274,6 +274,7 @@ function SetEnv-HeapSize
 {
     # Obtain total memory in MB and divide in half
     $halfRamCnt = [math]::Round(((Get-WmiObject Win32_PhysicalMemory | measure-object Capacity -sum).sum/1mb)/2,0)
+    $halfRamCnt = [math]::Min($halfRamCnt, 31744)
     $halfRam = $halfRamCnt.ToString() + 'm'
     lmsg "Half of total RAM in system is $halfRam mb."
 
@@ -570,8 +571,8 @@ function Install-WorkFlow
             $textToAppend = $textToAppend + "`ndiscovery.zen.ping.unicast.hosts: [$ipAddresses]"
         }
 
-        # In ES 2.0 you explicitly need to set network host to _non_loopback_ or the IP address of the host else other nodes cannot communicate
-        if ($elasticSearchVersion -match '2.0.0')
+        # In ES 2.x you explicitly need to set network host to _non_loopback_ or the IP address of the host else other nodes cannot communicate
+        if ($elasticSearchVersion -match '2.')
         {
             $textToAppend = $textToAppend + "`nnetwork.host: _non_loopback_"
         }
@@ -592,7 +593,7 @@ function Install-WorkFlow
     # Install marvel if specified
     if ($installMarvel)
     {
-        if ($elasticSearchVersion -match '2.0.0')
+        if ($elasticSearchVersion -match '2.')
         {
             cmd.exe /C "$elasticSearchBin\plugin.bat install license"
             cmd.exe /C "$elasticSearchBin\plugin.bat install marvel-agent"

--- a/elasticsearch/master-nodes-resources.json
+++ b/elasticsearch/master-nodes-resources.json
@@ -51,19 +51,26 @@
       "metadata": {
         "description": "Elasticsearch deployment platform settings"
       }
+    },
+    "namespace": {
+      "type": "string",
+      "metadata": {
+        "description": "Namespace for resources created by this template"
+      }
     }
   },
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
     "storageAccountName": "[parameters('storageAccountName')]",
-    "vmName": "masterVm"
+    "vmName": "[concat(parameters('namespace'), '-vm')]",
+    "nicName": "[concat(parameters('namespace'), '-nic')]"
   },
   "resources": [
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
-      "name": "elasticsearchMaster",
+      "name": "es-master-set",
       "location": "[parameters('location')]",
       "properties": {
         "platformUpdateDomainCount": 3,
@@ -73,7 +80,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat('masterNodeNic', copyindex())]",
+      "name": "[concat(variables('nicName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "masterNodesNicLoop",
@@ -97,25 +104,25 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat('masterVm', copyindex())]",
+      "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "masterVmLoop",
         "count": 3
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', 'masterNodeNic', copyindex())]",
-        "[concat('Microsoft.Compute/availabilitySets/', 'elasticsearchMaster')]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyindex())]",
+        "[concat('Microsoft.Compute/availabilitySets/', 'es-master-set')]"
       ],
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'elasticsearchMaster')]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'es-master-set')]"
         },
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat('esMaster', copyIndex())]",
+          "computerName": "[concat(variables('vmName'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -133,7 +140,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat('masterNodeNic', copyindex()))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), copyindex()))]"
             }
           ]
         }
@@ -141,11 +148,11 @@
       "resources": [
         {
           "type": "Microsoft.Compute/virtualMachines/extensions",
-          "name": "[concat('masterVm', copyindex(), '/installelasticsearch')]",
+          "name": "[concat(variables('vmName'), copyindex(), '/installelasticsearch')]",
           "apiVersion": "2015-06-15",
           "location": "[parameters('location')]",
           "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', 'masterVm', copyindex())]"
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyindex())]"
           ],
           "properties": "[parameters('osSettings').extentionSettings.master]"
         }

--- a/elasticsearch/shared-resources.json
+++ b/elasticsearch/shared-resources.json
@@ -44,7 +44,7 @@
         "name": "LBFE",
         "properties": {
           "publicIPAddress": {
-            "id": "[resourceId('Microsoft.Network/publicIPAddresses','publicIp')]"
+            "id": "[resourceId('Microsoft.Network/publicIPAddresses','public-ip')]"
           }
         }
       }
@@ -54,7 +54,7 @@
         "Name": "LBFE",
         "Properties": {
           "subnet": {
-            "Id": "[concat(resourceId('Microsoft.Network/virtualNetworks',parameters('networkSettings').virtualNetworkName), '/subnets/', parameters('networkSettings').subnet.master.name)]"
+            "Id": "[concat(resourceId('Microsoft.Network/virtualNetworks',parameters('networkSettings').virtualNetworkName), '/subnets/', parameters('networkSettings').subnet.other.name)]"
           },
           "privateIPAddress": "[parameters('ilbIpAddress')]",
           "privateIPAllocationMethod": "Static"
@@ -76,7 +76,7 @@
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
-      "name": "publicIp",
+      "name": "public-ip",
       "location": "[parameters('location')]",
       "properties": {
         "publicIPAllocationMethod": "Dynamic"
@@ -105,17 +105,23 @@
             "properties": {
               "addressPrefix": "[parameters('networkSettings').subnet.data.prefix]"
             }
+          },
+          {
+            "name": "[parameters('networkSettings').subnet.other.name]",
+            "properties": {
+              "addressPrefix": "[parameters('networkSettings').subnet.other.prefix]"
+            }
           }
         ]
       }
     },
     {
       "apiVersion": "2015-06-15",
-      "name": "loadBalancer",
+      "name": "es-load-balancer",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', 'publicIp')]"
+        "[concat('Microsoft.Network/publicIPAddresses/', 'public-ip')]"
       ],
       "properties": {
         "frontendIPConfigurations": "[variables('feLoadBalancerConfig')]",
@@ -126,34 +132,34 @@
         ],
         "loadBalancingRules": [
           {
-            "name": "es",
+            "name": "es-http-rule",
             "properties": {
               "frontendIPConfiguration": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/frontendIPConfigurations/LBFE')]"
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','es-load-balancer'),'/frontendIPConfigurations/LBFE')]"
               },
               "backendAddressPool": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/backendAddressPools/LBBE')]"
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','es-load-balancer'),'/backendAddressPools/LBBE')]"
               },
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "frontendPort": 9200,
               "backendPort": 9200,
               "enableFloatingIP": false,
               "idleTimeoutInMinutes": 5,
               "probe": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/probes/esProbe')]"
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','es-load-balancer'),'/probes/es-tcp-probe')]"
               }
             }
           },
           {
-            "name": "estransport",
+            "name": "es-tcp-rule",
             "properties": {
               "frontendIPConfiguration": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/frontendIPConfigurations/LBFE')]"
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','es-load-balancer'),'/frontendIPConfigurations/LBFE')]"
               },
               "backendAddressPool": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/backendAddressPools/LBBE')]"
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','es-load-balancer'),'/backendAddressPools/LBBE')]"
               },
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "frontendPort": 9300,
               "backendPort": 9300,
               "enableFloatingIP": false,
@@ -163,9 +169,9 @@
         ],
         "probes": [
           {
-            "name": "esProbe",
+            "name": "es-tcp-probe",
             "properties": {
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "port": 9200,
               "intervalInSeconds": 30,
               "numberOfProbes": 3

--- a/elasticsearch/test/client-nodes-resources.json
+++ b/elasticsearch/test/client-nodes-resources.json
@@ -9,7 +9,7 @@
       }
     },
     "adminPassword": {
-      "type": "string",
+      "type": "securestring",
       "metadata": {
         "description": "Admin password used when provisioning virtual machines"
       }
@@ -56,6 +56,12 @@
       "metadata": {
         "description": "loadBalancerBackendAddressPools config object"
       }
+    },
+    "namespace": {
+      "type": "string",
+      "metadata": {
+        "description": "Namespace for resources created by this template"
+      }
     }
   },
   "variables": {},
@@ -66,7 +72,7 @@
       "value": "[parameters('adminUsername')]"
     },
     "adminPassword": {
-      "type": "string",
+      "type": "securestring",
       "value": "[parameters('adminPassword')]"
     },
     "storageAccountName": {
@@ -96,6 +102,10 @@
     "lbBackendPools": {
       "type": "object",
       "value": "[parameters('lbBackendPools')]"
+    },
+    "namespace": {
+      "type": "string",
+      "value": "[parameters('namespace')]"
     }
   }
 }

--- a/elasticsearch/test/master-nodes-resources.json
+++ b/elasticsearch/test/master-nodes-resources.json
@@ -51,6 +51,12 @@
       "metadata": {
         "description": "Elasticsearch deployment platform settings"
       }
+    },
+    "namespace": {
+      "type": "string",
+      "metadata": {
+        "description": "Namespace for resources created by this template"
+      }
     }
   },
   "variables": {},
@@ -87,6 +93,10 @@
     "osSettings": {
       "type": "object",
       "value": "[parameters('osSettings')]"
+    },
+    "namespace": {
+      "type": "string",
+      "value": "[parameters('namespace')]"
     }
   }
 }

--- a/elasticsearch/tmpl/data-nodes.yml
+++ b/elasticsearch/tmpl/data-nodes.yml
@@ -51,8 +51,8 @@ parameters:
 variables:
   vmStorageAccountContainerName: vhd
   subnetRef: "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]"
-  storageAccountName: "[concat(parameters('storageSettings').prefix)]"
-  vmName: "[concat(parameters('namespace'), 'vm')]"
+  storageAccountName: "[parameters('storageSettings').prefix]"
+  vmName: "[concat(parameters('namespace'), '-vm')]"
 resources:
 - type: Microsoft.Storage/storageAccounts
   name: "[concat(variables('storageAccountName'), copyindex(1))]"
@@ -65,14 +65,14 @@ resources:
     accountType: "[parameters('storageSettings').accountType]"
 - apiVersion: '2015-06-15'
   type: Microsoft.Compute/availabilitySets
-  name: "[concat(parameters('namespace'), '-set')]"
+  name: "es-data-set"
   location: "[parameters('location')]"
   properties:
     platformUpdateDomainCount: 20
     platformFaultDomainCount: 3
 - apiVersion: '2015-06-15'
   type: Microsoft.Network/networkInterfaces
-  name: "[concat(parameters('namespace'), 'nic', copyindex())]"
+  name: "[concat(parameters('namespace'), '-nic', copyindex())]"
   location: "[parameters('location')]"
   copy:
     name: "[concat(parameters('namespace'),'nicLoop')]"
@@ -87,21 +87,21 @@ resources:
         loadBalancerBackendAddressPools: "[parameters('lbBackendPools').backendPools]"
 - apiVersion: '2015-06-15'
   type: Microsoft.Compute/virtualMachines
-  name: "[concat(parameters('namespace'), 'vm', copyindex())]"
+  name: "[concat(variables('vmName'), copyindex())]"
   location: "[parameters('location')]"
   copy:
     name: "[concat(parameters('namespace'), 'virtualMachineLoop')]"
     count: "[parameters('vmCount')]"
   dependsOn:
-  - "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), 'nic', copyindex())]"
+  - "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
   - "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
   properties:
     availabilitySet:
-      id: "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), '-set'))]"
+      id: "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
     hardwareProfile:
       vmSize: "[parameters('vmSize')]"
     osProfile:
-      computername: "[concat(parameters('namespace'), 'vm', copyIndex())]"
+      computername: "[concat(variables('vmName'), copyIndex())]"
       adminUsername: "[parameters('adminUsername')]"
       adminPassword: "[parameters('adminPassword')]"
     storageProfile:
@@ -122,12 +122,12 @@ resources:
         createOption: Empty
     networkProfile:
       networkInterfaces:
-      - id: "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'nic', copyindex()))]"
+      - id: "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'-nic', copyindex()))]"
   resources:
   - type: Microsoft.Compute/virtualMachines/extensions
-    name: "[concat(parameters('namespace'),'vm', copyindex(), '/installelasticsearch')]"
+    name: "[concat(variables('vmName'), copyindex(), '/installelasticsearch')]"
     apiVersion: '2015-06-15'
     location: "[parameters('location')]"
     dependsOn:
-    - "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), 'vm', copyindex())]"
+    - "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyindex())]"
     properties: "[parameters('osSettings').extentionSettings.data]"


### PR DESCRIPTION
 -update naming for nodes, load balancer rules, public ip, probe, storage accounts
 -add another subnet for client nodes, kibana node, jumpbox node and load balancer
 -prefix storage account names with hash to better distribute across storage clusters and prevent event 17
 -remove deployment name from storage account hash to allow incremental deployments
 -update list of allowed host values to prevent single core nodes or less than 4GB RAM
 -limit heap allocation in windows to 32GB