### PR TITLE
Generate random serial and enable basic auth in WinRM

### DIFF
--- a/201-vm-winrm-windows/ConfigureWinRM.ps1
+++ b/201-vm-winrm-windows/ConfigureWinRM.ps1
@@ -50,7 +50,11 @@ function Configure-WinRMHttpsListener
     $thumbprint = (Get-ChildItem cert:\LocalMachine\My | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
     if(-not $thumbprint)
     {
-        .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e 01/01/2022 -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12
+	# makecert ocassionally produces negative serial numbers
+	# which golang tls/crypto <1.6.1 cannot handle
+	# https://github.com/golang/go/issues/8265
+        $serial = Get-Random
+        .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e 01/01/2022 -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12 -# $serial
         $thumbprint=(Get-ChildItem cert:\Localmachine\my | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
 
         if(-not $thumbprint)

--- a/201-vm-winrm-windows/winrmconf.cmd
+++ b/201-vm-winrm-windows/winrmconf.cmd
@@ -1,1 +1,2 @@
-winrm create winrm/config/Listener?Address=*+Transport=HTTPS @{Hostname="%1";CertificateThumbprint="%2"}
+call winrm set winrm/config/service/auth @{Basic="true"}
+call winrm create winrm/config/Listener?Address=*+Transport=HTTPS @{Hostname="%1";CertificateThumbprint="%2"}


### PR DESCRIPTION
### Description of the change
- makecert ocassionally generates negative serial numbers, which seem to cause
  problems for connecting from winrm clients written in golang
- enabling basic auth to allow connections from winrm clients written in
  golang