### PR TITLE
Apply numpy/scipy fix from edX

### DIFF
--- a/openedx-fullstack-ubuntu/README.md
+++ b/openedx-fullstack-ubuntu/README.md
@@ -1,4 +1,4 @@
-# Deploy Open edX FullStack on Ubuntu
+# Deploy Open edX FullStack (Dogwood) on Ubuntu
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fopenedx-fullstack-ubuntu%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
@@ -7,7 +7,7 @@
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-This template deploys the Open edX full stack on Ubuntu. A default server-vars.yml is saved to */edx/app/edx_ansible*.
+This template deploys the Open edX full stack (Dogwood) on Ubuntu. A default server-vars.yml is saved to */edx/app/edx_ansible*.
 
 Connect to the virtual machine with SSH: `ssh {adminUsername}@{dnsNameForPublicIP}.{region}.cloudapp.azure.com`. Installation log can be found under */var/log/azure*.
 

--- a/openedx-fullstack-ubuntu/azuredeploy.json
+++ b/openedx-fullstack-ubuntu/azuredeploy.json
@@ -59,7 +59,7 @@
   },
   "variables": {
     "apiVersion": "2015-06-15",
-    "openedxVersion": "named-release/dogwood.3",
+    "openedxVersion": "named-release/dogwood.rc",
     "scriptDownloadUri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/openedx-fullstack-ubuntu/",
     "installScript": "install-openedx.sh",
     "installCommand": "[concat('bash -c ''nohup ./', variables('installScript'), ' ', variables('openedxVersion'), ' </dev/null &>/var/log/azure/openedx-install.log &''')]",

--- a/openedx-fullstack-ubuntu/metadata.json
+++ b/openedx-fullstack-ubuntu/metadata.json
@@ -1,7 +1,7 @@
 {
-  "itemDisplayName": "Deploy Open edX fullstack on a single Ubuntu VM.",
-  "description": "This template creates a single Ubuntu VM and deploys Open edX fullstack on it.",
-  "summary": "Deploy Open edX fullstack on a single Ubuntu VM.",
+  "itemDisplayName": "Deploy Open edX fullstack (Dogwood) on a single Ubuntu VM.",
+  "description": "This template creates a single Ubuntu VM and deploys Open edX fullstack (Dogwood) on it.",
+  "summary": "Deploy Open edX fullstack (Dogwood) on a single Ubuntu VM.",
   "githubUsername": "chenriksson",
   "dateUpdated": "2016-05-05"
 }


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Description of the change
Open edX installations started failing due to update to numpy/scipy python module dependencies. edX has fixed by enforcing a specific version of these modules. The patch was applied to the "dogwood.rc" branch, which is where they recommend sync'ing to. More details on Open edX slack channel at https://openedx.slack.com/messages/ops/

see: https://github.com/edx/edx-platform/commits/named-release/dogwood.rc