### PR TITLE
update atlasInfraName param

### DIFF
--- a/consul-on-ubuntu/azuredeploy.json
+++ b/consul-on-ubuntu/azuredeploy.json
@@ -315,7 +315,7 @@
           ]
         }, 
         "protectedSettings": { 
-            "commandToExecute": "[concat(variables('customScriptCommandToExecute'),' ', parameters('existingAtlasInfra'), ' ', parameters('existingAtlasToken'))]"
+            "commandToExecute": "[concat(variables('customScriptCommandToExecute'),' ', parameters('existingAtlasInfraName'), ' ', parameters('existingAtlasToken'))]"
         },
         "type": "CustomScriptForLinux", 
         "publisher": "Microsoft.OSTCExtensions"

--- a/consul-on-ubuntu/azuredeploy.parameters.json
+++ b/consul-on-ubuntu/azuredeploy.parameters.json
@@ -14,7 +14,7 @@
         "vmsize": {
             "value": "Standard_A1"
         },
-        "existingAtlasInfra": {
+        "existingAtlasInfraName": {
             "value": "GEN-UNIQUE"
         },
         "existingAtlasToken": {


### PR DESCRIPTION


### Changelog
* rename all `existingAtlasInfra` to `existingAtlasInfraName`

### Description of the change

During all of the previous clean-up a few instances of `existingAtlasInfra` did not get renamed to `existingAtlasInfraName`
