### PR TITLE
use lower case resource group name as container

### DIFF
--- a/sap-2-tier-marketplace-image/azuredeploy.json
+++ b/sap-2-tier-marketplace-image/azuredeploy.json
@@ -78,7 +78,7 @@
         "OSType": "Windows"
       },
       "SLES 12": {
-        "sku": "12",
+        "sku": "12-SP1",
         "offer": "SLES",
         "publisher": "SUSE",
         "OSType": "Linux"

--- a/sap-2-tier-marketplace-image/shared/configureSAPVM.sh
+++ b/sap-2-tier-marketplace-image/shared/configureSAPVM.sh
@@ -21,7 +21,7 @@ function addtofstab()
 		local uuid=${BASH_REMATCH[1]};
 		local mountCmd=""
 		log "adding fstab entry"
-		mountCmd="/dev/disk/by-uuid/$uuid $mountPath xfs  defaults  0  2"
+		mountCmd="/dev/disk/by-uuid/$uuid $mountPath xfs  defaults,nofail  0  2"
 		echo "$mountCmd" >> /etc/fstab
 		$(mount $mountPath)
 	else

--- a/sap-2-tier-marketplace-image/shared/os-disk-parts.json
+++ b/sap-2-tier-marketplace-image/shared/os-disk-parts.json
@@ -74,6 +74,7 @@
   "variables": {
     "osDiskName": "[concat(parameters('sidlower'),'-os.vhd')]",
     "osDiskCaching": "ReadWrite",
+    "resourceGroupLower":"[toLower(resourceGroup().name)]",
     "osDiskParts": {
       "image": {
         "imageReference": {
@@ -100,7 +101,7 @@
             "uri": "[parameters('userImageVhdUri')]"
           },
           "vhd": {
-            "uri": "[concat('http://',parameters('userImageStorageAccount'),'.blob.core.windows.net/', resourceGroup().name, '/', parameters('vmName'), '-', variables('osDiskName'))]"
+            "uri": "[concat('http://',parameters('userImageStorageAccount'),'.blob.core.windows.net/', variables('resourceGroupLower'), '/', parameters('vmName'), '-', variables('osDiskName'))]"
           },
           "caching": "[variables('osDiskCaching')]",
           "createOption": "FromImage"

--- a/sap-2-tier-marketplace-image/shared/os-disk-parts.json
+++ b/sap-2-tier-marketplace-image/shared/os-disk-parts.json
@@ -86,7 +86,7 @@
         "osDisk": {
           "name": "osdisk",
           "vhd": {
-            "uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net/', parameters('vmName'), '/', variables('osDiskName'))]"
+            "uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net/', concat('vhds-', uniqueString(parameters('vmName'))), '/', variables('osDiskName'))]"
           },
           "caching": "[variables('osDiskCaching')]",
           "createOption": "FromImage"
@@ -101,7 +101,7 @@
             "uri": "[parameters('userImageVhdUri')]"
           },
           "vhd": {
-            "uri": "[concat('http://',parameters('userImageStorageAccount'),'.blob.core.windows.net/', variables('resourceGroupLower'), '/', parameters('vmName'), '-', variables('osDiskName'))]"
+            "uri": "[concat('http://',parameters('userImageStorageAccount'),'.blob.core.windows.net/', concat('vhds-', uniqueString(resourceGroup().id)), '/', parameters('vmName'), '-', variables('osDiskName'))]"
           },
           "caching": "[variables('osDiskCaching')]",
           "createOption": "FromImage"

--- a/sap-3-tier-marketplace-image/azuredeploy.json
+++ b/sap-3-tier-marketplace-image/azuredeploy.json
@@ -1223,7 +1223,7 @@
           "osDiskType": { "value": "[variables('osDiskType')]" },
           "sidlower": { "value": "[variables('sidlower')]" },
           "vmName": { "value": "[concat(variables('vmNameDI'), '-', copyIndex())]" },
-          "vmSize": { "value": "[variables('ascsvmSize')]" },
+          "vmSize": { "value": "[variables('divmSize')]" },
           "adminUsername": { "value": "[parameters('adminUsername')]" },
           "adminPassword": { "value": "[parameters('adminPassword')]" },
           "cseExtPublisher": { "value": "[variables('cseExtPublisher')]" },

--- a/sap-3-tier-user-image/azuredeploy.json
+++ b/sap-3-tier-user-image/azuredeploy.json
@@ -1197,7 +1197,7 @@
           "osDiskType": { "value": "[variables('osDiskType')]" },
           "sidlower": { "value": "[variables('sidlower')]" },
           "vmName": { "value": "[concat(variables('vmNameDI'), '-', copyIndex())]" },
-          "vmSize": { "value": "[variables('ascsvmSize')]" },
+          "vmSize": { "value": "[variables('divmSize')]" },
           "adminUsername": { "value": "[parameters('adminUsername')]" },
           "adminPassword": { "value": "[parameters('adminPassword')]" },
           "cseExtPublisher": { "value": "[variables('cseExtPublisher')]" },


### PR DESCRIPTION
### Changelog
* fix issue for user image templates when resource group name has upper case characters

### Description of the change
The deployment of the user image templates (2-tier and 3-tier) would fail prior to this fix if the resource group name contains an upper case character