### PR TITLE
Update to Splunk 6.3.3

### DIFF
--- a/splunk-on-ubuntu/node-setup.sh
+++ b/splunk-on-ubuntu/node-setup.sh
@@ -76,7 +76,7 @@ CHEF_PKG_URL="https://opscode-omnibus-packages.s3.amazonaws.com/ubuntu/10.04/x86
 CHEF_PKG_MD5="6360faba9d6358d636be5618eecb21ee1dbdca7d  chef_12.5.1-1_amd64.deb"
 CHEF_PKG_CACHE="/etc/chef/local-mode-cache/cache/chef_12.5.1-1_amd64.deb"
 CHEF_GEM_PACKAGE_LOCAL_PATH="`pwd`/chef-vault-2.6.1.gem"
-CHEF_REPO_SPLUNK_URL="https://github.com/rarsan/chef-repo-splunk/tarball/v0.7"
+CHEF_REPO_SPLUNK_URL="https://github.com/rarsan/chef-repo-splunk/tarball/v0.8"
 
 # Arguments
 while getopts :r:p:c:i: optname; do


### PR DESCRIPTION
### Changelog
* Update Splunk Chef repo to v0.8 with latest Splunk 6.3.3

### Description of the change
Update to Splunk 6.3.3