### PR TITLE
Updated Storage Account

### DIFF
--- a/101-vm-simple-linux/azuredeploy.json
+++ b/101-vm-simple-linux/azuredeploy.json
@@ -61,7 +61,9 @@
       "name": "[variables('storageAccountName')]",
       "apiVersion": "2016-01-01",
       "location": "[resourceGroup().location]",
-      "sku": "[variables('storageAccountType')]",
+      "sku": {
+        "name": "[variables('storageAccountType')]"
+      },
       "kind": "Storage",
       "properties": {
       }

--- a/101-vm-simple-linux/azuredeploy.json
+++ b/101-vm-simple-linux/azuredeploy.json
@@ -59,10 +59,11 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2016-01-01",
       "location": "[resourceGroup().location]",
+      "sku": "[variables('storageAccountType')]",
+      "kind": "Storage",
       "properties": {
-        "accountType": "[variables('storageAccountType')]"
       }
     },
     {


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Updated Storage Account definition for idempotent use

### Description of the change
This fixes a problem where Storage Accounts were not treated in an idempotent fashion. Updating to 2016-01-01 for the API version, just for the Storage Account, will resolve this problem. However, the schema for the Storage Account changed, so we must add the `sku` and `kind` properties at the root of the Storage Account definition.