### PR TITLE
Title change to generic VM to assist with ACOM doc screenshots

### DIFF
--- a/101-vm-tags/README.md
+++ b/101-vm-tags/README.md
@@ -1,4 +1,4 @@
-# Simple deployment of an Windows VM with Tags
+# Simple deployment of a VM with Tags
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-vm-tags%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>


### PR DESCRIPTION
### Description of the change
Working with @mmccrory to refresh ACOM doc - https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-tag/
Suggesting change to title for generic VM to assist with cleaner Linux docs in order to update screenshots