### PR TITLE
Update azuredeploy.json to take vmName as a param

### DIFF
--- a/101-vm-from-user-image/azuredeploy.json
+++ b/101-vm-from-user-image/azuredeploy.json
@@ -47,14 +47,20 @@
       "metadata": {
         "description": "This is the size of your VM"
       }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "This is the name of your VM"
+      }
     }
   },
   "variables": {
     "location": "[resourceGroup().location]",
     "publicIPAddressName": "userImagePublicIP",
-    "vmName": "userImageVM",
-    "virtualNetworkName": "userImageVNET",
-    "nicName": "userImageVMNic",
+    "vmName": "[parameters('vmName')]",
+    "virtualNetworkName": "[concat(parameters('vmName'),'VNET')]",
+    "nicName": "[concat(parameters('vmName'),'NIC')]",
     "addressPrefix": "10.0.0.0/16",
     "subnet1Name": "Subnet-1",
     "subnet1Prefix": "10.0.0.0/24",


### PR DESCRIPTION
Update azuredeploy.json to take vmName as a param, possibly through slightly clumsy use of github (more used to the Bitbucket UI and did not have the repo cloned locally, but I think this change is something one pretty much always want).