### PR TITLE
remove invalid parameter 'location'

### DIFF
--- a/marketplace-samples/simple-windows-vm/mainTemplate.json
+++ b/marketplace-samples/simple-windows-vm/mainTemplate.json
@@ -132,9 +132,6 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "location": {
-            "value": "[resourceGroup().location]"
-          },
           "storageAccountType": {
             "value": "[parameters('storageAccountType')]"
           },
@@ -158,9 +155,6 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "location": {
-            "value": "[resourceGroup().location]"
-          },
           "publicIPAddressName": {
             "value": "[parameters('publicIPAddressName')]"
           },


### PR DESCRIPTION
### Changelog
* remove  'location' in template link parameter

### Description of the change
After commit https://github.com/Azure/azure-quickstart-templates/commit/0f250aedd241e4da239c3be2d84f27aef2f43172 .
We don't need location parameter.

FIX #1959

