### PR TITLE
mysql-replication: fix unused section in customscript

### DIFF
--- a/mysql-replication/azuredeploy.json
+++ b/mysql-replication/azuredeploy.json
@@ -423,12 +423,7 @@
             ]
           },
           "protectedSettings": {
-            "commandToExecute": "[concat(parameters('customScriptCommandToExecute'), ' ', copyIndex(1), ' ', variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255), ' ', variables('mysqlConfigFilePath'), ' ', variables('singleQuote'), parameters('mysqlReplicationPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlRootPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlProbePassword'), variables('singleQuote'), ' ', parameters('dbSubnetStartAddress'))]",
-            "Items": {
-              "mysqlRootPassword": "[parameters('mysqlRootPassword')]",
-              "mysqlReplicationPassword": "[parameters('mysqlReplicationPassword')]",
-              "mysqlProbePassword": "[parameters('mysqlProbePassword')]"
-            }
+            "commandToExecute": "[concat(parameters('customScriptCommandToExecute'), ' ', copyIndex(1), ' ', variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255), ' ', variables('mysqlConfigFilePath'), ' ', variables('singleQuote'), parameters('mysqlReplicationPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlRootPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlProbePassword'), variables('singleQuote'), ' ', parameters('dbSubnetStartAddress'))]"
           }
         }
       },


### PR DESCRIPTION
- removed unused `"Items"` key from custom script extension (not a valid key in the context of this exception anyway)

Fixes #2295
cc: @liupeirong PTAL