### PR TITLE
Support new CentOS-HPC images in Azure Gallery

### DIFF
--- a/intel-lustre-clients-on-centos/.ci_skip
+++ b/intel-lustre-clients-on-centos/.ci_skip
@@ -1,0 +1,1 @@
+To run this template you must first deploy a Lustre cluster in your subscription and use the existing virtual network when deploying the clients. For more details please see http://blogs.msdn.com/b/arsen/archive/2015/12/30/linux-azure-vm-scale-sets-with-shared-storage-using-lustre.aspx

--- a/intel-lustre-clients-on-centos/azuredeploy.json
+++ b/intel-lustre-clients-on-centos/azuredeploy.json
@@ -1,402 +1,451 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "artifactsBaseUrl": {
-            "type": "string",
-            "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/intel-lustre-clients-on-centos",
-            "metadata": {
-                "description": "Base URL of the solution template gallery package",
-                "artifactsBaseUrl": ""
-            }
-        },
-        "location": {
-            "type": "string",
-            "allowedValues": [
-                "West US",
-                "East US 2",
-                "East US",
-                "Central US",
-                "South Central US",
-                "North Central US",
-                "West Europe",
-                "North Europe",
-                "East Asia",
-                "Southeast Asia",
-                "Japan West",
-                "Japan East",
-                "Brazil South",
-                "Australia East",
-                "Australia Southeast",
-                "Central India",
-                "West India",
-                "South India"
-            ],
-            "metadata": {
-                "description": "Location for the Lustre nodes"
-            }
-        },
-        "imageSku": {
-            "type": "string",
-            "defaultValue": "6.6",
-            "allowedValues": [
-                "6.6",
-                "7.0"
-            ],
-            "metadata": {
-                "description": "OpenLogic CentOS version to use"
-            }
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Admin username for the virtual machines"
-            }
-        },
-        "authenticationType": {
-            "type": "string",
-            "defaultValue": "password",
-            "allowedValues": [
-                "password",
-                "sshPublicKey"
-            ],
-            "metadata": {
-                "description": "Authentication type for the virtual machines"
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Admin password for the virtual machines"
-            }
-        },
-        "sshPublicKey": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "SSH public key that will be included on all nodes. The OpenSSH public key can be generated with tools like ssh-keygen on Linux or OS X."
-            }
-        },
-        "dnsNamePrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "Globally unique DNS name prefix name must be between 3 and 50 characters long and can contain only dashes, numbers, and lowercase letters. The domain name suffix (e.g. westus.cloudapp.zure.com) will be automatically updated based on the selected location."
-            }
-        },
-        "clientAvailabilitySetName": {
-            "type": "string",
-            "defaultValue": "availset-lustre-clients",
-            "metadata": {
-                "description": "Lustre clients availability set name is important for grouping clients into deployments that can communicate with each other via RDMA"
-            }
-        },
-        "vmNamePrefix": {
-            "type": "string",
-            "defaultValue": "lustre",
-            "metadata": {
-                "description": "Prefix for the virtual machine names"
-            }
-        },
-        "clientVmSize": {
-            "type": "string",
-            "defaultValue": "Standard_D2",
-            "metadata": {
-                "description": "Size of the Lustre client VM"
-            },
-            "allowedValues": [
-                "Standard_D2",
-                "Standard_D3",
-                "Standard_D4",
-                "Standard_D11",
-                "Standard_D12",
-                "Standard_D13",
-                "Standard_D14",
-                "Standard_DS2",
-                "Standard_DS3",
-                "Standard_DS4",
-                "Standard_DS11",
-                "Standard_DS12",
-                "Standard_DS13",
-                "Standard_DS14",
-                "Standard_G1",
-                "Standard_G2",
-                "Standard_G3",
-                "Standard_G4",
-                "Standard_G5",
-                "Standard_GS1",
-                "Standard_GS2",
-                "Standard_GS3",
-                "Standard_GS4",
-                "Standard_GS5",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_A4",
-                "Standard_A5",
-                "Standard_A6",
-                "Standard_A7",
-                "Standard_A8",
-                "Standard_A9",
-                "Standard_A1",
-                "Standard_D1",
-                "Standard_DS1"
-            ]
-        },
-        "clientCount": {
-            "type": "int",
-            "defaultValue": 2,
-            "allowedValues": [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50 ],
-            "metadata": {
-                "description": "Number of Lustre clients"
-            }
-        },
-        "filesystemName": {
-            "type": "string",
-            "defaultValue": "scratch",
-            "metadata": {
-                "description": "Name of the Lustre filesystem exposed by the Lustre MGS node"
-            }
-        },
-        "mgsIpAddress": {
-            "type": "string",
-            "defaultValue": "10.1.0.4",
-            "metadata": {
-                "description": "IP address of the Lustre MGS node"
-            }
-        },
-        "storageAccountPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "Storage account prefix that will be used to create storage accounts for Lustre nodes"
-            }
-        },
-        "storageAccountType": {
-            "type": "string",
-            "defaultValue": "Standard_LRS",
-            "allowedValues": [
-                "Standard_LRS",
-                "Premium_LRS"
-            ],
-            "metadata": {
-                "description": "Storage account type (e.g. Premium_LRS or Standard_LRS)"
-            }
-        },
-        "existingVnetResourceGroupName": {
-            "type": "string",
-            "metadata": {
-                "description": "Existing Virtual Network Resource Group where Lustre servers are deployed"
-            }
-        },
-        "existingVnetName": {
-            "type": "string",
-            "defaultValue": "vnet-lustre",
-            "metadata": {
-                "description": "Existing Virtual Network name (e.g. vnet-lustre)"
-            }
-        },
-        "existingSubnetClientsName": {
-            "type": "string",
-            "defaultValue": "subnet-lustre-clients",
-            "metadata": {
-                "description": "Lustre clients will be deployed into this subnet within the existing Virtual Network"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "artifactsBaseUrl": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/intel-lustre-clients-on-centos",
+      "metadata": {
+        "description": "Base URL of the solution template gallery package",
+        "artifactsBaseUrl": ""
+      }
     },
-    "variables": {
-        "imagePublisher": "openlogic",
-        "imageOffer": "CentOS",
-        "clientAvailabilitySetSettings": {
-            "name": "[concat(parameters('clientAvailabilitySetName'))]",
-            "faultDomainCount": "3",
-            "updateDomainCount": "5"
-        },
-        "baseUrl": "[concat(parameters('artifactsBaseUrl'),'/')]",
-        "vnetID": "[resourceId(parameters('existingVnetResourceGroupName'), 'Microsoft.Network/virtualNetworks', parameters('existingVnetName'))]",
-        "subnetClientsID": "[concat(variables('vnetID'), '/subnets/', parameters('existingSubnetClientsName'))]",
-        "scriptUrlLustreClient": "[concat(variables('baseUrl'),'lustre_client.sh')]",
-        "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
-        "linuxConfiguration_sshPublicKey": {
-            "disablePasswordAuthentication": "true",
-            "ssh": {
-                "publicKeys": [
-                    {
-                        "path": "[variables('sshKeyPath')]",
-                        "keyData": "[parameters('sshPublicKey')]"
-                    }
-                ]
-            }
-        },
-        "linuxConfiguration_password": { },
-        "linuxConfiguration": "[variables(concat('linuxConfiguration_',parameters('authenticationType')))]"
+    "location": {
+      "type": "string",
+      "allowedValues": [
+        "West US",
+        "East US 2",
+        "East US",
+        "Central US",
+        "South Central US",
+        "North Central US",
+        "West Europe",
+        "North Europe",
+        "East Asia",
+        "Southeast Asia",
+        "Japan West",
+        "Japan East",
+        "Brazil South",
+        "Australia East",
+        "Australia Southeast",
+        "Central India",
+        "West India",
+        "South India",
+        "Canada Central",
+        "Canada East",
+        "UK North",
+        "UK South 2"
+      ],
+      "metadata": {
+        "description": "Location for the Lustre nodes"
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[concat(parameters('storageAccountPrefix'))]",
-            "location": "[parameters('location')]",
-            "properties": {
-                "accountType": "[parameters('storageAccountType')]"
-            }
-        },
-        {
-            "apiVersion": "2015-05-01-preview",
-            "type": "Microsoft.Compute/availabilitySets",
-            "name": "[variables('clientAvailabilitySetSettings').name]",
-            "location": "[parameters('location')]",
-            "properties": {
-                "platformFaultDomainCount": "[variables('clientAvailabilitySetSettings').faultDomainCount]",
-                "platformUpdateDomainCount": "[variables('clientAvailabilitySetSettings').updateDomainCount]"
-            }
-        },
-        {
-            "apiVersion": "2015-06-15",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[concat(parameters('vmNamePrefix'),'client0')]",
-            "location": "[parameters('location')]",
-            "properties": {
-                "publicIPAllocationMethod": "Dynamic",
-                "idleTimeoutInMinutes": 4,
-                "dnsSettings": {
-                    "domainNameLabel": "[concat(parameters('dnsNamePrefix'),'')]"
-                }
-            }
-        },
-        {
-            "apiVersion": "2015-06-15",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[concat(parameters('vmNamePrefix'), 'client0')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', parameters('vmNamePrefix'), 'client0')]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "ip1",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(parameters('vmNamePrefix'), 'client0'))]"
-                            },
-                            "subnet": {
-                                "id": "[variables('subnetClientsID')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "2015-06-15",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[concat(parameters('vmNamePrefix'), 'client', copyIndex(1))]",
-            "location": "[parameters('location')]",
-            "copy": {
-                "name": "clientNicCopy",
-                "count": "[sub(parameters('clientCount'),1)]"
-            },
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "ip1",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "subnet": {
-                                "id": "[variables('subnetClientsID')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "2015-06-15",
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[concat(parameters('vmNamePrefix'), 'client', copyIndex())]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountPrefix'))]",
-                "[concat('Microsoft.Compute/availabilitySets/', variables('clientAvailabilitySetSettings').name)]",
-                "[concat('Microsoft.Network/networkInterfaces/', parameters('vmNamePrefix'), 'client', copyIndex())]"
-            ],
-            "copy": {
-                "name": "clientVmCopy",
-                "count": "[parameters('clientCount')]"
-            },
-            "tags": {
-                "LustreType": "client"
-            },
-            "properties": {
-                "availabilitySet": {
-                    "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('clientAvailabilitySetSettings').name)]"
-                },
-                "hardwareProfile": {
-                    "vmSize": "[parameters('clientVmSize')]"
-                },
-                "osProfile": {
-                    "computerName": "[concat(parameters('vmNamePrefix'), 'client', copyIndex())]",
-                    "adminUserName": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPassword')]",
-                    "linuxConfiguration": "[variables('linuxConfiguration')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "[variables('imagePublisher')]",
-                        "offer": "[variables('imageOffer')]",
-                        "sku": "[parameters('imageSku')]",
-                        "version": "latest"
-                    },
-                    "osDisk": {
-                        "name": "osdisk",
-                        "vhd": {
-                            "uri": "[concat('http://', parameters('storageAccountPrefix'), '.blob.core.windows.net/vhds-client/', concat(parameters('vmNamePrefix'),'client',copyIndex()), '-osdisk.vhd')]"
-                        },
-                        "caching": "ReadWrite",
-                        "createOption": "FromImage"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('vmNamePrefix'), 'client', copyIndex()))]"
-                        }
-                    ]
-                }
-            }
-        },
-        {
-            "apiVersion": "2015-06-15",
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(parameters('vmNamePrefix'), 'client', copyIndex(), '/init')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('vmNamePrefix'),'client',copyIndex()))]"
-            ],
-            "copy": {
-                "name": "clientExtensionsCopy",
-                "count": "[parameters('clientCount')]"
-            },
-            "properties": {
-                "publisher": "Microsoft.OSTCExtensions",
-                "type": "CustomScriptForLinux",
-                "typeHandlerVersion": "1.3",
-                "settings": {
-                    "fileUris": [
-                        "[variables('scriptUrlLustreClient')]"
-                    ],
-                    "commandToExecute": "[concat('bash lustre_client.sh', ' -n CLIENTCENTOS', parameters('imageSku'), ' -i ', copyIndex(), ' -d 0', ' -m ', parameters('mgsIpAddress'), ' -l ', reference(resourceId('Microsoft.Network/networkInterfaces', concat(parameters('vmNamePrefix'), 'client', copyIndex()))).ipConfigurations[0].properties.privateIPAddress, ' -f ', parameters('filesystemName'))]"
-                }
-            }
-        }
-    ],
-    "outputs": {
-        "client0DomainName": {
-            "type": "string",
-            "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',concat(parameters('vmNamePrefix'),'client0'))).dnsSettings.fqdn]",
-            "metadata": {
-                "description": "SSH to the client0 node using this public IP address and run command mount to see all mount points"
-            }
-        }
+    "image": {
+      "type": "string",
+      "defaultValue": "OpenLogic:CentOS-HPC:7.1",
+      "allowedValues": [
+        "OpenLogic:CentOS-HPC:7.1",
+		"OpenLogic:CentOS-HPC:6.5",
+        "OpenLogic:CentOS:6.6",
+        "OpenLogic:CentOS:7.0"
+      ],
+      "metadata": {
+        "description": "OpenLogic CentOS version to use. CentOS-HPC includes RDMA drivers for compute-to-compute MPI InfiniBand on A8 and A9 VM sizes."
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Admin username for the virtual machines"
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "password",
+      "allowedValues": [
+        "password",
+        "sshPublicKey"
+      ],
+      "metadata": {
+        "description": "Authentication type for the virtual machines"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Admin password for the virtual machines"
+      }
+    },
+    "sshPublicKey": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "SSH public key that will be included on all nodes. The OpenSSH public key can be generated with tools like ssh-keygen on Linux or OS X."
+      }
+    },
+    "dnsNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Globally unique DNS name prefix name must be between 3 and 50 characters long and can contain only dashes, numbers, and lowercase letters. The domain name suffix (e.g. westus.cloudapp.zure.com) will be automatically updated based on the selected location."
+      }
+    },
+    "clientAvailabilitySetName": {
+      "type": "string",
+      "defaultValue": "availset-lustre-clients",
+      "metadata": {
+        "description": "Lustre clients availability set name is important for grouping clients into deployments that can communicate with each other via RDMA"
+      }
+    },
+    "vmNamePrefix": {
+      "type": "string",
+      "defaultValue": "lustre",
+      "metadata": {
+        "description": "Prefix for the virtual machine names"
+      }
+    },
+    "clientVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2_v2",
+      "metadata": {
+        "description": "Size of the Lustre client VM"
+      },
+      "allowedValues": [
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14",
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_D5_v2",
+        "Standard_D11_v2",
+        "Standard_D12_v2",
+        "Standard_D13_v2",
+        "Standard_D14_v2",
+        "Standard_D15_v2",
+        "Standard_DS2",
+        "Standard_DS3",
+        "Standard_DS4",
+        "Standard_DS11",
+        "Standard_DS12",
+        "Standard_DS13",
+        "Standard_DS14",
+        "Standard_DS2_v2",
+        "Standard_DS3_v2",
+        "Standard_DS4_v2",
+        "Standard_DS5_v2",
+        "Standard_DS11_v2",
+        "Standard_DS12_v2",
+        "Standard_DS13_v2",
+        "Standard_DS14_v2",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14",
+        "Standard_G1",
+        "Standard_G2",
+        "Standard_G3",
+        "Standard_G4",
+        "Standard_G5",
+        "Standard_GS1",
+        "Standard_GS2",
+        "Standard_GS3",
+        "Standard_GS4",
+        "Standard_GS5",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11",
+        "Standard_A1",
+        "Standard_D1",
+        "Standard_D1_v2",
+        "Standard_DS1",
+        "Standard_DS1_v2"
+      ]
+    },
+    "clientCount": {
+      "type": "int",
+      "defaultValue": 2,
+      "allowedValues": [ 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50 ],
+      "metadata": {
+        "description": "Number of Lustre clients"
+      }
+    },
+    "filesystemName": {
+      "type": "string",
+      "defaultValue": "scratch",
+      "metadata": {
+        "description": "Name of the Lustre filesystem exposed by the Lustre MGS node"
+      }
+    },
+    "mgsIpAddress": {
+      "type": "string",
+      "defaultValue": "10.1.0.4",
+      "metadata": {
+        "description": "IP address of the Lustre MGS node"
+      }
+    },
+    "storageAccountPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Storage account prefix that will be used to create storage accounts for Lustre nodes"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Storage account type (e.g. Premium_LRS or Standard_LRS). Make sure to select Premium_LRS only when using DS-series or GS-series Virtual Machines."
+      }
+    },
+    "existingVnetResourceGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "Existing Virtual Network Resource Group where Lustre servers are deployed"
+      }
+    },
+    "existingVnetName": {
+      "type": "string",
+      "defaultValue": "vnet-lustre",
+      "metadata": {
+        "description": "Existing Virtual Network name (e.g. vnet-lustre)"
+      }
+    },
+    "existingSubnetClientsName": {
+      "type": "string",
+      "defaultValue": "subnet-lustre-clients",
+      "metadata": {
+        "description": "Lustre clients will be deployed into this subnet within the existing Virtual Network"
+      }
     }
+  },
+  "variables": {
+    "imageReference_OpenLogic:CentOS-HPC:7.1": {
+      "publisher": "OpenLogic",
+      "offer": "CentOS-HPC",
+      "sku": "7.1",
+      "version": "latest"
+    },
+	"imageReference_OpenLogic:CentOS-HPC:6.5": {
+      "publisher": "OpenLogic",
+      "offer": "CentOS-HPC",
+      "sku": "6.5",
+      "version": "latest"
+    },
+    "imageReference_OpenLogic:CentOS:7.0": {
+      "publisher": "OpenLogic",
+      "offer": "CentOS",
+      "sku": "7.0",
+      "version": "latest"
+    },
+    "imageReference_OpenLogic:CentOS:6.6": {
+      "publisher": "OpenLogic",
+      "offer": "CentOS",
+      "sku": "6.6",
+      "version": "latest"
+    },
+    "imageReference": "[variables(concat('imageReference_',parameters('image')))]",
+    "clientAvailabilitySetSettings": {
+      "name": "[concat(parameters('clientAvailabilitySetName'))]",
+      "faultDomainCount": "3",
+      "updateDomainCount": "5"
+    },
+    "baseUrl": "[concat(parameters('artifactsBaseUrl'),'/')]",
+    "vnetID": "[resourceId(parameters('existingVnetResourceGroupName'), 'Microsoft.Network/virtualNetworks', parameters('existingVnetName'))]",
+    "subnetClientsID": "[concat(variables('vnetID'), '/subnets/', parameters('existingSubnetClientsName'))]",
+    "scriptUrlLustreClient": "[concat(variables('baseUrl'),'lustre_client.sh')]",
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+    "linuxConfiguration_sshPublicKey": {
+      "disablePasswordAuthentication": "true",
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[variables('sshKeyPath')]",
+            "keyData": "[parameters('sshPublicKey')]"
+          }
+        ]
+      }
+    },
+    "linuxConfiguration_password": { },
+    "linuxConfiguration": "[variables(concat('linuxConfiguration_',parameters('authenticationType')))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[concat(parameters('storageAccountPrefix'))]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "accountType": "[parameters('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[variables('clientAvailabilitySetSettings').name]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "platformFaultDomainCount": "[variables('clientAvailabilitySetSettings').faultDomainCount]",
+        "platformUpdateDomainCount": "[variables('clientAvailabilitySetSettings').updateDomainCount]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(parameters('vmNamePrefix'),'client0')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "idleTimeoutInMinutes": 4,
+        "dnsSettings": {
+          "domainNameLabel": "[concat(parameters('dnsNamePrefix'),'')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(parameters('vmNamePrefix'), 'client0')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('vmNamePrefix'), 'client0')]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ip1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(parameters('vmNamePrefix'), 'client0'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetClientsID')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(parameters('vmNamePrefix'), 'client', copyIndex(1))]",
+      "location": "[parameters('location')]",
+      "copy": {
+        "name": "clientNicCopy",
+        "count": "[sub(parameters('clientCount'),1)]"
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ip1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetClientsID')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('vmNamePrefix'), 'client', copyIndex())]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountPrefix'))]",
+        "[concat('Microsoft.Compute/availabilitySets/', variables('clientAvailabilitySetSettings').name)]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('vmNamePrefix'), 'client', copyIndex())]"
+      ],
+      "copy": {
+        "name": "clientVmCopy",
+        "count": "[parameters('clientCount')]"
+      },
+      "tags": {
+        "LustreType": "client"
+      },
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('clientAvailabilitySetSettings').name)]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('clientVmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('vmNamePrefix'), 'client', copyIndex())]",
+          "adminUserName": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "linuxConfiguration": "[variables('linuxConfiguration')]"
+        },
+        "storageProfile": {
+          "imageReference": "[variables('imageReference')]",
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', parameters('storageAccountPrefix'), '.blob.core.windows.net/vhds-client/', concat(parameters('vmNamePrefix'),'client',copyIndex()), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(parameters('vmNamePrefix'), 'client', copyIndex()))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmNamePrefix'), 'client', copyIndex(), '/init')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('vmNamePrefix'),'client',copyIndex()))]"
+      ],
+      "copy": {
+        "name": "clientExtensionsCopy",
+        "count": "[parameters('clientCount')]"
+      },
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.5",
+        "settings": {
+          "fileUris": [
+            "[variables('scriptUrlLustreClient')]"
+          ],
+          "commandToExecute": "[concat('bash lustre_client.sh', ' -n ', parameters('image'), ' -i ', copyIndex(), ' -d 0', ' -m ', parameters('mgsIpAddress'), ' -l ', reference(resourceId('Microsoft.Network/networkInterfaces', concat(parameters('vmNamePrefix'), 'client', copyIndex()))).ipConfigurations[0].properties.privateIPAddress, ' -f ', parameters('filesystemName'))]"
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "client0DomainName": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',concat(parameters('vmNamePrefix'),'client0'))).dnsSettings.fqdn]",
+      "metadata": {
+        "description": "SSH to the client0 node using this public IP address and run command mount to see all mount points"
+      }
+    }
+  }
 }

--- a/intel-lustre-clients-on-centos/lustre_client.sh
+++ b/intel-lustre-clients-on-centos/lustre_client.sh
@@ -187,6 +187,102 @@ install_lustre_centos70()
 	sed "/\[openlogic\]/a ${exclude}" -i /etc/yum.repos.d/OpenLogic.repo
 }
 
+install_lustre_centos_hpc_65()
+{
+	# Install wget and dstat
+	yum install -y wget dstat
+
+	# Install pdsh since it is convenient for managing multiple client hosts later
+	# RHEL/CentOS 6 64-Bit ##
+	wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+	rpm -ivh epel-release-6-8.noarch.rpm
+	yum install -y pdsh
+	
+	# Download stable Lustre client source targeting specific CentOS 6.5 kernel
+	# This code will be used to create the RPM for the currently running kernel
+	wget https://downloads.hpdd.intel.com/public/lustre/lustre-2.7.0/el6/client/SRPMS/lustre-client-2.7.0-2.6.32_504.8.1.el6.x86_64.src.rpm
+	
+	# Download current kernel-devel package from CentOS vault
+	wget --tries 10 --retry-connrefused --waitretry 15 http://vault.centos.org/6.5/updates/x86_64/Packages/kernel-devel-$(uname -r).rpm
+	if [ ! -f  kernel-devel-$(uname -r).rpm ]; then
+		# Try /os/
+		wget --tries 10 --retry-connrefused --waitretry 15 http://vault.centos.org/6.5/os/x86_64/Packages/kernel-devel-$(uname -r).rpm
+	fi
+	
+	# Un-exclude kernel updates in /etc/yum.conf
+	sed "s/exclude=/#exclude=/g" -i /etc/yum.conf
+	
+	# Install the downloaded kernel-devel package that is needed to recompile the Lustre client modules
+	yum --nogpgcheck localinstall -y kernel-devel-$(uname -r).rpm
+	
+	# Install the other packages necessary to recompile the Lustre client
+	# Documentation is here https://wiki.hpdd.intel.com/display/PUB/Rebuilding+the+Lustre-client+rpms+for+a+new+kernel
+	yum install -y rpm-build make libtool libselinux-devel
+	
+	# Rebuild the downloaded Lustre client RPM for the currently running kernel
+	rpmbuild --define "_topdir /root/rpmbuild" --rebuild --without servers lustre-client-2.7.0-2.6.32_504.8.1.el6.x86_64.src.rpm
+	
+	# Install the compiled RPM whose file names are based on the currently running kernel but with - replaced by _ (e.g. )
+	cd /root/rpmbuild/RPMS/x86_64/
+	yum --nogpgcheck localinstall -y lustre-client-2.7.0-$(uname -r | sed 's/-/_/').x86_64.rpm lustre-client-modules-2.7.0-$(uname -r | sed 's/-/_/').x86_64.rpm
+
+	modprobe lustre
+	
+	# To prevent the current kernel from being updated, add the following exclude line to [base] and [updates] in CentOS-Base.repo
+	exclude="exclude = kernel kernel-headers kernel-devel kernel-debug-devel"
+	sed "/\[base\]/a ${exclude}" -i /etc/yum.repos.d/CentOS-Base.repo
+	sed "/\[updates\]/a ${exclude}" -i /etc/yum.repos.d/CentOS-Base.repo
+	sed "/\[openlogic\]/a ${exclude}" -i /etc/yum.repos.d/OpenLogic.repo
+	
+	# Again exclude kernel updates in /etc/yum.conf
+	sed "s/#exclude=/exclude=/g" -i /etc/yum.conf
+}
+
+install_lustre_centos_hpc_71()
+{
+	# Install wget and dstat
+	yum install -y wget dstat
+	
+	# Download stable Lustre client source targeting specific CentOS 7.0 kernel
+	# This code will be used to create the RPM for the currently running kernel
+	wget https://downloads.hpdd.intel.com/public/lustre/lustre-2.7.0/el7/client/SRPMS/lustre-client-2.7.0-3.10.0_123.20.1.el7.x86_64.src.rpm
+	
+	# Download current kernel-devel package from CentOS vault
+	wget --tries 10 --retry-connrefused --waitretry 15 http://vault.centos.org/7.1.1503/updates/x86_64/Packages/kernel-devel-$(uname -r).rpm
+	if [ ! -f  kernel-devel-$(uname -r).rpm ]; then
+		# Try /os/
+		wget --tries 10 --retry-connrefused --waitretry 15 http://vault.centos.org/7.1.1503/os/x86_64/Packages/kernel-devel-$(uname -r).rpm
+	fi
+	
+	# Un-exclude kernel updates in /etc/yum.conf
+	sed "s/exclude=/#exclude=/g" -i /etc/yum.conf
+	
+	# Install the downloaded kernel-devel package that is needed to recompile the Lustre client modules
+	yum --nogpgcheck localinstall -y kernel-devel-$(uname -r).rpm
+	
+	# Install the other packages necessary to recompile the Lustre client
+	# Documentation is here https://wiki.hpdd.intel.com/display/PUB/Rebuilding+the+Lustre-client+rpms+for+a+new+kernel
+	yum install -y rpm-build make libtool libselinux-devel
+	
+	# Rebuild the downloaded Lustre client RPM for the currently running kernel
+	rpmbuild --define "_topdir /root/rpmbuild" --rebuild --without servers lustre-client-2.7.0-3.10.0_123.20.1.el7.x86_64.src.rpm
+	
+	# Install the compiled RPM whose file names are based on the currently running kernel but with - replaced by _ (e.g. )
+	cd /root/rpmbuild/RPMS/x86_64/
+	yum --nogpgcheck localinstall -y lustre-client-2.7.0-$(uname -r | sed 's/-/_/').x86_64.rpm lustre-client-modules-2.7.0-$(uname -r | sed 's/-/_/').x86_64.rpm
+
+	modprobe lustre
+	
+	# To prevent the current kernel from being updated, add the following exclude line to [base] and [updates] in CentOS-Base.repo
+	exclude="exclude = kernel kernel-headers kernel-devel kernel-debug-devel"
+	sed "/\[base\]/a ${exclude}" -i /etc/yum.repos.d/CentOS-Base.repo
+	sed "/\[updates\]/a ${exclude}" -i /etc/yum.repos.d/CentOS-Base.repo
+	sed "/\[openlogic\]/a ${exclude}" -i /etc/yum.repos.d/OpenLogic.repo
+	
+	# Again exclude kernel updates in /etc/yum.conf
+	sed "s/#exclude=/exclude=/g" -i /etc/yum.conf
+}
+
 create_client() {
 	log "Create Lustre CLIENT"
 	
@@ -213,12 +309,22 @@ create_client() {
 	lfs df -h
 }
 
-if [ "$NODETYPE" == "CLIENTCENTOS6.6" ]; then
+if [ "$NODETYPE" == "OpenLogic:CentOS:6.6" ]; then
 	install_lustre_centos66
 	create_client
 fi
 
-if [ "$NODETYPE" == "CLIENTCENTOS7.0" ]; then
+if [ "$NODETYPE" == "OpenLogic:CentOS:7.0" ]; then
 	install_lustre_centos70
+	create_client
+fi
+
+if [ "$NODETYPE" == "OpenLogic:CentOS-HPC:6.5" ]; then
+	install_lustre_centos_hpc_65
+	create_client
+fi
+
+if [ "$NODETYPE" == "OpenLogic:CentOS-HPC:7.1" ]; then
+	install_lustre_centos_hpc_71
 	create_client
 fi


### PR DESCRIPTION
### Changelog
* Refactor azuredeploy.json to support additional image reference types: OpenLogic:CentOS-HPC:7.1, OpenLogic:CentOS-HPC:6.5
* Add install_lustre_centos_hpc_65 and install_lustre_centos_hpc_71 functions to lustre_client.sh to compile the Lustre 2.7.0 clients on the appropriate kernel.

### Description of the change
Add support for new Azure Gallery CentOS images (6.5 and 7.1) that include Intel MPI libraries for HPC. These CentOS-HPC images include RDMA drivers for compute-to-compute MPI InfiniBand on A8 and A9 VM sizes.
