### PR TITLE
Shrink computer name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ apprenda60-express/provisionApprendaTestScript.ps1
 apprenda60-small/provisionApprendaTestScript.ps1
 apprenda60-express/provisionApprendaTestScript.ps1
 
+# local template parameters
+elasticsearch/azuredeploy.parameters.local.*
+
 # emacs autosaves
 auto-save-list
 custom.el
@@ -18,3 +21,4 @@ org-mode-config.el
 org-clock-save.el
 emacs-config.el
 .vscode/settings.json
+

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -206,10 +206,18 @@
       "metadata": {
         "description": "Provision a machine with Kibana on it"
       }
+    },
+    "templateRepo": {
+      "type": "string",
+      "defaultValue": "Azure",
+      "metadata": {
+        "description": "Change this value to your repo name if deploying from a fork"
+      } 
     }
   },
   "variables": {
-    "templateBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch/",
+    "templateBaseUrl": "[concat('https://raw.githubusercontent.com/', parameters('templateRepo'), '/azure-quickstart-templates/master/elasticsearch/')]",
+    "scriptBaseUrl": "[concat('https://raw.githubusercontent.com/', parameters('templateRepo'), '/azure-quickstart-templates/master/shared_scripts/ubuntu/')]",
     "locationMap": {
         "ResourceGroup":"[resourceGroup().location]",
         "West US":"[parameters('location')]",
@@ -304,7 +312,7 @@
     "ubuntuScripts": [
       "[concat(variables('templateBaseUrl'), 'elasticsearch-ubuntu-install.sh')]",
       "[concat(variables('templateBaseUrl'), 'kibana-install.sh')]",
-      "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/shared_scripts/ubuntu/vm-disk-utils-0.1.sh"
+      "[concat(variables('scriptBaseUrl'), 'vm-disk-utils-0.1.sh')]"
     ],
     "windowsScripts": [
       "[concat(variables('templateBaseUrl'), 'elasticsearch-windows-install.ps1')]"

--- a/elasticsearch/azuredeploy.parameters.json
+++ b/elasticsearch/azuredeploy.parameters.json
@@ -9,13 +9,13 @@
       "value": "GEN-PASSWORD"
     },
     "vmDataNodeCount": {
-      "value": 3
+      "value": 1
     },
     "virtualNetworkName": {
       "value": "es-vnet"
     },
     "esClusterName": {
-      "value": "cluster-name"
+      "value": "cln"
     },
     "loadBalancerType": {
       "value": "internal"
@@ -34,6 +34,9 @@
     },
     "OS": {
       "value": "ubuntu"
+    },
+    "templateRepo": {
+      "value": "Azure" 
     }
   }
 }

--- a/elasticsearch/client-nodes-resources.json
+++ b/elasticsearch/client-nodes-resources.json
@@ -124,7 +124,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat(variables('vmName'), copyIndex())]",
+          "computerName": "[concat('client-vm', copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/elasticsearch/data-nodes-0disk-resources.json
+++ b/elasticsearch/data-nodes-0disk-resources.json
@@ -147,7 +147,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
+          "computerName": "[concat('data-vm', copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/elasticsearch/data-nodes-16disk-resources.json
+++ b/elasticsearch/data-nodes-16disk-resources.json
@@ -147,7 +147,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
+          "computerName": "[concat('data-vm', copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/elasticsearch/data-nodes-2disk-resources.json
+++ b/elasticsearch/data-nodes-2disk-resources.json
@@ -147,7 +147,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
+          "computerName": "[concat('data-vm', copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/elasticsearch/data-nodes-4disk-resources.json
+++ b/elasticsearch/data-nodes-4disk-resources.json
@@ -147,7 +147,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
+          "computerName": "[concat('data-vm', copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/elasticsearch/data-nodes-8disk-resources.json
+++ b/elasticsearch/data-nodes-8disk-resources.json
@@ -147,7 +147,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
+          "computerName": "[concat('data-vm', copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/elasticsearch/jumpbox-resources.json
+++ b/elasticsearch/jumpbox-resources.json
@@ -131,7 +131,7 @@
           "vmSize": "[variables('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[variables('vmName')]",
+          "computerName": "jumpbox",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/elasticsearch/kibana-resources.json
+++ b/elasticsearch/kibana-resources.json
@@ -145,7 +145,7 @@
           "vmSize": "[variables('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[variables('vmName')]",
+          "computerName": "kibana",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/elasticsearch/master-nodes-resources.json
+++ b/elasticsearch/master-nodes-resources.json
@@ -122,7 +122,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat(variables('vmName'), copyIndex())]",
+          "computerName": "[concat('master-vm', copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/elasticsearch/tmpl/data-nodes.yml
+++ b/elasticsearch/tmpl/data-nodes.yml
@@ -101,7 +101,7 @@ resources:
     hardwareProfile:
       vmSize: "[parameters('vmSize')]"
     osProfile:
-      computername: "[concat(variables('vmName'), copyIndex())]"
+      computerName: "[concat('data-vm', copyIndex())]"
       adminUsername: "[parameters('adminUsername')]"
       adminPassword: "[parameters('adminPassword')]"
     storageProfile:


### PR DESCRIPTION
 Minor fixes and updates

We need to reduce the length of computerName for Windows deployments, since the limit there is 15 characters. Changes:

  - remove full namespace from computer name, for windows limit of 15 characters
  - update default cluster name and computer names to be shorter
  - use configurable deployment parameters to ease testing
  - fix master node naming
  - ignore local template parameters file