### PR TITLE
simplify template parameters on chef linux vm template

### DIFF
--- a/chef-json-parameters-linux-vm/azuredeploy.json
+++ b/chef-json-parameters-linux-vm/azuredeploy.json
@@ -2,12 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "newStorageAccountName": {
-      "type": "string",
-      "metadata": {
-        "description": "Unique  Name for the Storage Account where the Virtual Machine's disks will be placed"
-      }
-    },
     "vmDnsName": {
       "type": "string",
       "metadata": {
@@ -76,6 +70,10 @@
     "autoUpdateClient": {
       "type": "string",
       "defaultValue": "false",
+      "allowedValues": [
+        "true",
+        "false"
+      ],
       "metadata": {
         "description": "Optional Flag for auto update"
       }
@@ -123,6 +121,7 @@
     "vmExtensionName": "LinuxChefExtension",
     "vmName": "[parameters('vmDnsName')]",
     "storageAccountType": "Standard_LRS",
+    "newStorageAccountName": "[concat(uniquestring(resourceGroup().id), 'cheflinuxvm')]",
     "publicIPAddressName": "myPublicIP1",
     "publicIPAddressType": "Dynamic",
     "vmStorageAccountContainerName": "vhds",
@@ -138,7 +137,7 @@
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[parameters('newStorageAccountName')]",
+      "name": "[variables('newStorageAccountName')]",
       "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "properties": {
@@ -216,7 +215,7 @@
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],
       "properties": {
@@ -238,7 +237,7 @@
           "osDisk": {
             "name": "osdisk",
             "vhd": {
-              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/vhds/','osdisk.vhd')]"
+              "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/vhds/','osdisk.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"

--- a/chef-json-parameters-linux-vm/azuredeploy.parameters.json
+++ b/chef-json-parameters-linux-vm/azuredeploy.parameters.json
@@ -2,9 +2,6 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "newStorageAccountName": {
-      "value": "GEN-UNIQUE"
-    },
     "adminUserName": {
       "value": "azure"
     },


### PR DESCRIPTION
### Changelog
* Removed the need for a user to create a storage account name, mirrors the simple-linux-vm template
* Added allowed values to the auto update client parameterr

### Description of the change
The above changes are to make deploying a vm with Chef on it as simple as possible using the patterns in other templates.