### PR TITLE
Use swarm latest image instead of 1.0.1

### DIFF
--- a/docker-swarm-cluster/azuredeploy.json
+++ b/docker-swarm-cluster/azuredeploy.json
@@ -499,7 +499,7 @@
               "restart": "always"
             },
             "swarm": {
-              "image": "swarm:1.0.1",
+              "image": "swarm",
               "command": "[concat('manage --replication --advertise ', reference(concat(variables('vmNameMaster'), copyIndex(), '-nic')).ipConfigurations[0].properties.privateIPAddress, ':2375 --discovery-opt kv.path=docker/nodes consul://10.0.0.4:8500')]",
               "ports": [
                 "2375:2375"


### PR DESCRIPTION
### Description of the change
The current swarm template fixes on swarm:1.0.1 which is a little outdated. We could either use a new version, or always use the latest version. Given swarm is relatively stable I think it ok to use latest version. And we don't need to update it frequently. 

Signed-off-by: Dong Chen <dongluo.chen@docker.com>