### PR TITLE
Add --sha1 for bosh upload command (stemcell && CF release); Refine l…

### DIFF
--- a/bosh-setup/CHANGELOG.md
+++ b/bosh-setup/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.8.3 (2016-07-19)
+
+- Add --sha1 for bosh upload command (stemcell && CF release)
+- Switch to mirror.azure.cn to download releases and stemcells in AzureChinaCloud
+- Write more logs to install.log in dev-box
+
 # v1.8.2 (2016-07-18)
 
 - Add powerdns in bosh.yml

--- a/bosh-setup/azuredeploy.json
+++ b/bosh-setup/azuredeploy.json
@@ -133,21 +133,23 @@
       "boshAzureCPIReleaseSha1": "5d1d5f62a30911d5e07285d3dfa0f1c4b41262b9",
       "stemcellUrl": "https://bosh.io/d/stemcells/bosh-azure-hyperv-ubuntu-trusty-go_agent?v=3232.11",
       "stemcellSha1": "575a284a3e314a5e1dc78fed8ff73e8a1da9b78b",
-      "boshInitUrl": "https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.81-linux-amd64",
-      "cfReleaseUrl": "https://bosh.io/d/github.com/cloudfoundry/cf-release?v=238"
+      "boshInitUrl": "https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.95-linux-amd64",
+      "cfReleaseUrl": "https://bosh.io/d/github.com/cloudfoundry/cf-release?v=238",
+      "cfReleaseSha1": "fa6d35300f4fcd74a75fd8c7138f592acfcb32b0"
     },
     "environmentAzureChinaCloud": {
       "serviceHostBase": "core.chinacloudapi.cn",
       "secondaryDNS": "1.2.4.8",
       "dnsRecursor": "1.2.4.8",
-      "boshReleaseUrl": "[uri(variables('baseUriAzureChinaCloud'), 'releases/bosh-256.2.tgz')]",
+      "boshReleaseUrl": "http://mirror.azure.cn/bosh/release/bosh-256.2.tgz",
       "boshReleaseSha1": "ff2f4e16e02f66b31c595196052a809100cfd5a8",
-      "boshAzureCPIReleaseUrl": "[uri(variables('baseUriAzureChinaCloud'), 'releases/bosh-azure-cpi-release-13.tgz')]",
+      "boshAzureCPIReleaseUrl": "http://mirror.azure.cn/bosh/bosh-azure-cpi-release/bosh-azure-cpi-release-13.tgz",
       "boshAzureCPIReleaseSha1": "5d1d5f62a30911d5e07285d3dfa0f1c4b41262b9",
-      "stemcellUrl": "[uri(variables('baseUriAzureChinaCloud'), 'stemcells/bosh-stemcell-3232.11-azure-hyperv-ubuntu-trusty-go_agent.tgz')]",
+      "stemcellUrl": "http://mirror.azure.cn/bosh/bosh-azure-stemcells/bosh-stemcell-3232.11-azure-hyperv-ubuntu-trusty-go_agent.tgz",
       "stemcellSha1": "575a284a3e314a5e1dc78fed8ff73e8a1da9b78b",
-      "boshInitUrl": "[uri(variables('baseUriAzureChinaCloud'), 'bosh-init/bosh-init-0.0.81-linux-amd64')]",
-      "cfReleaseUrl": "[uri(variables('baseUriAzureChinaCloud'), 'releases/cf-release-238.tgz')]"
+      "boshInitUrl": "http://mirror.azure.cn/bosh/bosh-init/bosh-init-0.0.95-linux-amd64",
+      "cfReleaseUrl": "http://mirror.azure.cn/bosh/cf/cf-release-238.tgz",
+      "cfReleaseSha1": "fa6d35300f4fcd74a75fd8c7138f592acfcb32b0"
     },
     "environment": "[variables(concat('environment', parameters('environment')))]",
 
@@ -481,7 +483,7 @@
           "RESOURCE_GROUP_NAME": "[resourceGroup().name]",
           "DEFAULT_STORAGE_ACCOUNT_NAME": "[variables('defaultStorageAccountName')]",
           "STORAGE_ACCESS_KEY": "[listKeys(variables('storageid'), variables('apiVersion')).key1]",
-          "ADMIN_USER_NAME": "[parameters('adminUserName')]",
+          "ADMIN_USER_NAME": "[parameters('adminUsername')]",
           "ENVIRONMENT": "[parameters('environment')]",
           "SERVICE_HOST_BASE": "[variables('environment').serviceHostBase]",
           "SECONDARY_DNS": "[variables('environment').secondaryDNS]",
@@ -492,12 +494,13 @@
           "STEMCELL_URL": "[variables('environment').stemcellUrl]",
           "STEMCELL_SHA1": "[variables('environment').stemcellSha1]",
           "CF_RELEASE_URL": "[variables('environment').cfReleaseUrl]",
+          "CF_RELEASE_SHA1": "[variables('environment').cfReleaseSha1]",
           "BOSH_INIT_URL": "[variables('environment').boshInitUrl]",
           "KEEP_UNREACHABLE_VMS": "[variables('keepUnreachableVMs')]",
           "AUTO_DEPLOY_BOSH": "[parameters('autoDeployBosh')]"
         },
         "protectedSettings": {
-          "commandToExecute": "[concat('./setup_env', ' ', parameters('tenantID'), ' ', parameters('clientID'), ' \"', parameters('clientSecret'), '\"')]"
+          "commandToExecute": "[concat('bash -l -c \"./setup_env', ' ', parameters('tenantID'), ' ', parameters('clientID'), ' \"', parameters('clientSecret'), '\" >/home/', parameters('adminUsername'), '/install.log 2>&1\"')]"
         }
       }
     }

--- a/bosh-setup/metadata.json
+++ b/bosh-setup/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template helps you setup a development environment where you can deploy BOSH and Cloud Foundry.",
   "summary": "This template helps you setup a development environment where you can deploy BOSH and Cloud Foundry.",
   "githubUsername": "bingosummer",
-  "dateUpdated": "2016-07-18"
+  "dateUpdated": "2016-07-19"
 }

--- a/bosh-setup/scripts/deploy_cloudfoundry.sh
+++ b/bosh-setup/scripts/deploy_cloudfoundry.sh
@@ -23,8 +23,8 @@ password=$(echo $password | sed 's/\//\\\//g')
 password=${password:-$default_password}
 sed -i "s/REPLACE_WITH_PASSWORD/$password/g" $manifest
 
-bosh upload stemcell REPLACE_WITH_STEMCELL_URL --skip-if-exists
-bosh upload release REPLACE_WITH_CF_RELEASE_URL --skip-if-exists
+bosh upload stemcell REPLACE_WITH_STEMCELL_URL --sha1 REPLACE_WITH_STEMCELL_SHA1 --skip-if-exists
+bosh upload release REPLACE_WITH_CF_RELEASE_URL --sha1 REPLACE_WITH_CF_RELEASE_SHA1 --skip-if-exists
 
 bosh deployment $manifest
 bosh -n deploy

--- a/bosh-setup/scripts/init.sh
+++ b/bosh-setup/scripts/init.sh
@@ -37,4 +37,3 @@ wget $bosh_init_url
 chmod +x ./bosh-init-*
 sudo mv ./bosh-init-* /usr/local/bin/bosh-init
 
-echo "Finish"

--- a/bosh-setup/scripts/setup_env
+++ b/bosh-setup/scripts/setup_env
@@ -59,25 +59,27 @@ set -e
 username=$(get_setting ADMIN_USER_NAME)
 home_dir="/home/$username"
 
-# Generate SSH key pair for BOSH
+echo "Start to generate SSH key pair for BOSH..."
 bosh_key="bosh"
 ssh-keygen -t rsa -f $bosh_key -P "" -C ""
 chmod 400 $bosh_key
 cp $bosh_key $home_dir
 cp "$bosh_key.pub" $home_dir
 
-# Generate SSL certificate for cloud foundry
+echo "Start to generate SSL certificate for cloud foundry..."
 chmod +x create_cert.sh
 cf_key="cloudfoundry.key"
 cf_cert="cloudfoundry.cert"
 ./create_cert.sh $cf_key $cf_cert
 
+echo "Start to run setup_env.py..."
 bosh_director_ip=$(python setup_env.py ${tenant_id} ${client_id} ${client_secret} ${custom_script_config_file})
 
 # For backward compatibility
 sed -i "s/CLOUD_FOUNDRY_PUBLIC_IP/cf-ip/g" settings
 cp settings $home_dir
 
+echo "Start to specify params in bosh.yml..."
 REPLACE_WITH_NATS_PASSWORD=$(openssl rand -base64 16 | tr -dc 'a-zA-Z0-9')
 REPLACE_WITH_POSTGRES_PASSWORD=$(openssl rand -base64 16 | tr -dc 'a-zA-Z0-9')
 REPLACE_WITH_REGISTRY_PASSWORD=$(openssl rand -base64 16 | tr -dc 'a-zA-Z0-9')
@@ -111,15 +113,18 @@ cp multiple-vm-cf.yml $example_manifests
 
 cp cf* $home_dir
 bosh_init_url=$(get_setting BOSH_INIT_URL)
-install_log="$home_dir/install.log"
 chmod +x init.sh
-./init.sh $environment $bosh_init_url >$install_log 2>&1
+echo "Start to run init.sh..."
+./init.sh $environment $bosh_init_url
 
 chown -R $username $home_dir
 
 auto_deploy_bosh=$(get_setting AUTO_DEPLOY_BOSH)
 if [ "$auto_deploy_bosh" != "enabled" ]; then
+  echo "Finish"
   exit 0
 fi
 
+echo "Start to run deploy_bosh.sh..."
 su -c "./deploy_bosh.sh" - $username
+echo "Finish"

--- a/bosh-setup/scripts/setup_env.py
+++ b/bosh-setup/scripts/setup_env.py
@@ -154,7 +154,7 @@ def render_cloud_foundry_deployment_cmd(settings):
     if os.path.exists(cloudfoundry_deployment_cmd):
         with open(cloudfoundry_deployment_cmd, 'r') as tmpfile:
             contents = tmpfile.read()
-        keys = ["CF_RELEASE_URL", "STEMCELL_URL"]
+        keys = ["STEMCELL_URL", "STEMCELL_SHA1", "CF_RELEASE_URL", "CF_RELEASE_SHA1"]
         for key in keys:
             value = settings[key]
             contents = re.compile(re.escape("REPLACE_WITH_{0}".format(key))).sub(value, contents)


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
- Add --sha1 for bosh upload command (stemcell && CF release)
- Switch to mirror.azure.cn to download releases and stemcells in AzureChinaCloud
- Write more logs to install.log in dev-box

### Description of the change
With the changes, 
- BOSH checks SHA1 while uploading stemcell and CF release.
- Releases and stemcells in AzureChinaCloud are downloaded from mirror.azure.cn.
- More logs.