### PR TITLE
Allow user to override names of resources

### DIFF
--- a/docker-simple-on-ubuntu/azuredeploy.json
+++ b/docker-simple-on-ubuntu/azuredeploy.json
@@ -49,6 +49,34 @@
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }
     },
+    "publicIPAddressName": {
+      "type": "string",
+      "defaultValue": "myPublicIP",
+      "metadata": {
+        "description": "The name of the Public IP used to access the Virtual Machine, as it will appear in the portal/shell."
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "defaultValue": "MyDockerVM",
+      "metadata": {
+        "description": "The name of the new VM, as it will appear in the portal/shell."
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "MyVNET",
+      "metadata": {
+        "description": "The name of the new Virtual Network attached to the VM, as it will appear in the portal/shell."
+      }
+    },
+    "nicName": {
+      "type": "string",
+      "defaultValue": "myVMNic",
+      "metadata": {
+        "description": "The name of the new Virtual NIC attached to the VM's Virtual Network, as it will appear in the portal/shell."
+      }
+    },
     "ubuntuOSVersion": {
       "type": "string",
       "defaultValue": "14.04.2-LTS",
@@ -66,19 +94,15 @@
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
     "OSDiskName": "osdiskfordockersimple",
-    "nicName": "myVMNic",
     "extensionName": "DockerExtension",
     "addressPrefix": "10.0.0.0/16",
     "subnetName": "Subnet",
     "subnetPrefix": "10.0.0.0/24",
     "storageAccountType": "Standard_LRS",
-    "publicIPAddressName": "myPublicIP",
     "publicIPAddressType": "Dynamic",
     "vmStorageAccountContainerName": "vhds",
-    "vmName": "MyDockerVM",
     "vmSize": "Standard_D1",
-    "virtualNetworkName": "MyVNET",
-    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
   },
   "resources": [
@@ -94,7 +118,7 @@
     {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[variables('publicIPAddressName')]",
+      "name": "[parameters('publicIPAddressName')]",
       "location": "[parameters('location')]",
       "properties": {
         "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
@@ -106,7 +130,7 @@
     {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
-      "name": "[variables('virtualNetworkName')]",
+      "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
@@ -127,11 +151,11 @@
     {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('nicName')]",
+      "name": "[parameters('nicName')]",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
       ],
       "properties": {
         "ipConfigurations": [
@@ -140,7 +164,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressName'))]"
               },
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -153,18 +177,18 @@
     {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[variables('vmName')]",
+      "name": "[parameters('vmName')]",
       "location": "[parameters('location')]",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],
       "properties": {
         "hardwareProfile": {
           "vmSize": "[variables('vmSize')]"
         },
         "osProfile": {
-          "computerName": "[variables('vmName')]",
+          "computerName": "[parameters('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -187,7 +211,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',parameters('nicName'))]"
             }
           ]
         }
@@ -195,11 +219,11 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('vmName'),'/', variables('extensionName'))]",
+      "name": "[concat(parameters('vmName'),'/', variables('extensionName'))]",
       "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",

--- a/docker-simple-on-ubuntu/azuredeploy.json
+++ b/docker-simple-on-ubuntu/azuredeploy.json
@@ -5,7 +5,7 @@
     "newStorageAccountName": {
       "type": "string",
       "metadata": {
-        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
+        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed. Must be between 3 and 24 characters in length and use numbers and lower-case letters only."
       }
     },
     "location": {

--- a/docker-simple-on-ubuntu/azuredeploy.json
+++ b/docker-simple-on-ubuntu/azuredeploy.json
@@ -46,7 +46,7 @@
     "dnsNameForPublicIP": {
       "type": "string",
       "metadata": {
-        "description": "Unique DNS Name for the Public IP used to access the Virtual Machine.. Must contain only lowercase letters, numbers and hyphens. The first character must be a letter. The last character must be a letter or number. The value must be between 3 and 63 characters long."
+        "description": "Unique DNS Name for the Public IP used to access the Virtual Machine. Must contain only lowercase letters, numbers and hyphens. The first character must be a letter. The last character must be a letter or number. The value must be between 3 and 63 characters long."
       }
     },
     "publicIPAddressName": {

--- a/docker-simple-on-ubuntu/azuredeploy.json
+++ b/docker-simple-on-ubuntu/azuredeploy.json
@@ -46,35 +46,35 @@
     "dnsNameForPublicIP": {
       "type": "string",
       "metadata": {
-        "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+        "description": "Unique DNS Name for the Public IP used to access the Virtual Machine.. Must contain only lowercase letters, numbers and hyphens. The first character must be a letter. The last character must be a letter or number. The value must be between 3 and 63 characters long."
       }
     },
     "publicIPAddressName": {
       "type": "string",
       "defaultValue": "myPublicIP",
       "metadata": {
-        "description": "The name of the Public IP used to access the Virtual Machine, as it will appear in the portal/shell."
+        "description": "The name of the Public IP used to access the Virtual Machine, as it will appear in the portal/shell. Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens."
       }
     },
     "vmName": {
       "type": "string",
       "defaultValue": "MyDockerVM",
       "metadata": {
-        "description": "The name of the new VM, as it will appear in the portal/shell."
+        "description": "The name of the new VM, as it will appear in the portal/shell. Cannot contain special characters."
       }
     },
     "virtualNetworkName": {
       "type": "string",
       "defaultValue": "MyVNET",
       "metadata": {
-        "description": "The name of the new Virtual Network attached to the VM, as it will appear in the portal/shell."
+        "description": "The name of the new Virtual Network attached to the VM, as it will appear in the portal/shell. Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens."
       }
     },
     "nicName": {
       "type": "string",
       "defaultValue": "myVMNic",
       "metadata": {
-        "description": "The name of the new Virtual NIC attached to the VM's Virtual Network, as it will appear in the portal/shell."
+        "description": "The name of the new Virtual NIC attached to the VM's Virtual Network, as it will appear in the portal/shell. Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens."
       }
     },
     "ubuntuOSVersion": {


### PR DESCRIPTION
### Changelog
* Allow user to provide names of resources
* Improved descriptions of all parameters

### Description of the change
For all hard-coded resource names (e.g. MyDockerVM), make these template parameters with defaults so that the user can override them as desired. Include description of required formats to prevent deployment failures due to invalid values.