### PR TITLE
add consul-on-ubuntu template

### DIFF
--- a/consul-on-ubuntu/README.md
+++ b/consul-on-ubuntu/README.md
@@ -12,6 +12,8 @@ This will create a 3 node [Consul](https://www.consul.io/) cluster in Azure and 
 
 **NOTE** you will need to have an [Atlas](https://atlas.hashicorp.com/) account and token in order for auto-join to work.
 
+The Atlas documentation on how to create a token is located [here](https://atlas.hashicorp.com/help/user-accounts/authentication)
+
 This template is a bit odd as it gives each of the 3 nodes a public IP but then blocks all incoming traffic. Consul should probably be something 
 you use internally (not publically accessible) but I didn't want to include spinning up a NAT box just for this. The hack is to give each box 
 a public IP and then block off everything from the outside world accept for SSH. That is why the load balancer is internal as the idea is only internal 

--- a/consul-on-ubuntu/README.md
+++ b/consul-on-ubuntu/README.md
@@ -1,0 +1,22 @@
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fconsul-on-ubuntu%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fconsul-on-ubuntu%2Fazuredeploy.json" target="_blank">
+  <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+
+# Consul on Ubuntu
+
+This will create a 3 node [Consul](https://www.consul.io/) cluster in Azure and put them into an internal load balancer.
+
+**NOTE** you will need to have an [Atlas](https://atlas.hashicorp.com/) account and token in order for auto-join to work.
+
+This template is a bit odd as it gives each of the 3 nodes a public IP but then blocks all incoming traffic. Consul should probably be something 
+you use internally (not publically accessible) but I didn't want to include spinning up a NAT box just for this. The hack is to give each box 
+a public IP and then block off everything from the outside world accept for SSH. That is why the load balancer is internal as the idea is only internal 
+resources will be using it.
+
+
+
+

--- a/consul-on-ubuntu/azuredeploy.json
+++ b/consul-on-ubuntu/azuredeploy.json
@@ -1,0 +1,327 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appPrefix": {
+            "type": "string",
+            "metadata": {
+                "description": "Prefix for each component (VMs, networks, etc)"
+            }
+        },
+        "adminUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "Admin username for VM"
+            }
+        },
+        "adminPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "Admin password for VM"
+            }
+        },
+        "newStorageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Unique storage account name. Must be between 3 and 24 characters in length and use numbers and lower-case letters only."
+            }
+        },
+        "vmSize": {
+            "type": "string",
+            "defaultValue": "Standard_A1",
+            "allowedValues": [
+                "Standard_A1",
+                "Standard_A2",
+                "Standard_A3",
+                "Standard_D1",
+                "Standard_D2",
+                "Standard_D3"
+            ],
+            "metadata": {
+                "description": "Size of the Virtual Machine."
+            }
+        },
+        "atlasInfra": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of your infrastructure in Atlas (username/infraName)"
+            }
+        },
+        "atlasToken": {
+            "type": "string",
+            "metadata": {
+                "description": "Your access token from Atlas"
+            }
+        }
+    },
+    "variables": {
+        "numberOfInstances": 3,
+        "imagePublisher": "Canonical",
+        "imageOffer": "UbuntuServer",
+        "imageSKU": "14.04.3-LTS",
+        "customScriptFilePath": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/consul-on-ubuntu/install-consul.sh",
+        "customScriptCommandToExecute": "bash install-consul.sh",
+        "vnetIDRef": "[concat(parameters('appPrefix'),'_VNET')]",
+        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetIDRef'))]",
+        "addressPrefix": "10.0.0.0/16",
+        "subnet1Name": "Subnet-1",
+        "subnet1Prefix": "10.0.0.0/24",
+        "subnet1Ref": "[concat(variables('vnetID'),'/subnets/', variables('subnet1Name'))]",
+        "publicIPAddressType": "Dynamic",
+        "vmStorageAccountContainerName": "vhds"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('newStorageAccountName')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "accountType": "Standard_LRS"
+            }
+        },
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[concat('publicIP', copyindex())]",
+            "copy": {
+                "name": "ipLoop",
+                "count": "[variables('numberOfInstances')]"
+            },
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2015-05-01-preview",
+            "properties": {
+                "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
+            }
+        },
+        {
+            "type": "Microsoft.Compute/availabilitySets",
+            "name": "[concat(parameters('appPrefix'),'_AS')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[resourceGroup().location]",
+            "properties": {}
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "name": "[concat(parameters('appPrefix'),'_SG')]",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "securityRules": [
+                    {
+                        "name": "ssh_rule",
+                        "properties": {
+                            "description": "Allow external SSH",
+                            "protocol": "Tcp",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "22",
+                            "sourceAddressPrefix": "Internet",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 100,
+                            "direction": "Inbound"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[concat(parameters('appPrefix'),'_VNET')]",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/networkSecurityGroups/', parameters('appPrefix'),'_SG')]"
+            ],
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('addressPrefix')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "[variables('subnet1Name')]",
+                        "properties": {
+                            "addressPrefix": "[variables('subnet1Prefix')]"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "name": "[concat(parameters('appPrefix'),'_LB')]",
+            "type": "Microsoft.Network/loadBalancers",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('appPrefix'),'_VNET')]"
+            ],
+            "properties": {
+                "frontendIPConfigurations": [
+                    {
+                        "name": "loadBalancerFrontEnd",
+                        "properties": {
+                            "subnet": {
+                                "id": "[variables('subnet1Ref')]"
+                            }
+                        }
+                    }
+                ],
+                "backendAddressPools": [
+                    {
+                        "name": "loadBalancerBackEnd"
+                    }
+                ],
+                "loadBalancingRules": [
+                    {
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')), '/frontendIpConfigurations/loadBalancerFrontEnd')]"
+                            },
+                            "backendAddressPool": {
+                                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')), '/backendAddressPools/loadBalancerBackEnd')]"
+                            },
+                            "probe": {
+                                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')), '/probes/lbprobe')]"
+                            },
+                            "protocol": "Tcp",
+                            "frontendPort": 8500,
+                            "backendPort": 8500,
+                            "idleTimeoutInMinutes": 15
+                        },
+                        "name": "lbrule"
+                    }
+                ],
+                "probes": [
+                    {
+                        "properties": {
+                            "protocol": "Tcp",
+                            "port": 8500,
+                            "intervalInSeconds": 15,
+                            "numberOfProbes": 2
+                        },
+                        "name": "lbprobe"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat(parameters('appPrefix'),'_nic1', copyindex())]",
+            "location": "[resourceGroup().location]",
+            "copy": {
+                "name": "nicLoop",
+                "count": "[variables('numberOfInstances')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Network/publicIPAddresses/', 'publicIP', copyindex())]",
+                "[concat('Microsoft.Network/virtualNetworks/', parameters('appPrefix'),'_VNET')]",
+                "[concat('Microsoft.Network/loadBalancers/', parameters('appPrefix'),'_LB')]"
+            ],
+            "properties": {
+                "networkSecurityGroup": {
+                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', concat(parameters('appPrefix'),'_SG'))]"
+                },
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIpAddresses', concat('publicIP', copyindex()))]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnet1Ref')]"
+                            },
+                            "loadBalancerBackendAddressPools": [
+                                {
+                                    "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')),'/backendAddressPools/loadBalancerBackEnd')]"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-05-01-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(parameters('appPrefix'), '_vm', copyIndex())]",
+            "location": "[resourceGroup().location]",
+            "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Network/networkInterfaces/', parameters('appPrefix'),'_nic1', copyIndex())]",
+                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+                "[concat('Microsoft.Compute/availabilitySets/', parameters('appPrefix'),'_AS')]"
+            ],
+            "properties": {
+                "availabilitySet": {
+                    "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('appPrefix'),'_AS'))]"
+                },
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat('vm', copyIndex())]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('imagePublisher')]",
+                        "offer": "[variables('imageOffer')]",
+                        "sku": "[variables('imageSKU')]",
+                        "version": "latest"
+                    },
+                    "osDisk": {
+                        "name": "osdisk",
+                        "vhd": {
+                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyIndex(), '.vhd')]"
+                        },
+                        "caching": "ReadWrite",
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "properties": {
+                                "primary": true
+                            },
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('appPrefix'),'_nic1', copyindex()))]"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(parameters('appPrefix'), '_vm', copyIndex(), '/extension')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[resourceGroup().location]",
+            "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+            },
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', parameters('appPrefix'), '_vm', copyIndex())]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.OSTCExtensions",
+                "type": "CustomScriptForLinux",
+                "typeHandlerVersion": "1.3",
+                "autoUpgradeMinorVersion": true,
+                "settings": {
+                    "fileUris": [
+                        "[variables('customScriptFilePath')]"
+                    ],
+                    "commandToExecute": "[concat(variables('customScriptCommandToExecute'),' ', parameters('atlasInfra'), ' ', parameters('atlasToken'))]"
+                }
+            }
+        }
+    ]
+}

--- a/consul-on-ubuntu/azuredeploy.json
+++ b/consul-on-ubuntu/azuredeploy.json
@@ -1,4 +1,53 @@
 {
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#", 
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string", 
+      "metadata": {
+        "description": "Admin username for VM"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring", 
+      "metadata": {
+        "description": "Admin password for VM"
+      }
+    }, 
+    "vmSize": {
+      "defaultValue": "Standard_A1", 
+      "metadata": {
+        "description": "Size of the Virtual Machine."
+      }, 
+      "type": "string", 
+      "allowedValues": [
+        "Standard_A1", 
+        "Standard_A2", 
+        "Standard_A3", 
+        "Standard_D1_v2", 
+        "Standard_D2_v2", 
+        "Standard_D3_v2"
+      ]
+    }, 
+    "appPrefix": {
+      "type": "string", 
+      "metadata": {
+        "description": "Prefix for each component (VMs, networks, etc)"
+      }
+    }, 
+    "existingAtlasToken": {
+      "type": "string", 
+      "metadata": {
+        "description": "Your existing access token from Atlas"
+      }
+    }, 
+    "existingAtlasInfra": {
+      "type": "string", 
+      "metadata": {
+        "description": "The name of your existing infrastructure in Atlas (username/infraName)"
+      }
+    }
+  },
   "variables": {
     "imagePublisher": "Canonical", 
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetIDRef'))]", 
@@ -16,9 +65,7 @@
     "vnetIDRef": "[concat(parameters('appPrefix'),'_VNET')]", 
     "imageOffer": "UbuntuServer", 
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), parameters('appPrefix'))]"
-  }, 
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#", 
-  "contentVersion": "1.0.0.0", 
+  },  
   "resources": [
     {
       "properties": {
@@ -261,63 +308,18 @@
       "type": "Microsoft.Compute/virtualMachines/extensions", 
       "properties": {
         "autoUpgradeMinorVersion": true, 
-        "typeHandlerVersion": "1.3", 
+        "typeHandlerVersion": "1.4", 
         "settings": {
           "fileUris": [
             "[variables('customScriptFilePath')]"
-          ], 
-          "commandToExecute": "[concat(variables('customScriptCommandToExecute'),' ', parameters('atlasInfra'), ' ', parameters('atlasToken'))]"
+          ]
         }, 
+        "protectedSettings": { 
+            "commandToExecute": "[concat(variables('customScriptCommandToExecute'),' ', parameters('existingAtlasInfra'), ' ', parameters('existingAtlasToken'))]"
+        },
         "type": "CustomScriptForLinux", 
         "publisher": "Microsoft.OSTCExtensions"
       }
     }
-  ], 
-  "parameters": {
-    "existingAtlasToken": {
-      "type": "string", 
-      "metadata": {
-        "description": "Your existing access token from Atlas"
-      }
-    }, 
-    "existingAtlasInfra": {
-      "type": "string", 
-      "metadata": {
-        "description": "The name of your existing infrastructure in Atlas (username/infraName)"
-      }
-    }, 
-    "adminPassword": {
-      "type": "securestring", 
-      "metadata": {
-        "description": "Admin password for VM"
-      }
-    }, 
-    "vmSize": {
-      "defaultValue": "Standard_A1", 
-      "metadata": {
-        "description": "Size of the Virtual Machine."
-      }, 
-      "type": "string", 
-      "allowedValues": [
-        "Standard_A1", 
-        "Standard_A2", 
-        "Standard_A3", 
-        "Standard_D1_v2", 
-        "Standard_D2_v2", 
-        "Standard_D3_v2"
-      ]
-    }, 
-    "appPrefix": {
-      "type": "string", 
-      "metadata": {
-        "description": "Prefix for each component (VMs, networks, etc)"
-      }
-    }, 
-    "adminUsername": {
-      "type": "string", 
-      "metadata": {
-        "description": "Admin username for VM"
-      }
-    }
-  }
+  ]
 }

--- a/consul-on-ubuntu/azuredeploy.json
+++ b/consul-on-ubuntu/azuredeploy.json
@@ -41,7 +41,7 @@
         "description": "Your existing access token from Atlas"
       }
     }, 
-    "existingAtlasInfra": {
+    "existingAtlasInfraName": {
       "type": "string", 
       "metadata": {
         "description": "The name of your existing infrastructure in Atlas (username/infraName)"

--- a/consul-on-ubuntu/azuredeploy.json
+++ b/consul-on-ubuntu/azuredeploy.json
@@ -1,327 +1,323 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "appPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "Prefix for each component (VMs, networks, etc)"
+  "variables": {
+    "imagePublisher": "Canonical", 
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetIDRef'))]", 
+    "subnet1Name": "Subnet-1", 
+    "customScriptFilePath": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/consul-on-ubuntu/install-consul.sh", 
+    "vmStorageAccountContainerName": "vhds", 
+    "addressPrefix": "10.0.0.0/16", 
+    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/', variables('subnet1Name'))]", 
+    "numberOfInstances": 3, 
+    "apiVersion": "2015-06-15", 
+    "customScriptCommandToExecute": "bash install-consul.sh", 
+    "subnet1Prefix": "10.0.0.0/24", 
+    "publicIPAddressType": "Dynamic", 
+    "imageSKU": "14.04.3-LTS", 
+    "vnetIDRef": "[concat(parameters('appPrefix'),'_VNET')]", 
+    "imageOffer": "UbuntuServer", 
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), parameters('appPrefix'))]"
+  }, 
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#", 
+  "contentVersion": "1.0.0.0", 
+  "resources": [
+    {
+      "properties": {
+        "accountType": "Standard_LRS"
+      }, 
+      "type": "Microsoft.Storage/storageAccounts", 
+      "location": "[resourceGroup().location]", 
+      "apiVersion": "[variables('apiVersion')]", 
+      "name": "[variables('storageAccountName')]"
+    }, 
+    {
+      "name": "[concat('publicIP', copyindex())]", 
+      "apiVersion": "[variables('apiVersion')]", 
+      "location": "[resourceGroup().location]", 
+      "copy": {
+        "count": "[variables('numberOfInstances')]", 
+        "name": "ipLoop"
+      }, 
+      "type": "Microsoft.Network/publicIPAddresses", 
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
+      }
+    }, 
+    {
+      "properties": {}, 
+      "type": "Microsoft.Compute/availabilitySets", 
+      "location": "[resourceGroup().location]", 
+      "apiVersion": "[variables('apiVersion')]", 
+      "name": "[concat(parameters('appPrefix'),'_AS')]"
+    }, 
+    {
+      "properties": {
+        "securityRules": [
+          {
+            "name": "ssh_rule", 
+            "properties": {
+              "priority": 100, 
+              "direction": "Inbound", 
+              "protocol": "Tcp", 
+              "description": "Allow external SSH", 
+              "access": "Allow", 
+              "destinationPortRange": "22", 
+              "sourcePortRange": "*", 
+              "destinationAddressPrefix": "*", 
+              "sourceAddressPrefix": "Internet"
             }
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Admin username for VM"
+          }
+        ]
+      }, 
+      "type": "Microsoft.Network/networkSecurityGroups", 
+      "location": "[resourceGroup().location]", 
+      "apiVersion": "[variables('apiVersion')]", 
+      "name": "[concat(parameters('appPrefix'),'_SG')]"
+    }, 
+    {
+      "name": "[concat(parameters('appPrefix'),'_VNET')]", 
+      "apiVersion": "[variables('apiVersion')]", 
+      "location": "[resourceGroup().location]", 
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkSecurityGroups/', parameters('appPrefix'),'_SG')]"
+      ], 
+      "type": "Microsoft.Network/virtualNetworks", 
+      "properties": {
+        "subnets": [
+          {
+            "name": "[variables('subnet1Name')]", 
+            "properties": {
+              "addressPrefix": "[variables('subnet1Prefix')]"
             }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Admin password for VM"
-            }
-        },
-        "newStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique storage account name. Must be between 3 and 24 characters in length and use numbers and lower-case letters only."
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "defaultValue": "Standard_A1",
-            "allowedValues": [
-                "Standard_A1",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_D1",
-                "Standard_D2",
-                "Standard_D3"
-            ],
-            "metadata": {
-                "description": "Size of the Virtual Machine."
-            }
-        },
-        "atlasInfra": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of your infrastructure in Atlas (username/infraName)"
-            }
-        },
-        "atlasToken": {
-            "type": "string",
-            "metadata": {
-                "description": "Your access token from Atlas"
-            }
+          }
+        ], 
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
         }
-    },
-    "variables": {
-        "numberOfInstances": 3,
-        "imagePublisher": "Canonical",
-        "imageOffer": "UbuntuServer",
-        "imageSKU": "14.04.3-LTS",
-        "customScriptFilePath": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/consul-on-ubuntu/install-consul.sh",
-        "customScriptCommandToExecute": "bash install-consul.sh",
-        "vnetIDRef": "[concat(parameters('appPrefix'),'_VNET')]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetIDRef'))]",
-        "addressPrefix": "10.0.0.0/16",
-        "subnet1Name": "Subnet-1",
-        "subnet1Prefix": "10.0.0.0/24",
-        "subnet1Ref": "[concat(variables('vnetID'),'/subnets/', variables('subnet1Name'))]",
-        "publicIPAddressType": "Dynamic",
-        "vmStorageAccountContainerName": "vhds"
-    },
-    "resources": [
-        {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[parameters('newStorageAccountName')]",
-            "apiVersion": "2015-05-01-preview",
-            "location": "[resourceGroup().location]",
+      }
+    }, 
+    {
+      "name": "[concat(parameters('appPrefix'),'_LB')]", 
+      "apiVersion": "[variables('apiVersion')]", 
+      "location": "[resourceGroup().location]", 
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('appPrefix'),'_VNET')]"
+      ], 
+      "type": "Microsoft.Network/loadBalancers", 
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "loadBalancerFrontEnd", 
             "properties": {
-                "accountType": "Standard_LRS"
+              "subnet": {
+                "id": "[variables('subnet1Ref')]"
+              }
             }
-        },
-        {
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[concat('publicIP', copyindex())]",
-            "copy": {
-                "name": "ipLoop",
-                "count": "[variables('numberOfInstances')]"
-            },
-            "location": "[resourceGroup().location]",
-            "apiVersion": "2015-05-01-preview",
+          }
+        ], 
+        "loadBalancingRules": [
+          {
+            "name": "lbrule", 
             "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
+              "frontendIPConfiguration": {
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')), '/frontendIpConfigurations/loadBalancerFrontEnd')]"
+              }, 
+              "backendPort": 8500, 
+              "probe": {
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')), '/probes/lbprobe')]"
+              }, 
+              "protocol": "Tcp", 
+              "backendAddressPool": {
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')), '/backendAddressPools/loadBalancerBackEnd')]"
+              }, 
+              "frontendPort": 8500, 
+              "idleTimeoutInMinutes": 15
             }
-        },
-        {
-            "type": "Microsoft.Compute/availabilitySets",
-            "name": "[concat(parameters('appPrefix'),'_AS')]",
-            "apiVersion": "2015-05-01-preview",
-            "location": "[resourceGroup().location]",
-            "properties": {}
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "name": "[concat(parameters('appPrefix'),'_SG')]",
-            "location": "[resourceGroup().location]",
+          }
+        ], 
+        "backendAddressPools": [
+          {
+            "name": "loadBalancerBackEnd"
+          }
+        ], 
+        "probes": [
+          {
+            "name": "lbprobe", 
             "properties": {
-                "securityRules": [
-                    {
-                        "name": "ssh_rule",
-                        "properties": {
-                            "description": "Allow external SSH",
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "22",
-                            "sourceAddressPrefix": "Internet",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 100,
-                            "direction": "Inbound"
-                        }
-                    }
-                ]
+              "protocol": "Tcp", 
+              "numberOfProbes": 2, 
+              "intervalInSeconds": 15, 
+              "port": 8500
             }
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[concat(parameters('appPrefix'),'_VNET')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/networkSecurityGroups/', parameters('appPrefix'),'_SG')]"
-            ],
+          }
+        ]
+      }
+    }, 
+    {
+      "name": "[concat(parameters('appPrefix'),'_nic1', copyindex())]", 
+      "apiVersion": "[variables('apiVersion')]", 
+      "location": "[resourceGroup().location]", 
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', 'publicIP', copyindex())]", 
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('appPrefix'),'_VNET')]", 
+        "[concat('Microsoft.Network/loadBalancers/', parameters('appPrefix'),'_LB')]"
+      ], 
+      "copy": {
+        "count": "[variables('numberOfInstances')]", 
+        "name": "nicLoop"
+      }, 
+      "type": "Microsoft.Network/networkInterfaces", 
+      "properties": {
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', concat(parameters('appPrefix'),'_SG'))]"
+        }, 
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1", 
             "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('addressPrefix')]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('subnet1Name')]",
-                        "properties": {
-                            "addressPrefix": "[variables('subnet1Prefix')]"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "name": "[concat(parameters('appPrefix'),'_LB')]",
-            "type": "Microsoft.Network/loadBalancers",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('appPrefix'),'_VNET')]"
-            ],
-            "properties": {
-                "frontendIPConfigurations": [
-                    {
-                        "name": "loadBalancerFrontEnd",
-                        "properties": {
-                            "subnet": {
-                                "id": "[variables('subnet1Ref')]"
-                            }
-                        }
-                    }
-                ],
-                "backendAddressPools": [
-                    {
-                        "name": "loadBalancerBackEnd"
-                    }
-                ],
-                "loadBalancingRules": [
-                    {
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')), '/frontendIpConfigurations/loadBalancerFrontEnd')]"
-                            },
-                            "backendAddressPool": {
-                                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')), '/backendAddressPools/loadBalancerBackEnd')]"
-                            },
-                            "probe": {
-                                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')), '/probes/lbprobe')]"
-                            },
-                            "protocol": "Tcp",
-                            "frontendPort": 8500,
-                            "backendPort": 8500,
-                            "idleTimeoutInMinutes": 15
-                        },
-                        "name": "lbrule"
-                    }
-                ],
-                "probes": [
-                    {
-                        "properties": {
-                            "protocol": "Tcp",
-                            "port": 8500,
-                            "intervalInSeconds": 15,
-                            "numberOfProbes": 2
-                        },
-                        "name": "lbprobe"
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[concat(parameters('appPrefix'),'_nic1', copyindex())]",
-            "location": "[resourceGroup().location]",
-            "copy": {
-                "name": "nicLoop",
-                "count": "[variables('numberOfInstances')]"
-            },
-            "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', 'publicIP', copyindex())]",
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('appPrefix'),'_VNET')]",
-                "[concat('Microsoft.Network/loadBalancers/', parameters('appPrefix'),'_LB')]"
-            ],
-            "properties": {
-                "networkSecurityGroup": {
-                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', concat(parameters('appPrefix'),'_SG'))]"
-                },
-                "ipConfigurations": [
-                    {
-                        "name": "ipconfig1",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIpAddresses', concat('publicIP', copyindex()))]"
-                            },
-                            "subnet": {
-                                "id": "[variables('subnet1Ref')]"
-                            },
-                            "loadBalancerBackendAddressPools": [
-                                {
-                                    "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')),'/backendAddressPools/loadBalancerBackEnd')]"
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[concat(parameters('appPrefix'), '_vm', copyIndex())]",
-            "location": "[resourceGroup().location]",
-            "copy": {
-                "name": "virtualMachineLoop",
-                "count": "[variables('numberOfInstances')]"
-            },
-            "dependsOn": [
-                "[concat('Microsoft.Network/networkInterfaces/', parameters('appPrefix'),'_nic1', copyIndex())]",
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-                "[concat('Microsoft.Compute/availabilitySets/', parameters('appPrefix'),'_AS')]"
-            ],
-            "properties": {
-                "availabilitySet": {
-                    "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('appPrefix'),'_AS'))]"
-                },
-                "hardwareProfile": {
-                    "vmSize": "[parameters('vmSize')]"
-                },
-                "osProfile": {
-                    "computerName": "[concat('vm', copyIndex())]",
-                    "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "[variables('imagePublisher')]",
-                        "offer": "[variables('imageOffer')]",
-                        "sku": "[variables('imageSKU')]",
-                        "version": "latest"
-                    },
-                    "osDisk": {
-                        "name": "osdisk",
-                        "vhd": {
-                            "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyIndex(), '.vhd')]"
-                        },
-                        "caching": "ReadWrite",
-                        "createOption": "FromImage"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "properties": {
-                                "primary": true
-                            },
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('appPrefix'),'_nic1', copyindex()))]"
-                        }
-                    ]
+              "subnet": {
+                "id": "[variables('subnet1Ref')]"
+              }, 
+              "privateIPAllocationMethod": "Dynamic", 
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "[concat(resourceId('Microsoft.Network/loadBalancers', concat(parameters('appPrefix'),'_LB')),'/backendAddressPools/loadBalancerBackEnd')]"
                 }
+              ], 
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIpAddresses', concat('publicIP', copyindex()))]"
+              }
             }
-        },
-        {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(parameters('appPrefix'), '_vm', copyIndex(), '/extension')]",
-            "apiVersion": "2015-05-01-preview",
-            "location": "[resourceGroup().location]",
-            "copy": {
-                "name": "virtualMachineLoop",
-                "count": "[variables('numberOfInstances')]"
-            },
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('appPrefix'), '_vm', copyIndex())]"
-            ],
-            "properties": {
-                "publisher": "Microsoft.OSTCExtensions",
-                "type": "CustomScriptForLinux",
-                "typeHandlerVersion": "1.3",
-                "autoUpgradeMinorVersion": true,
-                "settings": {
-                    "fileUris": [
-                        "[variables('customScriptFilePath')]"
-                    ],
-                    "commandToExecute": "[concat(variables('customScriptCommandToExecute'),' ', parameters('atlasInfra'), ' ', parameters('atlasToken'))]"
-                }
+          }
+        ]
+      }
+    }, 
+    {
+      "name": "[concat(parameters('appPrefix'), '_vm', copyIndex())]", 
+      "apiVersion": "[variables('apiVersion')]", 
+      "location": "[resourceGroup().location]", 
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('appPrefix'),'_nic1', copyIndex())]", 
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]", 
+        "[concat('Microsoft.Compute/availabilitySets/', parameters('appPrefix'),'_AS')]"
+      ], 
+      "copy": {
+        "count": "[variables('numberOfInstances')]", 
+        "name": "virtualMachineLoop"
+      }, 
+      "type": "Microsoft.Compute/virtualMachines", 
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        }, 
+        "osProfile": {
+          "adminUsername": "[parameters('adminUsername')]", 
+          "computerName": "[concat('vm', copyIndex())]", 
+          "adminPassword": "[parameters('adminPassword')]"
+        }, 
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('appPrefix'),'_AS'))]"
+        }, 
+        "storageProfile": {
+          "imageReference": {
+            "sku": "[variables('imageSKU')]", 
+            "publisher": "[variables('imagePublisher')]", 
+            "version": "latest", 
+            "offer": "[variables('imageOffer')]"
+          }, 
+          "osDisk": {
+            "caching": "ReadWrite", 
+            "vhd": {
+              "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyIndex(), '.vhd')]"
+            }, 
+            "createOption": "FromImage", 
+            "name": "osdisk"
+          }
+        }, 
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('appPrefix'),'_nic1', copyindex()))]", 
+              "properties": {
+                "primary": true
+              }
             }
+          ]
         }
-    ]
+      }
+    }, 
+    {
+      "name": "[concat(parameters('appPrefix'), '_vm', copyIndex(), '/extension')]", 
+      "apiVersion": "[variables('apiVersion')]", 
+      "location": "[resourceGroup().location]", 
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('appPrefix'), '_vm', copyIndex())]"
+      ], 
+      "copy": {
+        "count": "[variables('numberOfInstances')]", 
+        "name": "virtualMachineLoop"
+      }, 
+      "type": "Microsoft.Compute/virtualMachines/extensions", 
+      "properties": {
+        "autoUpgradeMinorVersion": true, 
+        "typeHandlerVersion": "1.3", 
+        "settings": {
+          "fileUris": [
+            "[variables('customScriptFilePath')]"
+          ], 
+          "commandToExecute": "[concat(variables('customScriptCommandToExecute'),' ', parameters('atlasInfra'), ' ', parameters('atlasToken'))]"
+        }, 
+        "type": "CustomScriptForLinux", 
+        "publisher": "Microsoft.OSTCExtensions"
+      }
+    }
+  ], 
+  "parameters": {
+    "existingAtlasToken": {
+      "type": "string", 
+      "metadata": {
+        "description": "Your existing access token from Atlas"
+      }
+    }, 
+    "existingAtlasInfra": {
+      "type": "string", 
+      "metadata": {
+        "description": "The name of your existing infrastructure in Atlas (username/infraName)"
+      }
+    }, 
+    "adminPassword": {
+      "type": "securestring", 
+      "metadata": {
+        "description": "Admin password for VM"
+      }
+    }, 
+    "vmSize": {
+      "defaultValue": "Standard_A1", 
+      "metadata": {
+        "description": "Size of the Virtual Machine."
+      }, 
+      "type": "string", 
+      "allowedValues": [
+        "Standard_A1", 
+        "Standard_A2", 
+        "Standard_A3", 
+        "Standard_D1_v2", 
+        "Standard_D2_v2", 
+        "Standard_D3_v2"
+      ]
+    }, 
+    "appPrefix": {
+      "type": "string", 
+      "metadata": {
+        "description": "Prefix for each component (VMs, networks, etc)"
+      }
+    }, 
+    "adminUsername": {
+      "type": "string", 
+      "metadata": {
+        "description": "Admin username for VM"
+      }
+    }
+  }
 }

--- a/consul-on-ubuntu/azuredeploy.parameters.json
+++ b/consul-on-ubuntu/azuredeploy.parameters.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appPrefix": {
+            "value": "GEN-UNIQUE"
+        },
+        "adminUsername": {
+            "value": "GEN-UNIQUE"
+        },
+        "adminPassword": {
+            "value": "GEN-PASSWORD"
+        },
+        "newStorageAccountName": {
+            "value": "GEN-UNIQUE"
+        },
+        "vmsize": {
+            "value": "Standard_A1"
+        },
+        "atlasInfra": {
+            "value": "GEN-UNIQUE"
+        },
+        "atlasToken": {
+            "value": "GEN-UNIQUE"
+        }
+    }
+}

--- a/consul-on-ubuntu/azuredeploy.parameters.json
+++ b/consul-on-ubuntu/azuredeploy.parameters.json
@@ -11,16 +11,13 @@
         "adminPassword": {
             "value": "GEN-PASSWORD"
         },
-        "newStorageAccountName": {
-            "value": "GEN-UNIQUE"
-        },
         "vmsize": {
             "value": "Standard_A1"
         },
-        "atlasInfra": {
+        "existingAtlasInfra": {
             "value": "GEN-UNIQUE"
         },
-        "atlasToken": {
+        "existingAtlasToken": {
             "value": "GEN-UNIQUE"
         }
     }

--- a/consul-on-ubuntu/install-consul.sh
+++ b/consul-on-ubuntu/install-consul.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+sudo apt-get update && sudo apt-get install -y wget unzip
+
+sudo mkdir -p /opt/consul/data
+cd /opt/consul
+sudo wget https://releases.hashicorp.com/consul/0.6.3/consul_0.6.3_linux_amd64.zip
+sudo unzip consul_0.6.3_linux_amd64.zip
+sudo chmod 755 consul
+cd /opt/consul
+sudo nohup ./consul agent -server -bind 0.0.0.0 -client 0.0.0.0 -data-dir="/opt/consul/data" -bootstrap-expect 3 -atlas=$1 -atlas-join -atlas-token="$2" &

--- a/consul-on-ubuntu/metadata.json
+++ b/consul-on-ubuntu/metadata.json
@@ -1,6 +1,6 @@
 {
   "itemDisplayName": "Deploys a 3 node Consul Cluster",
-  "description": "This template deploys a 3 node Consul cluster and auto-joins the nodes via Atlas",
+  "description": "This template deploys a 3 node Consul cluster and auto-joins the nodes via Atlas. Consul is a tool for service discovery, distributed key/value store and a bunch of other cool things. Atlas is provided by Hashicorp (makers of Consul) as a way to quickly create Consul clusters without having to manually join each node",
   "summary": "This template deploys a 3 node Consul cluster and auto-joins the nodes via Atlas via a custom script",
   "githubUsername": "esell",
   "dateUpdated": "2016-03-02"

--- a/consul-on-ubuntu/metadata.json
+++ b/consul-on-ubuntu/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Deploys a 3 node Consul Cluster",
+  "description": "This template deploys a 3 node Consul cluster and auto-joins the nodes via Atlas",
+  "summary": "This template deploys a 3 node Consul cluster and auto-joins the nodes via Atlas via a custom script",
+  "githubUsername": "esell",
+  "dateUpdated": "2016-03-02"
+}


### PR DESCRIPTION
This PR is to add a new template that spins up a 3 node [Consul](https://www.consul.io) cluster and puts it behind an internal LB. The pre-reqs (hence the .ci_skip) are an account with Hashicorpo's [Atlas](https://atlas.hashicorp.com/) otherwise auto-creation of the cluster is a bit messy.