### PR TITLE
Retrieve latest stable version of GOEth instead of unstable

### DIFF
--- a/go-ethereum-on-ubuntu/azuredeploy.json
+++ b/go-ethereum-on-ubuntu/azuredeploy.json
@@ -193,7 +193,7 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
-            "https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/go-ethereum-on-ubuntu/configure-geth.sh"
+            "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/go-ethereum-on-ubuntu/configure-geth.sh"
           ],
           "commandToExecute": "[concat('sh configure-geth.sh ', parameters('adminUsername'))]"
         }

--- a/go-ethereum-on-ubuntu/azuredeploy.json
+++ b/go-ethereum-on-ubuntu/azuredeploy.json
@@ -193,7 +193,7 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
-            "https://raw.githubusercontent.com/bradled/azure-quickstart-templates/master/go-ethereum-on-ubuntu/configure-geth.sh"
+            "https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/go-ethereum-on-ubuntu/configure-geth.sh"
           ],
           "commandToExecute": "[concat('sh configure-geth.sh ', parameters('adminUsername'))]"
         }

--- a/go-ethereum-on-ubuntu/azuredeploy.json
+++ b/go-ethereum-on-ubuntu/azuredeploy.json
@@ -193,7 +193,7 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
-            "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/go-ethereum-on-ubuntu/configure-geth.sh"
+            "https://raw.githubusercontent.com/bradled/azure-quickstart-templates/master/go-ethereum-on-ubuntu/configure-geth.sh"
           ],
           "commandToExecute": "[concat('sh configure-geth.sh ', parameters('adminUsername'))]"
         }

--- a/go-ethereum-on-ubuntu/configure-geth.sh
+++ b/go-ethereum-on-ubuntu/configure-geth.sh
@@ -30,7 +30,6 @@ time sudo update-alternatives --install /usr/bin/node nodejs /usr/bin/nodejs 100
 time sudo apt-get -y git
 time sudo apt-get install -y software-properties-common
 time sudo add-apt-repository -y ppa:ethereum/ethereum
-time sudo add-apt-repository -y ppa:ethereum/ethereum-dev
 time sudo apt-get update
 time sudo apt-get install -y ethereum
 


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
Removed a single line in configure-geth.sh file to retrieve the latest stable version of GoEth instead of the latest unstable version.