### PR TITLE
Remove resource reference to allow quota check

### DIFF
--- a/cloudera-on-centos/azuredeploy.json
+++ b/cloudera-on-centos/azuredeploy.json
@@ -285,7 +285,7 @@
       "vnetNewOrExisting": "[parameters('vnetNewOrExisting')]",
       "virtualNetworkSubnetName": "[parameters('subnetName')]"
     },
-+    "VNetId": "[resourceId(variables('networkSpec').virtualNetworkRGName,concat('Microsoft.Network','/','virtualNetworks'),variables('networkSpec').virtualNetworkName)]"
+    "VNetId": "[resourceId(variables('networkSpec').virtualNetworkRGName,concat('Microsoft.Network','/','virtualNetworks'),variables('networkSpec').virtualNetworkName)]"
   },
   "resources": [
     {

--- a/cloudera-on-centos/azuredeploy.json
+++ b/cloudera-on-centos/azuredeploy.json
@@ -91,7 +91,7 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Resource Group Name for Vnet. For new VNet, use the same resource group for the cluster. O stherwise, type in existing resource group name"
+        "description": "Resource Group Name for Vnet. For new VNet leave it empty, otherwise type in existing resource group name"
       }
     },
     "subnetName": {
@@ -284,7 +284,8 @@
       "virtualNetworkRGName":"[parameters('virtualNetworkRGName')]",
       "vnetNewOrExisting": "[parameters('vnetNewOrExisting')]",
       "virtualNetworkSubnetName": "[parameters('subnetName')]"
-    }
+    },
++    "VNetId": "[resourceId(variables('networkSpec').virtualNetworkRGName,concat('Microsoft.Network','/','virtualNetworks'),variables('networkSpec').virtualNetworkName)]"
   },
   "resources": [
     {
@@ -331,7 +332,7 @@
         },
         "parameters": {
           "vnetID":{
-            "value":"[reference('Microsoft.Resources/deployments/shared-resources', '2015-01-01').outputs.vnetIDRef.value]"
+            "value":"[variables('VNetId')]"
           },
           "resourceAPIVersion":{
             "value":"[variables('resourceAPIVersion')]"
@@ -378,7 +379,7 @@
         },
         "parameters": {
           "vnetID":{
-            "value":"[reference('Microsoft.Resources/deployments/shared-resources', '2015-01-01').outputs.vnetIDRef.value]"
+            "value":"[variables('VNetId')]"
           },
           "resourceAPIVersion":{
             "value":"[variables('resourceAPIVersion')]"

--- a/cloudera-on-centos/ds13.json
+++ b/cloudera-on-centos/ds13.json
@@ -91,7 +91,7 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-        "description": "Resource Group Name for Vnet. For new VNet, use the same resource group for the cluster. O otherwise, type in existing resource group name"
+        "description": "Resource Group Name for Vnet. For new VNet leave it empty, otherwise type in existing resource group name"
       }
     },
     "subnetName": {
@@ -284,7 +284,8 @@
       "virtualNetworkRGName":"[parameters('virtualNetworkRGName')]",
       "vnetNewOrExisting": "[parameters('vnetNewOrExisting')]",
       "virtualNetworkSubnetName": "[parameters('subnetName')]"
-    }
+    },
+    "VNetId": "[resourceId(variables('networkSpec').virtualNetworkRGName,concat('Microsoft.Network','/','virtualNetworks'),variables('networkSpec').virtualNetworkName)]"
   },
   "resources": [
     {
@@ -331,7 +332,7 @@
         },
         "parameters": {
           "vnetID":{
-            "value":"[reference('Microsoft.Resources/deployments/shared-resources', '2015-01-01').outputs.vnetIDRef.value]"
+            "value":"[variables('VNetId')]"
           },
           "resourceAPIVersion":{
             "value":"[variables('resourceAPIVersion')]"
@@ -378,7 +379,7 @@
         },
         "parameters": {
           "vnetID":{
-            "value":"[reference('Microsoft.Resources/deployments/shared-resources', '2015-01-01').outputs.vnetIDRef.value]"
+            "value":"[variables('VNetId')]"
           },
           "resourceAPIVersion":{
             "value":"[variables('resourceAPIVersion')]"

--- a/cloudera-on-centos/shared-resources-existing-vnet.json
+++ b/cloudera-on-centos/shared-resources-existing-vnet.json
@@ -240,11 +240,5 @@
         ]
       }
     }
-  ],
-  "outputs": {
-    "vnetIDRef": {
-      "value": "[resourceId(parameters('networkSpec').virtualNetworkRGName,concat('Microsoft.Network','/','virtualNetworks'),parameters('networkSpec').virtualNetworkName)]",
-      "type": "string"
-    }
-  }
+  ]
 }

--- a/cloudera-on-centos/shared-resources-new-vnet.json
+++ b/cloudera-on-centos/shared-resources-new-vnet.json
@@ -267,11 +267,5 @@
         ]
       }
     }
-  ],
-  "outputs": {
-    "vnetIDRef": {
-      "value": "[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('networkSpec').virtualNetworkName)]",
-      "type": "string"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Description of the change
Quota check will may not run if reference is used, therefore, using other way to construct the vnet id to use for deployment.