### PR TITLE
Bind network security group to VMs and use Azure CPI v9.

### DIFF
--- a/bosh-setup/README.md
+++ b/bosh-setup/README.md
@@ -18,6 +18,11 @@ We look forward to hearing your feedback and suggestions!
 ```
 Template Changelog
 
+# v1.3.0 (2016-04-01)
+- Does not bind network security groups to subnets but bind network security groups to VMs.
+- Upgrade versions
+  - Upgrade Azure CPI version to v9. Please see new features in https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release
+
 # v1.2.0 (2016-03-28)
 - Add a subnet for Diego
 - Create network security groups for all subnets

--- a/bosh-setup/azuredeploy.json
+++ b/bosh-setup/azuredeploy.json
@@ -87,9 +87,9 @@
     "environment": "AzureCloud",
     "serviceHostBase": "core.windows.net",
     "keepUnreachableVMs": "false",
+    "devboxNetworkSecurityGroup": "nsg-devbox",
     "boshNetworkSecurityGroup": "nsg-bosh",
-    "cfNetworkSecurityGroup": "nsg-cf",
-    "diegoNetworkSecurityGroup": "nsg-diego"
+    "cfNetworkSecurityGroup": "nsg-cf"
   },
   "resources": [
     {
@@ -100,16 +100,82 @@
       "properties": {
         "securityRules": [
           {
-            "name": "devbox-ssh",
+            "name": "ssh",
             "properties": {
-              "description": "Allow SSH to devbox",
+              "description": "Allow SSH",
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "22",
               "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "[concat(variables('devboxPrivateIPAddress'),'/32')]",
+              "destinationAddressPrefix": "*",
               "access": "Allow",
-              "priority": 100,
+              "priority": 200,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "bosh-agent",
+            "properties": {
+              "description": "Allow bosh-agent",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "6868",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 201,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "bosh-director",
+            "properties": {
+              "description": "Allow bosh-director",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "25555",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 202,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "dns",
+            "properties": {
+              "description": "Allow DNS",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "53",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 203,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('devboxNetworkSecurityGroup')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "ssh",
+            "properties": {
+              "description": "Allow SSH",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 200,
               "direction": "Inbound"
             }
           }
@@ -123,16 +189,34 @@
       "location": "[variables('location')]",
       "properties": {
         "securityRules": [
-        ]
-      }
-    },
-    {
-      "apiVersion": "[variables('apiVersion')]",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('diegoNetworkSecurityGroup')]",
-      "location": "[variables('location')]",
-      "properties": {
-        "securityRules": [
+          {
+            "name": "cf-https",
+            "properties": {
+              "description": "Allow cf-https",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 200,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "cf-log",
+            "properties": {
+              "description": "Allow cf-log",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "4443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 201,
+              "direction": "Inbound"
+            }
+          }
         ]
       }
     },
@@ -180,11 +264,6 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('boshNetworkSecurityGroup'))]",
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('cfNetworkSecurityGroup'))]",
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('diegoNetworkSecurityGroup'))]"
-      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -195,28 +274,19 @@
           {
             "name": "[variables('subnetNameForBosh')]",
             "properties": {
-              "addressPrefix": "[variables('subnetAddressRangeForBosh')]",
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('boshNetworkSecurityGroup'))]"
-              }
+              "addressPrefix": "[variables('subnetAddressRangeForBosh')]"
             }
           },
           {
             "name": "[variables('subnetNameForCloudFoundry')]",
             "properties": {
-              "addressPrefix": "[variables('subnetAddressRangeForCloudFoundry')]",
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('cfNetworkSecurityGroup'))]"
-              }
+              "addressPrefix": "[variables('subnetAddressRangeForCloudFoundry')]"
             }
           },
           {
             "name": "[variables('subnetNameForDiego')]",
             "properties": {
-              "addressPrefix": "[variables('subnetAddressRangeForDiego')]",
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('diegoNetworkSecurityGroup'))]"
-              }
+              "addressPrefix": "[variables('subnetAddressRangeForDiego')]"
             }
           }
         ]
@@ -229,9 +299,13 @@
       "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', concat(parameters('vmName'), '-devbox'))]",
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('devboxNetworkSecurityGroup'))]"
       ],
       "properties": {
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('devboxNetworkSecurityGroup'))]"
+        },
         "ipConfigurations": [
           {
             "name": "ipconfig1",
@@ -329,7 +403,7 @@
           "enableInternalDNSCheck": false
         },
         "protectedSettings": {
-          "commandToExecute": "[concat('./setup_env', ' ', '\"VNET_NAME:', variables('virtualNetworkName'), ';SUBNET_NAME_FOR_BOSH:', variables('subnetNameForBosh'), ';SUBNET_ADDRESS_RANGE_FOR_BOSH:', variables('subnetAddressRangeForBosh'), ';SUBNET_NAME_FOR_CLOUD_FOUNDRY:', variables('subnetNameForCloudFoundry'), ';SUBNET_ADDRESS_RANGE_FOR_CLOUD_FOUNDRY:', variables('subnetAddressRangeForCloudFoundry'), ';CLOUD_FOUNDRY_PUBLIC_IP:', reference(concat(parameters('vmName'),'-cf')).ipAddress, ';BOSH_PUBLIC_IP:', reference(concat(parameters('vmName'),'-bosh')).ipAddress, ';SUBSCRIPTION_ID:', subscription().subscriptionId, ';DEFAULT_STORAGE_ACCOUNT_NAME:', variables('defaultStorageAccountName'), ';STORAGE_ACCESS_KEY:', listKeys(variables('storageid'), variables('apiVersion')).key1, ';RESOURCE_GROUP_NAME:', resourceGroup().name, ';KEEP_UNREACHABLE_VMS:', variables('keepUnreachableVMs'), ';NSG_NAME_FOR_BOSH:', variables('boshNetworkSecurityGroup'), ';NSG_NAME_FOR_CF:', variables('cfNetworkSecurityGroup'), ';NSG_NAME_FOR_DIEGO:', variables('diegoNetworkSecurityGroup'), '\" ', parameters('tenantID'), ' ', parameters('clientID'), ' \"', parameters('clientSecret'), '\" ', parameters('adminUserName'), ' ', parameters('autoDeployBosh'))]"
+          "commandToExecute": "[concat('./setup_env', ' ', '\"VNET_NAME:', variables('virtualNetworkName'), ';SUBNET_NAME_FOR_BOSH:', variables('subnetNameForBosh'), ';SUBNET_ADDRESS_RANGE_FOR_BOSH:', variables('subnetAddressRangeForBosh'), ';SUBNET_NAME_FOR_CLOUD_FOUNDRY:', variables('subnetNameForCloudFoundry'), ';SUBNET_ADDRESS_RANGE_FOR_CLOUD_FOUNDRY:', variables('subnetAddressRangeForCloudFoundry'), ';CLOUD_FOUNDRY_PUBLIC_IP:', reference(concat(parameters('vmName'),'-cf')).ipAddress, ';BOSH_PUBLIC_IP:', reference(concat(parameters('vmName'),'-bosh')).ipAddress, ';SUBSCRIPTION_ID:', subscription().subscriptionId, ';DEFAULT_STORAGE_ACCOUNT_NAME:', variables('defaultStorageAccountName'), ';STORAGE_ACCESS_KEY:', listKeys(variables('storageid'), variables('apiVersion')).key1, ';RESOURCE_GROUP_NAME:', resourceGroup().name, ';KEEP_UNREACHABLE_VMS:', variables('keepUnreachableVMs'), ';NSG_NAME_FOR_BOSH:', variables('boshNetworkSecurityGroup'), ';NSG_NAME_FOR_CLOUD_FOUNDRY:', variables('cfNetworkSecurityGroup'), '\" ', parameters('tenantID'), ' ', parameters('clientID'), ' \"', parameters('clientSecret'), '\" ', parameters('adminUserName'), ' ', parameters('autoDeployBosh'))]"
         }
       }
     }

--- a/bosh-setup/manifests/bosh.yml
+++ b/bosh-setup/manifests/bosh.yml
@@ -6,8 +6,8 @@ releases:
   url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=255.3
   sha1: 1a3d61f968b9719d9afbd160a02930c464958bf4
 - name: bosh-azure-cpi
-  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-azure-cpi-release?v=8
-  sha1: df37aaf44fd0dd6ccbdd0c83b3a7affa23f533fb
+  url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-azure-cpi-release?v=9
+  sha1: e4bf4d26b45b2752975e4054f7e406c5f4661c69
 
 networks:
 - name: public
@@ -121,6 +121,7 @@ jobs:
       client_secret: REPLACE_WITH_CLIENT_SECRET
       ssh_user: vcap
       ssh_public_key: REPLACE_WITH_SSH_PUBLIC_KEY
+      default_security_group: REPLACE_WITH_NSG_NAME_FOR_BOSH
 
     agent: {mbus: "nats://nats:nats-password@REPLACE_WITH_BOSH_DIRECTOR_IP:4222"}
 

--- a/bosh-setup/manifests/multiple-vm-cf.yml
+++ b/bosh-setup/manifests/multiple-vm-cf.yml
@@ -31,6 +31,7 @@ resource_pools:
     version: latest
   cloud_properties:
     instance_type: Standard_D1
+    security_group: REPLACE_WITH_NSG_NAME_FOR_CLOUD_FOUNDRY
   env:
     bosh:
       password: $6$4gDD3aV0rdqlrKC$2axHCxGKIObs6tAmMTqYCspcdvQXh3JJcvWOY2WGb4SrdXtnCyNaWlrf3WEqvYR2MYizEGp3kMmbpwBC6jsHt0

--- a/bosh-setup/manifests/single-vm-cf.yml
+++ b/bosh-setup/manifests/single-vm-cf.yml
@@ -31,6 +31,7 @@ resource_pools:
     version: latest
   cloud_properties:
     instance_type: Standard_D1
+    security_group: REPLACE_WITH_NSG_NAME_FOR_CLOUD_FOUNDRY
 
 compilation:
   workers: 1

--- a/bosh-setup/metadata.json
+++ b/bosh-setup/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template helps you setup a development environment where you can delpoy BOSH and Cloud Foundy.",
   "summary": "This template helps you setup a development environment where you can delpoy BOSH and Cloud Foundry.",
   "githubUsername": "bingosummer",
-  "dateUpdated": "2016-03-28"
+  "dateUpdated": "2016-04-01"
 }


### PR DESCRIPTION
### Changelog
# v1.3.0 (2016-04-01)
- Does not bind network security groups to subnets but bind network security groups to VMs.
- Upgrade versions
  - Upgrade Azure CPI version to v9. Please see new features in https://github.com/cloudfoundry-incubator/bosh-azure-cpi-release