### PR TITLE
Open edX CustomScript 2.0 fix (permissions changed)

### DIFF
--- a/openedx-devstack-ubuntu/install-openedx.sh
+++ b/openedx-devstack-ubuntu/install-openedx.sh
@@ -18,7 +18,8 @@ xqueue_version: \"$OPENEDX_RELEASE\"
 configuration_version: \"$OPENEDX_RELEASE\"
 edx_ansible_source_repo: \"$CONFIG_REPO\"
 EOF"
-sudo -u edx-ansible cp *.yml $ANSIBLE_ROOT
+cp *.yml $ANSIBLE_ROOT
+chown edx-ansible:edx-ansible $ANSIBLE_ROOT/*.yml
 
 cd /tmp
 git clone $CONFIG_REPO

--- a/openedx-fullstack-ubuntu/install-openedx.sh
+++ b/openedx-fullstack-ubuntu/install-openedx.sh
@@ -19,7 +19,8 @@ configuration_version: \"$OPENEDX_RELEASE\"
 edx_ansible_source_repo: \"$CONFIG_REPO\"
 COMMON_SSH_PASSWORD_AUTH: \"yes\"
 EOF"
-sudo -u edx-ansible cp *.yml $ANSIBLE_ROOT
+cp *.yml $ANSIBLE_ROOT
+chown edx-ansible:edx-ansible $ANSIBLE_ROOT/*.yml
 
 cd /tmp
 git clone $CONFIG_REPO

--- a/openedx-scalable-ubuntu/install-openedx.sh
+++ b/openedx-scalable-ubuntu/install-openedx.sh
@@ -36,7 +36,9 @@ forum_version: \"$EDX_VERSION\"
 xqueue_version: \"$EDX_VERSION\"
 COMMON_SSH_PASSWORD_AUTH: \"yes\"
 EOF"
-sudo -u edx-ansible cp *.{ini,yml} $ANSIBLE_ROOT
+cp *.{ini,yml} $ANSIBLE_ROOT
+chown edx-ansible:edx-ansible $ANSIBLE_ROOT/*.{ini,yml}
+
 
 # Setup SSH for remote installation
 apt-get -y install sshpass


### PR DESCRIPTION
Fixes installation error from CustomScript 2.0 rollout. Permissions for downloaded files changed so that group/everyone no longer had read access, which broke because the copy was done as different user.