### PR TITLE
Update path to AD DSC

### DIFF
--- a/rds-deployment/azuredeploy.json
+++ b/rds-deployment/azuredeploy.json
@@ -326,7 +326,7 @@
             "typeHandlerVersion": "2.11",
             "autoUpgradeMinorVersion": true,
             "settings": {
-              "ModulesUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/active-directory-new-domain/CreateADPDC.ps1.zip",
+              "ModulesUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/active-directory-new-domain/DSC/CreateADPDC.ps1.zip",
               "ConfigurationFunction": "CreateADPDC.ps1\\CreateADPDC",
               "Properties": {
                 "DomainName": "[parameters('adDomainName')]",


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Update path to AD DSC

### Description of the change
The AD team has moved their DSC resource to a different path, effectively breaking our template. I am updating the path here.