### PR TITLE
Minor fixes to LAP stack autoscale demo

### DIFF
--- a/201-vmss-lapstack-autoscale/README.md
+++ b/201-vmss-lapstack-autoscale/README.md
@@ -1,13 +1,13 @@
 ### Autoscale a VM Scale Set running a Ubuntu/Apache/PHP app ###
 
-Simple self-contained Ubuntu/Apache/PHP (LAP stack) autoscale & load balancing example. Scale Set scales up when avg CPU across all VMs > 60%, scales down when avg CPU < 50%.
+Simple self-contained Ubuntu/Apache/PHP (LAP stack) autoscale & load balancing example. VM Scale Set scales up when avg CPU across all VMs > 60%, scales down when avg CPU < 50%.
 
-- Deploy the scale set with an instance count of 1 
+- Deploy the VM Scale Set with an instance count of 1 
 - After it is deployed look at the resource group public IP address resource (in portal or resources explorer). Get the IP or domain name.
 - Browse to the website (port 80), which shows the current backend VM name.
 - Hit the "Do work" button with an iteration count of say 300 (represents seconds of max CPU).
-- After a few minutes the scale set capacity will increase, and refreshing the browser and going to the home page a few times will show additional backend VM name(s).
-- You can increase the work by connecting to more backend websites, or decrease by letting the iterations time-out, in which case the scale set will scale down - hence after about 10 minutes the capacity should be back down to 1.
+- After a few minutes the VM Scale Set capacity will increase, and refreshing the browser and going to the home page a few times will show additional backend VM name(s).
+- You can increase the work by connecting to more backend websites, or decrease by letting the iterations time-out, in which case the VM Scale Set will scale down - hence after about 10 minutes the capacity should be back down to 1.
 
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-quickstart-templates%2Fmaster%2F201-vmss-lapstack-autoscale%2Fazuredeploy.json" target="_blank">

--- a/201-vmss-lapstack-autoscale/azuredeploy.json
+++ b/201-vmss-lapstack-autoscale/azuredeploy.json
@@ -27,17 +27,17 @@
     },
     "vmSku":{
       "type":"string",
-      "defaultValue":"Standard_D3_v2",
+      "defaultValue":"Standard_D1_v2",
       "metadata":{
         "description":"Size of VMs in the VM Scale Set."
       }
     },
     "ubuntuOSVersion":{
       "type":"string",
-      "defaultValue":"14.04.2-LTS",
+      "defaultValue":"14.04.4-LTS",
       "allowedValues":[
         "15.10",
-        "14.04.2-LTS"
+        "14.04.4-LTS"
       ],
       "metadata":{
         "description":"The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version. Allowed values are: 15.10, 14.04.2-LTS."


### PR DESCRIPTION
Change to latest 14.04.4-LTS version. Deploy D1 (single core) instead of
D3 by default. Be consistent about VMSS naming convention.