### PR TITLE
Update to utilise newer F-Series VMs

### DIFF
--- a/create-hpc-cluster/azuredeploy.json
+++ b/create-hpc-cluster/azuredeploy.json
@@ -53,7 +53,12 @@
         "Standard_GS2",
         "Standard_GS3",
         "Standard_GS4",
-        "Standard_GS5"
+        "Standard_GS5",
+        "Standard_F1",
+        "Standard_F2",
+        "Standard_F4",
+        "Standard_F8",
+        "Standard_F16"
       ],
       "metadata": {
         "description": "The VM size for the head node"
@@ -137,7 +142,12 @@
         "Standard_GS2",
         "Standard_GS3",
         "Standard_GS4",
-        "Standard_GS5"
+        "Standard_GS5",
+        "Standard_F1",
+        "Standard_F2",
+        "Standard_F4",
+        "Standard_F8",
+        "Standard_F16"        
       ],
       "metadata": {
         "description": "The VM role size of the compute nodes"


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
*
*
*
*
*

### Description of the change
Existing template does not cover the F-Series VMs which are cheaper for CPU-intensive tasks and therefore rather suitable to being used in the HPC cluster