### PR TITLE
Roll back the CustomScript version to 1.4

### DIFF
--- a/bosh-setup/azuredeploy.json
+++ b/bosh-setup/azuredeploy.json
@@ -563,8 +563,7 @@
       "properties": {
         "publisher": "Microsoft.OSTCExtensions",
         "type": "CustomScriptForLinux",
-        "typeHandlerVersion": "1.5",
-        "autoUpgradeMinorVersion": true,
+        "typeHandlerVersion": "1.4",
         "settings": {
           "fileUris": "[variables('filesToDownload')]"
         },


### PR DESCRIPTION
After a full test and CustomScript 2.0 is supported in AzureChinaCloud in future, I will send a separate PR to switch to 2.0.
