### PR TITLE
adding strong password generation for bosh quickstart template

### DIFF
--- a/bosh-setup/manifests/bosh.yml
+++ b/bosh-setup/manifests/bosh.yml
@@ -60,18 +60,18 @@ jobs:
     nats:
       address: 127.0.0.1
       user: nats
-      password: nats-password
+      password: REPLACE_WITH_NATS_PASSWORD
 
     redis:
       listen_address: 127.0.0.1
       address: 127.0.0.1
-      password: redis-password
+      password: REPLACE_WITH_REDIS_PASSWORD
 
     postgres: &db
       listen_address: 127.0.0.1
       host: 127.0.0.1
       user: postgres
-      password: postgres-password
+      password: REPLACE_WITH_POSTGRES_PASSWORD
       database: bosh
       adapter: postgres
 
@@ -79,17 +79,17 @@ jobs:
       address: REPLACE_WITH_BOSH_DIRECTOR_IP
       host: REPLACE_WITH_BOSH_DIRECTOR_IP
       db: *db
-      http: {user: admin, password: admin, port: 25777}
+      http: {user: admin, password: REPLACE_WITH_REGISTRY_HTTP_PASSWORD, port: 25777}
       username: admin
-      password: admin
+      password: REPLACE_WITH_REGISTRY_PASSWORD
       port: 25777
 
     blobstore:
       address: REPLACE_WITH_BOSH_DIRECTOR_IP
       port: 25250
       provider: dav
-      director: {user: director, password: director-password}
-      agent: {user: agent, password: agent-password}
+      director: {user: director, password: REPLACE_WITH_DIRECTOR_PASSWORD}
+      agent: {user: agent, password: REPLACE_WITH_AGENT_PASSWORD}
 
     director:
       address: 127.0.0.1
@@ -104,11 +104,11 @@ jobs:
         provider: local
         local:
           users:
-          - {name: admin, password: admin}
-          - {name: hm-user, password: hm-password}
+          - {name: admin, password: REPLACE_WITH_ADMIN_PASSWORD}
+          - {name: hm-user, password: REPLACE_WITH_HM_PASSWORD}
 
     hm:
-      director_account: {user: hm-user, password: hm-password}
+      director_account: {user: hm-user, password: REPLACE_WITH_HM_PASSWORD}
       resurrector_enabled: true
 
     azure: &azure

--- a/bosh-setup/scripts/setup_env
+++ b/bosh-setup/scripts/setup_env
@@ -57,6 +57,27 @@ sed -i "s/CLOUD_FOUNDRY_PUBLIC_IP/cf-ip/g" settings
 cp settings $home_dir
 
 sed -i "s/REPLACE_WITH_BOSH_DIRECOT_IP/$bosh_director_ip/g" deploy_bosh.sh
+
+REPLACE_WITH_REGISTRY_HTTP_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+REPLACE_WITH_POSTGRES_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+REPLACE_WITH_NATS_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+REPLACE_WITH_REDIS_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+REPLACE_WITH_REGISTRY_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+REPLACE_WITH_HM_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+REPLACE_WITH_ADMIN_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+REPLACE_WITH_DIRECTOR_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+REPLACE_WITH_AGENT_PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+
+sed -i "s/REPLACE_WITH_REGISTRY_HTTP_PASSWORD/$REPLACE_WITH_REGISTRY_HTTP_PASSWORD/g" bosh.yml
+sed -i "s/REPLACE_WITH_POSTGRES_PASSWORD/$REPLACE_WITH_POSTGRES_PASSWORD/g" bosh.yml
+sed -i "s/REPLACE_WITH_NATS_PASSWORD/$REPLACE_WITH_NATS_PASSWORD/g" bosh.yml
+sed -i "s/REPLACE_WITH_REDIS_PASSWORD/$REPLACE_WITH_REDIS_PASSWORD/g" bosh.yml
+sed -i "s/REPLACE_WITH_REGISTRY_PASSWORD/$REPLACE_WITH_REGISTRY_PASSWORD/g" bosh.yml
+sed -i "s/REPLACE_WITH_HM_PASSWORD/$REPLACE_WITH_HM_PASSWORD/g" bosh.yml
+sed -i "s/REPLACE_WITH_ADMIN_PASSWORD/$REPLACE_WITH_ADMIN_PASSWORD/g" bosh.yml
+sed -i "s/REPLACE_WITH_DIRECTOR_PASSWORD/$REPLACE_WITH_DIRECTOR_PASSWORD/g" bosh.yml
+sed -i "s/REPLACE_WITH_AGENT_PASSWORD/$REPLACE_WITH_AGENT_PASSWORD/g" bosh.yml
+
 chmod +x deploy_bosh.sh
 cp deploy_bosh.sh $home_dir
 cp bosh.yml $home_dir


### PR DESCRIPTION
### Changelog
* Added tokens in bosh.yml to allow changing during initial setup of environment.
* Added script auto-generator 

### Description of the change
We want to ensure the best security for deployments.  To do this we should not use default passwords in Bosh. This PR fixes issue https://github.com/Azure/azure-quickstart-templates/issues/1860.

