### PR TITLE
bosh-setup change: Expose the VM size of BOSH VM as a parameter

### DIFF
--- a/bosh-setup/CHANGELOG.md
+++ b/bosh-setup/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.0.1 (2016-08-24)
+
+- Expose the VM size of BOSH VM as a parameter
+
 # v2.0.0 (2016-08-16)
 
 - Upgrade versions

--- a/bosh-setup/azuredeploy.json
+++ b/bosh-setup/azuredeploy.json
@@ -62,6 +62,27 @@
       "metadata": {
         "description": "The flag allowing to deploy Bosh automatically or not"
       }
+    },
+    "boshVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2_v2",
+      "allowedValues": [
+        "Standard_D1_v2",
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_DS1",
+        "Standard_DS2",
+        "Standard_DS3",
+        "Standard_DS4",
+        "Standard_DS1_v2",
+        "Standard_DS2_v2",
+        "Standard_DS3_v2",
+        "Standard_DS4_v2"
+      ],
+      "metadata": {
+        "description": "Please check if the region support this VM size https://azure.microsoft.com/en-us/regions/#services. For more information about virtual machine sizes, see https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-sizes/"
+      }
     }
   },
   "variables": {
@@ -105,7 +126,7 @@
     ],
 
     "baseUriAzureChinaCloud": "https://cloudfoundry.blob.core.chinacloudapi.cn/bosh-setup/",
-    "templateVersion": "v2-0-0",
+    "templateVersion": "v2-0-1",
     "baseUriAzureChinaCloudWithVersion": "[concat(variables('baseUriAzureChinaCloud'), variables('templateVersion'), '/')]",
     "filesToDownloadAzureChinaCloud": [
       "[uri(variables('baseUriAzureChinaCloudWithVersion'), 'scripts/setup_env')]",
@@ -471,7 +492,8 @@
               "CFLINUXFS2_RELEASE_SHA1": "[variables('environment').cflinuxfs2ReleaseSha1]",
               "BOSH_INIT_URL": "[variables('environment').boshInitUrl]",
               "KEEP_UNREACHABLE_VMS": "[variables('keepUnreachableVMs')]",
-              "AUTO_DEPLOY_BOSH": "[parameters('autoDeployBosh')]"
+              "AUTO_DEPLOY_BOSH": "[parameters('autoDeployBosh')]",
+              "BOSH_VM_SIZE": "[parameters('boshVmSize')]"
             }
           }
         }

--- a/bosh-setup/azuredeploy.parameters.json
+++ b/bosh-setup/azuredeploy.parameters.json
@@ -25,6 +25,9 @@
     },
     "autoDeployBosh": {
       "value": "disabled"
+    },
+    "boshVmSize": {
+      "value": "Standard_D2_v2"
     }
   }
 }

--- a/bosh-setup/manifests/bosh.yml
+++ b/bosh-setup/manifests/bosh.yml
@@ -30,7 +30,7 @@ resource_pools:
     url: REPLACE_WITH_STEMCELL_URL
     sha1: REPLACE_WITH_STEMCELL_SHA1
   cloud_properties:
-    instance_type: Standard_D1
+    instance_type: REPLACE_WITH_BOSH_VM_SIZE
 
 disk_pools:
 - name: disks

--- a/bosh-setup/scripts/setup_env.py
+++ b/bosh-setup/scripts/setup_env.py
@@ -71,7 +71,8 @@ def render_bosh_manifest(settings):
             "BOSH_AZURE_CPI_RELEASE_SHA1",
             "STEMCELL_URL",
             "STEMCELL_SHA1",
-            "ENVIRONMENT"
+            "ENVIRONMENT",
+            "BOSH_VM_SIZE"
         ]
         for k in keys:
             v = settings[k]


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Expose the VM size of BOSH VM as a parameter

### Description of the change

With this change, users can choose the Bosh VM size they want.