### PR TITLE
Removing pre-populated username and password

### DIFF
--- a/service-fabric-secure-cluster-5-node-1-nodetype-wad/azuredeploy.parameters.json
+++ b/service-fabric-secure-cluster-5-node-1-nodetype-wad/azuredeploy.parameters.json
@@ -12,10 +12,10 @@
       "value": 19080
     },
     "adminUserName": {
-      "value": "admuser"
+      "value": ""
     },
     "adminPassword": {
-      "value": "Password!1"
+      "value": ""
     },
     "loadBalancedAppPort1": {
       "value": 80


### PR DESCRIPTION

### Description of the change
The pre-populated username and password is a potential security problem if the cluster is created using those values.