### PR TITLE
docker-swarm: multi-host overlay networking

### DIFF
--- a/docker-swarm-cluster/README.md
+++ b/docker-swarm-cluster/README.md
@@ -25,6 +25,10 @@ This template creates the following cluster topology:
 
 > [![docker-swarm-azure](img/cluster-network.png)](img/cluster-network.png)
 
+The cluster will be interconnected with Docker multi-host networking setup
+so that you can easily create overlay networks with `docker network create`
+command.
+
 #### Swarm Managers
 
 The template provisions 3 Swarm manager VMs that use

--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -27,7 +27,7 @@
     "availabilitySetNodes": "swarm-nodes-set",
     "osImagePublisher": "CoreOS",
     "osImageOffer": "CoreOS",
-    "osImageSKU": "Stable",
+    "osImageSKU": "Beta",
     "managementPublicIPAddrName": "swarm-lb-masters-ip",
     "nodesPublicIPAddrName": "swarm-lb-nodes-ip",
     "virtualNetworkName": "swarm-vnet",
@@ -485,22 +485,22 @@
               "image": "progrium/consul",
               "command": "[concat('-server -node master', copyIndex(), ' ', variables('consulServerArgs')[copyIndex()])]",
               "ports": [
+                "8500:8500",
                 "8300:8300",
                 "8301:8301",
                 "8301:8301/udp",
                 "8302:8302",
                 "8302:8302/udp",
-                "8400:8400",
-                "8500:8500"
-              ],
+                "8400:8400"
+             ],
               "volumes": [
                 "/data/consul:/data"
               ],
               "restart": "always"
             },
             "swarm": {
-              "image": "swarm:1.0.0",
-              "command": "[concat('manage --replication --advertise ', reference(concat(variables('vmNameMaster'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2375 consul://10.0.0.4:8500/nodes')]",
+              "image": "swarm:1.0.1",
+              "command": "[concat('manage --replication --advertise ', reference(concat(variables('vmNameMaster'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2375 --discovery-opt kv.path=docker/nodes consul://10.0.0.4:8500')]",
               "ports": [
                 "2375:2375"
               ],
@@ -535,14 +535,11 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "docker": {
-            "port": "2375"
-          },
-          "compose": {
-            "swarm": {
-              "image": "swarm:1.0.0",
-              "restart": "always",
-              "command": "[concat('join --advertise=', reference(concat(variables('vmNameNode'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2375 consul://10.0.0.4:8500/nodes')]"
-            }
+            "port": "2375",
+	    "options": [
+	      "--cluster-store=consul://10.0.0.4:8500",
+	      "--cluster-advertise=eth0:2375"
+	    ]
           }
         }
       }


### PR DESCRIPTION
This updates the swarm template with Docker 1.9 multi-host networking features so that users can easily do `docker network create` and get overlay networks out of the box.

We're switching to CoreOS Beta feed because latest CoreOS Stable version as of this change is v835.12.0 and it does not have Docker 1.9 yet. We shall switch back to the stable channel once this situation changes.