### PR TITLE
Add bigchaindb-on-ubuntu folder

### DIFF
--- a/bigchaindb-on-ubuntu/README.md
+++ b/bigchaindb-on-ubuntu/README.md
@@ -7,17 +7,6 @@
 <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-To deploy this template using the scripts from the root of this repo:
-
-```PowerShell
-.\Deploy-AzureResourceGroup.ps1 -ResourceGroupLocation 'eastus' -ArtifactsStagingDirectory 'bigchaindb-on-ubuntu'
-```
-```bash
-azure-group-deploy.sh -a bigchaindb-on-ubuntu -l eastus -u
-```
-
-<hr>
-
 This template provisions a virtual machine running Ubuntu 14.04.4 LTS, plus various other Azure resources. (See the `azuredeploy.json` file for details.) It then runs the script `scripts/init.sh`, which:
 
 1. Installs RethinkDB and runs it (with a default RethinkDB configuration file).

--- a/bigchaindb-on-ubuntu/README.md
+++ b/bigchaindb-on-ubuntu/README.md
@@ -1,0 +1,42 @@
+# Deploy a One-Machine BigchainDB Node on Azure
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F100-STARTER-TEMPLATE-with-VALIDATION%2Fazuredeploy.json" target="_blank">
+<img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F100-STARTER-TEMPLATE-with-VALIDATION%2Fazuredeploy.json" target="_blank">
+<img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+To deploy this template using the scripts from the root of this repo:
+
+```PowerShell
+.\Deploy-AzureResourceGroup.ps1 -ResourceGroupLocation 'eastus' -ArtifactsStagingDirectory 'bigchaindb-on-ubuntu'
+```
+```bash
+azure-group-deploy.sh -a bigchaindb-on-ubuntu -l eastus -u
+```
+
+<hr>
+
+This template provisions a virtual machine running Ubuntu 14.04.4 LTS, plus various other Azure resources. (See the `azuredeploy.json` file for details.) It then runs the script `scripts/init.sh`, which:
+
+1. Installs RethinkDB and runs it (with a default RethinkDB configuration file).
+2. Installs BigchainDB dependencies and BigchainDB itself (i.e. the latest version on PyPI).
+
+That script does _not_ configure or run BigchainDB. To do that, first SSH in to the virtual machine. (You can find its hostname and IP address online in the Microsoft Azure Management Portal at https://portal.azure.com).
+
+On the virtual machine, generate a default configuration file (in `~/.bigchaindb`) by doing:
+```text
+bigchaindb -y configure
+```
+
+To run BigchainDB, do:
+```text
+bigchaindb start
+```
+
+`Tags: scalable, blockchain, database`
+
+## Documentation
+
+Documentation for BigchainDB is at https://bigchaindb.readthedocs.io/en/latest/index.html

--- a/bigchaindb-on-ubuntu/azuredeploy.json
+++ b/bigchaindb-on-ubuntu/azuredeploy.json
@@ -4,19 +4,31 @@
     "parameters": {
         "admin_username": {
             "defaultValue": null,
-            "type": "String"
+            "type": "String",
+            "metadata": {
+                "description": "The admin username"
+            }
         },
         "admin_password": {
             "defaultValue": null,
-            "type": "SecureString"
+            "type": "SecureString",
+            "metadata": {
+                "description": "The admin password"
+            }
         },
         "virtual_machine_name": {
             "defaultValue": "",
-            "type": "String"
+            "type": "String",
+            "metadata": {
+                "description": "A name for the virtual machine"
+            }
         },
         "virtual_machine_size": {
             "defaultValue": "Standard_D2",
             "type": "String",
+            "metadata": {
+                "description": "The virtual machine size"
+            },
             "allowedValues": [
                 "Standard_D1",
                 "Standard_D2",

--- a/bigchaindb-on-ubuntu/azuredeploy.json
+++ b/bigchaindb-on-ubuntu/azuredeploy.json
@@ -1,0 +1,234 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "admin_username": {
+            "defaultValue": null,
+            "type": "String"
+        },
+        "admin_password": {
+            "defaultValue": null,
+            "type": "SecureString"
+        },
+        "virtual_machine_name": {
+            "defaultValue": "",
+            "type": "String"
+        },
+        "virtual_machine_size": {
+            "defaultValue": "Standard_D2",
+            "type": "String",
+            "allowedValues": [
+                "Standard_D1",
+                "Standard_D2",
+                "Standard_D3",
+                "Standard_D4",
+                "Standard_DS1",
+                "Standard_DS2",
+                "Standard_DS3",
+                "Standard_DS4"
+            ]
+        }
+    },
+    "variables": {
+        "location": "[resourceGroup().location]",
+        "vmSize": "Standard_D2",
+        "storageAccount": "[parameters('virtual_machine_name')]",
+        "nicName": "[parameters('virtual_machine_name')]",
+        "publicIpName": "[parameters('virtual_machine_name')]",
+        "vnetName": "[parameters('virtual_machine_name')]",
+        "nsgName": "[parameters('virtual_machine_name')]",
+        "dnsName": "[parameters('virtual_machine_name')]",
+        "fileUris": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/bigchaindb-on-ubuntu/scripts/init.sh",
+        "commandToExecute": "init.sh"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[parameters('virtual_machine_name')]",
+            "apiVersion": "2015-06-15",
+            "location": "[variables('location')]",
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('virtual_machine_size')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "Canonical",
+                        "offer": "UbuntuServer",
+                        "sku": "14.04.4-LTS",
+                        "version": "latest"
+                    },
+                    "osDisk": {
+                        "name": "[concat(parameters('virtual_machine_name'), 'os_disk')]",
+                        "createOption": "FromImage",
+                        "vhd": {
+                            "uri": "[concat('https', '://', variables('storageAccount'), '.blob.core.windows.net', concat('/vhds/', variables('storageAccount'),'.vhd'))]"
+                        },
+                        "caching": "ReadWrite"
+                    },
+                    "dataDisks": []
+                },
+                "osProfile": {
+                    "computerName": "[parameters('virtual_machine_name')]",
+                    "adminUsername": "[parameters('admin_username')]",
+                    "linuxConfiguration": {
+                        "disablePasswordAuthentication": false
+                    },
+                    "secrets": [],
+                    "adminPassword": "[parameters('admin_password')]"
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+                        }
+                    ]
+                }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccount'))]",
+                "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicName')]",
+            "apiVersion": "2016-03-30",
+            "location": "[variables('location')]",
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAddress": "10.1.0.4",
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+                            },
+                            "subnet": {
+                                "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '/subnets/default')]"
+                            }
+                        }
+                    }
+                ],
+                "dnsSettings": {
+                    "dnsServers": []
+                },
+                "enableIPForwarding": false,
+                "networkSecurityGroup": {
+                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
+                }
+            },
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]",
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('nsgName'))]"
+            ]
+        },
+        {
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "name": "[variables('nsgName')]",
+            "apiVersion": "2016-03-30",
+            "location": "[variables('location')]",
+            "properties": {
+                "securityRules": [
+                    {
+                        "name": "default-allow-ssh",
+                        "properties": {
+                            "protocol": "Tcp",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "22",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 1000,
+                            "direction": "Inbound"
+                        }
+                    },
+                    {
+                        "name": "bigchaindb",
+                        "properties": {
+                            "protocol": "*",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "29015",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 1020,
+                            "direction": "Inbound"
+                        }
+                    }
+                ]
+            },
+            "dependsOn": []
+        },
+        {
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "[variables('publicIpName')]",
+            "apiVersion": "2016-03-30",
+            "location": "[variables('location')]",
+            "properties": {
+                "publicIPAllocationMethod": "Dynamic",
+                "dnsSettings": {
+                    "domainNameLabel": "[variables('dnsName')]"
+                },
+                "idleTimeoutInMinutes": 4
+            },
+            "dependsOn": []
+        },
+        {
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "[variables('vnetName')]",
+            "apiVersion": "2016-03-30",
+            "location": "[variables('location')]",
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "10.1.0.0/16"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "default",
+                        "properties": {
+                            "addressPrefix": "10.1.0.0/24"
+                        }
+                    }
+                ]
+            },
+            "dependsOn": []
+        },
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "sku": {
+                "name": "Standard_LRS",
+                "tier": "Standard"
+            },
+            "kind": "Storage",
+            "name": "[variables('storageAccount')]",
+            "apiVersion": "2016-01-01",
+            "location": "[variables('location')]",
+            "tags": {},
+            "properties": {},
+            "dependsOn": []
+        },
+        {
+            "type": "Microsoft.Compute/virtualMachines/extensions",
+            "name": "[concat(parameters('virtual_machine_name'),'/installcustomscript')]",
+            "apiVersion": "2015-05-01-preview",
+            "location": "[variables('location')]",
+            "dependsOn": [
+                "[concat('Microsoft.Compute/virtualMachines/', parameters('virtual_machine_name'))]"
+            ],
+            "properties": {
+                "publisher": "Microsoft.OSTCExtensions",
+                "type": "CustomScriptForLinux",
+                "typeHandlerVersion": "1.5",
+                "settings": {
+                "fileUris": ["https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/bigchaindb-on-ubuntu/scripts/init.sh"],
+                "commandToExecute": "sh init.sh"
+                }
+            }
+        }
+    ]
+}

--- a/bigchaindb-on-ubuntu/azuredeploy.parameters.json
+++ b/bigchaindb-on-ubuntu/azuredeploy.parameters.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "admin_username": {
+      "value": "admin"
+    },
+    "admin_password": {
+      "value": "GEN-PASSWORD"
+    },
+    "virtual_machine_name": {
+        "value": "bigchaindb_vm1"
+    },
+    "virtual_machine_size": {
+      "value": "Standard_D2"
+    }
+  }
+}

--- a/bigchaindb-on-ubuntu/azuredeploy.parameters.json
+++ b/bigchaindb-on-ubuntu/azuredeploy.parameters.json
@@ -9,7 +9,7 @@
       "value": "GEN-PASSWORD"
     },
     "virtual_machine_name": {
-        "value": "bigchaindb_vm1"
+        "value": "bigchaindbvm1"
     },
     "virtual_machine_size": {
       "value": "Standard_D2"

--- a/bigchaindb-on-ubuntu/azuredeploy.parameters.json
+++ b/bigchaindb-on-ubuntu/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "admin_username": {
-      "value": "admin"
+      "value": "bigchaindbadmin"
     },
     "admin_password": {
       "value": "GEN-PASSWORD"

--- a/bigchaindb-on-ubuntu/metadata.json
+++ b/bigchaindb-on-ubuntu/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "BigchainDB",
+  "description": "This template provisions a virtual machine with Ubuntu 14.04 as its operating system, installs the dependencies for a one-machine BigchainDB node, and starts RethinkDB. One can then SSH to the virtual machine to configure and run BigchainDB.",
+  "summary": "A one-machine BigchainDB node",
+  "githubUsername": "ttmc",
+  "dateUpdated": "2016-09-26"
+}

--- a/bigchaindb-on-ubuntu/scripts/init.sh
+++ b/bigchaindb-on-ubuntu/scripts/init.sh
@@ -1,0 +1,18 @@
+#!/bin/bash 
+
+echo "deb http://download.rethinkdb.com/apt trusty main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
+wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
+sudo apt-get -y update
+sudo apt-get -y install rethinkdb
+
+sudo cp /etc/rethinkdb/default.conf.sample /etc/rethinkdb/instances.d/instance1.conf
+
+sudo /etc/init.d/rethinkdb restart
+
+sudo apt-get -y install g++ python3-dev
+
+sudo apt-get -y install python3-setuptools
+sudo easy_install3 pip
+sudo pip3 install --upgrade pip wheel setuptools
+
+sudo pip install bigchaindb


### PR DESCRIPTION
This PR adds a new folder named `bigchaindb-on-ubuntu`. The template provisions an Ubuntu 14.04 virtual machine (and various other resources), then calls a script to install [BigchainDB](https://www.bigchaindb.com/) and all its dependencies.