### PR TITLE
mongod may not start reboot

### DIFF
--- a/mongodb-high-availability/mongodb-ubuntu-install.sh
+++ b/mongodb-high-availability/mongodb-ubuntu-install.sh
@@ -301,6 +301,12 @@ storage:
 #replication:
     #replSetName: "$REPLICA_SET_NAME"
 EOF
+
+	# Fixing an issue where the mongod will not start after reboot where when /run is tmpfs the /var/run/mongodb directory will be deleted at reboot
+	# After reboot, mongod wouldn't start since the pidFilePath is defined as /var/run/mongodb/mongod.pid in the configuration and path doesn't exist
+	sed -i "s|pre-start script|pre-start script\n  if [ ! -d /var/run/mongodb ]; then\n    mkdir -p /var/run/mongodb \&\& touch /var/run/mongodb/mongod.pid \&\& chmod 777 /var/run/mongodb/mongod.pid\n  fi\n|" /etc/init/mongod.conf
+
+
 }
 
 start_mongodb()


### PR DESCRIPTION
mongod may not start after reboot due to missing /var/run/mongodb
directory after reboot on systems where /var/run is tmpfs. Observed on
Ubuntu 14.04.