### PR TITLE
Removed extraneous parenthesis on line 246

### DIFF
--- a/cloudera-on-centos/shared-resources-existing-vnet.json
+++ b/cloudera-on-centos/shared-resources-existing-vnet.json
@@ -243,7 +243,7 @@
   ],
   "outputs": {
     "vnetIDRef": {
-      "value": "[resourceId(parameters('networkSpec').virtualNetworkRGName,concat('Microsoft.Network','/','virtualNetworks'),parameters('networkSpec').virtualNetworkName))]",
+      "value": "[resourceId(parameters('networkSpec').virtualNetworkRGName,concat('Microsoft.Network','/','virtualNetworks'),parameters('networkSpec').virtualNetworkName)]",
       "type": "string"
     }
   }


### PR DESCRIPTION
### Changelog
*
*
*
*
*

### Description of the change
Without this edit, the template fails to validate in azure when using an existing vnet/subnet:
"Deployment template validation failed: 'The template output 'vnetIDRef' at line '245' and column '19' is not valid: Unable to parse template language expression 'resourceId(parameters('networkSpec').virtualNetworkRGName,concat('Microsoft.Network','/','virtualNetworks'),parameters('networkSpec').virtualNetworkName))': expected token 'EndOfData' and actual 'RightParenthesis'. Please see http://aka.ms/arm-template-expressions for usage details..'."