### PR TITLE
Fix the args passed to resourceId()

### DIFF
--- a/elasticsearch/nestedtemplates/data-nodes-16disk-resources.json
+++ b/elasticsearch/nestedtemplates/data-nodes-16disk-resources.json
@@ -139,7 +139,7 @@
           "osDisk": {
             "name": "osdisk",
             "vhd": {
-              "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, 'vhds/', variables('vmName'), copyindex(), '-osdisk.vhd')]"
+              "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, 'vhds/', variables('vmName'), copyindex(), '-osdisk.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"
@@ -150,7 +150,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 0,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk1', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk1', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -160,7 +160,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 1,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk2', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk2', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -170,7 +170,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 2,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk3', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk3', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -180,7 +180,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 3,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk4', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk4', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -190,7 +190,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 4,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk5', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk5', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -200,7 +200,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 5,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk6', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk6', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -210,7 +210,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 6,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk7', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk7', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -220,7 +220,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 7,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk8', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk8', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -230,7 +230,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 8,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk9', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk9', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -240,7 +240,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 9,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk10', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk10', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"

--- a/elasticsearch/nestedtemplates/data-nodes-8disk-resources.json
+++ b/elasticsearch/nestedtemplates/data-nodes-8disk-resources.json
@@ -190,7 +190,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 4,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk5', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk5', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -200,7 +200,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 5,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk6', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk6', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -210,7 +210,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 6,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk7', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk7', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -220,7 +220,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 7,
               "vhd": {
-                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()]), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk8', '.vhd')]"
+                "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', concat(variables('storageAccountName'), parameters('storageSettings').mapping[copyindex()])), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', parameters('namespace'), 'vm', copyindex(), 'dataDisk8', '.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"


### PR DESCRIPTION
Some resource name parts weren't being concatenated together before being passed to resourceId()