### PR TITLE
Issues 2012 and 2014

### DIFF
--- a/deis-cluster-coreos/README.md
+++ b/deis-cluster-coreos/README.md
@@ -39,13 +39,13 @@ This template allows you to create a Deis cluster. The cluster is made up by thr
 		./deploy-deis.sh -n "[resource group name]" -l "West US" -f ./azuredeploy.json -e ./azuredeploy-parameters.json -c ./cloud-config.yaml
 
 
->**Note:** If you chose to use the "Deploy to Azure" button experience, you'll need to manually encode **cloud-config.yaml** as a Base64 string and enter the encoded string to the **customData** parameter. Although the template can be updated to use the built-in base64() founction, I found the triple-encoding is rather troublesome especially for readability and maintenance.
-
 8. Create load balancer API rule:
 
-        In order to expose the API (port 80) to the network, run the following command:
+      In order to expose the API (port 80) to the network, run the following command:
 
-                azure network lb rule create -g "[resource group name]" -l loadBalancer -n loadBalancerAPIRule -p tcp -f 888 -b 888 -e false -i 10 -a apiProbe
+		azure network lb rule create -g "[resource group name]" -l loadBalancer -n loadBalancerAPIRule -p tcp -f 888 -b 888 -e false -i 10 -a apiProbe
+
+>**Note:** If you chose to use the "Deploy to Azure" button experience, you'll need to manually encode **cloud-config.yaml** as a Base64 string and enter the encoded string to the **customData** parameter. Although the template can be updated to use the built-in base64() founction, I found the triple-encoding is rather troublesome especially for readability and maintenance.
 
 ##Install the client
 You need **deisctl** to control your Deis cluster. *deisctl* is automatically installed in all the cluster nodes. However, it's a good practice to use *deisctl* on a separate administrative machine. Because all nodes are configured with only private IP addresses, you'll need to use an SSH tunnel through the load balancer, which has a public IP, to the node machines. The following are the steps of setting up *deisctl* on a separate machine.

--- a/deis-cluster-coreos/README.md
+++ b/deis-cluster-coreos/README.md
@@ -41,6 +41,12 @@ This template allows you to create a Deis cluster. The cluster is made up by thr
 
 >**Note:** If you chose to use the "Deploy to Azure" button experience, you'll need to manually encode **cloud-config.yaml** as a Base64 string and enter the encoded string to the **customData** parameter. Although the template can be updated to use the built-in base64() founction, I found the triple-encoding is rather troublesome especially for readability and maintenance.
 
+8. Create load balancer API rule:
+
+        In order to expose the API (port 80) to the network, run the following command:
+
+                azure network lb rule create -g "[resource group name]" -l loadBalancer -n loadBalancerAPIRule -p tcp -f 888 -b 888 -e false -i 10 -a apiProbe
+
 ##Install the client
 You need **deisctl** to control your Deis cluster. *deisctl* is automatically installed in all the cluster nodes. However, it's a good practice to use *deisctl* on a separate administrative machine. Because all nodes are configured with only private IP addresses, you'll need to use an SSH tunnel through the load balancer, which has a public IP, to the node machines. The following are the steps of setting up *deisctl* on a separate machine.
 

--- a/deis-cluster-coreos/README.md
+++ b/deis-cluster-coreos/README.md
@@ -1,5 +1,5 @@
 # Deploy a Deis cluster
-
+  
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdeis-cluster-coreos%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>

--- a/deis-cluster-coreos/azuredeploy.json
+++ b/deis-cluster-coreos/azuredeploy.json
@@ -75,6 +75,12 @@
         "description": "Size in GB of the Docker volume."
       },
       "defaultValue": "100"
+    },
+    "coreosVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "Version of CoreOS to deploy."
+      }
     }
   },
   "variables": {
@@ -366,7 +372,7 @@
             "publisher": "[variables('imagePublisher')]",
             "offer": "[variables('imageOffer')]",
             "sku": "[variables('imageSKU')]",
-            "version": "647.2.0"
+            "version": "[parameters('coreosVersion')]"
           },
           "dataDisks": [
             {

--- a/deis-cluster-coreos/azuredeploy.json
+++ b/deis-cluster-coreos/azuredeploy.json
@@ -168,9 +168,6 @@
             "properties": {
               "loadBalancingRules": [
                 {
-                  "id": "[variables('lbAPIRuleID')]"
-                },
-                {
                   "id": "[variables('lbBuilderRuleID')]"
                 }
               ]
@@ -178,28 +175,6 @@
           }
         ],
         "loadBalancingRules": [
-          {
-            "name": "[variables('loadBalancerAPIRuleName')]",
-            "dependsOn": [
-              "[variables('lbIPConfig')]"
-            ],
-            "properties": {
-              "frontendIPConfiguration": {
-                "id": "[variables('lbIPConfig')]"
-              },
-              "backendAddressPool": {
-                "id": "[variables('lbPoolID')]"
-              },
-              "protocol": "TCP",
-              "frontendPort": "80",
-              "backendPort": "80",
-              "enableFloatingIP": false,
-              "idleTimeoutInMinutes": "10",
-              "probe": {
-                "id": "[variables('apiProbeID')]"
-              }
-            }
-          },
           {
             "name": "[variables('loadBalancerBuilderRuleName')]",
             "dependsOn": [

--- a/deis-cluster-coreos/azuredeploy.parameters.json
+++ b/deis-cluster-coreos/azuredeploy.parameters.json
@@ -1,29 +1,33 @@
 {
-  "newStorageAccountName": {
-    "value": "deishbai32"
-  },
-  "publicDomainName": {
-    "value": "deishbai32"
-  },
-  "vmSize": {
-    "value": "Standard_A1"
-  },
-  "adminUsername": {
-    "value": "core"
-  },
-  "sshKeyData": {
-    "value": ""
-  },
-  "customData": {
-    "value": ""
-  },
-  "numberOfNodes": {
-    "value": 3
-  },
-  "dockerVolumeSize": {
-    "value": 100
-  },
-  "coreosVersion": {
-    "value": "899.17.0"
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.1",
+  "parameters": {
+    "newStorageAccountName": {
+      "value": "deishbai32"
+    },
+    "publicDomainName": {
+      "value": "deishbai32"
+    },
+    "vmSize": {
+      "value": "Standard_A1"
+    },
+    "adminUsername": {
+      "value": "core"
+    },
+    "sshKeyData": {
+      "value": ""
+    },
+    "customData": {
+      "value": ""
+    },
+    "numberOfNodes": {
+      "value": 3
+    },
+    "dockerVolumeSize": {
+      "value": 100
+    },
+    "coreosVersion": {
+      "value": "899.17.0"
+    }
   }
 }

--- a/deis-cluster-coreos/azuredeploy.parameters.json
+++ b/deis-cluster-coreos/azuredeploy.parameters.json
@@ -15,10 +15,10 @@
       "value": "core"
     },
     "sshKeyData": {
-      "value": ""
+      "value": "GEN-SSH-PUB-KEY"
     },
     "customData": {
-      "value": ""
+      "value": "GEN-UNIQUE-32"
     },
     "numberOfNodes": {
       "value": 3

--- a/deis-cluster-coreos/azuredeploy.parameters.json
+++ b/deis-cluster-coreos/azuredeploy.parameters.json
@@ -22,5 +22,8 @@
   },
   "dockerVolumeSize": {
     "value": 100
+  },
+  "coreosVersion": {
+    "value": "899.17.0"
   }
 }


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Modified azuredeploy.json to add a coreosVersion parameter (See isue 2012)
* Modified azuredeploy.json to remove the loadBalancerAPIRule (see issue 2014)
* Modified README.md to manually add the loadBalancerAPIRule 
* Modified azuredeploy.parameters.json to have the updated coreosVersion

### Description of the change
Per issue 2012, the "deisctl platform start" command hung on starting the storage service. From the deis repo, it was determined that the problem originated on having a newer version of deis deployed on an older version of CoreOS. azuredeploy.json and azuredeploy.parameters.json were changed to enable updating the deployed version of CoreOS as new versions are released and tested.

Per issue 2014, creating the deployment of the resource group failed due to both load balancer rules using the same TCP port (even though a TCP port was specified in azuredeploy.json). The API rule was removed from azuredeploy.json and the README was updated to include the manual step to create the rule.