### PR TITLE
mysql-standalone-server-ubuntu: remove wrong setting key

### DIFF
--- a/mysql-standalone-server-ubuntu/azuredeploy.json
+++ b/mysql-standalone-server-ubuntu/azuredeploy.json
@@ -198,7 +198,6 @@
         "type": "CustomScriptForLinux",
         "typeHandlerVersion": "1.4",
         "settings": {
-          "autoUpgradeMinorVersion": true,
           "fileUris": [
             "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-standalone-server-ubuntu/install_mysql_server_5.6.sh"
           ]


### PR DESCRIPTION
@marcvaneijk you're not supposed to add `autoUpgradeMinorVersion` to `settings`. it should be one level above.