### PR TITLE
Updating scripts and readmes to reflect new Geth changes

### DIFF
--- a/go-ethereum-on-ubuntu/README.md
+++ b/go-ethereum-on-ubuntu/README.md
@@ -127,11 +127,16 @@ var initializer =  {from:web3.eth.accounts[0], data: guestBookCompiled.GuestBook
 ## Deploying the Contract
 We are now ready to deploy! Remember that `new` method? We can finally use it:
 
+You will need to enter the password you entered when first importing the private key to unlock your account.
+
+```
+personal.unlockAccount(personal.listAccounts[0])
+```
+
 ```
 var guestBook = contract.new(initializer, callback);
 ```
 
-You will be prompted to enter the password you entered when first importing the private key.
 
 Congratulations - you have a contract deployed to the Ethereum network!
 
@@ -161,7 +166,7 @@ Congratulations - your contract is now alive on the Ethereum Network!
 
 Go ahead and stop your miner for the moment:
 ```
-web3.miner.stop(1)
+web3.miner.stop()
 ```
 
 ## Reading from the contract

--- a/go-ethereum-on-ubuntu/configure-geth.sh
+++ b/go-ethereum-on-ubuntu/configure-geth.sh
@@ -49,4 +49,5 @@ wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/g
 wget https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/go-ethereum-on-ubuntu/GuestBook.sol
 
 date
+geth init genesis.json
 echo "completed geth install $$"

--- a/go-ethereum-on-ubuntu/start-private-blockchain.sh
+++ b/go-ethereum-on-ubuntu/start-private-blockchain.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-geth --maxpeers 0 --genesis genesis.json --networkid 101010101  --rpc --rpccorsdomain "*" console
+geth --maxpeers 0 --networkid 101010101  --rpc --rpccorsdomain "*" console


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Update README to unlock account earlier
* Update install script to initialize genesis block
* Update run script to remove stale --genesis flag

### Description of the change
With the latest versions of Geth, the `--gensis` flag has been replaced by a separate `init` command. This was breaking the deploy script. This PR fixes the breaking changes.