### PR TITLE
Updated sample to allow minecraft version to be supplied as param on template

### DIFF
--- a/minecraft-on-ubuntu/README.md
+++ b/minecraft-on-ubuntu/README.md
@@ -1,6 +1,6 @@
 # Install Minecraft server on an Ubuntu Virtual Machine using the Linux Custom Script Extension
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FDigitalBanana%2Fazure-quickstart-templates%2Fmaster%2Fminecraft-on-ubuntu%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fminecraft-on-ubuntu%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fminecraft-on-ubuntu%2Fazuredeploy.json" target="_blank">

--- a/minecraft-on-ubuntu/README.md
+++ b/minecraft-on-ubuntu/README.md
@@ -1,6 +1,6 @@
 # Install Minecraft server on an Ubuntu Virtual Machine using the Linux Custom Script Extension
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fgithub.com%2FDigitalBanana%2Fazure-quickstart-templates%2Fblob%2Fmaster%2Fminecraft-on-ubuntu%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FDigitalBanana%2Fazure-quickstart-templates%2Fmaster%2Fminecraft-on-ubuntu%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fminecraft-on-ubuntu%2Fazuredeploy.json" target="_blank">

--- a/minecraft-on-ubuntu/README.md
+++ b/minecraft-on-ubuntu/README.md
@@ -1,6 +1,6 @@
 # Install Minecraft server on an Ubuntu Virtual Machine using the Linux Custom Script Extension
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fminecraft-on-ubuntu%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fgithub.com%2FDigitalBanana%2Fazure-quickstart-templates%2Fblob%2Fmaster%2Fminecraft-on-ubuntu%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fminecraft-on-ubuntu%2Fazuredeploy.json" target="_blank">

--- a/minecraft-on-ubuntu/azuredeploy.json
+++ b/minecraft-on-ubuntu/azuredeploy.json
@@ -317,7 +317,7 @@
           "fileUris": [
             "https://raw.githubusercontent.com/DigitalBanana/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"
           ],
-          "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('minecraftServerVersion'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'))]"
+          "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('minecraftServerVersion'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'), ' ', parameters('minecraftServerVersion'))]"
         }
       }
     }

--- a/minecraft-on-ubuntu/azuredeploy.json
+++ b/minecraft-on-ubuntu/azuredeploy.json
@@ -315,7 +315,7 @@
         "typeHandlerVersion": "1.2",
         "settings": {
           "fileUris": [
-            "https://raw.githubusercontent.com/DigitalBanana/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"
+            "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"
           ],
           "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('minecraftServerVersion'), ' ', parameters('level-seed'))]"
         }

--- a/minecraft-on-ubuntu/azuredeploy.json
+++ b/minecraft-on-ubuntu/azuredeploy.json
@@ -304,7 +304,7 @@
         "typeHandlerVersion": "1.2",
         "settings": {
           "fileUris": [
-            "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"
+            "https://raw.githubusercontent.com/DigitalBanana/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"
           ],
           "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'))]"
         }

--- a/minecraft-on-ubuntu/azuredeploy.json
+++ b/minecraft-on-ubuntu/azuredeploy.json
@@ -317,7 +317,7 @@
           "fileUris": [
             "https://raw.githubusercontent.com/DigitalBanana/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"
           ],
-          "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'), ' ', parameters('minecraftServerVersion'))]"
+          "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('minecraftServerVersion'), ' ', parameters('level-seed'))]"
         }
       }
     }

--- a/minecraft-on-ubuntu/azuredeploy.json
+++ b/minecraft-on-ubuntu/azuredeploy.json
@@ -317,7 +317,7 @@
           "fileUris": [
             "https://raw.githubusercontent.com/DigitalBanana/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"
           ],
-          "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('minecraftServerVersion'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'), ' ', parameters('minecraftServerVersion'))]"
+          "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'), ' ', parameters('minecraftServerVersion'))]"
         }
       }
     }

--- a/minecraft-on-ubuntu/azuredeploy.json
+++ b/minecraft-on-ubuntu/azuredeploy.json
@@ -26,6 +26,17 @@
         "description": "Put a unique DNS Name for the Public IP used to access the Virtual Machine."
       }
     },
+    "minecraftServerVersion": {
+      "type": "string",
+      "defaultValue": "1.9",
+      "allowedValues": [
+        "1.8",
+        "1.9"
+      ],
+      "metadata": {
+        "description": "1.8 - Minecraft Version 1.8, 1.9 - Minecraft Version 1.9"
+      }
+    },
     "difficulty": {
       "type": "string",
       "defaultValue": "1",
@@ -306,7 +317,7 @@
           "fileUris": [
             "https://raw.githubusercontent.com/DigitalBanana/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"
           ],
-          "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'))]"
+          "commandToExecute": "[concat('bash install_minecraft.sh ', parameters('minecraftUser'), ' ', parameters('minecraftServerVersion'), ' ', parameters('difficulty'), ' ', parameters('level-name'), ' ', parameters('gamemode'), ' ', parameters('white-list'), ' ', parameters('enable-command-block'), ' ', parameters('spawn-monsters'), ' ', parameters('generate-structures'), ' ', parameters('level-seed'))]"
         }
       }
     }

--- a/minecraft-on-ubuntu/azuredeploy.parameters.json
+++ b/minecraft-on-ubuntu/azuredeploy.parameters.json
@@ -14,6 +14,9 @@
     "dnsNameForPublicIP": {
       "value": "uniquednsname"
     },
+    "minecraftServerVersion": {
+      "value": "1.9"
+    },
     "difficulty": {
       "value": "1"
     },

--- a/minecraft-on-ubuntu/install_minecraft.sh
+++ b/minecraft-on-ubuntu/install_minecraft.sh
@@ -47,9 +47,9 @@ mkdir $minecraft_server_path
 cd $minecraft_server_path
 
 # download the server jar
-while ! echo y | wget https://s3.amazonaws.com/Minecraft.Download/versions/1.8/minecraft_server.1.8.jar; do
+while ! echo y | wget https://s3.amazonaws.com/Minecraft.Download/versions/1.9/minecraft_server.1.9.jar; do
     sleep 10
-    wget https://s3.amazonaws.com/Minecraft.Download/versions/1.8/minecraft_server.1.8.jar
+    wget https://s3.amazonaws.com/Minecraft.Download/versions/1.9/minecraft_server.1.9.jar
 done
 
 # set permissions on install folder
@@ -71,7 +71,7 @@ echo 'eula=true' >> $minecraft_server_path/eula.txt
 touch /etc/systemd/system/minecraft-server.service
 printf '[Unit]\nDescription=Minecraft Service\nAfter=rc-local.service\n' >> /etc/systemd/system/minecraft-server.service
 printf '[Service]\nWorkingDirectory=%s\n' $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
-printf 'ExecStart=/usr/bin/java -Xms%s -Xmx%s -jar %s/minecraft_server.1.8.jar nogui\n' $memoryAlloc $memoryAlloc $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
+printf 'ExecStart=/usr/bin/java -Xms%s -Xmx%s -jar %s/minecraft_server.1.9.jar nogui\n' $memoryAlloc $memoryAlloc $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
 printf 'ExecReload=/bin/kill -HUP $MAINPID\nKillMode=process\nRestart=on-failure\n' >> /etc/systemd/system/minecraft-server.service
 printf '[Install]\nWantedBy=multi-user.target\nAlias=minecraft-server.service' >> /etc/systemd/system/minecraft-server.service
 

--- a/minecraft-on-ubuntu/install_minecraft.sh
+++ b/minecraft-on-ubuntu/install_minecraft.sh
@@ -8,16 +8,16 @@
 # $6 = enable-command-block
 # $7 = spawn-monsters
 # $8 = generate-structures
-# $9 = level-seed
-# $10 = minecraft Server Version
+# $9 = minecraft Server Version
+# $10 = level-seed
 
 # basic service and API settings
 minecraft_server_path=/srv/minecraft_server
 minecraft_user=minecraft
 minecraft_group=minecraft
 UUID_URL=https://api.mojang.com/users/profiles/minecraft/$1
-server_jar=minecraft_server.$10.jar
-SERVER_JAR_URL=https://s3.amazonaws.com/Minecraft.Download/versions/$10/minecraft_server.$10.jar
+server_jar=minecraft_server.$9.jar
+SERVER_JAR_URL=https://s3.amazonaws.com/Minecraft.Download/versions/$9/minecraft_server.$9.jar
 
 # add and update repos
 while ! echo y | apt-get install -y software-properties-common; do
@@ -105,6 +105,6 @@ printf 'white-list=%s\n' $5 >> $minecraft_server_path/server.properties
 printf 'enable-command-block=%s\n' $6 >> $minecraft_server_path/server.properties
 printf 'spawn-monsters=%s\n' $7 >> $minecraft_server_path/server.properties
 printf 'generate-structures=%s\n' $8 >> $minecraft_server_path/server.properties
-printf 'level-seed=%s\n' $9 >> $minecraft_server_path/server.properties
+printf 'level-seed=%s\n' $10 >> $minecraft_server_path/server.properties
 
 systemctl start minecraft-server

--- a/minecraft-on-ubuntu/install_minecraft.sh
+++ b/minecraft-on-ubuntu/install_minecraft.sh
@@ -50,9 +50,9 @@ mkdir $minecraft_server_path
 cd $minecraft_server_path
 
 # download the server jar
-while ! echo y | wget SERVER_JAR_URL; do
+while ! echo y | wget $SERVER_JAR_URL; do
     sleep 10
-    wget SERVER_JAR_URL
+    wget $SERVER_JAR_URL
 done
 
 # set permissions on install folder

--- a/minecraft-on-ubuntu/install_minecraft.sh
+++ b/minecraft-on-ubuntu/install_minecraft.sh
@@ -16,6 +16,8 @@ minecraft_server_path=/srv/minecraft_server
 minecraft_user=minecraft
 minecraft_group=minecraft
 UUID_URL=https://api.mojang.com/users/profiles/minecraft/$1
+server_jar=minecraft_server.$10.jar
+SERVER_JAR_URL=https://s3.amazonaws.com/Minecraft.Download/versions/$10/minecraft_server.$10.jar
 
 # add and update repos
 while ! echo y | apt-get install -y software-properties-common; do
@@ -48,9 +50,9 @@ mkdir $minecraft_server_path
 cd $minecraft_server_path
 
 # download the server jar
-while ! echo y | wget https://s3.amazonaws.com/Minecraft.Download/versions/$10/minecraft_server.$10.jar; do
+while ! echo y | wget SERVER_JAR_URL; do
     sleep 10
-    wget https://s3.amazonaws.com/Minecraft.Download/versions/$10/minecraft_server.$10.jar
+    wget SERVER_JAR_URL
 done
 
 # set permissions on install folder
@@ -72,7 +74,7 @@ echo 'eula=true' >> $minecraft_server_path/eula.txt
 touch /etc/systemd/system/minecraft-server.service
 printf '[Unit]\nDescription=Minecraft Service\nAfter=rc-local.service\n' >> /etc/systemd/system/minecraft-server.service
 printf '[Service]\nWorkingDirectory=%s\n' $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
-printf 'ExecStart=/usr/bin/java -Xms%s -Xmx%s -jar %s/minecraft_server.$10.jar nogui\n' $memoryAlloc $memoryAlloc $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
+printf 'ExecStart=/usr/bin/java -Xms%s -Xmx%s -jar %s/%s nogui\n' $memoryAlloc $memoryAlloc $minecraft_server_path $server_jar >> /etc/systemd/system/minecraft-server.service
 printf 'ExecReload=/bin/kill -HUP $MAINPID\nKillMode=process\nRestart=on-failure\n' >> /etc/systemd/system/minecraft-server.service
 printf '[Install]\nWantedBy=multi-user.target\nAlias=minecraft-server.service' >> /etc/systemd/system/minecraft-server.service
 

--- a/minecraft-on-ubuntu/install_minecraft.sh
+++ b/minecraft-on-ubuntu/install_minecraft.sh
@@ -9,6 +9,7 @@
 # $7 = spawn-monsters
 # $8 = generate-structures
 # $9 = level-seed
+# $10 = minecraft Server Version
 
 # basic service and API settings
 minecraft_server_path=/srv/minecraft_server
@@ -47,9 +48,9 @@ mkdir $minecraft_server_path
 cd $minecraft_server_path
 
 # download the server jar
-while ! echo y | wget https://s3.amazonaws.com/Minecraft.Download/versions/1.9/minecraft_server.1.9.jar; do
+while ! echo y | wget https://s3.amazonaws.com/Minecraft.Download/versions/$10/minecraft_server.$10.jar; do
     sleep 10
-    wget https://s3.amazonaws.com/Minecraft.Download/versions/1.9/minecraft_server.1.9.jar
+    wget https://s3.amazonaws.com/Minecraft.Download/versions/$10/minecraft_server.$10.jar
 done
 
 # set permissions on install folder
@@ -71,7 +72,7 @@ echo 'eula=true' >> $minecraft_server_path/eula.txt
 touch /etc/systemd/system/minecraft-server.service
 printf '[Unit]\nDescription=Minecraft Service\nAfter=rc-local.service\n' >> /etc/systemd/system/minecraft-server.service
 printf '[Service]\nWorkingDirectory=%s\n' $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
-printf 'ExecStart=/usr/bin/java -Xms%s -Xmx%s -jar %s/minecraft_server.1.9.jar nogui\n' $memoryAlloc $memoryAlloc $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
+printf 'ExecStart=/usr/bin/java -Xms%s -Xmx%s -jar %s/minecraft_server.$10.jar nogui\n' $memoryAlloc $memoryAlloc $minecraft_server_path >> /etc/systemd/system/minecraft-server.service
 printf 'ExecReload=/bin/kill -HUP $MAINPID\nKillMode=process\nRestart=on-failure\n' >> /etc/systemd/system/minecraft-server.service
 printf '[Install]\nWantedBy=multi-user.target\nAlias=minecraft-server.service' >> /etc/systemd/system/minecraft-server.service
 


### PR DESCRIPTION
### Changelog
* azuredeploy.json - added additional param minecraftServerVersion
azuredeploy.parameters.json - added additional param minecraftServerVersion
* install_minecraft.sh - added command line param (minecraftServerVersion) and reordered $9 and $10

### Description of the change
As minecraft 1.9 is now out and not backwards compatabile with 1.9 updated this template to allow minecraft server version to be supplied as a param (defaulting to 1.9). Some other files changed but these were just whole i had my fork open and both have been reverted (azuredeploy.json temporailry changed .sh file location to my fork, README.md temporarily changed template url to my fork)