### PR TITLE
jenkins-on-ubuntu: 14.04.2-LTS -> 14.04.4-LTS

### DIFF
--- a/jenkins-on-ubuntu/azuredeploy.json
+++ b/jenkins-on-ubuntu/azuredeploy.json
@@ -104,8 +104,8 @@
       "imageReference": {
         "publisher": "Canonical",
         "offer": "UbuntuServer",
-        "sku": "14.04.2-LTS",
-        "version": "14.04.201503090"
+        "sku": "14.04.4-LTS",
+        "version": "latest"
       },
       "scripts": [
         "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/jenkins-on-ubuntu/jenkMstrInstall.sh",
@@ -116,8 +116,8 @@
       "imageReference": {
         "publisher": "Canonical",
         "offer": "UbuntuServer",
-        "sku": "14.04.2-LTS",
-        "version": "14.04.201503090"
+        "sku": "14.04.4-LTS",
+        "version": "latest"
       },
       "scripts": [
         "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/jenkins-on-ubuntu/jenkSlaveInstall.sh"


### PR DESCRIPTION
This updates jenkins-on-ubuntu template so that it is using the latest available Trusty image.