### PR TITLE
Add additional diagnostics to response error

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -168,7 +168,7 @@ function validateTemplate(templatePath, parametersPath) {
       .send(JSON.stringify(requestBody))
       .end(function (response) {
         if (response.status !== 200) {
-          return reject(response.body);
+          return reject(response);
         }
 
         return resolve(response.body);


### PR DESCRIPTION
Sometimes the server appears unreachable. When this occurs it appears `response.body` is null. 

Returning the entire response may help surface some errors such as the HTTP status.