### PR TITLE
Fixed URL for the deploy button for NXT Blockchain Platform.

### DIFF
--- a/nxt-blockchain-ubuntu/README.md
+++ b/nxt-blockchain-ubuntu/README.md
@@ -2,7 +2,7 @@
 
 # Nxt blockchain platform
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fnxt-on-ubuntu%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fnxt-blockchain-ubuntu%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 


### PR DESCRIPTION
Just a simple URL change on the "Deploy to Azure" button, the first one was incorrect. :-)