### PR TITLE
Adding Puppet Enterprise Cluster template

### DIFF
--- a/puppet-enterprise-cluster/README.md
+++ b/puppet-enterprise-cluster/README.md
@@ -1,0 +1,11 @@
+# Puppet Master and Agent Deployment
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fkenazk%2Fkenaztemplates%2Fmaster%2Fpuppet-enterprise-cluster%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fkenazk%2Fkenaztemplates%2Fmaster%2Fpuppetenterprise%2Fazuredeploy.json" target="_blank">
+    <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+This template creates a Puppet Enterprise cluster consisting of a master and a configurable number of Windows & Linux agents.

--- a/puppet-enterprise-cluster/README.md
+++ b/puppet-enterprise-cluster/README.md
@@ -1,10 +1,10 @@
 # Puppet Master and Agent Deployment
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fkenazk%2Fkenaztemplates%2Fmaster%2Fpuppet-enterprise-cluster%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fkenazk%2Fazure-quickstart-templates%2Fmaster%2Fpuppet-enterprise-cluster%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fkenazk%2Fkenaztemplates%2Fmaster%2Fpuppetenterprise%2Fazuredeploy.json" target="_blank">
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fkenazk%2Fazure-quickstart-templates%2Fmaster%2Fpuppet-enterprise-cluster%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -14,6 +14,12 @@
         "description": "Password for the Virtual Machine. Used for both SSH and RDP access."
       }
     },
+    "consolePassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Puppet Enterprise Console."
+      }
+    },
     "windowsAgentCount": {
       "type": "int",
       "metadata": {
@@ -61,16 +67,19 @@
   },
   "resources": [
     {
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
-      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
+      "sku": {
+          "name": "[variables('storageAccountType')]"
+      },
+      "kind": "Storage",
       "properties": {
-        "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -82,7 +91,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat('peagentip', copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -98,7 +107,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -125,7 +134,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "puppetNetworkSecurityGroup",
       "location": "[resourceGroup().location]",
@@ -217,7 +226,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -243,7 +252,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat('peAgentNic',copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -294,7 +303,7 @@
           "computername": "[variables('puppetMasterVmName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]",
-          "customData": "[base64(concat('#!/bin/bash\n\ncat <<EOF >/tmp/puppet_override.answers\n','azure_externalFQDN=',reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn,'\n','azure_internalFQDN=$(hostname -f)\n\nq_puppet_enterpriseconsole_auth_password=',parameters('adminPassword'),'\nq_database_host=\\${azure_externalFQDN}\nq_puppet_enterpriseconsole_master_hostname=\\${azure_externalFQDN}\nq_puppet_enterpriseconsole_smtp_host=\\${azure_externalFQDN}\nq_puppetagent_certname=\\${azure_externalFQDN}\nq_puppetmaster_dnsaltnames=puppet,$(hostname),\\${azure_internalFQDN},\\${azure_externalFQDN}\nq_puppetagent_server=\\${azure_externalFQDN}\nq_puppetdb_hostname=\\${azure_externalFQDN}\nq_puppetmaster_certname=\\${azure_externalFQDN}\nEOF\nchmod +x /tmp/puppet_override.answers\n'))]"
+          "customData": "[base64(concat('#!/bin/bash\n\ncat <<EOF >/tmp/puppet_override.answers\n','azure_externalFQDN=',reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn,'\n','azure_internalFQDN=$(hostname -f)\n\nq_puppet_enterpriseconsole_auth_password=',parameters('consolePassword'),'\nq_database_host=\\${azure_externalFQDN}\nq_puppet_enterpriseconsole_master_hostname=\\${azure_externalFQDN}\nq_puppet_enterpriseconsole_smtp_host=\\${azure_externalFQDN}\nq_puppetagent_certname=\\${azure_externalFQDN}\nq_puppetmaster_dnsaltnames=puppet,$(hostname),\\${azure_internalFQDN},\\${azure_externalFQDN}\nq_puppetagent_server=\\${azure_externalFQDN}\nq_puppetdb_hostname=\\${azure_externalFQDN}\nq_puppetmaster_certname=\\${azure_externalFQDN}\nEOF\nchmod +x /tmp/puppet_override.answers\n'))]"
         },
         "storageProfile": {
           "imageReference": {
@@ -330,7 +339,7 @@
     {
         "type": "Microsoft.Compute/virtualMachines/extensions",
         "name": "[concat(variables('puppetMasterVmName'),'/CustomScriptExtension')]",
-        "apiVersion": "2015-05-01-preview",
+        "apiVersion": "2016-03-30",
         "location": "[resourceGroup().location]",
         "dependsOn": [
             "[concat('Microsoft.Compute/virtualMachines/', variables('puppetMasterVmName'))]"
@@ -340,7 +349,7 @@
            "type": "CustomScriptForLinux",
            "typeHandlerVersion": "1.3",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/kenazk/kenaztemplates/master/puppet-enterprise-cluster/wait.sh"],
+              "fileUris": ["https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/puppet-enterprise-cluster/wait.sh"],
               "commandToExecute": "./wait.sh"
            }
        }
@@ -401,7 +410,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat('WindowsAgentVm',copyIndex(),'/puppetExtension')]",
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2016-03-30",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "puppetAgentExtLoop",
@@ -476,7 +485,7 @@
     {
         "type": "Microsoft.Compute/virtualMachines/extensions",
         "name": "[concat('UbuntuAgentVM',copyIndex(),'/CustomScriptExtension')]",
-        "apiVersion": "2015-05-01-preview",
+        "apiVersion": "2016-03-30",
         "location": "[resourceGroup().location]",
         "copy": {
           "name": "linuxAgentExtLoop",
@@ -490,15 +499,16 @@
            "publisher": "Microsoft.OSTCExtensions",
            "type": "CustomScriptForLinux",
            "typeHandlerVersion": "1.3",
+           "autoUpgradeMinorVersion" : "true",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/kenazk/kenaztemplates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
+              "fileUris": ["https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
               "commandToExecute": "[concat('./install_puppet_agent.sh ', reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn)]"
            }
        }
     }
   ],
   "outputs" : {
-    "Here is the SSH URL:": {
+    "Puppet Enterprise Console FQDN:": {
       "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn]",
       "type": "string"
     }

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -428,6 +428,7 @@
         "publisher": "Puppet",
         "type": "PuppetAgent",
         "typeHandlerVersion": "1.5",
+        "autoUpgradeMinorVersion" : "true",
         "protectedSettings": {
           "PUPPET_MASTER_SERVER": "[reference(variables('publicIPAddressName'),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn]"
         }

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -354,7 +354,7 @@
            "autoUpgradeMinorVersion" : "true",
            "typeHandlerVersion": "1.3",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/puppet-enterprise-cluster/wait.sh"],
+              "fileUris": ["https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/puppet-enterprise-cluster/wait.sh"],
               "commandToExecute": "./wait.sh"
            }
        }
@@ -507,7 +507,7 @@
            "typeHandlerVersion": "1.3",
            "autoUpgradeMinorVersion" : "true",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
+              "fileUris": ["https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
               "commandToExecute": "[concat('./install_puppet_agent.sh ', reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn)]"
            }
        }

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -353,7 +353,7 @@
            "type": "CustomScriptForLinux",
            "typeHandlerVersion": "1.3",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/puppet-enterprise-cluster/wait.sh"],
+              "fileUris": ["https://raw.githubusercontent.com/kenazk/azure-quickstart-templates/master/puppet-enterprise-cluster/wait.sh"],
               "commandToExecute": "./wait.sh"
            }
        }
@@ -505,7 +505,7 @@
            "typeHandlerVersion": "1.3",
            "autoUpgradeMinorVersion" : "true",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
+              "fileUris": ["https://raw.githubusercontent.com/kenazk/azure-quickstart-templates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
               "commandToExecute": "[concat('./install_puppet_agent.sh ', reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn)]"
            }
        }

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -30,7 +30,9 @@
     },
     "vmSize": {
       "type": "string",
-      "metadata": "Size of Puppet agent VMs",
+      "metadata": {
+        "description": "Size of Puppet agent VMs"
+      },
       "defaultValue": "Standard_D1_v2"
     }
   },

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -25,14 +25,18 @@
       "metadata": {
         "description": "Number of Windows Puppet Agents to deploy. Assumes Windows Server 2012 R2."
       },
-      "defaultValue": 1
+      "defaultValue": 1,
+      "minValue":1,
+      "maxValue":100
     },
     "linuxAgentCount": {
       "type": "int",
       "metadata": {
         "description": "Number of Linux Puppet Agents to deploy. Assumes Ubuntu 14.04-LTS."
       },
-      "defaultValue": 1
+      "defaultValue": 1,
+      "minValue":1,
+      "maxValue":100
     },
     "vmSize": {
       "type": "string",

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -353,7 +353,7 @@
            "type": "CustomScriptForLinux",
            "typeHandlerVersion": "1.3",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/kenazk/azure-quickstart-templates/master/puppet-enterprise-cluster/wait.sh"],
+              "fileUris": ["https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/puppet-enterprise-cluster/wait.sh"],
               "commandToExecute": "./wait.sh"
            }
        }
@@ -505,7 +505,7 @@
            "typeHandlerVersion": "1.3",
            "autoUpgradeMinorVersion" : "true",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/kenazk/azure-quickstart-templates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
+              "fileUris": ["https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
               "commandToExecute": "[concat('./install_puppet_agent.sh ', reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn)]"
            }
        }

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -1,0 +1,504 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "User name for the Virtual Machine. Used for both SSH and RDP access."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine. Used for both SSH and RDP access."
+      }
+    },
+    "windowsAgentCount": {
+      "type": "int",
+      "metadata": {
+        "description": "Number of Windows Puppet Agents to deploy. Assumes Windows Server 2012 R2."
+      },
+      "defaultValue": 1
+    },
+    "linuxAgentCount": {
+      "type": "int",
+      "metadata": {
+        "description": "Number of Linux Puppet Agents to deploy. Assumes Ubuntu 14.04-LTS."
+      },
+      "defaultValue": 1
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": "Size of Puppet agent VMs",
+      "defaultValue": "Standard_D1_v2"
+    }
+  },
+  "variables": {
+    "puppetAgentCount": "[add(parameters('windowsAgentCount'),parameters('linuxAgentCount'))]",
+    "newStorageAccountName": "[concat('str',uniqueString(resourceGroup().id, deployment().name))]",
+    "dnsNameForPublicIP": "[concat('dns',uniqueString(resourceGroup().id, deployment().name))]",
+    "imagePublisher": "Puppet",
+    "imageOffer": "Puppet-Enterprise",
+    "imageSku": "2016-1",
+    "OSDiskName": "puppetMasterDisk",
+    "nicName": "puppetmasterNic",
+    "addressPrefix": "10.0.0.0/16",
+    "subnetName": "Subnet",
+    "subnetPrefix": "10.0.0.0/24",
+    "storageAccountType": "Standard_LRS",
+    "publicIPAddressName": "myPublicIP",
+    "publicIPAddressType": "Dynamic",
+    "vmStorageAccountContainerName": "vhds",
+    "puppetMasterVmName": "puppetmaster",
+    "vmName": "peagent",
+    "virtualNetworkName": "vnet1",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "publicIpId": "[resourceId(resourceGroup().Name,concat('Microsoft.Network','/','publicIPAddresses'),variables('publicIPAddressName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('newStorageAccountName')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[variables('dnsNameForPublicIP')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat('peagentip', copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "puppetAgentPipLoop",
+        "count": "[variables('puppetAgentCount')]"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[concat(variables('dnsNameForPublicIP'), copyIndex())]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkSecurityGroups/', 'puppetNetworkSecurityGroup')]"
+      ],
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'puppetNetworkSecurityGroup')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "puppetNetworkSecurityGroup",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "puppet",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8140",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "rdp",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "3389",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 101,
+              "direction": "Inbound"
+            }
+          },
+          {
+	           "name": "ssh",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 201,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "MCollective",
+            "properties": {
+              "description": "MCollective",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "61613",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 102,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "https",
+            "properties": {
+              "description": "MCollective",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 103,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "orchestrator",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8142",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 104,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat('peAgentNic',copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "puppetAgentNicLoop",
+        "count": "[variables('puppetAgentCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/','peagentip',copyIndex())]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',concat('peagentip',copyIndex()))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('puppetMasterVmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "plan": {
+        "name": "2016-1",
+        "product": "puppet-enterprise",
+        "publisher": "puppet"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[variables('puppetMasterVmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "customData": "[base64(concat('#!/bin/bash\n\ncat <<EOF >/tmp/puppet_override.answers\n','azure_externalFQDN=',reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn,'\n','azure_internalFQDN=$(hostname -f)\n\nq_puppet_enterpriseconsole_auth_password=',parameters('adminPassword'),'\nq_database_host=\\${azure_externalFQDN}\nq_puppet_enterpriseconsole_master_hostname=\\${azure_externalFQDN}\nq_puppet_enterpriseconsole_smtp_host=\\${azure_externalFQDN}\nq_puppetagent_certname=\\${azure_externalFQDN}\nq_puppetmaster_dnsaltnames=puppet,$(hostname),\\${azure_internalFQDN},\\${azure_externalFQDN}\nq_puppetagent_server=\\${azure_externalFQDN}\nq_puppetdb_hostname=\\${azure_externalFQDN}\nq_puppetmaster_certname=\\${azure_externalFQDN}\nEOF\nchmod +x /tmp/puppet_override.answers\n'))]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('imageSku')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net')]"
+          }
+        }
+      }
+    },
+    {
+        "type": "Microsoft.Compute/virtualMachines/extensions",
+        "name": "[concat(variables('puppetMasterVmName'),'/CustomScriptExtension')]",
+        "apiVersion": "2015-05-01-preview",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+            "[concat('Microsoft.Compute/virtualMachines/', variables('puppetMasterVmName'))]"
+        ],
+        "properties": {
+           "publisher": "Microsoft.OSTCExtensions",
+           "type": "CustomScriptForLinux",
+           "typeHandlerVersion": "1.3",
+           "settings": {
+              "fileUris": ["https://raw.githubusercontent.com/kenazk/kenaztemplates/master/puppet-enterprise-cluster/wait.sh"],
+              "commandToExecute": "./wait.sh"
+           }
+       }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat('WindowsAgentVM',copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "windowsAgentVmLoop",
+        "count": "[parameters('windowsAgentCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', 'peAgentNic', copyIndex())]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[concat('windowsAgentVM',copyIndex())]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "MicrosoftWindowsServer",
+            "offer": "WindowsServer",
+            "sku": "2012-R2-Datacenter",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/vhds/','osdisk',copyIndex(),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat('peAgentNic',copyIndex()))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net')]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat('WindowsAgentVm',copyIndex(),'/puppetExtension')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "puppetAgentExtLoop",
+        "count": "[parameters('windowsAgentCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', concat('WindowsAgentVm',copyIndex()))]",
+        "[concat('Microsoft.Compute/virtualMachines/', variables('puppetMasterVmName'),'/extensions/CustomScriptExtension')]"
+      ],
+      "properties": {
+        "publisher": "Puppet",
+        "type": "PuppetAgent",
+        "typeHandlerVersion": "1.5",
+        "protectedSettings": {
+          "PUPPET_MASTER_SERVER": "[reference(variables('publicIPAddressName'),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat('UbuntuAgentVM',copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "ubuntuAgentVmLoop",
+        "count": "[parameters('linuxAgentCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', 'peAgentNic', add(copyIndex(),parameters('windowsAgentCount')))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[concat('UbuntuAgentVM',copyIndex())]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "canonical",
+            "offer": "ubuntuserver",
+            "sku": "14.04.2-LTS",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/vhds/','osdisk',add(copyIndex(),parameters('windowsAgentCount')),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat('peAgentNic',add(copyIndex(),parameters('windowsAgentCount'))))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net')]"
+          }
+        }
+      }
+    },
+    {
+        "type": "Microsoft.Compute/virtualMachines/extensions",
+        "name": "[concat('UbuntuAgentVM',copyIndex(),'/CustomScriptExtension')]",
+        "apiVersion": "2015-05-01-preview",
+        "location": "[resourceGroup().location]",
+        "copy": {
+          "name": "linuxAgentExtLoop",
+          "count": "[parameters('linuxAgentCount')]"
+        },
+        "dependsOn": [
+            "[concat('Microsoft.Compute/virtualMachines/', concat('UbuntuAgentVm',copyIndex()))]",
+            "[concat('Microsoft.Compute/virtualMachines/', variables('puppetMasterVmName'),'/extensions/CustomScriptExtension')]"
+        ],
+        "properties": {
+           "publisher": "Microsoft.OSTCExtensions",
+           "type": "CustomScriptForLinux",
+           "typeHandlerVersion": "1.3",
+           "settings": {
+              "fileUris": ["https://raw.githubusercontent.com/kenazk/kenaztemplates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
+              "commandToExecute": "[concat('./install_puppet_agent.sh ', reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn)]"
+           }
+       }
+    }
+  ],
+  "outputs" : {
+    "Here is the SSH URL:": {
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn]",
+      "type": "string"
+    }
+  }
+}

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -44,7 +44,21 @@
         "description": "Size of Puppet agent VMs"
       },
       "defaultValue": "Standard_D1_v2"
-    }
+    },
+    "_artifactsLocation": {
+          "type": "string",
+          "metadata": {
+              "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+          },
+          "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/puppet-enterprise-cluster/"
+      },
+      "_artifactsLocationSasToken": {
+          "type": "securestring",
+          "metadata": {
+              "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+          },
+          "defaultValue": ""
+      }
   },
   "variables": {
     "puppetAgentCount": "[add(parameters('windowsAgentCount'),parameters('linuxAgentCount'))]",
@@ -354,7 +368,9 @@
            "autoUpgradeMinorVersion" : "true",
            "typeHandlerVersion": "1.3",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/puppet-enterprise-cluster/wait.sh"],
+              "fileUris": [
+                "[concat(parameters('_artifactsLocation'),'wait.sh')]"
+              ],
               "commandToExecute": "./wait.sh"
            }
        }
@@ -507,7 +523,9 @@
            "typeHandlerVersion": "1.3",
            "autoUpgradeMinorVersion" : "true",
            "settings": {
-              "fileUris": ["https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/puppet-enterprise-cluster/install_puppet_agent.sh"],
+              "fileUris": [
+                "[concat(parameters('_artifactsLocation'),'install_puppet_agent.sh')]"
+              ],
               "commandToExecute": "[concat('./install_puppet_agent.sh ', reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')), '2016-03-30').dnsSettings.fqdn)]"
            }
        }

--- a/puppet-enterprise-cluster/azuredeploy.json
+++ b/puppet-enterprise-cluster/azuredeploy.json
@@ -351,6 +351,7 @@
         "properties": {
            "publisher": "Microsoft.OSTCExtensions",
            "type": "CustomScriptForLinux",
+           "autoUpgradeMinorVersion" : "true",
            "typeHandlerVersion": "1.3",
            "settings": {
               "fileUris": ["https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/puppet-enterprise-cluster/wait.sh"],

--- a/puppet-enterprise-cluster/azuredeploy.parameters.json
+++ b/puppet-enterprise-cluster/azuredeploy.parameters.json
@@ -6,10 +6,10 @@
         "value":"admin123"
      },
      "adminPassword":{
-        "value":"Admin123_!"
+        "value":"GEN-PASSWORD"
      },
      "consolePassword":{
-        "value":"Admin123_!"
+        "value":"GEN-PASSWORD"
      },
      "windowsAgentCount":{
         "value":1

--- a/puppet-enterprise-cluster/azuredeploy.parameters.json
+++ b/puppet-enterprise-cluster/azuredeploy.parameters.json
@@ -8,6 +8,9 @@
      "adminPassword":{
         "value":"Admin123_!"
      },
+     "consolePassword":{
+        "value":"Admin123_!"
+     },
      "windowsAgentCount":{
         "value":1
      },

--- a/puppet-enterprise-cluster/azuredeploy.parameters.json
+++ b/puppet-enterprise-cluster/azuredeploy.parameters.json
@@ -1,17 +1,21 @@
 {
-   "adminUsername":{
-      "value":"admin123"
-   },
-   "adminPassword":{
-      "value":"Admin123_!"
-   },
-   "windowsAgentCount":{
-      "value":1
-   },
-   "linuxAgentCount":{
-      "value":1
-   },
-   "vmSize": {
-     "value": "Standard_D1_v2"
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+     "adminUsername":{
+        "value":"admin123"
+     },
+     "adminPassword":{
+        "value":"Admin123_!"
+     },
+     "windowsAgentCount":{
+        "value":1
+     },
+     "linuxAgentCount":{
+        "value":1
+     },
+     "vmSize": {
+       "value": "Standard_D1_v2"
+     }
    }
 }

--- a/puppet-enterprise-cluster/azuredeploy.parameters.json
+++ b/puppet-enterprise-cluster/azuredeploy.parameters.json
@@ -1,0 +1,17 @@
+{
+   "adminUsername":{
+      "value":"admin123"
+   },
+   "adminPassword":{
+      "value":"Admin123_!"
+   },
+   "windowsAgentCount":{
+      "value":1
+   },
+   "linuxAgentCount":{
+      "value":1
+   },
+   "vmSize": {
+     "value": "Standard_D1_v2"
+   }
+}

--- a/puppet-enterprise-cluster/install_puppet_agent.sh
+++ b/puppet-enterprise-cluster/install_puppet_agent.sh
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+curl -k https://$1:8140/packages/current/install.bash | sudo bash

--- a/puppet-enterprise-cluster/metadata.json
+++ b/puppet-enterprise-cluster/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Puppet Enterprise Cluster",
+  "description": "This template creates a Puppet Enterprise cluster consisting of a master and a configurable number of Windows & Linux agents",
+  "summary": "This template creates a Puppet Enterprise cluster consisting of a master and a configurable number of Windows & Linux agents",
+  "githubUsername": "kenazk",
+  "dateUpdated": "2016-07-27"
+}

--- a/puppet-enterprise-cluster/wait.sh
+++ b/puppet-enterprise-cluster/wait.sh
@@ -7,3 +7,4 @@ do
   fi
   sleep 5
 done
+sleep 3m

--- a/puppet-enterprise-cluster/wait.sh
+++ b/puppet-enterprise-cluster/wait.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+while :
+do
+  curl -k -s https://localhost:8140/status/v1/services | python -c 'import json,sys;obj=json.load(sys.stdin);sys.exit(0) if (obj["pe-master"]["state"] == "running") else sys.exit(1);'
+  if [[ $? == 0 ]]; then
+    exit
+  fi
+  sleep 5
+done


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
*
*
*
*
*

### Description of the change
New Puppet Enterprise Cluster template enables you to provision a
Puppet Master and configurable number of Windows and Linux Agents and
automatically connect them to the master.