### PR TITLE
enable standalone marvel cluster

### DIFF
--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,4 +1,4 @@
-# Install Elasticsearch cluster on Virtual Machines
+# Install an Elasticsearch cluster on Virtual Machines
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Felasticsearch%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
@@ -7,9 +7,11 @@
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-This template deploys an Elasticsearch cluster on Virtual Machines and uses template linking. The template provisions 3 dedicated master and client nodes in separate availability sets and storage accounts. A load balancer is configured with a rule to route traffic on port 9200 to the client nodes, and also includes a single SSH management rule mapped to one of the client nodes.  Multiple data disks are attached (the number depends on the size of the virtual machine selected) and data is striped across them as an approach to improve disk throughput.
+This template deploys an Elasticsearch cluster on Virtual Machines using linked templates. The template provisions 3 dedicated master nodes, with an optional number of client and data nodes, which are placed in separate availability sets and storage accounts. A load balancer is configured with a rule to route traffic on port 9200 to the client nodes, and also includes a single SSH management rule mapped to one of the client nodes or jumpbox if selected.  Multiple data disks are attached (the number depends on the size of the virtual machine selected) and data is striped across them as an approach to improve disk throughput.
 
-This template also deploys a Storage Account, Virtual Network, Availability Sets, Public IP addresses, Load Balancer, and a Network Interface.
+The template also provides the option of deploying a standalone Marvel cluster. If selected, this option will provision 3 additional nodes of the specified size which are both master and data eligible. The data nodes are then configured to send Marvel data to these nodes, which are configured in their own cluster.    
+
+This template deploys Virtual Machines, Storage Accounts, a Virtual Network, Availability Sets, Public IP addresses, a Load Balancer, and Network Interfaces.
 
 ##Notes
 Warning!  The configuration allows you to enabled external load balanced endpoints on a public IP.  The endpoint is not secure and it's recommended that you keep these endpoints internal or secure them. Elasticsearch Shield product should be considered.

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -205,7 +205,33 @@
         "no"
       ],
       "metadata": {
-        "description": "Install the marvel agent in the cluster"
+        "description": "Install the Marvel agent in the cluster"
+      }
+    },
+    "marvelCluster" : {
+      "type":"string",
+      "defaultValue":"yes",
+      "allowedValues": [
+        "yes",
+        "no"
+      ],
+      "metadata": {
+        "description": "Build a standalone 3 node cluster for Marvel data"
+      }
+    },
+    "vmSizeMarvelNodes": {
+      "type": "string",
+      "defaultValue": "Standard_D2_v2",
+      "allowedValues": [
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4"
+      ],
+      "metadata": {
+        "description": "Size of the Elasticsearch Marvel cluster nodes, if selected"
       }
     },
     "kibana":{
@@ -259,6 +285,12 @@
     "storageAccountNameAFS": "[concat(variables('storageAccountPrefix'), 'afs')]",
     "storageAccountNameShared": "[concat(variables('storageAccountPrefix'), 'sh')]",
     "masterNodesIpPrefix": "10.0.0.1",
+    "marvelNodesIpPrefix": "10.0.2.2",
+    "kibanaIPPrefix": {
+        "yes" : "[variables('marvelNodesIpPrefix')]",
+        "no": "[variables('masterNodesIpPrefix')]"
+    },
+    "kibanaIP" : "[concat('http://', variables('kibanaIPPrefix')[parameters('marvelCluster')], '0:9200')]",
     "networkSettings": {
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
       "addressPrefix": "10.0.0.0/16",
@@ -282,15 +314,22 @@
     },
     "esSettings": {
       "clusterName": "[parameters('esClusterName')]",
+      "marvelClusterName": "[concat(parameters('esClusterName'), '-marvel')]",
       "version": "[parameters('esVersion')]",
-      "discoveryHosts": "[concat(variables('masterNodesIpPrefix'), '-3')]"
+      "discoveryHosts": "[concat(variables('masterNodesIpPrefix'), '-3')]",
+      "marvelHosts": "[concat(variables('marvelNodesIpPrefix'), '-3')]"
     },
     "sharedTemplateUrl": "[concat(variables('templateBaseUrl'), 'shared-resources.json')]",
     "masterTemplateUrl": "[concat(variables('templateBaseUrl'), 'master-nodes-resources.json')]",
+    "marvelTemplates": {
+        "yes" : "marvel-nodes-resources.json",
+        "no" : "empty-resources.json"
+    },
     "clientTemplates": [
       "empty-resources.json",
       "client-nodes-resources.json"
     ],
+    "marvelTemplateUrl": "[concat(variables('templateBaseUrl'), variables('marvelTemplates')[parameters('marvelCluster')])]",    
     "clientTemplateUrl": "[concat(variables('templateBaseUrl'), variables('clientTemplates')[mod(add(parameters('vmClientNodeCount'),2),add(parameters('vmClientNodeCount'),1))])]",
     "lbBackEndPoolsAdded": {
       "backendPools": [
@@ -334,6 +373,17 @@
         "no":""
       } 
     },
+    "marvelExportParam" : {
+      "ubuntu" : {
+        "yes" : "[concat(' -e ', variables('marvelNodesIpPrefix'), '-3')]",
+        "no": ""  
+      },
+      "windows": {
+        "yes": "[concat(' -marvelEndpoints ', variables('marvelNodesIpPrefix'), '-3')]",
+        "no": ""
+      }
+    },
+    "marvelExportParamValue": "[variables('marvelExportParam')[parameters('OS')][parameters('marvelCluster')]]",
     "senseParamValue": "[variables('senseParam')[parameters('sense')]]",
     "marvelParamValue": "[variables('marvelParam')[parameters('OS')][parameters('marvel')]]",
     "afsParamValue": "[variables('afsParam')[parameters('OS')][parameters('afs')]]",
@@ -342,13 +392,6 @@
       "no": "empty-resources.json"
     },
     "kibanaTemplateUrl":"[concat(variables('templateBaseUrl'), variables('kibanaTemplates')[parameters('kibana')], '')]",
-    "scriptParams": [
-      "[concat('version=', parameters('esVersion'), ';')]",
-      "[concat('clusterName=', parameters('esClusterName'), ';')]",
-      "[concat('discoveryHosts=', variables('masterNodesIpPrefix'), '-3', ';')]",
-      "[concat('installMarvel=', parameters('marvel'), ';')]"
-    ],
-    "scriptParamString":"[concat(variables('scriptParams')[0], variables('scriptParams')[1], variables('scriptParams')[2], variables('scriptParams')[3] )]",
     "ubuntuScripts": [
       "[concat(variables('templateBaseUrl'), 'elasticsearch-ubuntu-install.sh')]",
       "[concat(variables('templateBaseUrl'), 'kibana-install.sh')]",
@@ -367,13 +410,22 @@
       },
       "managementPort":"22",
       "extensionSettings":{
+        "marvel": {
+            "publisher": "Microsoft.OSTCExtensions",
+            "type": "CustomScriptForLinux",
+            "typeHandlerVersion": "1.2",
+            "settings": {
+              "fileUris": "[variables('ubuntuScripts')]",
+              "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -wn ', variables('esSettings').marvelClusterName, ' -v ', variables('esSettings').version, ' -d ', variables('esSettings').marvelHosts, ' -k ')]"
+            }
+          },
         "master": {
             "publisher": "Microsoft.OSTCExtensions",
             "type": "CustomScriptForLinux",
             "typeHandlerVersion": "1.2",
             "settings": {
               "fileUris": "[variables('ubuntuScripts')]",
-              "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -xn ', variables('esSettings').clusterName, ' -v ', variables('esSettings').version, ' -d ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('afsParamValue'))]"
+              "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -xn ', variables('esSettings').clusterName, ' -v ', variables('esSettings').version, ' -d ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('marvelExportParamValue'), variables('afsParamValue'))]"
             }
           },
         "client": {
@@ -382,7 +434,7 @@
             "typeHandlerVersion": "1.2",
             "settings": {
               "fileUris": "[variables('ubuntuScripts')]",
-              "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -yn ', variables('esSettings').clusterName, ' -v ', variables('esSettings').version, ' -d ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('afsParamValue'))]"
+              "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -yn ', variables('esSettings').clusterName, ' -v ', variables('esSettings').version, ' -d ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('marvelExportParamValue'), variables('afsParamValue'))]"
             }
           },
         "data": {
@@ -391,7 +443,7 @@
           "typeHandlerVersion": "1.2",
           "settings": {
             "fileUris": "[variables('ubuntuScripts')]",
-            "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -zn ', variables('esSettings').clusterName, ' -v ', variables('esSettings').version, ' -d ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('afsParamValue'))]"
+            "commandToExecute": "[concat('bash elasticsearch-ubuntu-install.sh -zn ', variables('esSettings').clusterName, ' -v ', variables('esSettings').version, ' -d ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('marvelExportParamValue'), variables('afsParamValue'))]"
           }
         },
         "kibana": {
@@ -400,7 +452,7 @@
           "typeHandlerVersion": "1.2",
           "settings": {
             "fileUris": "[variables('ubuntuScripts')]",
-            "commandToExecute": "[concat('bash kibana-install.sh -v ', variables('esSettings').version, variables('marvelParamValue'), variables('senseParamValue'), ' -t http://', variables('masterNodesIpPrefix'), '0:9200')]"
+            "commandToExecute": "[concat('bash kibana-install.sh -v ', variables('esSettings').version, variables('marvelParamValue'), variables('senseParamValue'), ' -t ', variables('kibanaIP'))]"
           }
         }
       }
@@ -414,13 +466,22 @@
       },
       "managementPort":"3389",
       "extensionSettings":{
+        "marvel": {
+          "publisher": "Microsoft.Compute",
+          "type": "CustomScriptExtension",
+          "typeHandlerVersion": "1.4",
+          "settings": {
+            "fileUris": "[variables('windowsScripts')]",
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').marvelClusterName,' -discoveryEndpoints ', variables('esSettings').marvelHosts, ' -marvelOnlyNode -storageKey ')]"
+          }
+        },
         "master": {
           "publisher": "Microsoft.Compute",
           "type": "CustomScriptExtension",
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, ' -masterOnlyNode -installMarvel -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('marvelExportParamValue'), ' -masterOnlyNode -storageKey ')]"
           }
         },
         "client": {
@@ -429,7 +490,7 @@
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, ' -clientOnlyNode -installMarvel -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('marvelExportParamValue'), ' -clientOnlyNode -storageKey ')]"
           }
         },
         "data": {
@@ -438,7 +499,7 @@
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, ' -dataOnlyNode -installMarvel -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('marvelExportParamValue'), ' -dataOnlyNode -storageKey ')]"
           }
         }
       }
@@ -623,6 +684,50 @@
           },
           "namespace": {
             "value": "[concat(parameters('esClusterName'), '-master')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "marvel-nodes",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'shared')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('marvelTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "storageAccountName": {
+            "value": "[variables('storageAccountNameShared')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "marvelNodesIpPrefix": {
+            "value": "[variables('marvelNodesIpPrefix')]"
+          },
+          "location": {
+            "value": "[variables('location')]"
+          },
+          "vmSize": {
+            "value": "[parameters('vmSizeMarvelNodes')]"
+          },
+          "subnet": {
+            "value": "[variables('networkSettings').subnet.other]"
+          },
+          "osSettings": {
+            "value": "[variables('osSettings')]"
+          },
+          "namespace": {
+            "value": "[concat(parameters('esClusterName'), '-marvel')]"
           }
         }
       }

--- a/elasticsearch/data-nodes-16disk-resources.json
+++ b/elasticsearch/data-nodes-16disk-resources.json
@@ -124,7 +124,8 @@
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
+        "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
       ],
       "properties": {
         "availabilitySet": {

--- a/elasticsearch/data-nodes-2disk-resources.json
+++ b/elasticsearch/data-nodes-2disk-resources.json
@@ -124,7 +124,8 @@
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
+        "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
       ],
       "properties": {
         "availabilitySet": {

--- a/elasticsearch/data-nodes-4disk-resources.json
+++ b/elasticsearch/data-nodes-4disk-resources.json
@@ -124,7 +124,8 @@
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
+        "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
       ],
       "properties": {
         "availabilitySet": {

--- a/elasticsearch/data-nodes-8disk-resources.json
+++ b/elasticsearch/data-nodes-8disk-resources.json
@@ -124,7 +124,8 @@
         "count": "[parameters('vmCount')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
+        "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
       ],
       "properties": {
         "availabilitySet": {

--- a/elasticsearch/empty-resources.json
+++ b/elasticsearch/empty-resources.json
@@ -38,6 +38,10 @@
       "type": "object",
       "defaultValue": {}
     },
+    "marvelNodesIpPrefix": {
+      "type": "string",
+      "defaultValue": "" 
+    },
     "namespace": {
       "type": "string",
       "defaultValue": ""

--- a/elasticsearch/kibana-install.sh
+++ b/elasticsearch/kibana-install.sh
@@ -82,7 +82,7 @@ install_kibana() {
     fi
 
     # install the marvel plugin for 2.x
-    if [ ${INSTALL_MARVEL} ];
+    if [ ${INSTALL_MARVEL} -ne 0 ];
     then
         if [[ "${ES_VERSION}" == "2.2.0" ]];
         then
@@ -98,7 +98,7 @@ install_kibana() {
     fi
     
     # install the sense plugin for 2.x
-    if [ ${INSTALL_SENSE} ];
+    if [ ${INSTALL_SENSE} -ne 0 ];
     then
         if [[ "${ES_VERSION}" == \2* ]];
         then

--- a/elasticsearch/marvel-nodes-resources.json
+++ b/elasticsearch/marvel-nodes-resources.json
@@ -14,14 +14,15 @@
         "description": "Admin password used when provisioning virtual machines"
       }
     },
-    "storageSettings": {
-      "type": "object",
+    "storageAccountName": {
+      "type": "string",
       "metadata": {
-        "description": "Storage Account Settings"
+        "description": "Unique namespace for the Storage Account where the Virtual Machine's disks will be placed"
       }
     },
     "location": {
       "type": "string",
+      "defaultValue": "West US",
       "metadata": {
         "description": "Location where resources will be provisioned"
       }
@@ -29,86 +30,72 @@
     "subnet": {
       "type": "object",
       "metadata": {
-        "description": "The name of the subnet to deploy resources into"
+        "description": "The VNET and Subnet to deploy the nodes in to"
+      }
+    },
+    "marvelNodesIpPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Prefix used to append index for static addresses"
       }
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_A1",
+      "defaultValue": "Standard_A0",
       "metadata": {
-        "description": "Size of the Elasticsearch data nodes"
-      }
-    },
-    "vmCount": {
-      "type": "int",
-      "defaultValue": 2,
-      "metadata": {
-        "description": "Number of Elasticsearch data nodes"
+        "description": "Size of the Elasticsearch nodes"
       }
     },
     "osSettings": {
       "type": "object",
       "metadata": {
-        "description": "OS settings to deploy on"
-      }
-    },
-    "dataDiskSize": {
-      "type": "int",
-      "defaultValue": 1023,
-      "metadata": {
-        "description": "Size of each data disk attached to data nodes in (Gb)"
+        "description": "Elasticsearch deployment platform settings"
       }
     },
     "namespace": {
       "type": "string",
       "metadata": {
-        "description": "The namespace for resources created by this template"
-      }
-    },
-    "lbBackendPools": {
-      "type": "object",
-      "metadata": {
-        "description": "loadBalancerBackendAddressPools config object"
+        "description": "Namespace for resources created by this template"
       }
     }
   },
   "variables": {
     "vmStorageAccountContainerName": "vhd",
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[parameters('storageSettings').prefix]",
-    "storageAccountNameAFS": "[parameters('storageSettings').afs]",
-    "vmName": "[concat(parameters('namespace'), '-vm')]"
+    "storageAccountName": "[parameters('storageAccountName')]",
+    "vmName": "[concat(parameters('namespace'), '-vm')]",
+    "nicName": "[concat(parameters('namespace'), '-nic')]"
   },
   "resources": [
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
-      "name": "es-data-set",
+      "name": "es-marvel-set",
       "location": "[parameters('location')]",
       "properties": {
-        "platformUpdateDomainCount": 20,
+        "platformUpdateDomainCount": 3,
         "platformFaultDomainCount": 3
       }
     },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(parameters('namespace'), '-nic', copyindex())]",
+      "name": "[concat(variables('nicName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
-        "name": "[concat(parameters('namespace'),'nicLoop')]",
-        "count": "[parameters('vmCount')]"
+        "name": "marvelNodesNicLoop",
+        "count": 3
       },
       "properties": {
         "ipConfigurations": [
           {
             "name": "ipconfig1",
             "properties": {
-              "privateIPAllocationMethod": "Dynamic",
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[concat(parameters('marvelNodesIpPrefix'),copyindex())]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
-              },
-              "loadBalancerBackendAddressPools": "[parameters('lbBackendPools').backendPools]"
+              }
             }
           }
         ]
@@ -120,22 +107,22 @@
       "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
       "copy": {
-        "name": "[concat(parameters('namespace'), 'virtualMachineLoop')]",
-        "count": "[parameters('vmCount')]"
+        "name": "marvelVmLoop",
+        "count": 3
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]",
-        "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyindex())]",
+        "[concat('Microsoft.Compute/availabilitySets/', 'es-marvel-set')]"
       ],
       "properties": {
         "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', 'es-marvel-set')]"
         },
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[concat('data-vm', copyIndex())]",
+          "computerName": "[concat('marvel-vm', copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -144,7 +131,7 @@
           "osDisk": {
             "name": "osdisk",
             "vhd": {
-              "uri": "[concat('http://', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()], '.blob.core.windows.net/vhds/', variables('vmName'), copyindex(), '-osdisk.vhd')]"
+              "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/vhds/', variables('vmName'), copyindex(), '-osdisk.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"
@@ -153,7 +140,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('namespace'),'-nic', copyindex()))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), copyindex()))]"
             }
           ]
         }
@@ -168,12 +155,12 @@
             "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyindex())]"
           ],
           "properties": {
-            "publisher": "[parameters('osSettings').extensionSettings.data.publisher]",
-            "type": "[parameters('osSettings').extensionSettings.data.type]",
-            "typeHandlerVersion": "[parameters('osSettings').extensionSettings.data.typeHandlerVersion]",
+            "publisher": "[parameters('osSettings').extensionSettings.marvel.publisher]",
+            "type": "[parameters('osSettings').extensionSettings.marvel.type]",
+            "typeHandlerVersion": "[parameters('osSettings').extensionSettings.marvel.typeHandlerVersion]",
             "settings": {
-              "fileUris": "[parameters('osSettings').extensionSettings.data.settings.fileUris]",
-              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.data.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameAFS')), '2015-05-01-preview').key1)]"
+              "fileUris": "[parameters('osSettings').extensionSettings.marvel.settings.fileUris]",
+              "commandToExecute": "[concat(parameters('osSettings').extensionSettings.marvel.settings.commandToExecute, listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2015-05-01-preview').key1)]"
             }
           }
         }

--- a/elasticsearch/metadata.json
+++ b/elasticsearch/metadata.json
@@ -1,7 +1,7 @@
 {
   "itemDisplayName": "Install Elasticsearch cluster on Virtual Machines",
-  "description": "This template deploys an Elasticsearch cluster on Virtual Machines and uses template linking to create master, client, and data nodes.  The template provisions 3 dedicated masters and optional client nodes in separate availability sets. A configurable internal or external load balancer is provisioned to route traffic on port 9200 to the client nodes if they are used and if not it will route traffic to the data nodes.  Multiple data disks are attached and vary depending on the data node SKU size selected to improve disk throughput",
-  "summary": "Install Elasticsearch cluster on Virtual Machines",
+  "description": "This template deploys an Elasticsearch cluster on Virtual Machines using linked templates. The template provisions 3 dedicated master nodes, with an optional number of client and data nodes, which are placed in separate availability sets and storage accounts. The template also provides the option of deploying a standalone Marvel cluster.",
+  "summary": "Provision an Elasticsearch cluster on Virtual Machines",
   "githubUsername": "trentmswanson",
-  "dateUpdated": "2015-11-04"
+  "dateUpdated": "2016-02-29"
 }

--- a/elasticsearch/tmpl/data-nodes.yml
+++ b/elasticsearch/tmpl/data-nodes.yml
@@ -86,6 +86,7 @@ resources:
     count: "[parameters('vmCount')]"
   dependsOn:
   - "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), '-nic', copyindex())]"
+  - "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"
   properties:
     availabilitySet:
       id: "[resourceId('Microsoft.Compute/availabilitySets', 'es-data-set')]"


### PR DESCRIPTION
- add marvel options for cluster and vm size
- add marvel availability dataset, with dependency
- use marvel node endpoints and cluster name when cluster selected
- add marvel ip prefix to empty resources to ensure consistency
- fix marvel install bug, so marvel is not installed unless selected