### PR TITLE
Added validation_key_format parameter

### DIFF
--- a/chef-json-parameters-linux-vm/azuredeploy.json
+++ b/chef-json-parameters-linux-vm/azuredeploy.json
@@ -85,6 +85,14 @@
       "metadata": {
         "description": "JSON Escaped Validation Key"
       }
+    },
+    "validation_key_format": {
+      "type": "string",
+      "allowedValues": ["plaintext", "base64encoded"],
+      "defaultValue": "plaintext",
+      "metadata" : {
+        "description": "Format in which Validation Key is given. e.g. plaintext, base64encoded"
+      }
     }
   },
   "variables": {
@@ -263,7 +271,8 @@
             "chef_server_url": "[parameters('chef_server_url')]",
             "validation_client_name": "[parameters('validation_client_name')]"
           },
-          "runlist": "[parameters('runlist')]"
+          "runlist": "[parameters('runlist')]",
+          "validation_key_format": "[parameters('validation_key_format')]"
         },
         "protectedSettings": {
           "validation_key": "[parameters('validation_key')]"

--- a/chef-json-parameters-linux-vm/azuredeploy.parameters.json
+++ b/chef-json-parameters-linux-vm/azuredeploy.parameters.json
@@ -40,6 +40,9 @@
     },
     "validation_key": {
       "value": "GEN-UNIQUE"
+    },
+    "validation_key_format": {
+      "value": "plaintext"
     }
   }
 }


### PR DESCRIPTION
### Changelog
* Added `validation_key_format` option for chef extension

### Description of the change
User can specify the `validation_key_format` as `plaintext` or `base64encoded`. He can then provide the `validation_key` in the same format.