### PR TITLE
Fix parse port mapping

### DIFF
--- a/docker-parse/azuredeploy.json
+++ b/docker-parse/azuredeploy.json
@@ -255,7 +255,7 @@
             "parse": {
               "image": "felixrieseberg/parse",
               "ports": [
-                "8080:80"
+                "80:8080"
               ],
               "restart": "always"
             }


### PR DESCRIPTION
### Changelog
* Fixed port mapping in docker-parse

### Description of the change
Port mapping was 8080->80 but should be 80->8080 (host->container)