### PR TITLE
Remove blacklist entry for /dev/sdb?

### DIFF
--- a/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
+++ b/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
@@ -62,7 +62,7 @@ then
 fi
 
 #A set of disks to ignore from partitioning and formatting
-BLACKLIST="/dev/sda|/dev/sdb"
+BLACKLIST="/dev/sda"
 
 # Base path for data disk mount points
 DATA_BASE="/datadisks"


### PR DESCRIPTION
Hello All,
I've been struggling with missing disks using the elasticsearch template, deploying ubuntu VMs.

This script always succeeds in mounting at least one disk, but when two disks are attached to the VM, 90% of the time, one disk would not get mounted.

It appears as though the disk that doesnt get mounted appears at /dev/sdb.

Having reviewed the script, I can see that this has been intentionally skipped, in the BLACKLIST.

I am not an unbuntu expert, but changing this script as above meant that all my unbuntu deployments succeeded with all disks attached.

This pull request contains the simple change of removing the /dev/sdb disk from the blacklist variable, therefore allowing disks appearing there to be mounted.

Cheers,
Matt
### Description of the change
Sometimes, Azure attaches disks which turn up at /dev/sdb (ubuntu), and due to the previous blacklist setting, this disk was not getting mounted.