### PR TITLE
Update Zookeeper Template to 3.4.8 - fix broken template

### DIFF
--- a/zookeeper-cluster-ubuntu-vm/azuredeploy.json
+++ b/zookeeper-cluster-ubuntu-vm/azuredeploy.json
@@ -92,7 +92,7 @@
     "subnet1Prefix": "10.0.0.0/24",
     "nicName": "zookeeperNIC",
     "subnet1Ref": "[concat(variables('vnetID'),'/subnets/', variables('subnet1Name'))]",
-    "customScriptFilePath": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/zookeeper-cluster-ubuntu-vm/zookeeper.sh",
+    "customScriptFilePath": "https://raw.githubusercontent.com/ggalow/azure-quickstart-templates/master/zookeeper-cluster-ubuntu-vm/zookeeper.sh",
     "customScriptCommandToExecute": "sh zookeeper.sh ",
     "vmExtensionName": "zookeeperExtension"
   },

--- a/zookeeper-cluster-ubuntu-vm/azuredeploy.json
+++ b/zookeeper-cluster-ubuntu-vm/azuredeploy.json
@@ -92,7 +92,7 @@
     "subnet1Prefix": "10.0.0.0/24",
     "nicName": "zookeeperNIC",
     "subnet1Ref": "[concat(variables('vnetID'),'/subnets/', variables('subnet1Name'))]",
-    "customScriptFilePath": "https://raw.githubusercontent.com/ggalow/azure-quickstart-templates/master/zookeeper-cluster-ubuntu-vm/zookeeper.sh",
+    "customScriptFilePath": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/zookeeper-cluster-ubuntu-vm/zookeeper.sh",
     "customScriptCommandToExecute": "sh zookeeper.sh ",
     "vmExtensionName": "zookeeperExtension"
   },

--- a/zookeeper-cluster-ubuntu-vm/zookeeper.sh
+++ b/zookeeper-cluster-ubuntu-vm/zookeeper.sh
@@ -12,22 +12,22 @@ chmod a+x /usr/bin/javaws
 
 cd /usr/local
 
-wget "http://mirrors.ukfast.co.uk/sites/ftp.apache.org/zookeeper/stable/zookeeper-3.4.6.tar.gz"
-tar -xvf "zookeeper-3.4.6.tar.gz"
+wget "http://mirrors.ukfast.co.uk/sites/ftp.apache.org/zookeeper/stable/zookeeper-3.4.8.tar.gz"
+tar -xvf "zookeeper-3.4.8.tar.gz"
 
-touch zookeeper-3.4.6/conf/zoo.cfg
+touch zookeeper-3.4.8/conf/zoo.cfg
 
-echo "tickTime=2000" >> zookeeper-3.4.6/conf/zoo.cfg
-echo "dataDir=/var/lib/zookeeper" >> zookeeper-3.4.6/conf/zoo.cfg
-echo "clientPort=2181" >> zookeeper-3.4.6/conf/zoo.cfg
-echo "initLimit=5" >> zookeeper-3.4.6/conf/zoo.cfg
-echo "syncLimit=2" >> zookeeper-3.4.6/conf/zoo.cfg
-echo "server.1=10.0.0.4:2888:3888" >> zookeeper-3.4.6/conf/zoo.cfg
-echo "server.2=10.0.0.5:2888:3888" >> zookeeper-3.4.6/conf/zoo.cfg
-echo "server.3=10.0.0.6:2888:3888" >> zookeeper-3.4.6/conf/zoo.cfg
+echo "tickTime=2000" >> zookeeper-3.4.8/conf/zoo.cfg
+echo "dataDir=/var/lib/zookeeper" >> zookeeper-3.4.8/conf/zoo.cfg
+echo "clientPort=2181" >> zookeeper-3.4.8/conf/zoo.cfg
+echo "initLimit=5" >> zookeeper-3.4.8/conf/zoo.cfg
+echo "syncLimit=2" >> zookeeper-3.4.8/conf/zoo.cfg
+echo "server.1=10.0.0.4:2888:3888" >> zookeeper-3.4.8/conf/zoo.cfg
+echo "server.2=10.0.0.5:2888:3888" >> zookeeper-3.4.8/conf/zoo.cfg
+echo "server.3=10.0.0.6:2888:3888" >> zookeeper-3.4.8/conf/zoo.cfg
 
 mkdir -p /var/lib/zookeeper
 
 echo $(($1+1)) >> /var/lib/zookeeper/myid
 
-zookeeper-3.4.6/bin/zkServer.sh start
+zookeeper-3.4.8/bin/zkServer.sh start


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Update Zookeeper binaries from 3.4.6 to 3.4.8
* Fix broken Zookeeper binary path

### Description of the change
Latest Stable Zookeeper is 3.4.8. 3.4.6 was no longer in the path meaning the template would always fail.