### PR TITLE
"osdisk" VHD being overwritten.

### DIFF
--- a/multi-vm-chef-template-ubuntu-vm/azuredeploy.json
+++ b/multi-vm-chef-template-ubuntu-vm/azuredeploy.json
@@ -250,7 +250,7 @@
           "osDisk": {
             "name": "osdisk",
             "vhd": {
-              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/vhds/','osdisk.vhd')]"
+              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/vhds/','osdisk', copyindex(), '.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"


### PR DESCRIPTION
When creating multiple VMs using "copy()", the osdisk name should also be indexed.

If this is not done, then the same OS disk is overwritten for subsequent VMs.