### PR TITLE
OpenShift Origin 3.3

### DIFF
--- a/openshift-origin-rhel/README.md
+++ b/openshift-origin-rhel/README.md
@@ -38,29 +38,32 @@ You will need to create a Key Vault to store your SSH Private Key that will then
          Ex: [azure keyvault create -u KeyVaultName -g ResourceGroupName -l 'East US'] <br/>
   c.  Create Secret: azure keyvault secret set -u \<vault-name\> -s \<secret-name\> --file \<private-key-file-name\><br/>
          Ex: [azure keyvault secret set -u KeyVaultName -s SecretName --file ~/.ssh/id_rsa <br/>
+  <br/>
   d.  Enable the Keyvvault for Template Deployment: azure keyvault set-policy -u \<vault-name\> --enabled-for-template-deployment true <br/>
          Ex: [azure keyvault set-policy -u KeyVaultName --enabled-for-template-deployment true] <br/>
 
 ### azuredeploy.Parameters.json File Explained
 
-1.  _artifactsLocation: The base URL where artifacts required by this template are located
-2.  masterVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
-3.  nodeVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
-4.  osImage: Select from CentOS or RHEL for the Operating System
-5.  openshiftMasterHostName: Host name for the Master Node
-6.  openshiftMasterPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Master Node by
-7.  nodeLbPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Node Load Balancer by.  Used to access deployed applications
-8.  nodePrefix: prefix to be prepended to create host names for the Nodes
-9.  nodeInstanceCount: Number of Nodes to deploy
-10. adminUsername: Admin username for both OS login and OpenShift login
-11. adminPassword: Password for OpenShift login
-12. sshPublicKey: Copy your SSH Public Key here
-13. subscriptionId: Your Subscription ID<br/>
+1.  masterVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
+2.  nodeVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
+3.  osImage: Select from CentOS or RHEL for the Operating System
+4.  openshiftMasterHostName: Host name for the Master Node
+5.  openshiftMasterPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Master Node by
+6.  nodeLbPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Node Load Balancer by.  Used to access deployed applications
+7.  nodePrefix: prefix to be prepended to create host names for the Nodes
+8.  nodeInstanceCount: Number of Nodes to deploy
+9.  adminUsername: Admin username for both OS login and OpenShift login
+10.  adminPassword: Password for OpenShift login
+11. sshPublicKey: Copy your SSH Public Key here
+12. sshPrivateKey - id: Should adhere to: "/subscriptions/[subscirption GUID]/resourceGroups/[ResourceGroupName]/providers/Microsoft.KeyVault/vaults/[KeyVaultName]"<br/>
+    a. Example: "/subscriptions/111a111b-1234-1abc-aa1a-11df2345ab67/resourceGroups/MyResourceGroup/providers/Microsoft.KeyVault/vaults/MyKeyVault"
+13. sshPrivateKey - SecretName: The Secret Name you used when creating the Secret
+14. subscriptionId: Your Subscription ID<br/>
     a. PowerShell: get-AzureAccount
 	b. Azure CLI: azure account show  - Field is ID
-14. keyVaultResourceGroup: The name of the Resource Group that contains the Key Vault
-15. keyVaultName: The name of the Key Vault you created
-16. keyVaultSecret: The Secret Name you used when creating the Secret
+15. keyVaultResourceGroup: The name of the Resource Group that contains the Key Vault
+16. keyVaultName: The name of the Key Vault you created
+17. keyVaultSecret: The Secret Name you used when creating the Secret
 
 ## Deploy Template
 

--- a/openshift-origin-rhel/README.md
+++ b/openshift-origin-rhel/README.md
@@ -38,32 +38,29 @@ You will need to create a Key Vault to store your SSH Private Key that will then
          Ex: [azure keyvault create -u KeyVaultName -g ResourceGroupName -l 'East US'] <br/>
   c.  Create Secret: azure keyvault secret set -u \<vault-name\> -s \<secret-name\> --file \<private-key-file-name\><br/>
          Ex: [azure keyvault secret set -u KeyVaultName -s SecretName --file ~/.ssh/id_rsa <br/>
-  <br/>
   d.  Enable the Keyvvault for Template Deployment: azure keyvault set-policy -u \<vault-name\> --enabled-for-template-deployment true <br/>
          Ex: [azure keyvault set-policy -u KeyVaultName --enabled-for-template-deployment true] <br/>
 
 ### azuredeploy.Parameters.json File Explained
 
-1.  masterVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
-2.  nodeVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
-3.  osImage: Select from CentOS or RHEL for the Operating System
-4.  openshiftMasterHostName: Host name for the Master Node
-5.  openshiftMasterPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Master Node by
-6.  nodeLbPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Node Load Balancer by.  Used to access deployed applications
-7.  nodePrefix: prefix to be prepended to create host names for the Nodes
-8.  nodeInstanceCount: Number of Nodes to deploy
-9.  adminUsername: Admin username for both OS login and OpenShift login
-10.  adminPassword: Password for OpenShift login
-11. sshPublicKey: Copy your SSH Public Key here
-12. sshPrivateKey - id: Should adhere to: "/subscriptions/[subscirption GUID]/resourceGroups/[ResourceGroupName]/providers/Microsoft.KeyVault/vaults/[KeyVaultName]"<br/>
-    a. Example: "/subscriptions/111a111b-1234-1abc-aa1a-11df2345ab67/resourceGroups/MyResourceGroup/providers/Microsoft.KeyVault/vaults/MyKeyVault"
-13. sshPrivateKey - SecretName: The Secret Name you used when creating the Secret
-14. subscriptionId: Your Subscription ID<br/>
+1.  _artifactsLocation: The base URL where artifacts required by this template are located
+2.  masterVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
+3.  nodeVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
+4.  osImage: Select from CentOS or RHEL for the Operating System
+5.  openshiftMasterHostName: Host name for the Master Node
+6.  openshiftMasterPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Master Node by
+7.  nodeLbPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Node Load Balancer by.  Used to access deployed applications
+8.  nodePrefix: prefix to be prepended to create host names for the Nodes
+9.  nodeInstanceCount: Number of Nodes to deploy
+10. adminUsername: Admin username for both OS login and OpenShift login
+11. adminPassword: Password for OpenShift login
+12. sshPublicKey: Copy your SSH Public Key here
+13. subscriptionId: Your Subscription ID<br/>
     a. PowerShell: get-AzureAccount
 	b. Azure CLI: azure account show  - Field is ID
-15. keyVaultResourceGroup: The name of the Resource Group that contains the Key Vault
-16. keyVaultName: The name of the Key Vault you created
-17. keyVaultSecret: The Secret Name you used when creating the Secret
+14. keyVaultResourceGroup: The name of the Resource Group that contains the Key Vault
+15. keyVaultName: The name of the Key Vault you created
+16. keyVaultSecret: The Secret Name you used when creating the Secret
 
 ## Deploy Template
 

--- a/openshift-origin-rhel/README.md
+++ b/openshift-origin-rhel/README.md
@@ -38,32 +38,29 @@ You will need to create a Key Vault to store your SSH Private Key that will then
          Ex: [azure keyvault create -u KeyVaultName -g ResourceGroupName -l 'East US'] <br/>
   c.  Create Secret: azure keyvault secret set -u \<vault-name\> -s \<secret-name\> --file \<private-key-file-name\><br/>
          Ex: [azure keyvault secret set -u KeyVaultName -s SecretName --file ~/.ssh/id_rsa <br/>
-  <br/>
   d.  Enable the Keyvvault for Template Deployment: azure keyvault set-policy -u \<vault-name\> --enabled-for-template-deployment true <br/>
          Ex: [azure keyvault set-policy -u KeyVaultName --enabled-for-template-deployment true] <br/>
 
 ### azuredeploy.Parameters.json File Explained
 
-1.  masterVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
-2.  nodeVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
-3.  osImage: Select from CentOS or RHEL for the Operating System
-4.  openshiftMasterHostName: Host name for the Master Node
-5.  openshiftMasterPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Master Node by
-6.  nodeLbPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Node Load Balancer by.  Used to access deployed applications
-7.  nodePrefix: prefix to be prepended to create host names for the Nodes
-8.  nodeInstanceCount: Number of Nodes to deploy
-9.  adminUsername: Admin username for both OS login and OpenShift login
-10.  adminPassword: Password for OpenShift login
-11. sshPublicKey: Copy your SSH Public Key here
-12. sshPrivateKey - id: Should adhere to: "/subscriptions/[subscirption GUID]/resourceGroups/[ResourceGroupName]/providers/Microsoft.KeyVault/vaults/[KeyVaultName]"<br/>
-    a. Example: "/subscriptions/111a111b-1234-1abc-aa1a-11df2345ab67/resourceGroups/MyResourceGroup/providers/Microsoft.KeyVault/vaults/MyKeyVault"
-13. sshPrivateKey - SecretName: The Secret Name you used when creating the Secret
-14. subscriptionId: Your Subscription ID<br/>
+1.  _artifactsLocation: The base URL where artifacts required by this template are located
+2.  masterVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
+3.  nodeVmSize: Select from one of the allowed VM sizes listed in the azuredeploy.json file
+4.  osImage: Select from CentOS or RHEL for the Operating System
+5.  openshiftMasterHostName: Host name for the Master Node
+6.  openshiftMasterPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Master Node by
+7.  nodeLbPublicIpDnsLabelPrefix: A unique Public DNS name to reference the Node Load Balancer by.  Used to access deployed applications
+8.  nodePrefix: prefix to be prepended to create host names for the Nodes
+9.  nodeInstanceCount: Number of Nodes to deploy
+10. adminUsername: Admin username for both OS login and OpenShift login
+11. adminPassword: Password for OpenShift login
+12. sshPublicKey: Copy your SSH Public Key here
+13. subscriptionId: Your Subscription ID<br/>
     a. PowerShell: get-AzureAccount
-	b. Azure CLI: azure account show  - Field is ID
-15. keyVaultResourceGroup: The name of the Resource Group that contains the Key Vault
-16. keyVaultName: The name of the Key Vault you created
-17. keyVaultSecret: The Secret Name you used when creating the Secret
+	b. Azure CLI: azure account show - Field is ID
+14. keyVaultResourceGroup: The name of the Resource Group that contains the Key Vault
+15. keyVaultName: The name of the Key Vault you created
+16. keyVaultSecret: The Secret Name you used when creating the Secret
 
 ## Deploy Template
 

--- a/openshift-origin-rhel/README.md
+++ b/openshift-origin-rhel/README.md
@@ -15,6 +15,8 @@ This template deploys OpenShift Origin with basic username / password for authen
 |Storage Accounts   |2 Storage Accounts                                                                                                                  |
 |Virtual Machines   |Single master<br />User-defined number of nodes<br />All VMs include a single attached data disk for Docker thin pool logical volume|
 
+If you already have a Red Hat subscription and would like to deploy an OpenShift Container Platform (Enterprise) 3.3 cluster, please visit: https://github.com/haroldwongms/openshift-enterprise
+
 ### Generate SSH Keys
 
 You'll need to generate a pair of SSH keys in order to provision this template. Ensure that you do not include a passcode with the private key. <br/>

--- a/openshift-origin-rhel/azuredeploy.json
+++ b/openshift-origin-rhel/azuredeploy.json
@@ -98,14 +98,14 @@
 			"type": "string",
 			"minLength": 1,
 			"metadata": {
-				"description": "Administrator username on all VMs"
+				"description": "Admin username for both OS login and OpenShift login"
 			}
 		},
 		"adminPassword": {
 			"type": "securestring",
 			"minLength": 1,
 			"metadata": {
-				"description": "Administrator password for OpenShift Console"
+				"description": "Password for OpenShift login"
 			}
 		},
 		"sshPublicKey": {
@@ -141,11 +141,31 @@
 			"metadata": {
 				"description": "Key Vault Secret Name that contains the Private Key"
 			}
+		},
+		"defaultSubDomainType": {
+			"type": "string",
+			"defaultValue": "xipio",
+			"allowedValues": [
+				"xipio", "custom"
+			],
+			"metadata": {
+				"description": "Default Subdomain type - xip.io or custom (defined in next parameter)"
+			}
+		},
+		"defaultSubDomain": {
+			"type": "string",
+			"minLength": 1,
+			"metadata": {
+				"description": "Default Subdomain for application routing (Wildcard DNS). Entry is ignored if defaultSubDomainType set to xipio"
+			}
 		}
 	},
 	"variables": {
 		"location": "[resourceGroup().location]",
-		"storageAccountType": "Standard_LRS",
+		"apiVersionCompute": "2015-06-15",
+		"apiVersionNetwork": "2015-06-15",
+		"apiVersionStorage": "2015-06-15",
+		"apiVersionLinkTemplate": "2015-01-01",
 		"namingInfix": "[toLower(parameters('nodePrefix'))]",
 		"newStorageAccountMaster": "[concat(uniqueString(concat(resourceGroup().id, 'msa', '0')), 'msa')]",
 		"newStorageAccountNode": "[concat(uniqueString(concat(resourceGroup().id, 'nsa', '1')), 'nsa')]",
@@ -349,7 +369,7 @@
 			"type": "Microsoft.Network/virtualNetworks",
 			"name": "[variables('virtualNetworkName')]",
 			"location": "[variables('location')]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionNetwork')]",
 			"tags": {
 				"displayName": "VirtualNetwork"
 			},
@@ -375,7 +395,7 @@
 			"type": "Microsoft.Storage/storageAccounts",
 			"name": "[variables('newStorageAccountMaster')]",
 			"location": "[variables('location')]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionStorage')]",
 			"tags": {
 				"displayName": "StorageAccounts"
 			},
@@ -386,7 +406,7 @@
 			"type": "Microsoft.Storage/storageAccounts",
 			"name": "[variables('newStorageAccountNode')]",
 			"location": "[variables('location')]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionStorage')]",
 			"tags": {
 				"displayName": "StorageAccounts"
 			},
@@ -397,7 +417,7 @@
 			"type": "Microsoft.Network/publicIPAddresses",
 			"name": "[parameters('nodeLbPublicIpDnsLabelPrefix')]",
 			"location": "[resourceGroup().location]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionNetwork')]",
 			"tags": {
 				"displayName": "OpenShiftNodeLBPublicIP"
 			},
@@ -410,14 +430,14 @@
 		}, {
 			"type": "Microsoft.Compute/availabilitySets",
 			"name": "nodes",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionCompute')]",
 			"location": "[resourceGroup().location]",
 			"properties": {}
 		}, {
 			"type": "Microsoft.Network/loadBalancers",
 			"name": "[variables('nodeLoadBalancerName')]",
 			"location": "[variables('location')]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionNetwork')]",
 			"tags": {
 				"displayName": "OpenShiftNodeLB"
 			},
@@ -493,7 +513,7 @@
 			"type": "Microsoft.Network/publicIPAddresses",
 			"name": "[parameters('openshiftMasterPublicIpDnsLabelPrefix')]",
 			"location": "[resourceGroup().location]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionNetwork')]",
 			"tags": {
 				"displayName": "OpenShiftMasterPublicIP"
 			},
@@ -507,7 +527,7 @@
 			"type": "Microsoft.Network/networkInterfaces",
 			"name": "[concat(parameters('openshiftMasterHostname'), 'nic')]",
 			"location": "[resourceGroup().location]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionNetwork')]",
 			"tags": {
 				"displayName": "OpenShiftMasterNetworkInterface"
 			},
@@ -532,7 +552,7 @@
 			"type": "Microsoft.Compute/virtualMachines",
 			"name": "[parameters('openshiftMasterHostname')]",
 			"location": "[resourceGroup().location]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionCompute')]",
 			"tags": {
 				"displayName": "OpenShiftMasterVirtualMachine"
 			},
@@ -587,7 +607,7 @@
 			"type": "Microsoft.Compute/virtualMachines/extensions",
 			"name": "[concat(parameters('openshiftMasterHostname'), '/deployOpenShift')]",
 			"location": "[resourceGroup().location]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionCompute')]",
 			"tags": {
 				"displayName": "PrepMaster"
 			},
@@ -610,7 +630,7 @@
 			"type": "Microsoft.Network/networkInterfaces",
 			"name": "[concat(variables('namingInfix'), copyIndex(), 'nic')]",
 			"location": "[resourceGroup().location]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionNetwork')]",
 			"tags": {
 				"displayName": "OpenShiftNodeNetworkInterfaces"
 			},
@@ -639,7 +659,7 @@
 			"type": "Microsoft.Compute/virtualMachines",
 			"name": "[concat(variables('namingInfix'), '-', copyIndex())]",
 			"location": "[resourceGroup().location]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionCompute')]",
 			"tags": {
 				"displayName": "OpenShiftNodes"
 			},
@@ -701,7 +721,7 @@
 			"type": "Microsoft.Compute/virtualMachines/extensions",
 			"name": "[concat(variables('namingInfix'), '-', copyIndex(), '/prepNodes')]",
 			"location": "[resourceGroup().location]",
-			"apiVersion": "2015-06-15",
+			"apiVersion": "[variables('apiVersionCompute')]",
 			"tags": {
 				"displayName": "PrepNodes"
 			},
@@ -727,7 +747,7 @@
 		}, {
 			"name": "OpenShiftDeployment",
 			"type": "Microsoft.Resources/deployments",
-			"apiVersion": "2015-01-01",
+			"apiVersion": "[variables('apiVersionLinkTemplate')]",
 			"dependsOn": [
 				"[concat('Microsoft.Compute/virtualMachines/', parameters('openshiftMasterHostname'), '/extensions/deployOpenShift')]",
 				"nodeScriptLoop"
@@ -763,11 +783,14 @@
 					"adminPassword": {
 						"value": "[parameters('adminPassword')]"
 					},
-					"defaultSubDomain": {
+					"xipioDomain": {
 						"value": "[concat(reference(parameters('nodeLbPublicIpDnsLabelPrefix')).ipAddress, '.xip.io')]"
 					},
-					"sshPublicKey": {
-						"value": "[parameters('sshPublicKey')]"
+					"customDomain": {
+						"value": "[parameters('defaultSubDomain')]"
+					},
+					"subDomainChosen": {
+						"value": "[concat(parameters('defaultSubDomainType'), 'Domain')]"
 					},
 					"sshPrivateKey": {
 						"reference": {

--- a/openshift-origin-rhel/nested/openshiftdeploy.json
+++ b/openshift-origin-rhel/nested/openshiftdeploy.json
@@ -57,16 +57,22 @@
 				"description": "Administrator password for OpenShift Console"
 			}
 		},
-		"defaultSubDomain": {
+		"xipioDomain": {
 			"type": "string",
 			"metadata": {
-				"description": "Default Subdomain for application routing"
+				"description": "Xip.io Subdomain for application routing"
 			}
 		},
-		"sshPublicKey": {
-			"type": "securestring",
+		"customDomain": {
+			"type": "string",
 			"metadata": {
-				"description": "SSH public key on all VMs"
+				"description": "custom Subdomain for application routing"
+			}
+		},
+		"subDomainChosen": {
+			"type": "string",
+			"metadata": {
+				"description": "Subdomain chosen for application routing"
 			}
 		},
 		"sshPrivateKey": {
@@ -109,7 +115,7 @@
 				]
 			},
 			"protectedSettings": {
-				"commandToExecute": "[concat('bash ', variables('openshiftDeploymentScriptFileName'), ' \"', parameters('adminUsername'), '\" \"', parameters('adminPassword'), '\" \"', parameters('sshPublicKey'), '\" \"', parameters('sshPrivateKey'), '\" \"', parameters('openshiftMasterHostname'), '\" \"', parameters('openshiftMasterPublicIpFqdn'), '\" \"', parameters('openshiftMasterPublicIpAddress'), '\" \"', parameters('nodePrefix'), '\" \"', parameters('nodeInstanceCount'), '\" \"', parameters('defaultSubDomain'), '\"')]"
+				"commandToExecute": "[concat('bash ', variables('openshiftDeploymentScriptFileName'), ' \"', parameters('adminUsername'), '\" \"', parameters('adminPassword'), '\" \"', parameters('sshPrivateKey'), '\" \"', parameters('openshiftMasterHostname'), '\" \"', parameters('openshiftMasterPublicIpFqdn'), '\" \"', parameters('openshiftMasterPublicIpAddress'), '\" \"', parameters('nodePrefix'), '\" \"', parameters('nodeInstanceCount'), '\" \"', parameters(parameters('subDomainChosen')), '\"')]"
 			}
 		}
 	}],

--- a/openshift-origin-rhel/nested/openshiftdeploy.json
+++ b/openshift-origin-rhel/nested/openshiftdeploy.json
@@ -57,22 +57,16 @@
 				"description": "Administrator password for OpenShift Console"
 			}
 		},
-		"xipioDomain": {
+		"defaultSubDomain": {
 			"type": "string",
 			"metadata": {
-				"description": "Xip.io Subdomain for application routing"
+				"description": "Default Subdomain for application routing"
 			}
 		},
-		"customDomain": {
-			"type": "string",
+		"sshPublicKey": {
+			"type": "securestring",
 			"metadata": {
-				"description": "custom Subdomain for application routing"
-			}
-		},
-		"subDomainChosen": {
-			"type": "string",
-			"metadata": {
-				"description": "Subdomain chosen for application routing"
+				"description": "SSH public key on all VMs"
 			}
 		},
 		"sshPrivateKey": {
@@ -115,7 +109,7 @@
 				]
 			},
 			"protectedSettings": {
-				"commandToExecute": "[concat('bash ', variables('openshiftDeploymentScriptFileName'), ' \"', parameters('adminUsername'), '\" \"', parameters('adminPassword'), '\" \"', parameters('sshPrivateKey'), '\" \"', parameters('openshiftMasterHostname'), '\" \"', parameters('openshiftMasterPublicIpFqdn'), '\" \"', parameters('openshiftMasterPublicIpAddress'), '\" \"', parameters('nodePrefix'), '\" \"', parameters('nodeInstanceCount'), '\" \"', parameters(parameters('subDomainChosen')), '\"')]"
+				"commandToExecute": "[concat('bash ', variables('openshiftDeploymentScriptFileName'), ' \"', parameters('adminUsername'), '\" \"', parameters('adminPassword'), '\" \"', parameters('sshPublicKey'), '\" \"', parameters('sshPrivateKey'), '\" \"', parameters('openshiftMasterHostname'), '\" \"', parameters('openshiftMasterPublicIpFqdn'), '\" \"', parameters('openshiftMasterPublicIpAddress'), '\" \"', parameters('nodePrefix'), '\" \"', parameters('nodeInstanceCount'), '\" \"', parameters('defaultSubDomain'), '\"')]"
 			}
 		}
 	}],

--- a/openshift-origin-rhel/nested/openshiftdeploy.json
+++ b/openshift-origin-rhel/nested/openshiftdeploy.json
@@ -5,7 +5,7 @@
 		"_artifactsLocation": {
 			"type": "string",
 			"metadata": {
-				"description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+				"description": "The base URL where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
 			}
 		},
 		"openshiftMasterHostname": {
@@ -57,16 +57,22 @@
 				"description": "Administrator password for OpenShift Console"
 			}
 		},
-		"defaultSubDomain": {
+		"xipioDomain": {
 			"type": "string",
 			"metadata": {
-				"description": "Default Subdomain for application routing"
+				"description": "Xip.io Subdomain for application routing"
 			}
 		},
-		"sshPublicKey": {
-			"type": "securestring",
+		"customDomain": {
+			"type": "string",
 			"metadata": {
-				"description": "SSH public key on all VMs"
+				"description": "custom Subdomain for application routing"
+			}
+		},
+		"subDomainChosen": {
+			"type": "string",
+			"metadata": {
+				"description": "Subdomain chosen for application routing"
 			}
 		},
 		"sshPrivateKey": {
@@ -109,7 +115,7 @@
 				]
 			},
 			"protectedSettings": {
-				"commandToExecute": "[concat('bash ', variables('openshiftDeploymentScriptFileName'), ' \"', parameters('adminUsername'), '\" \"', parameters('adminPassword'), '\" \"', parameters('sshPublicKey'), '\" \"', parameters('sshPrivateKey'), '\" \"', parameters('openshiftMasterHostname'), '\" \"', parameters('openshiftMasterPublicIpFqdn'), '\" \"', parameters('openshiftMasterPublicIpAddress'), '\" \"', parameters('nodePrefix'), '\" \"', parameters('nodeInstanceCount'), '\" \"', parameters('defaultSubDomain'), '\"')]"
+				"commandToExecute": "[concat('bash ', variables('openshiftDeploymentScriptFileName'), ' \"', parameters('adminUsername'), '\" \"', parameters('adminPassword'), '\" \"', parameters('sshPrivateKey'), '\" \"', parameters('openshiftMasterHostname'), '\" \"', parameters('openshiftMasterPublicIpFqdn'), '\" \"', parameters('openshiftMasterPublicIpAddress'), '\" \"', parameters('nodePrefix'), '\" \"', parameters('nodeInstanceCount'), '\" \"', parameters(parameters('subDomainChosen')), '\"')]"
 			}
 		}
 	}],

--- a/openshift-origin-rhel/scripts/deployOpenShift.sh
+++ b/openshift-origin-rhel/scripts/deployOpenShift.sh
@@ -4,14 +4,13 @@ set -e
 
 SUDOUSER=$1
 PASSWORD=$2
-PUBLICKEY=$3
-PRIVATEKEY=$4
-MASTER=$5
-MASTERPUBLICIPHOSTNAME=$6
-MASTERPUBLICIPADDRESS=$7
-NODEPREFIX=$8
-NODECOUNT=$9
-ROUTING=${10}
+PRIVATEKEY=$3
+MASTER=$4
+MASTERPUBLICIPHOSTNAME=$5
+MASTERPUBLICIPADDRESS=$6
+NODEPREFIX=$7
+NODECOUNT=$8
+ROUTING=$9
 
 DOMAIN=$( awk 'NR==2' /etc/resolv.conf | awk '{ print $2 }' )
 
@@ -19,7 +18,6 @@ DOMAIN=$( awk 'NR==2' /etc/resolv.conf | awk '{ print $2 }' )
 
 echo "Generating keys"
 
-runuser -l $SUDOUSER -c "echo \"$PUBLICKEY\" > ~/.ssh/id_rsa.pub"
 runuser -l $SUDOUSER -c "echo \"$PRIVATEKEY\" > ~/.ssh/id_rsa"
 runuser -l $SUDOUSER -c "chmod 600 ~/.ssh/id_rsa*"
 
@@ -44,6 +42,8 @@ nodes
 ansible_ssh_user=$SUDOUSER
 ansible_become=yes
 deployment_type=origin
+openshift_release=v1.3
+openshift_image_tag=v1.3.0
 docker_udev_workaround=True
 openshift_use_dnsmasq=no
 openshift_master_default_subdomain=$ROUTING
@@ -51,7 +51,7 @@ openshift_master_default_subdomain=$ROUTING
 openshift_master_cluster_public_hostname=$MASTERPUBLICIPHOSTNAME
 openshift_master_cluster_public_vip=$MASTERPUBLICIPADDRESS
 
-# Enable Azure AD auth
+# Enable htpasswd auth for username / password authentication
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
 
 # host group for masters
@@ -60,15 +60,15 @@ $MASTER.$DOMAIN
 
 # host group for nodes
 [nodes]
-$MASTER.$DOMAIN
+$MASTER.$DOMAIN openshift_node_labels="{'region': 'master', 'zone': 'default'}"
 EOF
 
 for (( c=0; c<$NODECOUNT; c++ ))
 do
-  echo "$NODEPREFIX-$c.$DOMAIN" >> /etc/ansible/hosts
+  echo "$NODEPREFIX-$c.$DOMAIN openshift_node_labels=\"{'region': 'infra', 'zone': 'default'}\"" >> /etc/ansible/hosts
 done
 
-runuser -l $SUDOUSER -c "git clone -b release-1.3 https://github.com/openshift/openshift-ansible /home/$SUDOUSER/openshift-ansible"
+runuser -l $SUDOUSER -c "git clone https://github.com/openshift/openshift-ansible /home/$SUDOUSER/openshift-ansible"
 
 echo "Executing Ansible playbook"
 
@@ -87,7 +87,7 @@ runuser -l $SUDOUSER -c "sudo oadm registry"
 
 echo "Deploying Router"
 
-runuser -l $SUDOUSER -c "sudo oadm router osrouter --replicas=$NODECOUNT --credentials=/etc/origin/master/openshift-router.kubeconfig --service-account=router"
+runuser -l $SUDOUSER -c "sudo oadm router osrouter --replicas=$NODECOUNT --selector=region=infra"
 
 echo "Re-enabling requiretty"
 

--- a/openshift-origin-rhel/scripts/deployOpenShift.sh
+++ b/openshift-origin-rhel/scripts/deployOpenShift.sh
@@ -83,11 +83,11 @@ sed -i -e '/Defaults    env_keep += "LC_TIME LC_ALL LANGUAGE LINGUAS _XKB_CHARSE
 
 echo "Deploying Registry"
 
-runuser -l $SUDOUSER -c "sudo oadm registry"
+# runuser -l $SUDOUSER -c "sudo oadm registry"
 
 echo "Deploying Router"
 
-runuser -l $SUDOUSER -c "sudo oadm router osrouter --replicas=$NODECOUNT --selector=region=infra"
+# runuser -l $SUDOUSER -c "sudo oadm router osrouter --replicas=$NODECOUNT --selector=region=infra"
 
 echo "Re-enabling requiretty"
 

--- a/openshift-origin-rhel/scripts/deployOpenShift.sh
+++ b/openshift-origin-rhel/scripts/deployOpenShift.sh
@@ -68,7 +68,7 @@ do
   echo "$NODEPREFIX-$c.$DOMAIN" >> /etc/ansible/hosts
 done
 
-runuser -l $SUDOUSER -c "git clone https://github.com/openshift/openshift-ansible /home/$SUDOUSER/openshift-ansible"
+runuser -l $SUDOUSER -c "git clone -b release-1.3 https://github.com/openshift/openshift-ansible /home/$SUDOUSER/openshift-ansible"
 
 echo "Executing Ansible playbook"
 

--- a/openshift-origin-rhel/scripts/masterPrep.sh
+++ b/openshift-origin-rhel/scripts/masterPrep.sh
@@ -16,8 +16,8 @@ yum -y --enablerepo=epel install ansible
 # Disable EPEL to prevent unexpected packages from being pulled in during installation.
 yum-config-manager epel --disable
 
-# Install Docker
-yum -y install docker
+# Install Docker 1.10.3
+yum -y install docker-1.10.3
 
 # Create thin pool logical volume for Docker
 echo "DEVS=/dev/sdc" >> /etc/sysconfig/docker-storage-setup

--- a/openshift-origin-rhel/scripts/nodePrep.sh
+++ b/openshift-origin-rhel/scripts/nodePrep.sh
@@ -13,8 +13,8 @@ yum -y clean all
 # Disable EPEL to prevent unexpected packages from being pulled in during installation.
 yum-config-manager epel --disable
 
-# Install Docker
-yum -y install docker
+# Install Docker 1.10.3
+yum -y install docker-1.10.3
 
 # Create thin pool logical volume for Docker
 echo "DEVS=/dev/sdc" >> /etc/sysconfig/docker-storage-setup


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
Updated ARM templates and scripts to deploy OpenShift Origin 3.3

### Description of the change
masterPrep.sh, nodePrep.sh, deployOpenShift.sh - deploy Docker 1.10.3 and OpenShift 3.3
azuredeploy.json, openshiftdeploy.json - parametrized API versions, added option for xip.io or custom domain, cleaned up unnecessary variables. 