### PR TITLE
github-enterprise template: correct NSG association to subnet

### DIFF
--- a/github-enterprise/azuredeploy.json
+++ b/github-enterprise/azuredeploy.json
@@ -123,7 +123,9 @@
                         "name": "[variables('subnetName')]",
                         "properties": {
                             "addressPrefix": "[variables('subnetPrefix')]",
-                            "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+                            "networkSecurityGroup": {
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+                            }
                         }
                     }
                 ]


### PR DESCRIPTION
There was an incorrect syntax for associating NSG to the subnet - was this:
...
   properties: {
       id: "..."
   }
I replaced with:
... 
   properties: {
       "networkSecurityGroup": {
             id: "..."
       }
   }