### PR TITLE
V1.4.2

### DIFF
--- a/bosh-setup/README.md
+++ b/bosh-setup/README.md
@@ -18,6 +18,12 @@ We look forward to hearing your feedback and suggestions!
 ```
 Template Changelog
 
+# v1.4.2 (2016-05-06)
+
+- Upgrade versions
+  - Upgrade bosh version to 256.2
+- Remove redis from bosh.yml as of bosh v256+
+
 # v1.4.1 (2016-04-28)
 
 - Add a retry for apt-get update

--- a/bosh-setup/azuredeploy.json
+++ b/bosh-setup/azuredeploy.json
@@ -126,8 +126,8 @@
 
     "environmentAzureCloud": {
       "serviceHostBase": "core.windows.net",
-      "boshReleaseUrl": "https://bosh.io/d/github.com/cloudfoundry/bosh?v=255.3",
-      "boshReleaseSha1": "1a3d61f968b9719d9afbd160a02930c464958bf4",
+      "boshReleaseUrl": "https://bosh.io/d/github.com/cloudfoundry/bosh?v=256.2",
+      "boshReleaseSha1": "ff2f4e16e02f66b31c595196052a809100cfd5a8",
       "boshAzureCPIReleaseUrl": "https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-azure-cpi-release?v=10",
       "boshAzureCPIReleaseSha1": "48725899f8b3f0f625bdb3bcff97bc0d6bf193e1",
       "stemcellUrl": "https://bosh.io/d/stemcells/bosh-azure-hyperv-ubuntu-trusty-go_agent?v=3169",
@@ -137,8 +137,8 @@
     },
     "environmentAzureChinaCloud": {
       "serviceHostBase": "core.chinacloudapi.cn",
-      "boshReleaseUrl": "[uri(variables('baseUriAzureChinaCloud'), 'releases/bosh-255.3.tgz')]",
-      "boshReleaseSha1": "1a3d61f968b9719d9afbd160a02930c464958bf4",
+      "boshReleaseUrl": "[uri(variables('baseUriAzureChinaCloud'), 'releases/bosh-256.2.tgz')]",
+      "boshReleaseSha1": "ff2f4e16e02f66b31c595196052a809100cfd5a8",
       "boshAzureCPIReleaseUrl": "[uri(variables('baseUriAzureChinaCloud'), 'releases/bosh-azure-cpi-release-10.tgz')]",
       "boshAzureCPIReleaseSha1": "48725899f8b3f0f625bdb3bcff97bc0d6bf193e1",
       "stemcellUrl": "[uri(variables('baseUriAzureChinaCloud'), 'stemcells/bosh-stemcell-3169-azure-hyperv-ubuntu-trusty-go_agent.tgz')]",

--- a/bosh-setup/manifests/bosh.yml
+++ b/bosh-setup/manifests/bosh.yml
@@ -40,7 +40,6 @@ jobs:
 - name: bosh
   templates:
   - {name: nats, release: bosh}
-  - {name: redis, release: bosh}
   - {name: postgres, release: bosh}
   - {name: blobstore, release: bosh}
   - {name: director, release: bosh}
@@ -61,11 +60,6 @@ jobs:
       address: 127.0.0.1
       user: nats
       password: nats-password
-
-    redis:
-      listen_address: 127.0.0.1
-      address: 127.0.0.1
-      password: redis-password
 
     postgres: &db
       listen_address: 127.0.0.1

--- a/bosh-setup/metadata.json
+++ b/bosh-setup/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template helps you setup a development environment where you can delpoy BOSH and Cloud Foundy.",
   "summary": "This template helps you setup a development environment where you can delpoy BOSH and Cloud Foundry.",
   "githubUsername": "bingosummer",
-  "dateUpdated": "2016-04-28"
+  "dateUpdated": "2016-05-06"
 }


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Upgrade bosh version to 256.2
* redis was removed as of v256+

### Description of the change

In the latest version 256+ of BOSH, redis is not needed.