### PR TITLE
Add extra dependencies to ensure MSDeploy is not interrupted

### DIFF
--- a/webapp-blob-connection/azuredeploy.json
+++ b/webapp-blob-connection/azuredeploy.json
@@ -111,7 +111,8 @@
             "name": "web",
             "type": "config",
             "dependsOn": [
-              "[concat('Microsoft.Web/sites/', parameters('WebAppName'))]"
+              "[concat('Microsoft.Web/sites/', parameters('WebAppName'))]",
+              "[concat('Microsoft.Web/sites/', parameters('WebAppName'), '/extensions/MSDeploy')]"
             ],
             "tags": {
               "displayName": "WebAppConfig"
@@ -146,7 +147,8 @@
             "type": "config",
             "apiVersion": "2015-08-01",
             "dependsOn": [
-              "[concat('Microsoft.Web/sites/', parameters('WebAppName'))]"
+              "[concat('Microsoft.Web/sites/', parameters('WebAppName'))]",
+              "[concat('Microsoft.Web/sites/', parameters('WebAppName'), '/extensions/MSDeploy')]"
             ],
             "tags": {
               "displayName": "WebAppConnectionStrings"


### PR DESCRIPTION
### Changelog
* Added extra dependencies in `config` and `connectionstrings`

### Description of the change
These are required as `config` and `connectionstrings` can restart the app pool which breaks the `MSDeploy` installation if it is running at the same time.
