### PR TITLE
Update azuredeploy.json - Typo for VM Name - Secondry > Secondary

### DIFF
--- a/sqlvm-alwayson-cluster/azuredeploy.json
+++ b/sqlvm-alwayson-cluster/azuredeploy.json
@@ -393,7 +393,7 @@
       "noOfSqlVMs": 2,
       "vmContainerName": "vhds",
       "adPDCVMName": "ad-primary-dc",
-      "adBDCVMName": "ad-secondry-dc",
+      "adBDCVMName": "ad-secondary-dc",
       "sqlVMName": "sqlserver-",
       "sqlwVMName": "cluster-fsw",
       "windowsImagePublisher": "MicrosoftWindowsServer",


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Changed 'Secondry' to 'Secondary'

### Description of the change

We noticed this typo today when we deployed this template. Works very well minus this one typo.