### PR TITLE
params, sharing state and location fix

### DIFF
--- a/cisco-csr-1000v/azuredeploy.json
+++ b/cisco-csr-1000v/azuredeploy.json
@@ -23,13 +23,17 @@
                 "description": "Virtual Network Address prefix"
             }
         },
-        "vnetNewOrExisting" : {
-            "type" : "string",
-            "defaultValue" : "",
-            "metadata": {
-                "description": "Identifies whether to use new or existing Virtual Network"
-            }
-        },
+      "vnetNewOrExisting": {
+        "type": "string",
+        "defaultValue": "new",
+        "allowedValues": [
+          "new",
+          "existing"
+        ],
+        "metadata": {
+          "description": "Identifies whether to use new or existing Virtual Network"
+        }
+      },
         "Subnet1Prefix": {
             "type": "string",
             "defaultValue": "",
@@ -257,9 +261,6 @@
                     },
                     "publicIPAddressType": {
                         "value": "[variables('publicIPAddressType')]"
-                    },
-                    "publicIPNewOrExisting": {
-                        "value": "[parameters('publicIPNewOrExisting')]"
                     },
                     "dnsPrefix": {
                         "value": "[parameters('publicIPDnsName')]"

--- a/cisco-csr-1000v/publicip-new.json
+++ b/cisco-csr-1000v/publicip-new.json
@@ -13,9 +13,6 @@
     },
     "publicIpRGName": {
       "type": "string"
-    },
-    "publicIPNewOrExisting" : {
-      "type" : "string"
     }
   },
   "resources": [

--- a/cisco-csr-1000v/vnet-new.json
+++ b/cisco-csr-1000v/vnet-new.json
@@ -5,9 +5,6 @@
     "virtualNetworkName": {
       "type": "string"
     },
-    "location": {
-      "type": "string"
-    },
     "virtualNetworkAddressPrefix": {
       "type": "string"
     },
@@ -38,7 +35,7 @@
             "apiVersion": "2015-06-15",
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[parameters('virtualNetworkName')]",
-            "location": "[parameters('location')]",
+            "location": "[resourceGroup().location]",
             "properties": {
                 "addressSpace": {
                     "addressPrefixes": [


### PR DESCRIPTION
-vNet param missed default and allowedValue
- inconsistent in params with sharing state nested deployments
- Location fix from param to resourceGroup().location