### PR TITLE
Change Max count for agents

### DIFF
--- a/101-acs-dcos/azuredeploy.json
+++ b/101-acs-dcos/azuredeploy.json
@@ -15,7 +15,7 @@
         "description": "The number of agents for the cluster.  This value can be from 1 to 40 (note, for DC/OS clusters you will also get 1 or 2 public agents in addition to these seleted masters)"
       },
       "minValue":1,
-      "maxValue":100
+      "maxValue":40
     },
     "agentVMSize": {
       "type": "string",


### PR DESCRIPTION


### Changelog
* change the max number of agents for a dc/os cluster

### Description of the change
If DC/OS would go just up to 40 the max value should be 40 not 100