### PR TITLE
remove default dns name, which forces interaction instead of prompting

### DIFF
--- a/diskraid-ubuntu-vm/azuredeploy.json
+++ b/diskraid-ubuntu-vm/azuredeploy.json
@@ -70,7 +70,6 @@
     },
     "dnsName": {
       "type": "string",
-      "defaultValue": "uniqueName",
       "metadata": {
         "description": "Load balancer subdomain name: for example (<subdomain>.westus.cloudapp.azure.com)"
       }


### PR DESCRIPTION
if you call from the cli, you get prompted for everything that does not have a default value. including a dns name that is "uniquename" will always force manual intervention: