### PR TITLE
Update ALL SQL IaaS Template DSC Extension Handler from 2.16 to 2.19

### DIFF
--- a/201-vm-sql-full-autobackup/nested/preparingSqlServerSa.json
+++ b/201-vm-sql-full-autobackup/nested/preparingSqlServerSa.json
@@ -54,7 +54,7 @@
          "properties":{  
             "publisher":"Microsoft.Powershell",
             "type":"DSC",
-            "typeHandlerVersion":"2.16",
+            "typeHandlerVersion":"2.19",
             "autoUpgradeMinorVersion":false,
             "settings":{  
                "ModulesUrl":"[parameters('sqlVMPrepareModulesURL')]",

--- a/201-vm-sql-full-autopatching/nested/preparingSqlServerSa.json
+++ b/201-vm-sql-full-autopatching/nested/preparingSqlServerSa.json
@@ -54,7 +54,7 @@
          "properties":{  
             "publisher":"Microsoft.Powershell",
             "type":"DSC",
-            "typeHandlerVersion":"2.16",
+            "typeHandlerVersion":"2.19",
             "autoUpgradeMinorVersion":false,
             "settings":{  
                "ModulesUrl":"[parameters('sqlVMPrepareModulesURL')]",

--- a/201-vm-sql-full-keyvault/nested/preparingSqlServerSa.json
+++ b/201-vm-sql-full-keyvault/nested/preparingSqlServerSa.json
@@ -54,7 +54,7 @@
          "properties":{  
             "publisher":"Microsoft.Powershell",
             "type":"DSC",
-            "typeHandlerVersion":"2.16",
+            "typeHandlerVersion":"2.19",
             "autoUpgradeMinorVersion":false,
             "settings":{  
                "ModulesUrl":"[parameters('sqlVMPrepareModulesURL')]",

--- a/301-vm-sql-full-autobackup-autopatching-keyvault/nested/preparingSqlServerSa.json
+++ b/301-vm-sql-full-autobackup-autopatching-keyvault/nested/preparingSqlServerSa.json
@@ -54,7 +54,7 @@
          "properties":{  
             "publisher":"Microsoft.Powershell",
             "type":"DSC",
-            "typeHandlerVersion":"2.16",
+            "typeHandlerVersion":"2.19",
             "autoUpgradeMinorVersion":false,
             "settings":{  
                "ModulesUrl":"[parameters('sqlVMPrepareModulesURL')]",

--- a/sqlvm-alwayson-cluster/nested/configuringAlwaysOn.json
+++ b/sqlvm-alwayson-cluster/nested/configuringAlwaysOn.json
@@ -75,7 +75,7 @@
          "properties":{  
             "publisher":"Microsoft.Powershell",
             "type":"DSC",
-            "typeHandlerVersion":"2.16",
+            "typeHandlerVersion":"2.19",
             "autoUpgradeMinorVersion":false,
             "settings":{  
                "modulesURL":"[parameters('createClusterModulesURL')]",

--- a/sqlvm-alwayson-cluster/nested/configuringBackupADVM.json
+++ b/sqlvm-alwayson-cluster/nested/configuringBackupADVM.json
@@ -33,7 +33,7 @@
          "properties":{  
             "publisher":"Microsoft.Powershell",
             "type":"DSC",
-            "typeHandlerVersion":"2.16",
+            "typeHandlerVersion":"2.19",
             "autoUpgradeMinorVersion":false,
             "settings":{  
                "modulesURL":"[parameters('adBDCModulesURL')]",

--- a/sqlvm-alwayson-cluster/nested/preparingSqlServer.json
+++ b/sqlvm-alwayson-cluster/nested/preparingSqlServer.json
@@ -92,7 +92,7 @@
          "properties":{  
             "publisher":"Microsoft.Powershell",
             "type":"DSC",
-            "typeHandlerVersion":"2.16",
+            "typeHandlerVersion":"2.19",
             "autoUpgradeMinorVersion":false,
             "settings":{  
                "modulesURL":"[parameters('fswModulesURL')]",
@@ -183,7 +183,7 @@
          "properties":{  
             "publisher":"Microsoft.Powershell",
             "type":"DSC",
-            "typeHandlerVersion":"2.16",
+            "typeHandlerVersion":"2.19",
             "autoUpgradeMinorVersion":false,
             "settings":{  
                "modulesURL":"[parameters('sqlAOPrepareModulesURL')]",

--- a/sqlvm-alwayson-cluster/nested/provisioningVM1.json
+++ b/sqlvm-alwayson-cluster/nested/provisioningVM1.json
@@ -190,7 +190,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "2.16",
+            "typeHandlerVersion": "2.19",
             "autoUpgradeMinorVersion": false,
             "settings": {
               "modulesURL": "[parameters('adPDCModulesURL')]",

--- a/sqlvm-alwayson-cluster/nested/provisioningVM2.json
+++ b/sqlvm-alwayson-cluster/nested/provisioningVM2.json
@@ -190,7 +190,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "2.16",
+            "typeHandlerVersion": "2.19",
             "autoUpgradeMinorVersion": false,
             "settings": {
               "modulesURL": "[parameters('adPDCModulesURL')]",

--- a/sqlvm-alwayson-cluster/nested/provisioningVM3.json
+++ b/sqlvm-alwayson-cluster/nested/provisioningVM3.json
@@ -190,7 +190,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "2.16",
+            "typeHandlerVersion": "2.19",
             "autoUpgradeMinorVersion": false,
             "settings": {
               "modulesURL": "[parameters('adPDCModulesURL')]",

--- a/sqlvm-alwayson-cluster/nested/provisioningVM4.json
+++ b/sqlvm-alwayson-cluster/nested/provisioningVM4.json
@@ -190,7 +190,7 @@
           "properties": {
             "publisher": "Microsoft.Powershell",
             "type": "DSC",
-            "typeHandlerVersion": "2.16",
+            "typeHandlerVersion": "2.19",
             "autoUpgradeMinorVersion": false,
             "settings": {
               "modulesURL": "[parameters('adPDCModulesURL')]",


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
*
*
*
*
*

### Description of the change

We have validated all templates with 2.19 version of the dsc extension. Please help us to merge this, thank you.