### PR TITLE
Remove default values

### DIFF
--- a/service-fabric-secure-cluster-5-node-1-nodetype-wad/azuredeploy.json
+++ b/service-fabric-secure-cluster-5-node-1-nodetype-wad/azuredeploy.json
@@ -4,7 +4,6 @@
   "parameters": {
     "clusterName": {
       "type": "string",
-      "defaultValue": "Cluster",
       "metadata": {
         "description": "Name of your cluster - Between 3 and 23 characters. Letters and numbers only"
       }
@@ -25,7 +24,6 @@
     },
     "adminUserName": {
       "type": "string",
-      "defaultValue": "testadm",
       "metadata": {
         "description": "Remote desktop user Id"
       }


### PR DESCRIPTION
### Description of the change
Removing default values for clusterName and adminUserName so users don't accidentally create clusters with default values.