### PR TITLE
Fix the timeout issue of "pip install" in China

### DIFF
--- a/bosh-setup/README.md
+++ b/bosh-setup/README.md
@@ -18,6 +18,10 @@ We look forward to hearing your feedback and suggestions!
 ```
 Template Changelog
 
+# v1.6.1 (2016-06-16)
+
+- Fix the timeout issue of "pip install" in China
+
 # v1.6.0 (2016-06-08)
 
 - Upgrade versions

--- a/bosh-setup/metadata.json
+++ b/bosh-setup/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template helps you setup a development environment where you can deploy BOSH and Cloud Foundry.",
   "summary": "This template helps you setup a development environment where you can deploy BOSH and Cloud Foundry.",
   "githubUsername": "bingosummer",
-  "dateUpdated": "2016-06-08"
+  "dateUpdated": "2016-06-16"
 }

--- a/bosh-setup/scripts/setup_env
+++ b/bosh-setup/scripts/setup_env
@@ -1,25 +1,29 @@
 #!/usr/bin/env bash
 
+function retryop()
+{
+  retry=0
+  max_retries=10
+  interval=30
+  while [ ${retry} -lt ${max_retries} ]; do
+    echo "Operation: $1, Retry #${retry}"
+    eval $1
+    if [ $? -eq 0 ]; then
+      echo "Successfully."
+      break
+    else
+      let retry=retry+1
+      sleep $interval
+    fi
+  done
+}
+
 echo "Start to update package lists from repositories..."
-n=0
-max=10
-interval=30
-until [ $n -ge $max ]
-do
-  apt-get update && break
-  n=$[$n+1]
-  echo "Failed to update package lists. Sleep $interval seconds and retry #$n ..."
-  sleep $interval
-done
-if [ $n -ge $max ]; then
-  echo "Failed to update package lists with retrying $max times"
-  exit 1
-fi
+retryop "apt-get update"
+
+retryop "apt-get -y install python-pip jq"
 
 set -e
-
-apt-get -y install python-pip jq
-pip install msrest msrestazure azure==2.0.0rc1 azure-storage netaddr
 
 seq_no=$(cat ../../mrseq)
 custom_script_config_file="../../config/${seq_no}.settings"
@@ -33,6 +37,24 @@ function get_setting() {
   local value=$(echo $settings | jq ".$key" -r)
   echo $value
 }
+
+environment=$(get_setting ENVIRONMENT)
+
+set +e
+
+echo "Start to install python packages..."
+pkg_list="msrest msrestazure azure==2.0.0rc1 azure-storage netaddr"
+if [ "$environment" = "AzureChinaCloud" ]; then
+  for pkg in $pkg_list; do
+    retryop "pip install $pkg --index-url https://pypi.mirrors.ustc.edu.cn/simple/ --default-timeout=60"
+  done
+else
+  for pkg in $pkg_list; do
+    retryop "pip install $pkg"
+  done
+fi
+
+set -e
 
 username=$(get_setting ADMIN_USER_NAME)
 home_dir="/home/$username"
@@ -69,7 +91,6 @@ cp single-vm-cf.yml $example_manifests
 cp multiple-vm-cf.yml $example_manifests
 
 cp cf* $home_dir
-environment=$(get_setting ENVIRONMENT)
 bosh_init_url=$(get_setting BOSH_INIT_URL)
 install_log="$home_dir/install.log"
 chmod +x init.sh


### PR DESCRIPTION
### Changelog
* Add --index-url and --default-timeout
* Retry to install Python packages if failed

### Description of the change
Sometimes we got the following error, especially in China.
```
Downloading/unpacking msrest
  Getting page https://pypi.python.org/simple/msrest/
  Could not fetch URL https://pypi.python.org/simple/msrest/: connection error: HTTPSConnectionPool(host='pypi.python.org', port=443): Max retries exceeded with url: /simple/msrest/ (Caused by <class 'socket.gaierror'>: [Errno -2] Name or service not known)
  Will skip URL https://pypi.python.org/simple/msrest/ when looking for download links for msrest
  Getting page https://pypi.python.org/simple/
Cleaning up...
  Removing temporary dir /tmp/pip_build_root...
Exception:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/pip/basecommand.py", line 122, in main
    status = self.run(options, args)
  File "/usr/lib/python2.7/dist-packages/pip/commands/install.py", line 278, in run
    requirement_set.prepare_files(finder, force_root_egg_info=self.bundle, bundle=self.bundle)
  File "/usr/lib/python2.7/dist-packages/pip/req.py", line 1178, in prepare_files
    url = finder.find_requirement(req_to_install, upgrade=self.upgrade)
  File "/usr/lib/python2.7/dist-packages/pip/index.py", line 196, in find_requirement
    url_name = self._find_url_name(Link(self.index_urls[0], trusted=True), url_name, req) or req.url_name
  File "/usr/lib/python2.7/dist-packages/pip/index.py", line 361, in _find_url_name
    page = self._get_page(index_url, req)
  File "/usr/lib/python2.7/dist-packages/pip/index.py", line 568, in _get_page
    session=self.session,
  File "/usr/lib/python2.7/dist-packages/pip/index.py", line 670, in get_page
    resp = session.get(url, headers={"Accept": "text/html"})
  File "/usr/share/python-wheels/requests-2.2.1-py2.py3-none-any.whl/requests/sessions.py", line 467, in get
    return self.request('GET', url, **kwargs)
  File "/usr/lib/python2.7/dist-packages/pip/download.py", line 237, in request
    return super(PipSession, self).request(method, url, *args, **kwargs)
  File "/usr/share/python-wheels/requests-2.2.1-py2.py3-none-any.whl/requests/sessions.py", line 455, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/share/python-wheels/requests-2.2.1-py2.py3-none-any.whl/requests/sessions.py", line 558, in send
    r = adapter.send(request, **kwargs)
  File "/usr/share/python-wheels/requests-2.2.1-py2.py3-none-any.whl/requests/adapters.py", line 394, in send
    r.content
  File "/usr/share/python-wheels/requests-2.2.1-py2.py3-none-any.whl/requests/models.py", line 679, in content
    self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
  File "/usr/share/python-wheels/requests-2.2.1-py2.py3-none-any.whl/requests/models.py", line 616, in generate
    decode_content=True):
  File "/usr/share/python-wheels/urllib3-1.7.1-py2.py3-none-any.whl/urllib3/response.py", line 225, in stream
    data = self.read(amt=amt, decode_content=decode_content)
  File "/usr/share/python-wheels/urllib3-1.7.1-py2.py3-none-any.whl/urllib3/response.py", line 174, in read
    data = self._fp.read(amt)
  File "/usr/lib/python2.7/httplib.py", line 573, in read
    s = self.fp.read(amt)
  File "/usr/lib/python2.7/socket.py", line 380, in read
    data = self._sock.recv(left)
  File "/usr/lib/python2.7/ssl.py", line 341, in recv
    return self.read(buflen)
  File "/usr/lib/python2.7/ssl.py", line 260, in read
    return self._sslobj.read(len)
SSLError: The read operation timed out
```

The solution is to add a retry logic.
For `AzureChinaCloud`, we use a local pypi mirror `https://pypi.mirrors.ustc.edu.cn/simple/` to avoid the timeout.