### PR TITLE
Add lint and reformat target.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,7 @@ var grunt = require('grunt');
 require('load-grunt-tasks')(grunt);
 
 var files = ['test/*.js'];
+var templates = ['**/*.json'];
 
 grunt.initConfig({
   mochacli: {
@@ -36,6 +37,24 @@ grunt.initConfig({
               config: '.beautifyrc'
           }
       },
+      lint: {
+          files: {
+              src: templates
+          },
+          options: {
+              mode: 'VERIFY_ONLY',
+              config: '.beautifyrc'
+          }
+      },
+      reformat: {
+          files: {
+              src: templates
+          },
+          options: {
+              mode: 'VERIFY_AND_WRITE',
+              config: '.beautifyrc'
+          }
+      },
       write: {
           files: {
               src: files
@@ -46,4 +65,4 @@ grunt.initConfig({
       }
   }
 });
-grunt.registerTask('test', ['jshint', 'jscs', 'jsbeautifier', 'mochacli']);
+grunt.registerTask('test', ['jshint', 'jscs', 'jsbeautifier:test', 'jsbeautifier:write', 'mochacli']);


### PR DESCRIPTION
This is part of the ground work to have a consistent style to the template
JSON documents.  Two targets are defined.

 * Lint - verify all JSON templates follow the approved style.
 * Reformat - modify all JSON templates to follow the approved style.

The lint target will be used to gate the build in a future commit.  If a
PR does not meet the approved style it will fail the build

The reformat target is for developers. Developers should execute this
target before sending a PR to match the approved style.