### PR TITLE
Update api mgmt template to use new API version and RG location

### DIFF
--- a/101-azure-api-management-create/azuredeploy.json
+++ b/101-azure-api-management-create/azuredeploy.json
@@ -1,80 +1,60 @@
 ﻿{
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters":
-    {
-        "publisherEmail":
-        {
-            "type": "string",
-            "minLength": 1,
-	    "metadata": {
-		"description": "The email address of the owner of the service"
-	    }
-        }
-        ,
-        "publisherName":
-        {
-            "type": "string",
-            "minLength": 1,
-	    "metadata": {
-		"description": "The name of the owner of the service"
-	    }	
-        }
-        ,
-        "sku":
-        {
-            "type": "string",
-            "allowedValues": [
-            "Developer",
-            "Standard",
-            "Premium"
-            ],
-            "defaultValue": "Developer",
-	    "metadata": {
-		"description": "The pricing tier of this API Management service"
-	    }	
-        }
-        ,
-        "skuCount":
-        {
-            "type": "string",
-            "allowedValues": [
-            "1",
-            "2"
-            ],
-            "defaultValue": "1",
-	    "metadata": {
-		"description": "The instance size of this API Management service."
-	    }	
-        }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "publisherEmail": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "The email address of the owner of the service"
+      }
+    },
+    "publisherName": {
+      "type": "string",
+      "minLength": 1,
+      "metadata": {
+        "description": "The name of the owner of the service"
+      }
+    },
+    "sku": {
+      "type": "string",
+      "allowedValues": [
+        "Developer",
+        "Standard",
+        "Premium"
+      ],
+      "defaultValue": "Standard",
+      "metadata": {
+        "description": "The pricing tier of this API Management service. Developer is not recommended for production and has no SLA"
+      }
+    },
+    "capacity": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "The number of units this API Management service has. The performance per unit varies based on tier. See the FAQ here for more information: https://azure.microsoft.com/en-us/pricing/details/api-management/"
+      }
     }
-    ,
-    "variables":
+  },
+  "variables": {
+    "apiManagementServiceName": "[concat('apiservice', uniqueString(resourceGroup().id))]"
+  },
+  "resources": [
     {
-        "apiManagementServiceName": "[concat('apiservice', uniqueString(resourceGroup().id))]"
+      "apiVersion": "2016-07-07",
+      "name": "[variables('apiManagementServiceName')]",
+      "type": "Microsoft.ApiManagement/service",
+      "location": "[resourceGroup().location]",
+      "tags": {
+      },
+      "properties": {
+        "publisherEmail": "[parameters('publisherEmail')]",
+        "publisherName": "[parameters('publisherName')]"
+      },
+      "sku": {
+        "capacity": "[parameters('capacity')]",
+        "name": "[parameters('sku')]"
+      }
     }
-    ,
-    "resources": [
-    {
-        "apiVersion": "2014-02-14",
-        "name": "[variables('apiManagementServiceName')]",
-        "type": "Microsoft.ApiManagement/service",
-        "location": "West US",
-        "tags":
-        {
-        }
-        ,
-        "properties":
-        {
-            "sku":
-            {
-                "name": "[parameters('sku')]",
-                "capacity": "[parameters('skuCount')]"
-            }
-            ,                
-            "publisherEmail": "[parameters('publisherEmail')]",
-            "publisherName": "[parameters('publisherName')]"
-        }
-    }
-    ]
+  ]
 }

--- a/101-azure-api-management-create/azuredeploy.json
+++ b/101-azure-api-management-create/azuredeploy.json
@@ -23,7 +23,7 @@
         "Standard",
         "Premium"
       ],
-      "defaultValue": "Standard",
+      "defaultValue": "Developer",
       "metadata": {
         "description": "The pricing tier of this API Management service. Developer is not recommended for production and has no SLA"
       }

--- a/101-azure-api-management-create/metadata.json
+++ b/101-azure-api-management-create/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template creates a developer instance of Azure API Management",
   "summary": "Create an API Management instance using a template",
   "githubUsername": "miaojiang",
-  "dateUpdated": "2016-04-22"
+  "dateUpdated": "2016-09-23"
 }


### PR DESCRIPTION
### Changelog
- Update API management template to use API version 2016-07-07 instead of 2014-02-14
- Change location to use the location of the resource group rather than a hard coded location
- Change capacity parameter to an int rather than a string. Previous template also restricted capacity to only 1 and 2, though API mgmt services can have potentially unlimited. Removed restriction.
- Change default tier to Standard as the old default Developer has no SLA and is not recommended for production
- Clarify some parameter descriptions
