### PR TITLE
Passing custom data to a Windows VM such as VM Name, Datacenter Regio…

### DIFF
--- a/101-vm-customdata-windows/README.md
+++ b/101-vm-customdata-windows/README.md
@@ -1,0 +1,7 @@
+# Deploy a Virtual Machine with CustomData
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-vm-customdata-windows%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+This template allows you to create a Virtual Machine and passes in Custom Data. In this template the Virtual Machine Name, The Datacenter Region and the Fully Qualified DNS Name, FQDN will be passed in as Custom Data, but you could tweak it to provide other information to your VM. The information is then accessible from within the VM by reading and parsing the file C:\CustomData\AzureData.bin. Even if information is base64 encoded in the template, the data is automatically decoded and is easily consumed from within scripts or other. This kind of information could be useful if the VM need to be aware about itself or the deployment that created the VM. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.

--- a/101-vm-customdata-windows/azuredeploy.json
+++ b/101-vm-customdata-windows/azuredeploy.json
@@ -1,0 +1,241 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmLocation": {
+      "type": "string",
+      "allowedValues": [
+        "North Europe",
+        "West Europe",
+        "Central US",
+        "East US"
+      ]
+    },
+    "windowsOSVersion": {
+      "type": "string",
+      "allowedValues": [
+        "2008-R2-SP1",
+        "2012-Datacenter",
+        "2012-R2-Datacenter"
+      ],
+      "metadata": {
+        "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of Virtual Machine to create."
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "allowedValues": [
+        "Standard_DS1_v2",
+        "Standard_DS2_v2",
+        "Standard_DS3_v2",
+        "Standard_DS4_v2",
+        "Standard_DS5_v2",
+        "Standard_DS11_v2",
+        "Standard_DS12_v2",
+        "Standard_DS13_v2",
+        "Standard_DS14_v2",
+        "Standard_DS15_v2"
+      ]
+    },
+    "adminUsername": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Admin username to be created on the Virtual Machine."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
+    },
+
+    "vnetName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Name of Virtual Network to create or deploy VM to."
+      }
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Address prefix/space for IP addresses inside virtual network."
+      }
+    },
+    "subnetName": {
+      "type": "string",
+      "minLength": 1,
+      "defaultValue": "subnet1"
+    },
+    "subnetAddressPrefix": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "Address prefix for IP addresses inside subnet."
+      }
+    },
+    "fqdnPrefix": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "The combination of fqdnPrefix and vmName will be part of the Fully Qualified Domain Name, FQDN, for this VM and need to be globaly unique. Make sure you chose unique enough vmName and/or fqdnPart"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "minLength": 3,
+      "metadata": {
+        "description": "Globally unique storage account name to use for Virtual Disks"
+      }
+    }
+  },
+  "variables": {
+    "osDiskName": "[concat(parameters('vmName'), 'osdisk')]",
+    "osDiskContainerName": "vhds",
+    "nicName": "[concat(parameters('vmName'), 'nic')]",
+    "pipName": "[concat(parameters('vmName'), 'pip')]",
+    "dnsName": "[concat(parameters('fqdnPrefix'), parameters('vmName'))]",
+    "imagePublisher": "MicrosoftWindowsServer",
+    "imageOffer": "WindowsServer",
+    "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]",
+    "subnetRef": "[concat(variables('vnetId'), '/subnets/', parameters('subnetName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('storageAccountName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[parameters('vmLocation')]",
+      "tags": {
+        "displayName": "StorageAccount"
+      },
+      "properties": {
+        "accountType": "Premium_LRS"
+      }
+    },
+    {
+      "apiVersion": "2016-03-30",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('pipName')]",
+      "location": "[parameters('vmLocation')]",
+      "tags": {
+        "displayName": "PublicIPAddress"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[variables('dnsName')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('vnetName')]",
+      "location": "[parameters('vmLocation')]",
+      "tags": {
+        "displayName": "VirtualNetwork"
+      },
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('vnetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetAddressPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2016-03-30",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[parameters('vmLocation')]",
+      "tags": {
+        "displayName": "NetworkInterface"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('pipName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('pipName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[parameters('vmLocation')]",
+      "tags": {
+        "displayName": "VirtualMachine"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "customData": "[base64(concat(parameters('vmName'), '|', parameters('vmLocation'), '|', reference(variables('pipName')).dnsSettings.fqdn))]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('windowsOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net/', variables('osDiskContainerName'), '/', variables('osDiskName'), '.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/101-vm-customdata-windows/azuredeploy.parameters.json
+++ b/101-vm-customdata-windows/azuredeploy.parameters.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "value": "vmadmin"
+    },
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "vmName": {
+      "value": "vm001"
+    },
+    "vmSize": {
+      "value": "Standard_DS2_v2"
+    },
+    "vmLocation": {
+      "value": "North Europe"
+    },
+    "windowsOSVersion": {
+      "value": "2012-R2-Datacenter"
+    },
+    "vnetName": {
+      "value": "vnet1"
+    },
+    "vnetAddressPrefix": {
+      "value": "10.0.0.0/16"
+    },
+    "subnetAddressPrefix": {
+      "value": "10.0.0.0/24"
+    },
+    "storageAccountName": {
+      "value": "GEN-UNIQUE"
+    },
+      "fqdnPrefix": {
+          "value": "GEN-UNIQUE"
+      }
+  }
+}

--- a/101-vm-customdata-windows/metadata.json
+++ b/101-vm-customdata-windows/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Deploy a Windows Virtual Machine with Custom Data (region, VM name and FQDN) passed in",
+  "description": "This template allows you to create a Virtual Machine and passes in Custom Data. In this template the Virtual Machine Name, The Datacenter Region and the Fully Qualified DNS Name, FQDN will be passed in as Custom Data, but you could tweak it to provide other information to your VM. The information is then accessible from within the VM by reading and parsing the file C:\\CustomData\\AzureData.bin. Even if information is base64 encoded in the template, the data is automatically decoded and is easily consumed from within scripts or other. This kind of information could be useful if the VM need to be aware about itself or the deployment that created the VM. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.",
+  "summary": "Deploy a Windows Virtual Machine with Custom Data (region, VM name and FQDN) passed in",
+  "githubUsername": "krist00fer",
+  "dateUpdated": "2016-05-16"
+}


### PR DESCRIPTION
### Contributing guide

https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md
### Changelog

2016-05-16 New Template
### Description of the change

This template allows you to create a Virtual Machine and passes in Custom Data. In this template the Virtual Machine Name, The Datacenter Region and the Fully Qualified DNS Name, FQDN will be passed in as Custom Data, but you could tweak it to provide other information to your VM. The information is then accessible from within the VM by reading and parsing the file C:\CustomData\AzureData.bin. Even if information is base64 encoded in the template, the data is automatically decoded and is easily consumed from within scripts or other. This kind of information could be useful if the VM need to be aware about itself or the deployment that created the VM. This template also deploys a Storage Account, Virtual Network, Public IP addresses and a Network Interface.
