### PR TITLE
undo bosh-setup custom script migration

### DIFF
--- a/bosh-setup/azuredeploy.json
+++ b/bosh-setup/azuredeploy.json
@@ -561,9 +561,9 @@
         "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
       ],
       "properties": {
-        "publisher": "Microsoft.Azure.Extensions",
-        "type": "CustomScript",
-        "typeHandlerVersion": "2.0",
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.5",
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[variables('filesToDownload')]"


### PR DESCRIPTION
Undoing bosh-setup template changes.

@bingosummer will submit changes separately once it's available in Mooncake

cc: @gatneil 