### PR TITLE
Adjust defaults for _artifactsLocation and _artifactsLocationSasToken

### DIFF
--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -295,14 +295,14 @@
     },
     "_artifactsLocation": {
       "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch/",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch",
       "metadata": {
         "description": "Change this value to your repo name if deploying from a fork"
       }
     },
     "_artifactsLocationSasToken": {
       "type": "securestring",
-      "defaultValue": "?",
+      "defaultValue": "",
       "metadata": {
         "description": "Auto-generated token to access _artifactsLocation"
       }

--- a/elasticsearch/azuredeploy.json
+++ b/elasticsearch/azuredeploy.json
@@ -310,8 +310,7 @@
   },
   "variables": {
     "nestedTemplatesFolderName": "nestedtemplates",
-    "scriptsFolderName": "scripts",
-    "scriptsLocation": "[concat(parameters('_artifactsLocation'), '/', variables('scriptsFolderName'), '/')]",
+    "scriptsLocation": "[concat(parameters('_artifactsLocation'), '/scripts/')]",
     "sharedScriptsLocation": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/shared_scripts/ubuntu/",
     "storageAccountPrefix": "[concat(substring(uniqueString(resourceGroup().id, parameters('esClusterName')), 0, 6), substring(parameters('esClusterName'), 0, 3))]",
     "storageAccountNameAFS": "[concat(variables('storageAccountPrefix'), 'afs')]",
@@ -535,7 +534,7 @@
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File ', variables('scriptsFolderName'), '/elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version, ' -elasticClusterName ', variables('esSettings').marvelClusterName, ' -discoveryEndpoints ', variables('esSettings').marvelHosts, ' -marvelOnlyNode -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version, ' -elasticClusterName ', variables('esSettings').marvelClusterName, ' -discoveryEndpoints ', variables('esSettings').marvelHosts, ' -marvelOnlyNode -storageKey ')]"
           }
         },
         "master": {
@@ -544,7 +543,7 @@
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File ', variables('scriptsFolderName'), '/elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version, ' -elasticClusterName ', variables('esSettings').clusterName, ' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('cloudAzureParamValue'), variables('marvelParamValue'), variables('marvelExportParamValue'), ' -masterOnlyNode -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version, ' -elasticClusterName ', variables('esSettings').clusterName, ' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('cloudAzureParamValue'), variables('marvelParamValue'), variables('marvelExportParamValue'), ' -masterOnlyNode -storageKey ')]"
           }
         },
         "client": {
@@ -553,7 +552,7 @@
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File ', variables('scriptsFolderName'), '/elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version, ' -elasticClusterName ', variables('esSettings').clusterName, ' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('cloudAzureParamValue'), variables('marvelParamValue'), variables('marvelExportParamValue'), ' -clientOnlyNode -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version, ' -elasticClusterName ', variables('esSettings').clusterName, ' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('cloudAzureParamValue'), variables('marvelParamValue'), variables('marvelExportParamValue'), ' -clientOnlyNode -storageKey ')]"
           }
         },
         "data": {
@@ -562,7 +561,7 @@
           "typeHandlerVersion": "1.4",
           "settings": {
             "fileUris": "[variables('windowsScripts')]",
-            "commandToExecute": "[concat('powershell.exe -File ', variables('scriptsFolderName'), '/elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version, ' -elasticClusterName ', variables('esSettings').clusterName, ' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('cloudAzureParamValue'), variables('marvelParamValue'), variables('marvelExportParamValue'), ' -dataOnlyNode -storageKey ')]"
+            "commandToExecute": "[concat('powershell.exe -File elasticsearch-windows-install.ps1 -elasticSearchVersion ', variables('esSettings').version, ' -elasticClusterName ', variables('esSettings').clusterName, ' -discoveryEndpoints ', variables('esSettings').discoveryHosts, variables('cloudAzureParamValue'), variables('marvelParamValue'), variables('marvelExportParamValue'), ' -dataOnlyNode -storageKey ')]"
           }
         }
       }


### PR DESCRIPTION
Minor fixes for publishing the template via the Portal, where the default values for _artifactsLocation* are used to retrieve scripts and nested templates directly from https://raw.githubusercontent.com rather than staging them in a storage account. 