### PR TITLE
make mdadm raiding more resillient

### DIFF
--- a/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
+++ b/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
@@ -273,9 +273,10 @@ create_striped_volume()
 	done
 
     MDDEVICE=$(get_next_md_device)    
-    
+	sudo udevadm control --stop-exec-queue
 	mdadm --create ${MDDEVICE} --level 0 --raid-devices ${#PARTITIONS[@]} ${PARTITIONS[*]}
-
+	sudo udevadm control --start-exec-queue
+	
 	MOUNTPOINT=$(get_next_mountpoint)
 	echo "Next mount point appears to be ${MOUNTPOINT}"
 	[ -d "${MOUNTPOINT}" ] || mkdir -p "${MOUNTPOINT}"
@@ -297,8 +298,8 @@ create_striped_volume()
 check_mdadm() {
     dpkg -s mdadm >/dev/null 2>&1
     if [ ${?} -ne 0 ]; then
-        apt-get -y update
-        DEBIAN_FRONTEND=noninteractive apt-get -y install mdadm --fix-missing
+        (apt-get -y update || (sleep 15; apt-get -y update)) > /dev/null
+        DEBIAN_FRONTEND=noninteractive sudo apt-get -y install mdadm --fix-missing
     fi
 }
 


### PR DESCRIPTION
This is a PR with two changes that made our disk provisioning more resilient over at https://github.com/elastic/azure-marketplace

The first problem was that quite often `mdadm` was not being installed properly and the command was never available on the machine. We solved this by retrying `apt-get update` and installing mdadm under sudo.

The other thing we saw was that quite often we'd get `resource busy` messages from `mdadm` which caused `mkfs.ext4` to fail and later on in the script the call to `blkid` to not return a UUID for `/dev/md0` which in turn made the call to `add_to_fstab` to be called with no UUID.

In short this caused `/datadisks/disk1` to point to the local `sda` partition `30gb` instead of the attached raided disks (2TB in this particular case).

The cause for this seems to be a race condition and the fix documented here:

http://dev.bizo.com/2012/07/mdadm-device-or-resource-busy.html

Has worked very well on our template.