### PR TITLE
Add website cluster on CentOS 

### DIFF
--- a/website-cluster-centos/README.md
+++ b/website-cluster-centos/README.md
@@ -30,7 +30,7 @@ Each server has dynamic private ip address. Web servers belong to web subnet, th
 
 
 ##Important Notice
-Each server uses raid0 to improve performance. We use 4 data disks on each server for raid0. The size of data disks(setup raid0) on each server are determined by yourself. However, there is size of data disks limit per the server size. Before you set the size of data disks, please refer to the link https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-sizes/ for the correct choice.
+Each server uses raid0 to improve performance. We use 4 data disks on each server for raid0. The size of each data disk is set to 100GB. Execute the command "df -h" to find out the mount details, /dev/md0 is for the data disks. The VM size is set to Standard_A3. You can check the VM size details by clicking the URL https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-sizes/ .
 
 
 

--- a/website-cluster-centos/README.md
+++ b/website-cluster-centos/README.md
@@ -1,0 +1,75 @@
+# Install Website Cluster
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F251744647%2Fazure-quickstart-templates%2Fmaster%2Fwebsite-cluster-centos%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+<a href="
+http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2F251744647%2Fazure-quickstart-templates%2Fmaster%2Fwebsite-cluster-centos%2Fazuredeploy.json" target="_blank">
+    <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+
+This template deploys a website cluster and enables Zabbix monitoring, and allows user to define the number of web servers. The website cluster contains 1 load balancer, 3 web servers, 1 redis master with 1 redis slave, 1 MySQL master with 1 MySQL slave by default.
+
+This template also allows you to input your existing zabbix server IP address to monitor these servers.
+
+The load balancer exposes on public IP addresses that you can access through SSH on the standard port, also port 80 open so that you can access your website through browsers.
+
+The servers are under the same net 10.0.0.0/24, there are 4 subnets under this net: web subnet, haproxy subnet, redis subnet, mysql subnet. The details are below:
+
+- web: 10.0.0.0/28
+
+- mysql: 10.0.0.16/28
+
+- redis: 10.0.0.32/28
+
+- haproxy: 10.0.0.48/28
+
+
+Each server has dynamic private ip address. Web servers belong to web subnet, the ip addresses usually start from 10.0.0.4; MySQL servers belong to mysql subnet, the ip addresses start from 10.0.0.20; redis servers belong to redis subnet, the ip addresses start from 10.0.0.36; load balancer belongs to haproxy subnet, the ip address start from 10.0.0.52.
+
+
+##Important Notice
+Each server uses raid0 to improve performance. We use 4 data disks on each server for raid0. The size of data disks(setup raid0) on each server are determined by yourself. However, there is size of data disks limit per the server size. Before you set the size of data disks, please refer to the link https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-sizes/ for the correct choice.
+
+
+
+##After deployment, you can do below to verify if the website cluster really works or not:
+
+1. Open the URL http://your load balancer public ip/mysql.php to see if can connect to MySQL DB successfully.
+
+
+2. Check MySQL data replication status. SSH connect to load balancer, then SSH connect to MySQL slave(usually 10.0.0.21), then execute below:
+  ```
+  $mysql -uroot -p<mysqlpassword>
+
+  use testdb;
+
+  select * from test01;
+  ```
+
+  You should see some records in the test01 table.
+
+  
+3. Check redis data replication status. SSH connect to load balancer, then SSH connect to redis master(usually 10.0.0.36), then execute below:
+  ```
+  $/usr/local/redis/src/redis-cli
+
+  set hello world
+
+  get hello
+  ```
+
+  SSH connect to redis slave(usually 10.0.0.37), then execute below:
+  ```
+  $/usr/local/redis/src/redis-cli
+
+  get hello
+  ```
+  
+  You should get the output as same as redis master does.
+
+
+##Known Limitations
+- The website uses one load balancer and the load balancer uses haproxy software. You can create more load balancers and you can even use Azure's traffic manager to do the load balanceing.
+- You can add more web servers and database servers after the deployment.

--- a/website-cluster-centos/README.md
+++ b/website-cluster-centos/README.md
@@ -1,10 +1,10 @@
 # Install Website Cluster
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2F251744647%2Fazure-quickstart-templates%2Fmaster%2Fwebsite-cluster-centos%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fwebsite-cluster-centos%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 <a href="
-http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2F251744647%2Fazure-quickstart-templates%2Fmaster%2Fwebsite-cluster-centos%2Fazuredeploy.json" target="_blank">
+http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fwebsite-cluster-centos%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
@@ -71,5 +71,5 @@ Each server uses raid0 to improve performance. We use 4 data disks on each serve
 
 
 ##Known Limitations
-- The website uses one load balancer and the load balancer uses haproxy software. You can create more load balancers and you can even use Azure's traffic manager to do the load balanceing.
+- The website uses one load balancer and the load balancer uses haproxy software. You can create more load balancers and you can even use Azure's traffic manager to do the load balancing.
 - You can add more web servers and database servers after the deployment.

--- a/website-cluster-centos/azuredeploy.json
+++ b/website-cluster-centos/azuredeploy.json
@@ -233,7 +233,7 @@
     {
       "name": "shared",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -253,7 +253,7 @@
     {
       "name": "[concat('webNode', copyindex())]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]"
       ],
@@ -316,7 +316,7 @@
     {
       "name": "redisMasterNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]"
       ],
@@ -372,7 +372,7 @@
     {
       "name": "redisSlaveNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'redisMasterNode')]"
@@ -429,7 +429,7 @@
     {
       "name": "mysqlMasterNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]"
       ],
@@ -488,7 +488,7 @@
     {
       "name": "mysqlSlaveNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'mysqlMasterNode')]"
@@ -548,7 +548,7 @@
     {
       "name": "lbNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'mysqlSlaveNode')]",

--- a/website-cluster-centos/azuredeploy.json
+++ b/website-cluster-centos/azuredeploy.json
@@ -36,15 +36,6 @@
         "description": "Different environments in Azure. Choose AzureCloud for Global Azure, and choose AzureChinaCloud for Mooncake (Azure China Cloud)."
       }
     },
-    "sizeOfDataDiskInGB": {
-      "type": "int",
-      "minValue": 1,
-      "maxValue": 1023,
-      "defaultValue": 20,
-      "metadata": {
-        "description": "The size of each data disk, the value is between 1 and 1023. We use 4 data disks on each VM for raid0 to improve performance."
-      }
-    },
     "centOsVersion": {
       "type": "string",
       "defaultValue": "7.0",
@@ -69,99 +60,52 @@
         "description": "Number of web server nodes"
       }
     },
-    "lbNodeVmSize": {
-      "type": "string",
-      "defaultValue": "Standard_A3",
-      "allowedValues": [
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_A4",
-        "Standard_A5",
-        "Standard_A6",
-        "Standard_A7",
-        "Standard_D2",
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D2_v2",
-        "Standard_D3_v2",
-        "Standard_D4_v2"
-      ],
-      "metadata": {
-        "description": "The size of the virtual machines used when provisioning the lb node"
-      }
-    },
-    "webNodeVmSize": {
-      "type": "string",
-      "defaultValue": "Standard_A3",
-      "allowedValues": [
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_A4",
-        "Standard_A5",
-        "Standard_A6",
-        "Standard_A7",
-        "Standard_D2",
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D2_v2",
-        "Standard_D3_v2",
-        "Standard_D4_v2"
-      ],
-      "metadata": {
-        "description": "The size of the virtual machines used when provisioning the web server nodes"
-      }
-    },
-    "dbNodeVmSize": {
-      "type": "string",
-      "defaultValue": "Standard_A3",
-      "allowedValues": [
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_A4",
-        "Standard_A5",
-        "Standard_A6",
-        "Standard_A7",
-        "Standard_D2",
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D2_v2",
-        "Standard_D3_v2",
-        "Standard_D4_v2"
-      ],
-      "metadata": {
-        "description": "The size of the virtual machines used when provisioning redis and MySQL nodes"
-      }
-    },
     "zabbixServerIPAddress": {
       "type": "string",
       "defaultValue": "",
       "metadata": {
 	    "description": "The zabbix server IP which will monitor the nodes' status. Null means no zabbix server."
 	  }
-	}
+	},
+    "_artifactsLocation": {
+      "type": "string",
+      "metadata": {
+      "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+      },
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/website-cluster-centos/"
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring",
+      "metadata": {
+      "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+      },
+      "defaultValue": ""
+    },
+    "_artifactsChinaLocation": {
+      "type": "string",
+      "metadata": {
+      "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+      },
+      "defaultValue": "http://msmirrors.blob.core.chinacloudapi.cn/website-cluster-centos/"
+    },
+    "_artifactsChinaLocationSasToken": {
+      "type": "securestring",
+      "metadata": {
+      "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+      },
+      "defaultValue": ""
+    }
   },
   "variables": {
-    "baseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/website-cluster-centos/",
-    "baseChinaUrl": "http://msmirrors.blob.core.chinacloudapi.cn/website-cluster-centos/",
     "environmentAzureCloud": {
       "serviceEndPoint": ".blob.core.windows.net/vhds/",
-      "templateBaseUrl": "[concat(variables('baseUrl'), 'nested/')]",
-      "lbNodeScript": "[concat(variables('baseUrl'), 'scripts/lb.sh')]",
-      "webNodeScript": "[concat(variables('baseUrl'), 'scripts/web.sh')]",
-      "redisMasterNodeScript": "[concat(variables('baseUrl'), 'scripts/redisMaster.sh')]",
-      "redisSlaveNodeScript": "[concat(variables('baseUrl'), 'scripts/redisSlave.sh')]",
-      "mysqlMasterNodeScript": "[concat(variables('baseUrl'), 'scripts/mysqlMaster.sh')]",
-      "mysqlSlaveNodeScript": "[concat(variables('baseUrl'), 'scripts/mysqlSlave.sh')]"
+      "templateBaseUrl": "[concat(parameters('_artifactsLocation'), 'nested/')]",
+      "templateBaseScriptsUrl": "[concat(parameters('_artifactsLocation'), 'scripts/')]"
     },
     "environmentAzureChinaCloud": {
       "serviceEndPoint": ".blob.core.chinacloudapi.cn/vhds/",
-      "templateBaseUrl": "[concat(variables('baseChinaUrl'), 'nested/')]",
-      "lbNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/lb.sh')]",
-      "webNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/web.sh')]",
-      "redisMasterNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/redisMaster.sh')]",
-      "redisSlaveNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/redisSlave.sh')]",
-      "mysqlMasterNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/mysqlMaster.sh')]",
-      "mysqlSlaveNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/mysqlSlave.sh')]"
+      "templateBaseUrl": "[concat(parameters('_artifactsChinaLocation'), 'nested/')]",
+      "templateBaseScriptsUrl": "[concat(parameters('_artifactsChinaLocation'), 'scripts/')]"
     },
     "environment": "[variables(concat('environment', parameters('environment')))]",    
     "sharedTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'shared-resources.json')]",
@@ -171,9 +115,19 @@
     "redisSlaveTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'redisSlave-resources.json')]",
     "mysqlMasterTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'mysqlMaster-resources.json')]",
     "mysqlSlaveTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'mysqlSlave-resources.json')]",
+    "lbNodeScript": "[concat(variables('environment').templateBaseScriptsUrl, 'lb.sh')]",
+    "webNodeScript": "[concat(variables('environment').templateBaseScriptsUrl, 'web.sh')]",
+    "redisMasterNodeScript": "[concat(variables('environment').templateBaseScriptsUrl, 'redisMaster.sh')]",
+    "redisSlaveNodeScript": "[concat(variables('environment').templateBaseScriptsUrl, 'redisSlave.sh')]",
+    "mysqlMasterNodeScript": "[concat(variables('environment').templateBaseScriptsUrl, 'mysqlMaster.sh')]",
+    "mysqlSlaveNodeScript": "[concat(variables('environment').templateBaseScriptsUrl, 'mysqlSlave.sh')]",
     "namespace": "websiteCluster-",
     "virtualNetworkName": "websiteVNET1",
     "numDataDisks": "4",
+    "sizeOfDataDiskInGB": 100,
+    "lbNodeVmSize": "Standard_A3",
+    "webNodeVmSize": "Standard_A3",
+    "dbNodeVmSize": "Standard_A3",
     "apiVersion": "2015-01-01",
     "networkSettings": {
       "virtualNetworkName": "[variables('virtualNetworkName')]",
@@ -216,7 +170,7 @@
         "version": "latest"
       },
       "scripts": [
-        "[variables('environment').lbNodeScript]"
+        "[variables('lbNodeScript')]"
       ]
     },
     "webOsSettings": {
@@ -227,7 +181,7 @@
         "version": "latest"
       },
       "scripts": [
-        "[variables('environment').webNodeScript]"
+        "[variables('webNodeScript')]"
       ]
     },
     "redisMasterOsSettings": {
@@ -238,7 +192,7 @@
         "version": "latest"
       },
       "scripts": [
-        "[variables('environment').redisMasterNodeScript]"
+        "[variables('redisMasterNodeScript')]"
       ]
     },
     "redisSlaveOsSettings": {
@@ -249,7 +203,7 @@
         "version": "latest"
       },
       "scripts": [
-        "[variables('environment').redisSlaveNodeScript]"
+        "[variables('redisSlaveNodeScript')]"
       ]
     },
     "mysqlMasterOsSettings": {
@@ -260,7 +214,7 @@
         "version": "latest"
       },
       "scripts": [
-        "[variables('environment').mysqlMasterNodeScript]"
+        "[variables('mysqlMasterNodeScript')]"
       ]
     },
     "mysqlSlaveOsSettings": {
@@ -271,7 +225,7 @@
         "version": "latest"
       },
       "scripts": [
-        "[variables('environment').mysqlSlaveNodeScript]"
+        "[variables('mysqlSlaveNodeScript')]"
       ]
     }
   },
@@ -333,7 +287,7 @@
             "value": "[variables('networkSettings').subnet.web]"
           },
           "sizeOfDataDiskInGB": {
-            "value": "[parameters('sizeOfDataDiskInGB')]"
+            "value": "[variables('sizeOfDataDiskInGB')]"
           },
           "numDataDisks": {
             "value": "[variables('numDataDisks')]"
@@ -348,7 +302,7 @@
             "value": "[parameters('dnsNamePrefix')]"
           },
           "vmSize": {
-            "value": "[parameters('webNodeVmSize')]"
+            "value": "[variables('webNodeVmSize')]"
           },
           "zabbixServerIPAddress": {
              "value": "[parameters('zabbixServerIPAddress')]"
@@ -392,7 +346,7 @@
             "value": "[parameters('dnsNamePrefix')]"
           },
           "sizeOfDataDiskInGB": {
-            "value": "[parameters('sizeOfDataDiskInGB')]"
+            "value": "[variables('sizeOfDataDiskInGB')]"
           },
           "numDataDisks": {
             "value": "[variables('numDataDisks')]"
@@ -404,7 +358,7 @@
             "value": "[variables('environment').serviceEndPoint]"
           },
           "vmSize": {
-            "value": "[parameters('dbNodeVmSize')]"
+            "value": "[variables('dbNodeVmSize')]"
           },
           "zabbixServerIPAddress": {
              "value": "[parameters('zabbixServerIPAddress')]"
@@ -449,7 +403,7 @@
             "value": "[parameters('dnsNamePrefix')]"
           },
           "sizeOfDataDiskInGB": {
-            "value": "[parameters('sizeOfDataDiskInGB')]"
+            "value": "[variables('sizeOfDataDiskInGB')]"
           },
           "numDataDisks": {
             "value": "[variables('numDataDisks')]"
@@ -461,7 +415,7 @@
             "value": "[variables('environment').serviceEndPoint]"
           },
           "vmSize": {
-            "value": "[parameters('dbNodeVmSize')]"
+            "value": "[variables('dbNodeVmSize')]"
           },
           "zabbixServerIPAddress": {
              "value": "[parameters('zabbixServerIPAddress')]"
@@ -508,7 +462,7 @@
             "value": "[parameters('dnsNamePrefix')]"
           },
           "sizeOfDataDiskInGB": {
-            "value": "[parameters('sizeOfDataDiskInGB')]"
+            "value": "[variables('sizeOfDataDiskInGB')]"
           },
           "numDataDisks": {
             "value": "[variables('numDataDisks')]"
@@ -520,7 +474,7 @@
             "value": "[variables('environment').serviceEndPoint]"
           },
           "vmSize": {
-            "value": "[parameters('dbNodeVmSize')]"
+            "value": "[variables('dbNodeVmSize')]"
           },
           "zabbixServerIPAddress": {
              "value": "[parameters('zabbixServerIPAddress')]"
@@ -568,7 +522,7 @@
             "value": "[parameters('dnsNamePrefix')]"
           },
           "sizeOfDataDiskInGB": {
-            "value": "[parameters('sizeOfDataDiskInGB')]"
+            "value": "[variables('sizeOfDataDiskInGB')]"
           },
           "numDataDisks": {
             "value": "[variables('numDataDisks')]"
@@ -580,7 +534,7 @@
             "value": "[variables('environment').serviceEndPoint]"
           },
           "vmSize": {
-            "value": "[parameters('dbNodeVmSize')]"
+            "value": "[variables('dbNodeVmSize')]"
           },
           "zabbixServerIPAddress": {
              "value": "[parameters('zabbixServerIPAddress')]"
@@ -626,7 +580,7 @@
             "value": "[parameters('dnsNamePrefix')]"
           },
           "sizeOfDataDiskInGB": {
-            "value": "[parameters('sizeOfDataDiskInGB')]"
+            "value": "[variables('sizeOfDataDiskInGB')]"
           },
           "numDataDisks": {
             "value": "[variables('numDataDisks')]"
@@ -641,7 +595,7 @@
             "value": "[variables('environment').serviceEndPoint]"
           },
           "vmSize": {
-            "value": "[parameters('lbNodeVmSize')]"
+            "value": "[variables('lbNodeVmSize')]"
           },
           "zabbixServerIPAddress": {
              "value": "[parameters('zabbixServerIPAddress')]"

--- a/website-cluster-centos/azuredeploy.json
+++ b/website-cluster-centos/azuredeploy.json
@@ -1,0 +1,657 @@
+﻿{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Administrator user name used when provisioning virtual machines"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Administrator password used when provisioning virtual machines"
+      }
+    },
+    "mysqlPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "MySQL password used when provisioning MySQL Clusters"
+      }
+    },
+    "dnsNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Name for the publicly accessible primary node. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
+    "environment": {
+      "type": "string",
+      "allowedValues": [
+        "AzureCloud",
+        "AzureChinaCloud"
+      ],
+      "metadata": {
+        "description": "Different environments in Azure. Choose AzureCloud for Global Azure, and choose AzureChinaCloud for Mooncake (Azure China Cloud)."
+      }
+    },
+    "sizeOfDataDiskInGB": {
+      "type": "int",
+      "minValue": 1,
+      "maxValue": 1023,
+      "defaultValue": 20,
+      "metadata": {
+        "description": "The size of each data disk, the value is between 1 and 1023. We use 4 data disks on each VM for raid0 to improve performance."
+      }
+    },
+    "centOsVersion": {
+      "type": "string",
+      "defaultValue": "7.0",
+      "allowedValues": [
+        "6.5",
+        "6.6",
+        "6.7",
+        "7.0",
+        "7.1",
+        "7.2"		
+      ],
+      "metadata": {
+        "description": "The CentOS version for the VM. This will pick a fully patched image of this given CentOS version."
+      }
+    },
+    "webNodeCount": {
+      "type": "int",
+      "minValue": 1,
+      "maxValue": 11,
+      "defaultValue": 3,
+      "metadata": {
+        "description": "Number of web server nodes"
+      }
+    },
+    "lbNodeVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_A3",
+      "allowedValues": [
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2"
+      ],
+      "metadata": {
+        "description": "The size of the virtual machines used when provisioning the lb node"
+      }
+    },
+    "webNodeVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_A3",
+      "allowedValues": [
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2"
+      ],
+      "metadata": {
+        "description": "The size of the virtual machines used when provisioning the web server nodes"
+      }
+    },
+    "dbNodeVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_A3",
+      "allowedValues": [
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2"
+      ],
+      "metadata": {
+        "description": "The size of the virtual machines used when provisioning redis and MySQL nodes"
+      }
+    },
+    "zabbixServerIPAddress": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+	    "description": "The zabbix server IP which will monitor the nodes' status. Null means no zabbix server."
+	  }
+	}
+  },
+  "variables": {
+    "baseUrl": "https://raw.githubusercontent.com/251744647/azure-quickstart-templates/master/website-cluster-centos/",
+    "baseChinaUrl": "http://msmirrors.blob.core.chinacloudapi.cn/website-cluster-centos/",
+    "environmentAzureCloud": {
+      "serviceEndPoint": ".blob.core.windows.net/vhds/",
+      "templateBaseUrl": "[concat(variables('baseUrl'), 'nested/')]",
+      "lbNodeScript": "[concat(variables('baseUrl'), 'scripts/lb.sh')]",
+      "webNodeScript": "[concat(variables('baseUrl'), 'scripts/web.sh')]",
+      "redisMasterNodeScript": "[concat(variables('baseUrl'), 'scripts/redisMaster.sh')]",
+      "redisSlaveNodeScript": "[concat(variables('baseUrl'), 'scripts/redisSlave.sh')]",
+      "mysqlMasterNodeScript": "[concat(variables('baseUrl'), 'scripts/mysqlMaster.sh')]",
+      "mysqlSlaveNodeScript": "[concat(variables('baseUrl'), 'scripts/mysqlSlave.sh')]"
+    },
+    "environmentAzureChinaCloud": {
+      "serviceEndPoint": ".blob.core.chinacloudapi.cn/vhds/",
+      "templateBaseUrl": "[concat(variables('baseChinaUrl'), 'nested/')]",
+      "lbNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/lb.sh')]",
+      "webNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/web.sh')]",
+      "redisMasterNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/redisMaster.sh')]",
+      "redisSlaveNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/redisSlave.sh')]",
+      "mysqlMasterNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/mysqlMaster.sh')]",
+      "mysqlSlaveNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/mysqlSlave.sh')]"
+    },
+    "environment": "[variables(concat('environment', parameters('environment')))]",    
+    "sharedTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'shared-resources.json')]",
+    "lbTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'lb-resources.json')]",
+    "webTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'web-resources.json')]",
+    "redisMasterTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'redisMaster-resources.json')]",
+    "redisSlaveTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'redisSlave-resources.json')]",
+    "mysqlMasterTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'mysqlMaster-resources.json')]",
+    "mysqlSlaveTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'mysqlSlave-resources.json')]",
+    "namespace": "websiteCluster-",
+    "virtualNetworkName": "websiteVNET1",
+    "numDataDisks": "4",
+    "apiVersion": "2015-01-01",
+    "networkSettings": {
+      "virtualNetworkName": "[variables('virtualNetworkName')]",
+      "addressPrefix": "10.0.0.0/24",
+      "subnet": {
+        "web": {
+          "name": "web",
+          "prefix": "10.0.0.0/28",
+          "vnet": "[variables('virtualNetworkName')]"
+        },
+        "mysql": {
+          "name": "mysql",
+          "prefix": "10.0.0.16/28",
+          "vnet": "[variables('virtualNetworkName')]"
+        },
+        "redis": {
+          "name": "redis",
+          "prefix": "10.0.0.32/28",
+          "vnet": "[variables('virtualNetworkName')]"
+        },
+        "haproxy": {
+          "name": "haproxy",
+          "prefix": "10.0.0.48/28",
+          "vnet": "[variables('virtualNetworkName')]"
+        }
+      },
+      "statics": {
+        "clusterRange": {
+          "base": "10.0.0.",
+          "start": 5
+        },
+        "primaryIp": "10.0.0.240"
+      }
+    },
+    "lbOsSettings": {
+      "imageReference": {
+        "publisher": "OpenLogic",
+        "offer": "CentOS",
+        "sku": "[parameters('centOsVersion')]",
+        "version": "latest"
+      },
+      "scripts": [
+        "[variables('environment').lbNodeScript]"
+      ]
+    },
+    "webOsSettings": {
+      "imageReference": {
+        "publisher": "OpenLogic",
+        "offer": "CentOS",
+        "sku": "[parameters('centOsVersion')]",
+        "version": "latest"
+      },
+      "scripts": [
+        "[variables('environment').webNodeScript]"
+      ]
+    },
+    "redisMasterOsSettings": {
+      "imageReference": {
+        "publisher": "OpenLogic",
+        "offer": "CentOS",
+        "sku": "[parameters('centOsVersion')]",
+        "version": "latest"
+      },
+      "scripts": [
+        "[variables('environment').redisMasterNodeScript]"
+      ]
+    },
+    "redisSlaveOsSettings": {
+      "imageReference": {
+        "publisher": "OpenLogic",
+        "offer": "CentOS",
+        "sku": "[parameters('centOsVersion')]",
+        "version": "latest"
+      },
+      "scripts": [
+        "[variables('environment').redisSlaveNodeScript]"
+      ]
+    },
+    "mysqlMasterOsSettings": {
+      "imageReference": {
+        "publisher": "OpenLogic",
+        "offer": "CentOS",
+        "sku": "[parameters('centOsVersion')]",
+        "version": "latest"
+      },
+      "scripts": [
+        "[variables('environment').mysqlMasterNodeScript]"
+      ]
+    },
+    "mysqlSlaveOsSettings": {
+      "imageReference": {
+        "publisher": "OpenLogic",
+        "offer": "CentOS",
+        "sku": "[parameters('centOsVersion')]",
+        "version": "latest"
+      },
+      "scripts": [
+        "[variables('environment').mysqlSlaveNodeScript]"
+      ]
+    }
+  },
+  "resources": [
+    {
+      "name": "shared",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "[variables('apiVersion')]",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('sharedTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          },
+          "namespace": {
+            "value": "[variables('namespace')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "[concat('webNode', copyindex())]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "[variables('apiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'shared')]"
+      ],
+      "copy": {
+        "name": "vmLoop",
+        "count": "[parameters('webNodeCount')]"
+      },
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('webTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "mysqlPassword": {
+            "value": "[parameters('mysqlPassword')]"
+          },
+          "namespace": {
+            "value": "[variables('namespace')]"
+          },
+          "vmbasename": {
+            "value": "[concat('web', copyindex())]"
+          },
+          "subnet": {
+            "value": "[variables('networkSettings').subnet.web]"
+          },
+          "sizeOfDataDiskInGB": {
+            "value": "[parameters('sizeOfDataDiskInGB')]"
+          },
+          "numDataDisks": {
+            "value": "[variables('numDataDisks')]"
+          },
+          "templateBaseUrl": {
+            "value": "[variables('environment').templateBaseUrl]"
+          },
+          "serviceEndPoint": {
+            "value": "[variables('environment').serviceEndPoint]"
+          },
+          "dnsname": {
+            "value": "[parameters('dnsNamePrefix')]"
+          },
+          "vmSize": {
+            "value": "[parameters('webNodeVmSize')]"
+          },
+          "zabbixServerIPAddress": {
+             "value": "[parameters('zabbixServerIPAddress')]"
+          },
+          "osSettings": {
+            "value": "[variables('webOsSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "redisMasterNode",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "[variables('apiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'shared')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('redisMasterTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "namespace": {
+            "value": "[variables('namespace')]"
+          },
+          "vmbasename": {
+            "value": "redisMaster"
+          },
+          "subnet": {
+            "value": "[variables('networkSettings').subnet.redis]"
+          },
+          "dnsname": {
+            "value": "[parameters('dnsNamePrefix')]"
+          },
+          "sizeOfDataDiskInGB": {
+            "value": "[parameters('sizeOfDataDiskInGB')]"
+          },
+          "numDataDisks": {
+            "value": "[variables('numDataDisks')]"
+          },
+          "templateBaseUrl": {
+            "value": "[variables('environment').templateBaseUrl]"
+          },
+          "serviceEndPoint": {
+            "value": "[variables('environment').serviceEndPoint]"
+          },
+          "vmSize": {
+            "value": "[parameters('dbNodeVmSize')]"
+          },
+          "zabbixServerIPAddress": {
+             "value": "[parameters('zabbixServerIPAddress')]"
+          },
+          "osSettings": {
+            "value": "[variables('redisMasterOsSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "redisSlaveNode",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "[variables('apiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'shared')]",
+        "[concat('Microsoft.Resources/deployments/', 'redisMasterNode')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('redisSlaveTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "namespace": {
+            "value": "[variables('namespace')]"
+          },
+          "vmbasename": {
+            "value": "redisSlave"
+          },
+          "subnet": {
+            "value": "[variables('networkSettings').subnet.redis]"
+          },
+          "dnsname": {
+            "value": "[parameters('dnsNamePrefix')]"
+          },
+          "sizeOfDataDiskInGB": {
+            "value": "[parameters('sizeOfDataDiskInGB')]"
+          },
+          "numDataDisks": {
+            "value": "[variables('numDataDisks')]"
+          },
+          "templateBaseUrl": {
+            "value": "[variables('environment').templateBaseUrl]"
+          },
+          "serviceEndPoint": {
+            "value": "[variables('environment').serviceEndPoint]"
+          },
+          "vmSize": {
+            "value": "[parameters('dbNodeVmSize')]"
+          },
+          "zabbixServerIPAddress": {
+             "value": "[parameters('zabbixServerIPAddress')]"
+          },
+          "osSettings": {
+            "value": "[variables('redisSlaveOsSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "mysqlMasterNode",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "[variables('apiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'shared')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('mysqlMasterTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "mysqlPassword": {
+            "value": "[parameters('mysqlPassword')]"
+          },
+          "namespace": {
+            "value": "[variables('namespace')]"
+          },
+          "vmbasename": {
+            "value": "mysqlMaster"
+          },
+          "subnet": {
+            "value": "[variables('networkSettings').subnet.mysql]"
+          },
+          "dnsname": {
+            "value": "[parameters('dnsNamePrefix')]"
+          },
+          "sizeOfDataDiskInGB": {
+            "value": "[parameters('sizeOfDataDiskInGB')]"
+          },
+          "numDataDisks": {
+            "value": "[variables('numDataDisks')]"
+          },
+          "templateBaseUrl": {
+            "value": "[variables('environment').templateBaseUrl]"
+          },
+          "serviceEndPoint": {
+            "value": "[variables('environment').serviceEndPoint]"
+          },
+          "vmSize": {
+            "value": "[parameters('dbNodeVmSize')]"
+          },
+          "zabbixServerIPAddress": {
+             "value": "[parameters('zabbixServerIPAddress')]"
+          },
+          "osSettings": {
+            "value": "[variables('mysqlMasterOsSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "mysqlSlaveNode",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "[variables('apiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'shared')]",
+        "[concat('Microsoft.Resources/deployments/', 'mysqlMasterNode')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('mysqlSlaveTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "mysqlPassword": {
+            "value": "[parameters('mysqlPassword')]"
+          },
+          "namespace": {
+            "value": "[variables('namespace')]"
+          },
+          "vmbasename": {
+            "value": "mysqlSlave"
+          },
+          "subnet": {
+            "value": "[variables('networkSettings').subnet.mysql]"
+          },
+          "dnsname": {
+            "value": "[parameters('dnsNamePrefix')]"
+          },
+          "sizeOfDataDiskInGB": {
+            "value": "[parameters('sizeOfDataDiskInGB')]"
+          },
+          "numDataDisks": {
+            "value": "[variables('numDataDisks')]"
+          },
+          "templateBaseUrl": {
+            "value": "[variables('environment').templateBaseUrl]"
+          },
+          "serviceEndPoint": {
+            "value": "[variables('environment').serviceEndPoint]"
+          },
+          "vmSize": {
+            "value": "[parameters('dbNodeVmSize')]"
+          },
+          "zabbixServerIPAddress": {
+             "value": "[parameters('zabbixServerIPAddress')]"
+          },
+          "osSettings": {
+            "value": "[variables('mysqlSlaveOsSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "lbNode",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "[variables('apiVersion')]",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'shared')]",
+        "[concat('Microsoft.Resources/deployments/', 'mysqlSlaveNode')]",
+        "['vmLoop']"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('lbTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "namespace": {
+            "value": "[variables('namespace')]"
+          },
+          "vmbasename": {
+            "value": "lb"
+          },
+          "subnet": {
+            "value": "[variables('networkSettings').subnet.haproxy]"
+          },
+          "dnsname": {
+            "value": "[parameters('dnsNamePrefix')]"
+          },
+          "sizeOfDataDiskInGB": {
+            "value": "[parameters('sizeOfDataDiskInGB')]"
+          },
+          "numDataDisks": {
+            "value": "[variables('numDataDisks')]"
+          },
+          "webNodeCount": {
+            "value": "[parameters('webNodeCount')]"
+          },
+          "templateBaseUrl": {
+            "value": "[variables('environment').templateBaseUrl]"
+          },
+          "serviceEndPoint": {
+            "value": "[variables('environment').serviceEndPoint]"
+          },
+          "vmSize": {
+            "value": "[parameters('lbNodeVmSize')]"
+          },
+          "zabbixServerIPAddress": {
+             "value": "[parameters('zabbixServerIPAddress')]"
+          },
+          "osSettings": {
+            "value": "[variables('lbOsSettings')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/website-cluster-centos/azuredeploy.json
+++ b/website-cluster-centos/azuredeploy.json
@@ -141,7 +141,7 @@
 	}
   },
   "variables": {
-    "baseUrl": "https://raw.githubusercontent.com/251744647/azure-quickstart-templates/master/website-cluster-centos/",
+    "baseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/website-cluster-centos/",
     "baseChinaUrl": "http://msmirrors.blob.core.chinacloudapi.cn/website-cluster-centos/",
     "environmentAzureCloud": {
       "serviceEndPoint": ".blob.core.windows.net/vhds/",

--- a/website-cluster-centos/azuredeploy.parameters.json
+++ b/website-cluster-centos/azuredeploy.parameters.json
@@ -17,23 +17,11 @@
     "webNodeCount": {
       "value": 3
     },
-    "sizeOfDataDiskInGB": {
-      "value": 20
-    },
     "dnsNamePrefix": {
       "value": "GEN-UNIQUE"
     },
     "centOsVersion": {
         "value": "7.0"
-    },
-    "lbNodeVmSize": {
-      "value": "Standard_A3"
-    },
-    "webNodeVmSize": {
-      "value": "Standard_A3"
-    },
-    "dbNodeVmSize": {
-      "value": "Standard_A3"
     },
     "zabbixServerIPAddress": {
       "value": "Null"

--- a/website-cluster-centos/azuredeploy.parameters.json
+++ b/website-cluster-centos/azuredeploy.parameters.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "value": "azureuser"
+    },
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "mysqlPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "environment": {
+      "value": "AzureCloud"
+    },
+    "webNodeCount": {
+      "value": 3
+    },
+    "sizeOfDataDiskInGB": {
+      "value": 20
+    },
+    "dnsNamePrefix": {
+      "value": "GEN-UNIQUE"
+    },
+    "centOsVersion": {
+        "value": "7.0"
+    },
+    "lbNodeVmSize": {
+      "value": "Standard_A3"
+    },
+    "webNodeVmSize": {
+      "value": "Standard_A3"
+    },
+    "dbNodeVmSize": {
+      "value": "Standard_A3"
+    },
+    "zabbixServerIPAddress": {
+      "value": "Null"
+    }
+  }
+}

--- a/website-cluster-centos/metadata.json
+++ b/website-cluster-centos/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template deploys a website cluster and enables Zabbix monitoring, and allows user to define the number of web servers. ",
   "summary": "The website cluster contains 1 load balancer, 3 web servers, 1 redis master with 1 redis slave, 1 MySQL master with 1 MySQL slave by default.",
   "githubUsername": "251744647",
-  "dateUpdated": "2016-07-18"
+  "dateUpdated": "2016-07-25"
 }

--- a/website-cluster-centos/metadata.json
+++ b/website-cluster-centos/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "website cluster",
+  "description": "This template deploys a website cluster and enables Zabbix monitoring, and allows user to define the number of web servers. ",
+  "summary": "The website cluster contains 1 load balancer, 3 web servers, 1 redis master with 1 redis slave, 1 MySQL master with 1 MySQL slave by default.",
+  "githubUsername": "251744647",
+  "dateUpdated": "2016-07-18"
+}

--- a/website-cluster-centos/nested/disksSelector.json
+++ b/website-cluster-centos/nested/disksSelector.json
@@ -1,0 +1,937 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "numDataDisks": {
+      "type": "string",
+      "allowedValues": [
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "10",
+        "11",
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "32",
+        "64"
+      ],
+      "metadata": {
+        "description": "This parameter allows the user to select the number of disks they want"
+      }
+    },
+    "diskStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the storage account where the data disks are stored"
+      }
+    },
+    "diskCaching": {
+      "type": "string",
+      "allowedValues": [
+        "None",
+        "ReadOnly",
+        "ReadWrite"
+      ],
+      "metadata": {
+        "description": "Caching type for the data disks"
+      }
+    },
+    "diskSizeGB": {
+      "type": "int",
+      "minValue": 1,
+      "maxValue": 1023,
+      "metadata": {
+        "description": "Size of the data disks"
+      }
+    }
+  },
+  "variables": {
+    "_comment1": "disksArray is ugly :( but it gets the job done. If anyone can make it better, please do!",
+    "disksArray": {
+      "1": "[variables('dataDisks')['1']]",
+      "2": "[concat(variables('dataDisks')['1'], variables('dataDisks')['2'])]",
+      "3": "[concat(variables('dataDisks')['1'], variables('dataDisks')['2'], variables('dataDisks')['3'])]",
+      "4": "[variables('diskDeltas')['4delta']]",
+      "5": "[concat(variables('diskDeltas')['4delta'], variables('dataDisks')['5'])]",
+      "6": "[concat(variables('diskDeltas')['4delta'], variables('dataDisks')['5'], variables('dataDisks')['6'])]",
+      "7": "[concat(variables('diskDeltas')['4delta'], variables('dataDisks')['5'], variables('dataDisks')['6'], variables('dataDisks')['7'])]",
+      "8": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'])]",
+      "9": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('dataDisks')['9'])]",
+      "10": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('dataDisks')['9'], variables('dataDisks')['10'])]",
+      "11": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('dataDisks')['9'], variables('dataDisks')['10'], variables('dataDisks')['11'])]",
+      "12": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('diskDeltas')['12delta'])]",
+      "13": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('diskDeltas')['12delta'], variables('dataDisks')['13'])]",
+      "14": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('diskDeltas')['12delta'], variables('dataDisks')['13'], variables('dataDisks')['14'])]",
+      "15": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('diskDeltas')['12delta'], variables('dataDisks')['13'], variables('dataDisks')['14'], variables('dataDisks')['15'])]",
+      "16": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('diskDeltas')['12delta'], variables('diskDeltas')['16delta'])]",
+      "32": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('diskDeltas')['12delta'], variables('diskDeltas')['16delta'], variables('diskDeltas')['32delta'])]",
+      "64": "[concat(variables('diskDeltas')['4delta'], variables('diskDeltas')['8delta'], variables('diskDeltas')['12delta'], variables('diskDeltas')['16delta'], variables('diskDeltas')['32delta'], variables('diskDeltas')['64delta'])]"
+    },
+    "dataDisks": {
+      "1": [
+        {
+          "name": "datadisk1",
+          "lun": 0,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk1.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "2": [
+        {
+          "name": "datadisk2",
+          "lun": 1,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk2.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "3": [
+        {
+          "name": "datadisk3",
+          "lun": 2,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk3.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "4": [
+        {
+          "name": "datadisk4",
+          "lun": 3,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk4.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "5": [
+        {
+          "name": "datadisk5",
+          "lun": 4,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk5.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "6": [
+        {
+          "name": "datadisk6",
+          "lun": 5,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk6.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "7": [
+        {
+          "name": "datadisk7",
+          "lun": 6,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk7.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "8": [
+        {
+          "name": "datadisk8",
+          "lun": 7,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk8.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "9": [
+        {
+          "name": "datadisk9",
+          "lun": 8,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk9.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "10": [
+        {
+          "name": "datadisk10",
+          "lun": 9,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk10.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "11": [
+        {
+          "name": "datadisk11",
+          "lun": 10,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk11.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "12": [
+        {
+          "name": "datadisk12",
+          "lun": 11,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk12.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "13": [
+        {
+          "name": "datadisk13",
+          "lun": 12,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk13.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "14": [
+        {
+          "name": "datadisk14",
+          "lun": 13,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk14.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "15": [
+        {
+          "name": "datadisk15",
+          "lun": 14,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk15.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "16": [
+        {
+          "name": "datadisk16",
+          "lun": 15,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk16.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "17": [
+        {
+          "name": "datadisk17",
+          "lun": 16,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk17.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "18": [
+        {
+          "name": "datadisk18",
+          "lun": 17,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk18.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "19": [
+        {
+          "name": "datadisk19",
+          "lun": 18,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk19.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "20": [
+        {
+          "name": "datadisk20",
+          "lun": 19,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk20.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "21": [
+        {
+          "name": "datadisk21",
+          "lun": 20,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk21.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "22": [
+        {
+          "name": "datadisk22",
+          "lun": 21,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk22.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "23": [
+        {
+          "name": "datadisk23",
+          "lun": 22,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk23.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "24": [
+        {
+          "name": "datadisk24",
+          "lun": 23,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk24.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "25": [
+        {
+          "name": "datadisk25",
+          "lun": 24,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk25.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "26": [
+        {
+          "name": "datadisk26",
+          "lun": 25,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk26.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "27": [
+        {
+          "name": "datadisk27",
+          "lun": 26,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk27.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "28": [
+        {
+          "name": "datadisk28",
+          "lun": 27,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk28.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "29": [
+        {
+          "name": "datadisk29",
+          "lun": 28,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk29.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "30": [
+        {
+          "name": "datadisk30",
+          "lun": 29,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk30.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "31": [
+        {
+          "name": "datadisk31",
+          "lun": 30,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk31.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "32": [
+        {
+          "name": "datadisk32",
+          "lun": 31,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk32.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "33": [
+        {
+          "name": "datadisk33",
+          "lun": 32,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk33.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "34": [
+        {
+          "name": "datadisk34",
+          "lun": 33,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk34.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "35": [
+        {
+          "name": "datadisk35",
+          "lun": 34,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk35.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "36": [
+        {
+          "name": "datadisk36",
+          "lun": 35,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk36.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "37": [
+        {
+          "name": "datadisk37",
+          "lun": 36,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk37.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "38": [
+        {
+          "name": "datadisk38",
+          "lun": 37,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk38.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "39": [
+        {
+          "name": "datadisk39",
+          "lun": 38,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk39.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "40": [
+        {
+          "name": "datadisk40",
+          "lun": 39,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk40.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "41": [
+        {
+          "name": "datadisk41",
+          "lun": 40,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk41.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "42": [
+        {
+          "name": "datadisk42",
+          "lun": 41,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk42.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "43": [
+        {
+          "name": "datadisk43",
+          "lun": 42,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk43.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "44": [
+        {
+          "name": "datadisk44",
+          "lun": 43,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk44.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "45": [
+        {
+          "name": "datadisk45",
+          "lun": 44,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk45.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "46": [
+        {
+          "name": "datadisk46",
+          "lun": 45,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk46.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "47": [
+        {
+          "name": "datadisk47",
+          "lun": 46,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk47.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "48": [
+        {
+          "name": "datadisk48",
+          "lun": 47,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk48.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "49": [
+        {
+          "name": "datadisk49",
+          "lun": 48,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk49.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "50": [
+        {
+          "name": "datadisk50",
+          "lun": 49,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk50.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "51": [
+        {
+          "name": "datadisk51",
+          "lun": 50,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk51.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "52": [
+        {
+          "name": "datadisk52",
+          "lun": 51,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk52.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "53": [
+        {
+          "name": "datadisk53",
+          "lun": 52,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk53.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "54": [
+        {
+          "name": "datadisk54",
+          "lun": 53,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk54.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "55": [
+        {
+          "name": "datadisk55",
+          "lun": 54,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk55.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "56": [
+        {
+          "name": "datadisk56",
+          "lun": 55,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk56.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "57": [
+        {
+          "name": "datadisk57",
+          "lun": 56,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk57.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "58": [
+        {
+          "name": "datadisk58",
+          "lun": 57,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk58.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "59": [
+        {
+          "name": "datadisk59",
+          "lun": 58,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk59.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "60": [
+        {
+          "name": "datadisk60",
+          "lun": 59,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk60.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "61": [
+        {
+          "name": "datadisk61",
+          "lun": 60,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk61.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "62": [
+        {
+          "name": "datadisk62",
+          "lun": 61,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk62.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "63": [
+        {
+          "name": "datadisk63",
+          "lun": 62,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk63.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ],
+      "64": [
+        {
+          "name": "datadisk64",
+          "lun": 63,
+          "vhd": {
+            "uri": "[concat('http://', parameters('diskStorageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk64.vhd')]"
+          },
+          "createOption": "Empty",
+          "caching": "[parameters('diskCaching')]",
+          "diskSizeGB": "[parameters('diskSizeGB')]"
+        }
+      ]
+    },
+    "_comment2": "The delta arrays below build the difference from 0 to 4, 4 to 8, 8 to 12 disks and so on",
+    "diskDeltas": {
+      "4delta": [
+        "[variables('dataDisks')['1'][0]]",
+        "[variables('dataDisks')['2'][0]]",
+        "[variables('dataDisks')['3'][0]]",
+        "[variables('dataDisks')['4'][0]]"
+      ],
+      "8delta": [
+        "[variables('dataDisks')['5'][0]]",
+        "[variables('dataDisks')['6'][0]]",
+        "[variables('dataDisks')['7'][0]]",
+        "[variables('dataDisks')['8'][0]]"
+      ],
+      "12delta": [
+        "[variables('dataDisks')['9'][0]]",
+        "[variables('dataDisks')['10'][0]]",
+        "[variables('dataDisks')['11'][0]]",
+        "[variables('dataDisks')['12'][0]]"
+      ],
+      "16delta": [
+        "[variables('dataDisks')['13'][0]]",
+        "[variables('dataDisks')['14'][0]]",
+        "[variables('dataDisks')['15'][0]]",
+        "[variables('dataDisks')['16'][0]]"
+      ],
+      "32delta": [
+        "[variables('dataDisks')['17'][0]]",
+        "[variables('dataDisks')['18'][0]]",
+        "[variables('dataDisks')['19'][0]]",
+        "[variables('dataDisks')['20'][0]]",
+        "[variables('dataDisks')['21'][0]]",
+        "[variables('dataDisks')['22'][0]]",
+        "[variables('dataDisks')['23'][0]]",
+        "[variables('dataDisks')['24'][0]]",
+        "[variables('dataDisks')['25'][0]]",
+        "[variables('dataDisks')['26'][0]]",
+        "[variables('dataDisks')['27'][0]]",
+        "[variables('dataDisks')['28'][0]]",
+        "[variables('dataDisks')['29'][0]]",
+        "[variables('dataDisks')['30'][0]]",
+        "[variables('dataDisks')['31'][0]]",
+        "[variables('dataDisks')['32'][0]]"
+      ],
+      "64delta": [
+        "[variables('dataDisks')['33'][0]]",
+        "[variables('dataDisks')['34'][0]]",
+        "[variables('dataDisks')['35'][0]]",
+        "[variables('dataDisks')['36'][0]]",
+        "[variables('dataDisks')['37'][0]]",
+        "[variables('dataDisks')['38'][0]]",
+        "[variables('dataDisks')['39'][0]]",
+        "[variables('dataDisks')['40'][0]]",
+        "[variables('dataDisks')['41'][0]]",
+        "[variables('dataDisks')['42'][0]]",
+        "[variables('dataDisks')['43'][0]]",
+        "[variables('dataDisks')['44'][0]]",
+        "[variables('dataDisks')['45'][0]]",
+        "[variables('dataDisks')['46'][0]]",
+        "[variables('dataDisks')['47'][0]]",
+        "[variables('dataDisks')['48'][0]]",
+        "[variables('dataDisks')['49'][0]]",
+        "[variables('dataDisks')['50'][0]]",
+        "[variables('dataDisks')['51'][0]]",
+        "[variables('dataDisks')['52'][0]]",
+        "[variables('dataDisks')['53'][0]]",
+        "[variables('dataDisks')['54'][0]]",
+        "[variables('dataDisks')['55'][0]]",
+        "[variables('dataDisks')['56'][0]]",
+        "[variables('dataDisks')['57'][0]]",
+        "[variables('dataDisks')['58'][0]]",
+        "[variables('dataDisks')['59'][0]]",
+        "[variables('dataDisks')['60'][0]]",
+        "[variables('dataDisks')['61'][0]]",
+        "[variables('dataDisks')['62'][0]]",
+        "[variables('dataDisks')['63'][0]]",
+        "[variables('dataDisks')['64'][0]]"
+      ]
+    }
+  },
+  "resources": [],
+  "outputs": {
+    "dataDiskArray": {
+      "type": "array",
+      "value": "[variables('disksArray')[parameters('numDataDisks')]]"
+    }
+  }
+}
+

--- a/website-cluster-centos/nested/lb-resources.json
+++ b/website-cluster-centos/nested/lb-resources.json
@@ -1,0 +1,274 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string"
+    },
+    "adminPassword": {
+      "type": "securestring"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "serviceEndPoint": {
+      "type": "string"
+    },
+    "webNodeCount": {
+      "type": "int"
+    },
+    "vmbasename": {
+      "type": "string"
+    },
+    "dnsname": {
+      "type": "string"
+    },
+    "osSettings": {
+      "type": "object"
+    },
+    "numDataDisks": {
+      "type": "string"
+    },
+    "sizeOfDataDiskInGB": {
+      "type": "int"
+    },
+    "templateBaseUrl": {
+      "type": "string"
+    },
+    "vmSize": {
+      "type": "string"
+    },
+    "zabbixServerIPAddress": {
+      "type": "string"
+    },
+    "subnet": {
+      "type": "object"
+    }
+  },
+  "variables": {
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), parameters('vmbasename'))]",
+    "apiVersion": "2015-06-15",
+    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('securityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "http",
+            "properties": {
+              "description": "Allows Http traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10050",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent1",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10051",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsname')]"
+        }
+      }
+    },
+	{
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('namespace'), parameters('vmbasename'), 'PublicIp')]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp'))]"
+              },
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              },
+			  "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), parameters('vmbasename'), 'nic')]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('vmbasename'), 'vm')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": "[parameters('osSettings').imageReference]",
+          "dataDisks": [ 
+             { 
+               "name": "datadisk1", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 0, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk1.vhd')]" 
+               }, 
+               "createOption": "Empty",
+               "caching": "ReadWrite"			   
+             }, 
+             { 
+               "name": "datadisk2", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 1, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk2.vhd')]" 
+               }, 
+               "caching": "ReadWrite",
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk3", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 2, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk3.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk4", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 3, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk4.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             } 
+           ], 
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), parameters('vmbasename'), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), parameters('vmbasename'), 'nic'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/lbInstall')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('namespace'), parameters('vmbasename'), 'nic')]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.4",
+		"autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": "[parameters('osSettings').scripts]"
+		},
+		"protectedSettings": {
+          "commandToExecute": "[concat('bash lb.sh ', parameters('webNodeCount'), ' ', parameters('zabbixServerIPAddress'))]"
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/website-cluster-centos/nested/lb-resources.json
+++ b/website-cluster-centos/nested/lb-resources.json
@@ -53,7 +53,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -62,7 +62,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -128,7 +128,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp')]",
       "location": "[resourceGroup().location]",
@@ -140,7 +140,7 @@
       }
     },
 	{
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -168,7 +168,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[resourceGroup().location]",
@@ -250,7 +250,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/lbInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",

--- a/website-cluster-centos/nested/mysqlMaster-resources.json
+++ b/website-cluster-centos/nested/mysqlMaster-resources.json
@@ -53,7 +53,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -62,7 +62,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -128,7 +128,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -150,7 +150,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -232,7 +232,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/mysqlMasterInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"

--- a/website-cluster-centos/nested/mysqlMaster-resources.json
+++ b/website-cluster-centos/nested/mysqlMaster-resources.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string"
+    },
+    "adminPassword": {
+      "type": "securestring"
+    },
+    "mysqlPassword": {
+      "type": "securestring"
+    },
+    "serviceEndPoint": {
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "vmbasename": {
+      "type": "string"
+    },
+    "osSettings": {
+      "type": "object"
+    },
+    "vmSize": {
+      "type": "string"
+    },
+    "dnsname": {
+      "type": "string"
+    },
+    "numDataDisks": {
+      "type": "string"
+    },
+    "sizeOfDataDiskInGB": {
+      "type": "int"
+    },
+    "templateBaseUrl": {
+      "type": "string"
+    },
+    "subnet": {
+      "type": "object"
+    },
+    "zabbixServerIPAddress": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'mysqlmaster')]",
+    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('securityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "mysql",
+            "properties": {
+              "description": "Allows MySQL traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "3306",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10050",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent1",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10051",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              },
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('vmbasename'), 'vm')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": "[parameters('osSettings').imageReference]",
+          "dataDisks": [ 
+             { 
+               "name": "datadisk1", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 0, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk1.vhd')]" 
+               }, 
+               "createOption": "Empty",
+               "caching": "ReadWrite"			   
+             }, 
+             { 
+               "name": "datadisk2", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 1, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk2.vhd')]" 
+               }, 
+               "caching": "ReadWrite",
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk3", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 2, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk3.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk4", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 3, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk4.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             } 
+           ], 
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), parameters('vmbasename'), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/mysqlMasterInstall')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.4",
+		"autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": "[parameters('osSettings').scripts]"
+		},
+		"protectedSettings": {
+          "commandToExecute": "[concat('bash mysqlMaster.sh ', parameters('mysqlPassword'), ' ', parameters('zabbixServerIPAddress'))]"
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/website-cluster-centos/nested/mysqlSlave-resources.json
+++ b/website-cluster-centos/nested/mysqlSlave-resources.json
@@ -53,7 +53,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -62,7 +62,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -128,7 +128,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -150,7 +150,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -232,7 +232,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/mysqlSlaveInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"

--- a/website-cluster-centos/nested/mysqlSlave-resources.json
+++ b/website-cluster-centos/nested/mysqlSlave-resources.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string"
+    },
+    "adminPassword": {
+      "type": "securestring"
+    },
+    "mysqlPassword": {
+      "type": "securestring"
+    },
+    "serviceEndPoint": {
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "vmbasename": {
+      "type": "string"
+    },
+    "osSettings": {
+      "type": "object"
+    },
+    "vmSize": {
+      "type": "string"
+    },
+    "dnsname": {
+      "type": "string"
+    },
+    "numDataDisks": {
+      "type": "string"
+    },
+    "sizeOfDataDiskInGB": {
+      "type": "int"
+    },
+    "templateBaseUrl": {
+      "type": "string"
+    },
+    "subnet": {
+      "type": "object"
+    },
+    "zabbixServerIPAddress": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'mysqlslave')]",
+    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('securityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "mysql",
+            "properties": {
+              "description": "Allows MySQL traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "3306",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10050",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent1",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10051",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              },
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('vmbasename'), 'vm')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": "[parameters('osSettings').imageReference]",
+          "dataDisks": [ 
+             { 
+               "name": "datadisk1", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 0, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk1.vhd')]" 
+               }, 
+               "createOption": "Empty",
+               "caching": "ReadWrite"			   
+             }, 
+             { 
+               "name": "datadisk2", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 1, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk2.vhd')]" 
+               }, 
+               "caching": "ReadWrite",
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk3", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 2, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk3.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk4", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 3, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk4.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             } 
+           ], 
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), parameters('vmbasename'), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/mysqlSlaveInstall')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.4",
+		"autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": "[parameters('osSettings').scripts]"
+		},
+		"protectedSettings": {
+          "commandToExecute": "[concat('bash mysqlSlave.sh ', parameters('mysqlPassword'), ' ', parameters('zabbixServerIPAddress'))]"
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/website-cluster-centos/nested/redisMaster-resources.json
+++ b/website-cluster-centos/nested/redisMaster-resources.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string"
+    },
+    "adminPassword": {
+      "type": "securestring"
+    },
+    "serviceEndPoint": {
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "vmbasename": {
+      "type": "string"
+    },
+    "osSettings": {
+      "type": "object"
+    },
+    "vmSize": {
+      "type": "string"
+    },
+    "dnsname": {
+      "type": "string"
+    },
+    "numDataDisks": {
+      "type": "string"
+    },
+    "sizeOfDataDiskInGB": {
+      "type": "int"
+    },
+    "templateBaseUrl": {
+      "type": "string"
+    },
+    "subnet": {
+      "type": "object"
+    },
+    "zabbixServerIPAddress": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'redismaster')]",
+    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('securityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "redis",
+            "properties": {
+              "description": "Allows Redis traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "6379",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10050",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent1",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10051",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              },
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('vmbasename'), 'vm')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": "[parameters('osSettings').imageReference]",
+          "dataDisks": [ 
+             { 
+               "name": "datadisk1", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 0, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk1.vhd')]" 
+               }, 
+               "createOption": "Empty",
+               "caching": "ReadWrite"			   
+             }, 
+             { 
+               "name": "datadisk2", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 1, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk2.vhd')]" 
+               }, 
+               "caching": "ReadWrite",
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk3", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 2, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk3.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk4", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 3, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk4.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             } 
+           ], 
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), parameters('vmbasename'), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/redisMasterInstall')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.4",
+		"autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": "[parameters('osSettings').scripts]"
+		},
+		"protectedSettings": {
+          "commandToExecute": "[concat('bash redisMaster.sh ', parameters('zabbixServerIPAddress'))]"
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/website-cluster-centos/nested/redisMaster-resources.json
+++ b/website-cluster-centos/nested/redisMaster-resources.json
@@ -50,7 +50,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -59,7 +59,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -125,7 +125,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -147,7 +147,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -229,7 +229,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/redisMasterInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"

--- a/website-cluster-centos/nested/redisSlave-resources.json
+++ b/website-cluster-centos/nested/redisSlave-resources.json
@@ -1,0 +1,252 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string"
+    },
+    "adminPassword": {
+      "type": "securestring"
+    },
+    "serviceEndPoint": {
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "vmbasename": {
+      "type": "string"
+    },
+    "osSettings": {
+      "type": "object"
+    },
+    "vmSize": {
+      "type": "string"
+    },
+    "dnsname": {
+      "type": "string"
+    },
+    "numDataDisks": {
+      "type": "string"
+    },
+    "sizeOfDataDiskInGB": {
+      "type": "int"
+    },
+    "templateBaseUrl": {
+      "type": "string"
+    },
+    "subnet": {
+      "type": "object"
+    },
+    "zabbixServerIPAddress": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'redisslave')]",
+    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('securityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "redis",
+            "properties": {
+              "description": "Allows Redis traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "6379",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10050",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent1",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10051",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              },
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('vmbasename'), 'vm')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": "[parameters('osSettings').imageReference]",
+          "dataDisks": [ 
+             { 
+               "name": "datadisk1", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 0, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk1.vhd')]" 
+               }, 
+               "createOption": "Empty",
+               "caching": "ReadWrite"			   
+             }, 
+             { 
+               "name": "datadisk2", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 1, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk2.vhd')]" 
+               }, 
+               "caching": "ReadWrite",
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk3", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 2, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk3.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk4", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 3, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk4.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             } 
+           ], 
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), parameters('vmbasename'), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/redisSlaveInstall')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.4",
+		"autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": "[parameters('osSettings').scripts]"
+		},
+		"protectedSettings": {
+          "commandToExecute": "[concat('bash redisSlave.sh ', parameters('zabbixServerIPAddress'))]"
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/website-cluster-centos/nested/redisSlave-resources.json
+++ b/website-cluster-centos/nested/redisSlave-resources.json
@@ -50,7 +50,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -59,7 +59,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -125,7 +125,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -147,7 +147,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -229,7 +229,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/redisSlaveInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"

--- a/website-cluster-centos/nested/shared-resources.json
+++ b/website-cluster-centos/nested/shared-resources.json
@@ -22,14 +22,14 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSettings').virtualNetworkName]",
       "location": "[resourceGroup().location]",

--- a/website-cluster-centos/nested/shared-resources.json
+++ b/website-cluster-centos/nested/shared-resources.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "networkSettings": {
+      "type": "object",
+      "metadata": {
+        "Description": "Network settings object"
+      }
+    },
+    "namespace": {
+      "type": "string",
+      "metadata": {
+        "Description": "namespace"
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+	"apiVersion": "2015-06-15"
+  
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[concat(parameters('namespace'), 'set')]",
+      "location": "[resourceGroup().location]",
+      "properties": {}
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('networkSettings').virtualNetworkName]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('networkSettings').addressPrefix]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('networkSettings').subnet.web.name]",
+            "properties": {
+              "addressPrefix": "[parameters('networkSettings').subnet.web.prefix]"
+            }
+          },
+          {
+            "name": "[parameters('networkSettings').subnet.mysql.name]",
+            "properties": {
+              "addressPrefix": "[parameters('networkSettings').subnet.mysql.prefix]"
+            }
+          },
+          {
+            "name": "[parameters('networkSettings').subnet.redis.name]",
+            "properties": {
+              "addressPrefix": "[parameters('networkSettings').subnet.redis.prefix]"
+            }
+          },
+          {
+            "name": "[parameters('networkSettings').subnet.haproxy.name]",
+            "properties": {
+              "addressPrefix": "[parameters('networkSettings').subnet.haproxy.prefix]"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/website-cluster-centos/nested/web-resources.json
+++ b/website-cluster-centos/nested/web-resources.json
@@ -53,7 +53,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -62,7 +62,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -128,7 +128,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -150,7 +150,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -232,7 +232,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/webInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"

--- a/website-cluster-centos/nested/web-resources.json
+++ b/website-cluster-centos/nested/web-resources.json
@@ -1,0 +1,255 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string"
+    },
+    "adminPassword": {
+      "type": "securestring"
+    },
+    "mysqlPassword": {
+      "type": "securestring"
+    },
+    "serviceEndPoint": {
+      "type": "string"
+    },
+    "namespace": {
+      "type": "string"
+    },
+    "vmbasename": {
+      "type": "string"
+    },
+    "osSettings": {
+      "type": "object"
+    },
+    "vmSize": {
+      "type": "string"
+    },
+    "dnsname": {
+      "type": "string"
+    },
+    "numDataDisks": {
+      "type": "string"
+    },
+    "sizeOfDataDiskInGB": {
+      "type": "int"
+    },
+    "templateBaseUrl": {
+      "type": "string"
+    },
+    "subnet": {
+      "type": "object"
+    },
+    "zabbixServerIPAddress": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), parameters('vmbasename'))]",
+    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('securityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "http",
+            "properties": {
+              "description": "Allows Web traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10050",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+		  {
+            "name": "zabbixAgent1",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10051",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              },
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "[variables('apiVersion')]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('vmbasename'), 'vm')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": "[parameters('osSettings').imageReference]",
+          "dataDisks": [ 
+             { 
+               "name": "datadisk1", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 0, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk1.vhd')]" 
+               }, 
+               "createOption": "Empty",
+               "caching": "ReadWrite"			   
+             }, 
+             { 
+               "name": "datadisk2", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 1, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk2.vhd')]" 
+               }, 
+               "caching": "ReadWrite",
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk3", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 2, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk3.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             }, 
+             { 
+               "name": "datadisk4", 
+               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
+               "lun": 3, 
+               "vhd": { 
+                 "Uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), 'datadisk4.vhd')]" 
+               },
+               "caching": "ReadWrite",			   
+               "createOption": "Empty" 
+             } 
+           ], 
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', variables('storageAccountName'), parameters('serviceEndPoint'), parameters('vmbasename'), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/webInstall')]",
+      "apiVersion": "[variables('apiVersion')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.4",
+		"autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": "[parameters('osSettings').scripts]"
+		},
+		"protectedSettings": {
+          "commandToExecute": "[concat('bash web.sh ', parameters('mysqlPassword'), ' ', parameters('adminUsername'), ' ', parameters('zabbixServerIPAddress'))]"
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/website-cluster-centos/scripts/lb.sh
+++ b/website-cluster-centos/scripts/lb.sh
@@ -1,0 +1,150 @@
+#/bin/bash
+
+webNodeCount=$1
+zabbixServer=$2
+
+
+	
+install_haproxy() {
+	cd /tmp
+	yum install wget -y
+		for((i=1;i<=5;i++))
+		do
+			wget http://www.haproxy.org/download/1.6/src/haproxy-1.6.3.tar.gz
+			if [[ $? -eq 0 ]];then
+				break
+			else
+				continue
+			fi
+		done
+	tar zxvf haproxy-1.6.3.tar.gz
+	cd haproxy-1.6.3
+	yum install gcc -y
+	make TARGET=linux2628 PREFIX=/usr/local/haproxy
+	make install PREFIX=/usr/local/haproxy
+
+
+}
+
+
+disk_format() {
+	cd /tmp
+	mkdir /data
+	yum install wget -y
+	for ((j=1;j<=3;j++))
+	do
+		wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/shared_scripts/ubuntu/vm-disk-utils-0.1.sh 
+		if [[ -f /tmp/vm-disk-utils-0.1.sh ]]; then
+			bash /tmp/vm-disk-utils-0.1.sh -b /data/ -s
+			if [[ $? -eq 0 ]]; then
+				sed -i 's/disk1//' /etc/fstab
+				umount /data/disk1
+				mount /dev/md0 /data
+			fi
+			break
+		else
+			echo "download vm-disk-utils-0.1.sh failed. try again."
+			continue
+		fi
+	done
+		
+}
+
+
+install_zabbix() {
+	#install zabbix agent
+	cd /tmp
+	yum install -y gcc wget > /dev/null
+	for((n=1;n<=5;n++))
+	do
+		wget http://jaist.dl.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/2.2.5/zabbix-2.2.5.tar.gz
+		if [[ $? -eq 0 ]];then
+			break
+		else
+			continue
+		fi
+	done
+	tar zxvf zabbix-2.2.5.tar.gz
+	cd zabbix-2.2.5
+	groupadd zabbix
+	useradd zabbix -g zabbix -s /sbin/nologin
+	mkdir -p /usr/local/zabbix
+	./configure --prefix=/usr/local/zabbix --enable-agent
+	make install > /dev/null
+	cp misc/init.d/fedora/core/zabbix_agentd /etc/init.d/
+	sed -i 's/BASEDIR=\/usr\/local/BASEDIR=\/usr\/local\/zabbix/g' /etc/init.d/zabbix_agentd
+	sed -i '$azabbix-agent    10050/tcp\nzabbix-agent    10050/udp' /etc/services
+	sed -i '/^LogFile/s/tmp/var\/log/' /usr/local/zabbix/etc/zabbix_agentd.conf
+	hostName=`hostname`
+	sed -i "s/^Hostname=Zabbix server/Hostname=$hostName/" /usr/local/zabbix/etc/zabbix_agentd.conf
+	if [[ $zabbixServer =~ ([0-9]{1,3}.){3}[0-9]{1,3} ]];then
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^ServerActive=127.0.0.1/ServerActive=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agent.conf
+	fi
+	touch /var/log/zabbix_agentd.log
+	chown zabbix:zabbix /var/log/zabbix_agentd.log
+
+	#start zabbix agent
+	chkconfig --add zabbix_agentd
+	chkconfig zabbix_agentd on
+	/etc/init.d/zabbix_agentd start
+
+}
+
+
+config_haproxy() {
+haproxyConfigFile="/usr/local/haproxy/haproxy.cfg"
+cat > ${haproxyConfigFile} <<EOF
+global         
+       maxconn 4096           
+       chroot /usr/local/haproxy
+        uid 99                 
+        gid 99               
+       daemon                  
+       pidfile /usr/local/haproxy/haproxy.pid  
+
+defaults             
+       log    global
+        log     127.0.0.1       local3        
+       mode    http         
+       option  httplog       
+        option  dontlognull  
+        option  httpclose    
+       retries 3           
+       option  redispatch   
+       maxconn 2000                     
+       timeout connect     5000           
+       timeout client     50000          
+       timeout server     50000          
+
+frontend http-in                       
+       bind *:80
+        mode    http 
+        option  httplog
+        log     global
+        default_backend httppool 
+       
+backend httppool                    
+       balance source
+EOF
+
+
+	for ((k=1;k<=$webNodeCount;k++))
+	do
+		let ip=3+$k
+		sed -i "\$a server  web${k} 10.0.0.${ip}:80  weight 5 check inter 2000 rise 2 fall 3" ${haproxyConfigFile}
+		sed -i '$s/^/       /' ${haproxyConfigFile}
+	done	
+
+	#start haproxy
+	/usr/local/haproxy/sbin/haproxy -f /usr/local/haproxy/haproxy.cfg
+}
+
+
+
+
+install_haproxy
+disk_format
+config_haproxy
+install_zabbix

--- a/website-cluster-centos/scripts/mysqlMaster.sh
+++ b/website-cluster-centos/scripts/mysqlMaster.sh
@@ -1,0 +1,135 @@
+#/bin/bash
+
+
+mysqlPassword=$1
+zabbixServer=$2
+
+
+	
+install_mysql() {
+
+	#get repo
+	yum install wget -y
+	for((i=1;i<=5;i++))
+	do
+		wget http://repo.mysql.com/mysql-community-release-el6-5.noarch.rpm
+		if [[ $? -ne 0 ]];then
+			if [[ $i == 5 ]];then
+				echo "tried 5 times to download repo but failed. exit. try again later."
+				exit 1
+			fi
+			continue
+		else
+			echo "download repo successfully"
+			break
+		fi
+	done
+	yum localinstall -y mysql-community-release-el6-5.noarch.rpm
+
+	#install mysql 5.6
+	for((i=1;i<=5;i++))
+	do
+		yum install -y mysql-community-server
+		if [[ $? -ne 0 ]];then
+			if [[ $i == 5 ]];then
+				echo "tried 5 times to install mysql server but failed. exit. try again later."
+				exit 10
+			fi
+			yum clean all
+			continue
+		else
+			echo "installed mysql server successfully."
+			break
+		fi
+	done
+
+	#configure my.cnf
+	sed -i '/\[mysqld\]/a server-id = 1\nlog_bin = /var/lib/mysql/mysql-bin.log' /etc/my.cnf
+	
+	#auto-start
+	chkconfig mysqld on
+	
+
+}
+
+
+disk_format() {
+	cd /tmp
+	yum install wget -y
+	for ((j=1;j<=3;j++))
+	do
+		wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/shared_scripts/ubuntu/vm-disk-utils-0.1.sh 
+		if [[ -f /tmp/vm-disk-utils-0.1.sh ]]; then
+			bash /tmp/vm-disk-utils-0.1.sh -b /var/lib/mysql -s
+			if [[ $? -eq 0 ]]; then
+				sed -i 's/disk1//' /etc/fstab
+				umount /var/lib/mysql/disk1
+				mount /dev/md0 /var/lib/mysql
+				chown -R mysql:mysql /var/lib/mysql
+			fi
+			break
+		else
+			echo "download vm-disk-utils-0.1.sh failed. try again."
+			continue
+		fi
+	done
+		
+}
+
+
+install_zabbix() {
+	#install zabbix agent
+	cd /tmp
+	yum install -y gcc wget > /dev/null
+	for((n=1;n<=5;n++))
+	do
+		wget http://jaist.dl.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/2.2.5/zabbix-2.2.5.tar.gz
+		if [[ $? -eq 0 ]];then
+			break
+		else
+			continue
+		fi
+	done
+	tar zxvf zabbix-2.2.5.tar.gz
+	cd zabbix-2.2.5
+	groupadd zabbix
+	useradd zabbix -g zabbix -s /sbin/nologin
+	mkdir -p /usr/local/zabbix
+	./configure --prefix=/usr/local/zabbix --enable-agent
+	make install > /dev/null
+	cp misc/init.d/fedora/core/zabbix_agentd /etc/init.d/
+	sed -i 's/BASEDIR=\/usr\/local/BASEDIR=\/usr\/local\/zabbix/g' /etc/init.d/zabbix_agentd
+	sed -i '$azabbix-agent    10050/tcp\nzabbix-agent    10050/udp' /etc/services
+	sed -i '/^LogFile/s/tmp/var\/log/' /usr/local/zabbix/etc/zabbix_agentd.conf
+	hostName=`hostname`
+	sed -i "s/^Hostname=Zabbix server/Hostname=$hostName/" /usr/local/zabbix/etc/zabbix_agentd.conf
+	if [[ $zabbixServer =~ ([0-9]{1,3}.){3}[0-9]{1,3} ]];then
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^ServerActive=127.0.0.1/ServerActive=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agent.conf
+	fi
+	touch /var/log/zabbix_agentd.log
+	chown zabbix:zabbix /var/log/zabbix_agentd.log
+
+	#start zabbix agent
+	chkconfig --add zabbix_agentd
+	chkconfig zabbix_agentd on
+	/etc/init.d/zabbix_agentd start
+
+}
+
+start_mysql() {
+	#start mysql
+	service mysqld start
+
+	#set mysql root password
+	mysqladmin -uroot password "$mysqlPassword" 2> /dev/null
+
+	#grant privileges
+	mysql -uroot -p$mysqlPassword -e "grant replication slave on *.* to 'repluser'@'%' identified by 'replpass';grant all privileges on *.* to 'root'@'%' identified by '$mysqlPassword';flush privileges;"
+}
+
+install_mysql
+disk_format
+start_mysql
+install_zabbix

--- a/website-cluster-centos/scripts/mysqlSlave.sh
+++ b/website-cluster-centos/scripts/mysqlSlave.sh
@@ -1,0 +1,146 @@
+#/bin/bash
+
+
+mysqlPassword=$1
+zabbixServer=$2
+masterIP=10.0.0.20
+
+
+	
+install_mysql() {
+
+	#get repo
+	yum install wget -y
+	for((i=1;i<=5;i++))
+	do
+		wget http://repo.mysql.com/mysql-community-release-el6-5.noarch.rpm
+		if [[ $? -ne 0 ]];then
+			if [[ $i == 5 ]];then
+				echo "tried 5 times to download repo but failed. exit. try again later."
+				exit 1
+			fi
+			continue
+		else
+			echo "download repo successfully"
+			break
+		fi
+	done
+	yum localinstall -y mysql-community-release-el6-5.noarch.rpm
+
+	#install mysql 5.6
+	for((i=1;i<=5;i++))
+	do
+		yum install -y mysql-community-server
+		if [[ $? -ne 0 ]];then
+			if [[ $i == 5 ]];then
+				echo "tried 5 times to install mysql server but failed. exit. try again later."
+				exit 10
+			fi
+			yum clean all
+			continue
+		else
+			echo "installed mysql server successfully."
+			break
+		fi
+	done
+
+	#configure my.cnf
+	sed -i '/\[mysqld\]/a server-id = 2\nlog_bin = /var/lib/mysql/mysql-bin.log\nreplicate-ignore-db = mysql' /etc/my.cnf
+	
+	#auto-start
+	chkconfig mysqld on
+	
+
+}
+
+
+disk_format() {
+	cd /tmp
+	yum install wget -y
+	for ((j=1;j<=3;j++))
+	do
+		wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/shared_scripts/ubuntu/vm-disk-utils-0.1.sh 
+		if [[ -f /tmp/vm-disk-utils-0.1.sh ]]; then
+			bash /tmp/vm-disk-utils-0.1.sh -b /var/lib/mysql -s
+			if [[ $? -eq 0 ]]; then
+				sed -i 's/disk1//' /etc/fstab
+				umount /var/lib/mysql/disk1
+				mount /dev/md0 /var/lib/mysql
+				chown -R mysql:mysql /var/lib/mysql
+			fi
+			break
+		else
+			echo "download vm-disk-utils-0.1.sh failed. try again."
+			continue
+		fi
+	done
+		
+}
+
+
+install_zabbix() {
+	#install zabbix agent
+	cd /tmp
+	yum install -y gcc wget > /dev/null
+	for((n=1;n<=5;n++))
+	do
+		wget http://jaist.dl.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/2.2.5/zabbix-2.2.5.tar.gz
+		if [[ $? -eq 0 ]];then
+			break
+		else
+			continue
+		fi
+	done
+	tar zxvf zabbix-2.2.5.tar.gz
+	cd zabbix-2.2.5
+	groupadd zabbix
+	useradd zabbix -g zabbix -s /sbin/nologin
+	mkdir -p /usr/local/zabbix
+	./configure --prefix=/usr/local/zabbix --enable-agent
+	make install > /dev/null
+	cp misc/init.d/fedora/core/zabbix_agentd /etc/init.d/
+	sed -i 's/BASEDIR=\/usr\/local/BASEDIR=\/usr\/local\/zabbix/g' /etc/init.d/zabbix_agentd
+	sed -i '$azabbix-agent    10050/tcp\nzabbix-agent    10050/udp' /etc/services
+	sed -i '/^LogFile/s/tmp/var\/log/' /usr/local/zabbix/etc/zabbix_agentd.conf
+	hostName=`hostname`
+	sed -i "s/^Hostname=Zabbix server/Hostname=$hostName/" /usr/local/zabbix/etc/zabbix_agentd.conf
+	if [[ $zabbixServer =~ ([0-9]{1,3}.){3}[0-9]{1,3} ]];then
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^ServerActive=127.0.0.1/ServerActive=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agent.conf
+	fi
+	touch /var/log/zabbix_agentd.log
+	chown zabbix:zabbix /var/log/zabbix_agentd.log
+
+	#start zabbix agent
+	chkconfig --add zabbix_agentd
+	chkconfig zabbix_agentd on
+	/etc/init.d/zabbix_agentd start
+
+}
+
+start_mysql() {
+	#start mysql
+	service mysqld start
+
+	#set mysql root password
+	mysqladmin -uroot password "$mysqlPassword" 2> /dev/null
+
+	#grant privileges
+	mysql -uroot -p$mysqlPassword -e "grant all privileges on *.* to 'root'@'%' identified by '$mysqlPassword';flush privileges;"
+
+	#configure slave
+	mysql -uroot -p$mysqlPassword -e "change master to master_host='$masterIP',master_user='repluser',master_password='replpass';start slave;"
+	slaveStatus=`mysql -uroot -p$mysqlPassword -e "show slave status\G" |grep -i "Running: Yes"|wc -l`
+	if [[ $slaveStatus -ne 2 ]];then
+		echo "master-slave replication issue!"
+	else
+		echo "master-slave configuration succeeds! "
+	fi
+
+}
+
+install_mysql
+disk_format
+install_zabbix
+start_mysql

--- a/website-cluster-centos/scripts/redisMaster.sh
+++ b/website-cluster-centos/scripts/redisMaster.sh
@@ -1,0 +1,113 @@
+#/bin/bash
+
+zabbixServer=$1
+
+	
+install_redis() {
+
+	#download redis
+	cd /usr/local/
+	yum install -y wget
+	for((i=1;i<=5;i++))
+	do
+		wget http://download.redis.io/releases/redis-3.0.7.tar.gz
+		if [[ $? -ne 0 ]];then
+			if [[ $i == 5 ]];then
+				echo "tried 5 times to download redis but failed. exit. try again later."
+				exit 1
+			fi
+			continue
+		else
+			echo "download redis successfully"
+			break
+		fi
+	done
+
+	#install redis
+	tar xzvf redis-3.0.7.tar.gz
+	mv redis-3.0.7 redis
+	cd redis
+	yum install gcc -y
+	make
+
+	#ocnfigure redis
+	cp redis.conf /etc/
+	sed -i 's/daemonize no/daemonize yes/' /etc/redis.conf
+	cd src
+
+}
+
+
+disk_format() {
+	cd /tmp
+	yum install wget -y
+	for ((j=1;j<=3;j++))
+	do
+		wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/shared_scripts/ubuntu/vm-disk-utils-0.1.sh 
+		if [[ -f /tmp/vm-disk-utils-0.1.sh ]]; then
+			bash /tmp/vm-disk-utils-0.1.sh -b /data/ -s
+			if [[ $? -eq 0 ]]; then
+				sed -i 's/disk1//' /etc/fstab
+				umount /data/
+				mount /dev/md0 /data/
+			fi
+			break
+		else
+			echo "download vm-disk-utils-0.1.sh failed. try again."
+			continue
+		fi
+	done
+		
+}
+
+
+install_zabbix() {
+	#install zabbix agent
+	cd /tmp
+	yum install -y gcc wget > /dev/null
+	for((n=1;n<=5;n++))
+	do
+		wget http://jaist.dl.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/2.2.5/zabbix-2.2.5.tar.gz
+		if [[ $? -eq 0 ]];then
+			break
+		else
+			continue
+		fi
+	done
+	tar zxvf zabbix-2.2.5.tar.gz
+	cd zabbix-2.2.5
+	groupadd zabbix
+	useradd zabbix -g zabbix -s /sbin/nologin
+	mkdir -p /usr/local/zabbix
+	./configure --prefix=/usr/local/zabbix --enable-agent
+	make install > /dev/null
+	cp misc/init.d/fedora/core/zabbix_agentd /etc/init.d/
+	sed -i 's/BASEDIR=\/usr\/local/BASEDIR=\/usr\/local\/zabbix/g' /etc/init.d/zabbix_agentd
+	sed -i '$azabbix-agent    10050/tcp\nzabbix-agent    10050/udp' /etc/services
+	sed -i '/^LogFile/s/tmp/var\/log/' /usr/local/zabbix/etc/zabbix_agentd.conf
+	hostName=`hostname`
+	sed -i "s/^Hostname=Zabbix server/Hostname=$hostName/" /usr/local/zabbix/etc/zabbix_agentd.conf
+	if [[ $zabbixServer =~ ([0-9]{1,3}.){3}[0-9]{1,3} ]];then
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^ServerActive=127.0.0.1/ServerActive=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agent.conf
+	fi
+	touch /var/log/zabbix_agentd.log
+	chown zabbix:zabbix /var/log/zabbix_agentd.log
+
+	#start zabbix agent
+	chkconfig --add zabbix_agentd
+	chkconfig zabbix_agentd on
+	/etc/init.d/zabbix_agentd start
+
+}
+
+
+install_redis
+disk_format
+#start redis
+/usr/local/redis/src/redis-server /etc/redis.conf
+install_zabbix
+
+
+

--- a/website-cluster-centos/scripts/redisSlave.sh
+++ b/website-cluster-centos/scripts/redisSlave.sh
@@ -1,0 +1,117 @@
+#/bin/bash
+
+zabbixServer=$1
+masterIP=10.0.0.36
+
+
+	
+	
+install_redis() {
+
+	#download redis
+	cd /usr/local/
+	yum install -y wget
+	for((i=1;i<=5;i++))
+	do
+		wget http://download.redis.io/releases/redis-3.0.7.tar.gz
+		if [[ $? -ne 0 ]];then
+			if [[ $i == 5 ]];then
+				echo "tried 5 times to download redis but failed. exit. try again later."
+				exit 1
+			fi
+			continue
+		else
+			echo "download redis successfully"
+			break
+		fi
+	done
+
+	#install redis
+	tar xzvf redis-3.0.7.tar.gz
+	mv redis-3.0.7 redis
+	cd redis
+	yum install gcc -y
+	make
+
+	#ocnfigure redis
+	cp redis.conf /etc/
+	sed -i 's/daemonize no/daemonize yes/' /etc/redis.conf
+	sed -i "s/# slaveof <masterip> <masterport>/slaveof $masterIP 6379/" /etc/redis.conf
+	cd src
+
+}
+
+
+disk_format() {
+	cd /tmp
+	yum install wget -y
+	for ((j=1;j<=3;j++))
+	do
+		wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/shared_scripts/ubuntu/vm-disk-utils-0.1.sh 
+		if [[ -f /tmp/vm-disk-utils-0.1.sh ]]; then
+			bash /tmp/vm-disk-utils-0.1.sh -b /data/ -s
+			if [[ $? -eq 0 ]]; then
+				sed -i 's/disk1//' /etc/fstab
+				umount /data/
+				mount /dev/md0 /data/
+			fi
+			break
+		else
+			echo "download vm-disk-utils-0.1.sh failed. try again."
+			continue
+		fi
+	done
+		
+}
+
+
+install_zabbix() {
+	#install zabbix agent
+	cd /tmp
+	yum install -y gcc wget > /dev/null
+	for((n=1;n<=5;n++))
+	do
+		wget http://jaist.dl.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/2.2.5/zabbix-2.2.5.tar.gz
+		if [[ $? -eq 0 ]];then
+			break
+		else
+			continue
+		fi
+	done
+	tar zxvf zabbix-2.2.5.tar.gz
+	cd zabbix-2.2.5
+	groupadd zabbix
+	useradd zabbix -g zabbix -s /sbin/nologin
+	mkdir -p /usr/local/zabbix
+	./configure --prefix=/usr/local/zabbix --enable-agent
+	make install > /dev/null
+	cp misc/init.d/fedora/core/zabbix_agentd /etc/init.d/
+	sed -i 's/BASEDIR=\/usr\/local/BASEDIR=\/usr\/local\/zabbix/g' /etc/init.d/zabbix_agentd
+	sed -i '$azabbix-agent    10050/tcp\nzabbix-agent    10050/udp' /etc/services
+	sed -i '/^LogFile/s/tmp/var\/log/' /usr/local/zabbix/etc/zabbix_agentd.conf
+	hostName=`hostname`
+	sed -i "s/^Hostname=Zabbix server/Hostname=$hostName/" /usr/local/zabbix/etc/zabbix_agentd.conf
+	if [[ $zabbixServer =~ ([0-9]{1,3}.){3}[0-9]{1,3} ]];then
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^ServerActive=127.0.0.1/ServerActive=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agent.conf
+	fi
+	touch /var/log/zabbix_agentd.log
+	chown zabbix:zabbix /var/log/zabbix_agentd.log
+
+	#start zabbix agent
+	chkconfig --add zabbix_agentd
+	chkconfig zabbix_agentd on
+	/etc/init.d/zabbix_agentd start
+
+}
+
+
+install_redis
+disk_format
+#start redis
+/usr/local/redis/src/redis-server /etc/redis.conf
+install_zabbix
+
+
+

--- a/website-cluster-centos/scripts/web.sh
+++ b/website-cluster-centos/scripts/web.sh
@@ -1,0 +1,157 @@
+#/bin/bash
+
+
+mysqlPassword=$1
+insertValue=$2
+zabbixServer=$3
+masterIP=10.0.0.20
+
+	
+install_ap() {
+
+
+	#install apache 2.4 php5
+	yum install httpd php php-mysql -y
+
+
+	#start httpd
+	service httpd start
+
+	#auto-start 
+	chkconfig httpd on
+	chkconfig firewalld off
+	chkconfig iptables off
+	service firewalld stop
+	service iptables stop
+
+	#set selinux
+	sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/sysconfig/selinux
+	sed -i 's/^SELINUX=.*/SELINUX=disabled/' /etc/selinux/config
+	setenforce 0
+
+}
+
+
+disk_format() {
+	cd /tmp
+	yum install wget -y
+	for ((j=1;j<=3;j++))
+	do
+		wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/shared_scripts/ubuntu/vm-disk-utils-0.1.sh 
+		if [[ -f /tmp/vm-disk-utils-0.1.sh ]]; then
+			bash /tmp/vm-disk-utils-0.1.sh -b /var/www/html -s
+			if [[ $? -eq 0 ]]; then
+				sed -i 's/disk1//' /etc/fstab
+				umount /var/www/html/disk1
+				mount /dev/md0 /var/www/html
+			fi
+			break
+		else
+			echo "download vm-disk-utils-0.1.sh failed. try again."
+			continue
+		fi
+	done
+		
+}
+
+
+install_zabbix() {
+	#install zabbix agent
+	cd /tmp
+	yum install -y gcc wget > /dev/null
+	for((n=1;n<=5;n++))
+	do
+		wget http://jaist.dl.sourceforge.net/project/zabbix/ZABBIX%20Latest%20Stable/2.2.5/zabbix-2.2.5.tar.gz
+		if [[ $? -eq 0 ]];then
+			break
+		else
+			continue
+		fi
+	done
+	tar zxvf zabbix-2.2.5.tar.gz
+	cd zabbix-2.2.5
+	groupadd zabbix
+	useradd zabbix -g zabbix -s /sbin/nologin
+	mkdir -p /usr/local/zabbix
+	./configure --prefix=/usr/local/zabbix --enable-agent
+	make install > /dev/null
+	cp misc/init.d/fedora/core/zabbix_agentd /etc/init.d/
+	sed -i 's/BASEDIR=\/usr\/local/BASEDIR=\/usr\/local\/zabbix/g' /etc/init.d/zabbix_agentd
+	sed -i '$azabbix-agent    10050/tcp\nzabbix-agent    10050/udp' /etc/services
+	sed -i '/^LogFile/s/tmp/var\/log/' /usr/local/zabbix/etc/zabbix_agentd.conf
+	hostName=`hostname`
+	sed -i "s/^Hostname=Zabbix server/Hostname=$hostName/" /usr/local/zabbix/etc/zabbix_agentd.conf
+	if [[ $zabbixServer =~ ([0-9]{1,3}.){3}[0-9]{1,3} ]];then
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^ServerActive=127.0.0.1/ServerActive=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agentd.conf
+		sed -i "s/^Server=127.0.0.1/Server=$zabbixServer/" /usr/local/zabbix/etc/zabbix_agent.conf
+	fi
+	touch /var/log/zabbix_agentd.log
+	chown zabbix:zabbix /var/log/zabbix_agentd.log
+
+	#start zabbix agent
+	chkconfig --add zabbix_agentd
+	chkconfig zabbix_agentd on
+	/etc/init.d/zabbix_agentd start
+
+}
+
+
+create_test_page() {
+#create test php page
+cat > /var/www/html/info.php <<EOF
+<?php
+phpinfo();
+?>
+EOF
+
+#create test php-mysql page
+cat > /var/www/html/mysql.php <<EOF
+<?php
+\$conn = mysql_connect('$masterIP', 'root', '$mysqlPassword');
+if (!\$conn) {
+    die('Could not connect:' . mysql_error());
+}
+echo 'Connected to MySQL sucessfully!';
+
+if(mysql_query("create database testdb")){
+    echo "    Created database testdb successfully!";
+}else{
+    echo "    Database testdb already exists!";
+}
+
+\$db_selected = mysql_select_db('testdb',\$conn);
+
+if(mysql_query("create table test01(name varchar(10))")){
+    echo "    Created table test01 successfuly!";
+}else{
+    echo "    Table test01 already exists!";
+}
+
+if(mysql_query("insert into test01 values ('$insertValue')")){
+    echo "    Inserted value $insertValue into test01 successfully!";
+}else{
+    echo "    Inserted value $insertValue into test01 failed!";
+}
+
+\$result = mysql_query("select * from testdb.test01");
+while(\$row = mysql_fetch_array(\$result))
+{
+echo "    Welcome ";
+echo \$row["name"];
+echo "!!!";
+}
+
+mysql_close(\$conn)
+?>
+EOF
+
+}
+
+
+
+
+install_ap
+disk_format
+create_test_page
+install_zabbix


### PR DESCRIPTION
This template deploys a website cluster and enables Zabbix monitoring, and allows user to define the number of web servers. The website cluster contains 1 load balancer, 3 web servers, 1 redis master with 1 redis slave, 1 MySQL master with 1 MySQL slave by default.