### PR TITLE
Elasticsearch template updates

### DIFF
--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -176,9 +176,10 @@
     },
     "esVersion": {
       "type": "string",
-      "defaultValue": "2.2.1",
+      "defaultValue": "2.3.1",
       "allowedValues": [
-        "2.2.1",
+        "2.3.1",
+        "2.2.2",
         "2.1.2",
         "1.7.5"
       ],

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -536,7 +536,7 @@
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('marvelExportParamValue'), ' -masterOnlyNode -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('cloudAzureParamValue'), variables('marvelParamValue'), variables('marvelExportParamValue'), ' -masterOnlyNode -storageKey ')]"
           }
         },
         "client": {
@@ -545,7 +545,7 @@
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('marvelExportParamValue'), ' -clientOnlyNode -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('cloudAzureParamValue'), variables('marvelParamValue'), variables('marvelExportParamValue'), ' -clientOnlyNode -storageKey ')]"
           }
         },
         "data": {
@@ -554,7 +554,7 @@
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('marvelParamValue'), variables('marvelExportParamValue'), ' -dataOnlyNode -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version,' -elasticClusterName ', variables('esSettings').clusterName,' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('cloudAzureParamValue'), variables('marvelParamValue'), variables('marvelExportParamValue'), ' -dataOnlyNode -storageKey ')]"
           }
         }
       }

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -211,7 +211,7 @@
     },
     "marvelCluster" : {
       "type":"string",
-      "defaultValue":"yes",
+      "defaultValue":"no",
       "allowedValues": [
         "yes",
         "no"

--- a/elasticsearch/kibana-install.sh
+++ b/elasticsearch/kibana-install.sh
@@ -29,7 +29,7 @@ help()
 {
     echo "Usage: $(basename $0) [-v es_version] [-t target_host] [-m] [-s] [-h]"
     echo "Options:"
-    echo "  -v    elasticsearch version to target (default: 2.2.1)"
+    echo "  -v    elasticsearch version to target (default: 2.3.1)"
     echo "  -t    target host (default: http://10.0.1.4:9200)"
     echo "  -m    install marvel (default: no)"
     echo "  -s    install sense (default: no)"
@@ -51,8 +51,13 @@ install_java() {
 }
 
 install_kibana() {
-    # default - ES 2.2.1
-    kibana_url="https://download.elastic.co/kibana/kibana/kibana-4.4.2-linux-x64.tar.gz"
+    # default - ES 2.3.1
+	kibana_url="https://download.elastic.co/kibana/kibana/kibana-4.5.0-linux-x64.tar.gz"
+	
+	if [[ "${ES_VERSION}" == "2.2.2" ]]; 
+    then
+		kibana_url="https://download.elastic.co/kibana/kibana/kibana-4.4.2-linux-x64.tar.gz"
+	fi
     
     if [[ "${ES_VERSION}" == "2.1.2" ]]; 
     then
@@ -84,16 +89,11 @@ install_kibana() {
     # install the marvel plugin for 2.x
     if [ ${INSTALL_MARVEL} -ne 0 ];
     then
-        if [[ "${ES_VERSION}" == "2.2.1" ]];
+		if [[ "${ES_VERSION}" == \2* ]];
         then
-            /opt/kibana/bin/kibana plugin --install elasticsearch/marvel/2.2.1
+            /opt/kibana/bin/kibana plugin --install elasticsearch/marvel/${ES_VERSION}
         fi
-        
-        if [[ "${ES_VERSION}" == "2.1.2" ]]; 
-        then
-            /opt/kibana/bin/kibana plugin --install elasticsearch/marvel/2.1.2
-        fi
-        
+
         # for 1.x marvel is installed only within the cluster, not on the kibana node 
     fi
     
@@ -130,7 +130,7 @@ then
     error "You must be root to run this script."
 fi
 
-ES_VERSION="2.2.1"
+ES_VERSION="2.3.1"
 INSTALL_MARVEL=0
 INSTALL_SENSE=0
 ELASTICSEARCH_URL="http://10.0.1.4:9200"


### PR DESCRIPTION
- add support for the cloud-azure plugin to Windows
- update the versions of Elasticsearch to include 2.3.1 and 2.2.2, Kibana to 4.5.0
- disable the standalone Marvel cluster by default, as this prevents the use of Kibana over the main cluster without further manual steps