### PR TITLE
Remove default values

### DIFF
--- a/service-fabric-unsecure-cluster-5-node-1-nodetype/azuredeploy.json
+++ b/service-fabric-unsecure-cluster-5-node-1-nodetype/azuredeploy.json
@@ -4,7 +4,6 @@
   "parameters": {
     "clusterName": {
       "type": "string",
-      "defaultValue": "Cluster",
       "metadata": {
         "description": "Name of your cluster - Between 3 and 23 characters. Letters and numbers only"
       }
@@ -25,7 +24,6 @@
     },
     "adminUserName": {
       "type": "string",
-      "defaultValue": "testadm",
       "metadata": {
         "description": "Remote desktop user Id"
       }


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
*
*
*
*
*

### Description of the change
Removing default values for clusterName and adminUserName properties so that users don't accidentally deploy a cluster with the wrong name or with a username they did not intend.