### PR TITLE
Parameter subnet is undefined in the json file

### DIFF
--- a/kafka-ubuntu-multidisks/datastore-16disk-resources.json
+++ b/kafka-ubuntu-multidisks/datastore-16disk-resources.json
@@ -16,6 +16,9 @@
     },
     "machineSettingsbroker": {
       "type": "object"
+    },
+    "subnet": {
+      "type": "object"
     }
   },
   "variables": {


### PR DESCRIPTION
The template validation fails due to the parameter subnet not being defined in this json file. So, the deployment doesn't work for large kafka clusters.