### PR TITLE
updated commands to set properties on the vault

### DIFF
--- a/101-vm-secure-password/README.md
+++ b/101-vm-secure-password/README.md
@@ -27,10 +27,10 @@ After this you'll need to enable the Key Vault for template deployment and deplo
 
 ## PowerShell
 ```
-Set-AzureRmKeyVaultAccessPolicy -VaultName Contoso -EnabledForTemplateDeployment -EnabledForDeployment
+Set-AzureRmKeyVaultAccessPolicy -VaultName Contoso -EnabledForTemplateDeployment
 ```
 
 ### CLI
 ```
-azure keyvault set-policy --vault-name Contoso --enabled-for-deployment true --enabled-for-template-deployment true
+azure keyvault set-policy --vault-name Contoso --enabled-for-template-deployment true
 ```


### PR DESCRIPTION
The EnableForDeployment property is *not* required for getting secrets during template deployment.  Only EnabledForTemplateDeployment is required.