### PR TITLE
Moved Redis Connection string from connectionstrings to appsettings

### DIFF
--- a/201-web-app-redis-cache-sql-database/azuredeploy.json
+++ b/201-web-app-redis-cache-sql-database/azuredeploy.json
@@ -221,17 +221,26 @@
           "type": "config",
           "name": "connectionstrings",
           "dependsOn": [
-            "[concat('Microsoft.Web/Sites/', variables('webSiteName'))]"
+            "[concat('Microsoft.Web/Sites/', variables('webSiteName'))]",
+            "[concat('Microsoft.Sql/servers/', variables('sqlserverName'))]"
           ],
           "properties": {
             "TeamContext": {
               "value": "[concat('Data Source=tcp:', reference(concat('Microsoft.Sql/servers/', variables('sqlserverName'))).fullyQualifiedDomainName, ',1433;Initial Catalog=', parameters('databaseName'), ';User Id=', parameters('administratorLogin'), '@', variables('sqlserverName'), ';Password=', parameters('administratorLoginPassword'), ';')]",
               "type": "SQLServer"
-            },
-            "Cache": {
-              "value": "[concat(variables('cacheName'),'.redis.cache.windows.net,abortConnect=false,ssl=true,password=', listKeys(resourceId('Microsoft.Cache/Redis', variables('cacheName')), '2015-08-01').primaryKey)]",
-              "type": "Custom"
             }
+          }
+        },
+        {
+          "apiVersion": "2015-08-01",
+          "type": "config",
+          "name": "appsettings",
+          "dependsOn": [
+            "[concat('Microsoft.Web/Sites/', variables('webSiteName'))]",
+            "[concat('Microsoft.Cache/Redis/', variables('cacheName'))]"
+          ],
+          "properties": {
+            "CacheConnection": "[concat(variables('cacheName'),'.redis.cache.windows.net,abortConnect=false,ssl=true,password=', listKeys(resourceId('Microsoft.Cache/Redis', variables('cacheName')), '2015-08-01').primaryKey)]"
           }
         }
       ]


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Moved Redis Connection string from connectionstrings to appsettings
* Added additional dependencies for the connection strings so they aren't created before their respective resources are ready
*
*
*

### Description of the change

Moved Redis Connection string from connectionstrings to appsettings so that it aligns with best practices for Redis cache connection strings in a Web App and added additional dependencies for the connection strings so they aren't created before their respective resources are ready
