### PR TITLE
Remove the BOM.

### DIFF
--- a/mysql-ha-pxc/azuredeploy.json
+++ b/mysql-ha-pxc/azuredeploy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {

--- a/mysql-replication/azuredeploy.json
+++ b/mysql-replication/azuredeploy.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/spark-and-cassandra-on-centos/azuredeploy.json
+++ b/spark-and-cassandra-on-centos/azuredeploy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {


### PR DESCRIPTION
Remove the BOM because not all JSON parsers handle this case.  The majority of files in the repository do not have a BOM, so I'm maintaining the existing standard.