### PR TITLE
Fixed Ubunto tcp keep alive according to official MongoDb doc

### DIFF
--- a/mongodb-on-ubuntu/mongo-install-ubuntu.sh
+++ b/mongodb-on-ubuntu/mongo-install-ubuntu.sh
@@ -10,5 +10,8 @@ sudo grep -q -F 'transparent_hugepage=never' /etc/default/grub || echo 'transpar
 # Install updates
 sudo apt-get -y update
 
+# Modified tcp keepalive according to https://docs.mongodb.org/ecosystem/platforms/windows-azure/
+sudo bash -c "sudo echo net.ipv4.tcp_keepalive_time = 120 >> /etc/sysctl.conf"
+
 #Install Mongo DB
 sudo apt-get install -y mongodb-org

--- a/mongodb-on-ubuntu/mongo-install-ubuntu.sh
+++ b/mongodb-on-ubuntu/mongo-install-ubuntu.sh
@@ -15,3 +15,7 @@ sudo bash -c "sudo echo net.ipv4.tcp_keepalive_time = 120 >> /etc/sysctl.conf"
 
 #Install Mongo DB
 sudo apt-get install -y mongodb-org
+
+# Uncomment this to bind to all ip addresses
+# sudo sed -i -e 's/bindIp: 127.0.0.1/bindIp: 0.0.0.0/g' /etc/mongod.conf
+# sudo service mongod restart


### PR DESCRIPTION
Basically this is useful otherwise some to prevent socket timeout problem when connecting thourgh the public ip.

See https://docs.mongodb.org/ecosystem/platforms/windows-azure/

Plus I have added an optional configuration to bind to all IP address