### PR TITLE
fix unmounted disks in Ubuntu

### DIFF
--- a/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
+++ b/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
@@ -61,9 +61,6 @@ then
     exit 3
 fi
 
-#A set of disks to ignore from partitioning and formatting
-BLACKLIST="/dev/sda|/dev/sdb"
-
 # Base path for data disk mount points
 DATA_BASE="/datadisks"
 
@@ -120,7 +117,7 @@ has_filesystem() {
 scan_for_new_disks() {
     # Looks for unpartitioned disks
     declare -a RET
-    DEVS=($(ls -1 /dev/sd*|egrep -v "${BLACKLIST}"|egrep -v "[0-9]$"))
+    DEVS=($(ls -1 /dev/sd*|egrep -v "[0-9]$"))
     for DEV in "${DEVS[@]}";
     do
         # The disk will be considered a candidate for partitioning


### PR DESCRIPTION
Further to #1427 

This PR is to ensure all attached disks get mounted when using the elasticsearch template (and it probably helps with a few others?)

The symptom is that after deploying the template, the elasticsearch nodes dont have the free disk space that they should.  Root cause is that the extra disks that are attached during the VM provisioning are not mounted by this script, due to a blacklist of devices not to mount.  If this blacklist is removed, the script runs and results in consistent disk mounting.

Cheers,
Matt
### Description of the change
Azure can mount extra attached disks to /dev/sda and /dev/sdb.
See below - two 1TB disks have been attached to this ubuntu 14 LTS gallery image:
$ lsblk
NAME MAJ:MIN RM SIZE RO TYPE MOUNTPOINT
sda 8:0 0 1023G 0 disk
sdb 8:16 0 1023G 0 disk
sdc 8:32 0 29.3G 0 disk
└─sdc1 8:33 0 29.3G 0 part /
sdd 8:48 0 200G 0 disk
└─sdd1 8:49 0 200G 0 part /mnt
sr0 11:0 1 1.1M 0 rom

Removed the blacklist setting so that this disks are mounted.