### PR TITLE
Update the Openchain version

### DIFF
--- a/openchain-blockchain-coinprism/azuredeploy.json
+++ b/openchain-blockchain-coinprism/azuredeploy.json
@@ -40,9 +40,9 @@
     },
     "openchainVersion": {
       "type": "string",
-      "defaultValue": "0.5.0",
+      "defaultValue": "0.6.2",
       "allowedValues": [
-        "0.5.0"
+        "0.6.2"
       ],
       "metadata": {
         "description": "The version of Openchain to deploy."

--- a/openchain-blockchain-coinprism/azuredeploy.parameters.json
+++ b/openchain-blockchain-coinprism/azuredeploy.parameters.json
@@ -8,9 +8,6 @@
         "vmSize": {
             "value": "Standard_A0"
         },
-        "openchainVersion": {
-            "value": "0.6.2"
-        },
         "openchainAdminKey": {
             "value": "XpGxyLkMdXd9EsiR2XHvqgnHi4QwBZk9mH"
         },

--- a/openchain-blockchain-coinprism/azuredeploy.parameters.json
+++ b/openchain-blockchain-coinprism/azuredeploy.parameters.json
@@ -9,7 +9,7 @@
             "value": "Standard_A0"
         },
         "openchainVersion": {
-            "value": "0.5.0"
+            "value": "0.6.2"
         },
         "openchainAdminKey": {
             "value": "XpGxyLkMdXd9EsiR2XHvqgnHi4QwBZk9mH"

--- a/openchain-blockchain-coinprism/install_openchain.sh
+++ b/openchain-blockchain-coinprism/install_openchain.sh
@@ -12,7 +12,6 @@ git clone https://github.com/openchain/docker.git openchain
 cd openchain
 git checkout v$2
 cp templates/docker-compose-proxy.yml docker-compose.yml
-cp templates/project.json openchain/project.json
 cp templates/nginx.conf nginx/nginx.conf
 mkdir data
 cp templates/config.json data/config.json


### PR DESCRIPTION
### Changelog
* Update the Openchain version from 0.5.0 to 0.6.2.

### Description of the change

Openchain 0.6 is based on the RTM version of .NET Core 1.0, whereas 0.5 was based on RC1. This change updates the version being deployed by the template to 0.6.2.