### PR TITLE
split out afs storage for optimum throughput

### DIFF
--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -256,6 +256,7 @@
     },
     "location":"[variables('locationMap')[parameters('location')]]",
     "storageAccountPrefix": "[concat(substring(uniqueString(resourceGroup().id, parameters('esClusterName')), 0, 6), substring(parameters('esClusterName'), 0, 3))]",
+    "storageAccountNameAFS": "[concat(variables('storageAccountPrefix'), 'afs')]",
     "storageAccountNameShared": "[concat(variables('storageAccountPrefix'), 'sh')]",
     "masterNodesIpPrefix": "10.0.0.1",
     "networkSettings": {
@@ -325,8 +326,8 @@
     },
     "afsParam": {
       "ubuntu": {
-        "yes": "[concat(' -a ', variables('storageAccountNameShared'), ' -c -k ')]",
-        "no": "[concat(' -a ', variables('storageAccountNameShared'), ' -k ')]"
+        "yes": "[concat(' -a ', variables('storageAccountNameAFS'), ' -c -k ')]",
+        "no": "[concat(' -a ', variables('storageAccountNameAFS'), ' -k ')]"
       },
       "windows": {
         "yes":"",
@@ -572,6 +573,7 @@
       "count":"[div(sub(add(parameters('vmDataNodeCount'), variables('nodesPerStorageAccount')), 1), variables('nodesPerStorageAccount'))]",
       "mapping":"[variables('storageBinPackMap')]",
       "accountType":"[variables('dataSkuSettings')[parameters('vmSizeDataNodes')].storageAccountType]",
+      "afs":"[variables('storageAccountNameAFS')]",
       "shared":"[variables('storageAccountNameShared')]",
       "prefix":"[concat(variables('storageAccountPrefix'), 'da')]"
     },
@@ -642,8 +644,8 @@
           "networkSettings": {
             "value": "[variables('networkSettings')]"
           },
-          "storageAccountName": {
-            "value": "[variables('storageAccountNameShared')]"
+          "storageSettings": {
+            "value": "[variables('dataNodeStorageSettings')]"
           },
           "loadBalancerType": {
             "value": "[parameters('loadBalancerType')]"

--- a/elasticsearch/data-nodes-0disk-resources.json
+++ b/elasticsearch/data-nodes-0disk-resources.json
@@ -76,23 +76,10 @@
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
     "storageAccountName": "[parameters('storageSettings').prefix]",
-    "storageAccountNameShared": "[parameters('storageSettings').shared]",
+    "storageAccountNameAFS": "[parameters('storageSettings').afs]",
     "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[concat(variables('storageAccountName'), copyindex(1))]",
-      "apiVersion": "2015-05-01-preview",
-      "location": "[parameters('location')]",
-      "copy": {
-        "name": "[concat(parameters('namespace'),'storageLoop')]",
-        "count": "[parameters('storageSettings').count]"
-      },
-      "properties": {
-        "accountType": "[parameters('storageSettings').accountType]"
-      }
-    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
@@ -137,8 +124,7 @@
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
       ],
       "properties": {
         "availabilitySet": {
@@ -186,7 +172,7 @@
             "typeHandlerVersion": "[parameters('osSettings').extensionSettings.data.typeHandlerVersion]",
             "settings": {
               "fileUris": "[parameters('osSettings').extensionSettings.data.settings.fileUris]",
-              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameShared')), '2015-05-01-preview').key1)]"
+              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameAFS')), '2015-05-01-preview').key1)]"
             }
           }
         }

--- a/elasticsearch/data-nodes-16disk-resources.json
+++ b/elasticsearch/data-nodes-16disk-resources.json
@@ -76,23 +76,10 @@
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
     "storageAccountName": "[parameters('storageSettings').prefix]",
-    "storageAccountNameShared": "[parameters('storageSettings').shared]",
+    "storageAccountNameAFS": "[parameters('storageSettings').afs]",
     "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[concat(variables('storageAccountName'), copyindex(1))]",
-      "apiVersion": "2015-05-01-preview",
-      "location": "[parameters('location')]",
-      "copy": {
-        "name": "[concat(parameters('namespace'),'storageLoop')]",
-        "count": "[parameters('storageSettings').count]"
-      },
-      "properties": {
-        "accountType": "[parameters('storageSettings').accountType]"
-      }
-    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
@@ -137,8 +124,7 @@
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
       ],
       "properties": {
         "availabilitySet": {
@@ -348,7 +334,7 @@
             "typeHandlerVersion": "[parameters('osSettings').extensionSettings.data.typeHandlerVersion]",
             "settings": {
               "fileUris": "[parameters('osSettings').extensionSettings.data.settings.fileUris]",
-              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameShared')), '2015-05-01-preview').key1)]"
+              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameAFS')), '2015-05-01-preview').key1)]"
             }
           }
         }

--- a/elasticsearch/data-nodes-2disk-resources.json
+++ b/elasticsearch/data-nodes-2disk-resources.json
@@ -76,23 +76,10 @@
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
     "storageAccountName": "[parameters('storageSettings').prefix]",
-    "storageAccountNameShared": "[parameters('storageSettings').shared]",
+    "storageAccountNameAFS": "[parameters('storageSettings').afs]",
     "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[concat(variables('storageAccountName'), copyindex(1))]",
-      "apiVersion": "2015-05-01-preview",
-      "location": "[parameters('location')]",
-      "copy": {
-        "name": "[concat(parameters('namespace'),'storageLoop')]",
-        "count": "[parameters('storageSettings').count]"
-      },
-      "properties": {
-        "accountType": "[parameters('storageSettings').accountType]"
-      }
-    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
@@ -137,8 +124,7 @@
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
       ],
       "properties": {
         "availabilitySet": {
@@ -208,7 +194,7 @@
             "typeHandlerVersion": "[parameters('osSettings').extensionSettings.data.typeHandlerVersion]",
             "settings": {
               "fileUris": "[parameters('osSettings').extensionSettings.data.settings.fileUris]",
-              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameShared')), '2015-05-01-preview').key1)]"
+              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameAFS')), '2015-05-01-preview').key1)]"
             }
           }
         }

--- a/elasticsearch/data-nodes-4disk-resources.json
+++ b/elasticsearch/data-nodes-4disk-resources.json
@@ -76,23 +76,10 @@
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
     "storageAccountName": "[parameters('storageSettings').prefix]",
-    "storageAccountNameShared": "[parameters('storageSettings').shared]",
+    "storageAccountNameAFS": "[parameters('storageSettings').afs]",
     "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[concat(variables('storageAccountName'), copyindex(1))]",
-      "apiVersion": "2015-05-01-preview",
-      "location": "[parameters('location')]",
-      "copy": {
-        "name": "[concat(parameters('namespace'),'storageLoop')]",
-        "count": "[parameters('storageSettings').count]"
-      },
-      "properties": {
-        "accountType": "[parameters('storageSettings').accountType]"
-      }
-    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
@@ -137,8 +124,7 @@
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
       ],
       "properties": {
         "availabilitySet": {
@@ -228,7 +214,7 @@
             "typeHandlerVersion": "[parameters('osSettings').extensionSettings.data.typeHandlerVersion]",
             "settings": {
               "fileUris": "[parameters('osSettings').extensionSettings.data.settings.fileUris]",
-              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameShared')), '2015-05-01-preview').key1)]"
+              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameAFS')), '2015-05-01-preview').key1)]"
             }
           }
         }

--- a/elasticsearch/data-nodes-8disk-resources.json
+++ b/elasticsearch/data-nodes-8disk-resources.json
@@ -76,23 +76,10 @@
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
     "storageAccountName": "[parameters('storageSettings').prefix]",
-    "storageAccountNameShared": "[parameters('storageSettings').shared]",
+    "storageAccountNameAFS": "[parameters('storageSettings').afs]",
     "vmName": "[concat(parameters('namespace'), '-vm')]"
   },
   "resources": [
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[concat(variables('storageAccountName'), copyindex(1))]",
-      "apiVersion": "2015-05-01-preview",
-      "location": "[parameters('location')]",
-      "copy": {
-        "name": "[concat(parameters('namespace'),'storageLoop')]",
-        "count": "[parameters('storageSettings').count]"
-      },
-      "properties": {
-        "accountType": "[parameters('storageSettings').accountType]"
-      }
-    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
@@ -137,8 +124,7 @@
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
       ],
       "properties": {
         "availabilitySet": {
@@ -268,7 +254,7 @@
             "typeHandlerVersion": "[parameters('osSettings').extensionSettings.data.typeHandlerVersion]",
             "settings": {
               "fileUris": "[parameters('osSettings').extensionSettings.data.settings.fileUris]",
-              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameShared')), '2015-05-01-preview').key1)]"
+              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameAFS')), '2015-05-01-preview').key1)]"
             }
           }
         }

--- a/elasticsearch/shared-resources.json
+++ b/elasticsearch/shared-resources.json
@@ -25,10 +25,10 @@
         "description": "Load balancer setting (internal/external)"
       }
     },
-    "storageAccountName": {
-      "type": "string",
+    "storageSettings": {
+      "type": "object",
       "metadata": {
-        "description": "Storage account used for share virtual machine images"
+        "description": "Storage Account Settings"
       }
     },
     "ilbIpAddress": {
@@ -39,6 +39,9 @@
     }
   },
   "variables": {
+    "storageAccountName": "[parameters('storageSettings').prefix]",
+    "storageAccountNameAFS": "[parameters('storageSettings').afs]",
+    "storageAccountNameShared": "[parameters('storageSettings').shared]",
     "externalFELBConfig": [
       {
         "name": "LBFE",
@@ -66,13 +69,35 @@
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[parameters('storageAccountName')]",
+      "name": "[variables('storageAccountNameShared')]",
       "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "properties": {
         "accountType": "Standard_LRS"
       }
     },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountNameAFS')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[parameters('location')]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[concat(variables('storageAccountName'), copyindex(1))]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[parameters('location')]",
+      "copy": {
+        "name": "storageLoop",
+        "count": "[parameters('storageSettings').count]"
+      },
+      "properties": {
+        "accountType": "[parameters('storageSettings').accountType]"
+      }
+    },    
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",

--- a/elasticsearch/test/empty-resources.json
+++ b/elasticsearch/test/empty-resources.json
@@ -37,6 +37,10 @@
     "lbBackendPools": {
       "type": "object",
       "defaultValue": {}
+    },
+    "namespace": {
+      "type": "string",
+      "defaultValue": ""
     }
   },
   "variables": {},
@@ -77,6 +81,10 @@
     "lbBackendPools": {
       "type": "object",
       "value": "[parameters('lbBackendPools')]"
+    },
+    "namespace": {
+      "type": "string",
+      "value": "[parameters('namespace')]"
     }
   }
 }

--- a/elasticsearch/test/shared-resources.json
+++ b/elasticsearch/test/shared-resources.json
@@ -25,10 +25,10 @@
         "description": "Load balancer setting (internal/external)"
       }
     },
-    "storageAccountName": {
-      "type": "string",
+    "storageSettings": {
+      "type": "object",
       "metadata": {
-        "description": "Storage account used for share virtual machine images"
+        "description": "Storage Account Settings"
       }
     },
     "ilbIpAddress": {
@@ -53,9 +53,9 @@
       "type": "string",
       "value": "[parameters('loadBalancerType')]"
     },
-    "storageAccountName": {
-      "type": "string",
-      "value": "[parameters('storageAccountName')]"
+    "storageSettings": {
+      "type": "object",
+      "value": "[parameters('storageSettings')]"
     },
     "ilbIpAddress": {
       "type": "string",

--- a/elasticsearch/tmpl/data-nodes.yml
+++ b/elasticsearch/tmpl/data-nodes.yml
@@ -52,18 +52,9 @@ variables:
   vmStorageAccountContainerName: vhd
   subnetRef: "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]"
   storageAccountName: "[parameters('storageSettings').prefix]"
-  storageAccountNameShared: "[parameters('storageSettings').shared]"
+  storageAccountNameAFS: "[parameters('storageSettings').afs]"
   vmName: "[concat(parameters('namespace'), '-vm')]"
 resources:
-- type: Microsoft.Storage/storageAccounts
-  name: "[concat(variables('storageAccountName'), copyindex(1))]"
-  apiVersion: 2015-05-01-preview
-  location: "[parameters('location')]"
-  copy:
-    name: "[concat(parameters('namespace'),'storageLoop')]"
-    count: "[parameters('storageSettings').count]"
-  properties:
-    accountType: "[parameters('storageSettings').accountType]"
 - apiVersion: '2015-06-15'
   type: Microsoft.Compute/availabilitySets
   name: "es-data-set"
@@ -95,7 +86,6 @@ resources:
     count: "[parameters('vmCount')]"
   dependsOn:
   - "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
-  - "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])]"
   properties:
     availabilitySet:
       id: "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
@@ -137,4 +127,4 @@ resources:
         typeHandlerVersion: "[parameters('osSettings').extensionSettings.data.typeHandlerVersion]"
         settings: 
             fileUris: "[parameters('osSettings').extensionSettings.data.settings.fileUris]"
-            commandToExecute: "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameShared')), '2015-05-01-preview').key1)]"
+            commandToExecute: "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameAFS')), '2015-05-01-preview').key1)]"


### PR DESCRIPTION
- move storage account creation to the shared resources template
- split out shared OS storage from AFS storage
- use shared storage account for OS disks
- remove dependency across templates