### PR TITLE
simply echoing 'check'  option to $HAPROXY_CFG file

### DIFF
--- a/haproxy-redundant-floatingip-ubuntu/haproxyvm-configure.sh
+++ b/haproxy-redundant-floatingip-ubuntu/haproxyvm-configure.sh
@@ -92,7 +92,7 @@ listen http 0.0.0.0:$LB_PORT
         if [[ -z $APPVM_IP ]]; then
             echo "Unknown hostname $APPVM. Cannot be added to $HAPROXY_CFG." >&2
         else
-            echo "    server $APPVM $APPVM_IP:$APPVM_PORT maxconn 5000" >> $HAPROXY_CFG
+            echo "    server $APPVM $APPVM_IP:$APPVM_PORT maxconn 5000 check" >> $HAPROXY_CFG
         fi 
     done
 

--- a/haproxy-redundant-floatingip-ubuntu/metadata.json
+++ b/haproxy-redundant-floatingip-ubuntu/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template creates a redundant haproxy setup with 2 Ubuntu VMs configured behind Azure load balancer with floating IP enabled. Each of the Ubuntu VMs run haproxy to load balance requests to other application VMs (running Apache in this case). Keepalived enables redundancy for the haproxy VMs by assigning the floating IP to the MASTER and blocking the load-balancer probe on the BACKUP. This template also deploys a Storage Account, Virtual Network, Public IP address, Network Interfaces.",
   "summary": "Create a redundant haproxy setup with 2 Ubuntu VMs configured behind Azure load balancer with floating IP enabled.",
   "githubUsername": "sivaedupuganti",
-  "dateUpdated": "2015-12-22"
+  "dateUpdated": "2016-03-07"
 }


### PR DESCRIPTION
Default code would not provide availability as HAProxy was configured not to do health checking on backend web servers (https://www.haproxy.com/doc/aloha/7.0/haproxy/healthchecks.html#checking-a-http-service). If one of them failed, HAProxy would not forward the client request to any of the web server.