### PR TITLE
remove items for 2.0 handler

### DIFF
--- a/cloudera-on-centos/setup-cloudera.json
+++ b/cloudera-on-centos/setup-cloudera.json
@@ -78,13 +78,7 @@
           ]
         },
         "protectedSettings": {
-          "commandToExecute": "[concat('sh bootstrap-cloudera.sh \"', variables('masterIP'), '\" \"', variables('workerIP'), '\" \"', parameters('dnsNamePrefix'), '\" \"', parameters('fqdn'), '\" ', parameters('clusterSpec').masterNodeCount, ' ', parameters('clusterSpec').dataNodeCount, ' \"', parameters('vmSpec').adminUserName, '\" \"', parameters('clusterSpec').highAvailability, '\" \"', parameters('vmSpec').adminPassword, '\" \"', parameters('cmUsername'), '\" \"', parameters('cmPassword'), '\" \"', parameters('emailAddress'), '\" \"', parameters('businessPhone'), '\" \"', parameters('firstName'), '\" \"', parameters('lastName'), '\" \"', parameters('jobRole'), '\" \"', parameters('jobFunction'), '\" \"', parameters('company'), '\" \"', parameters('installCDH'), '\" \"', parameters('vmSpec').vmSize, '\" >> /home/$ADMINUSER/bootstrap-cloudera.log 2>&1')]",
-          "Items": {
-            "AdminUserName": "[parameters('vmSpec').adminUserName]",
-            "AdminPassword": "[parameters('vmSpec').adminPassword]",
-            "CMUserName": "[parameters('cmUsername')]",
-            "CMPassword": "[parameters('cmPassword')]"
-          }
+          "commandToExecute": "[concat('sh bootstrap-cloudera.sh \"', variables('masterIP'), '\" \"', variables('workerIP'), '\" \"', parameters('dnsNamePrefix'), '\" \"', parameters('fqdn'), '\" ', parameters('clusterSpec').masterNodeCount, ' ', parameters('clusterSpec').dataNodeCount, ' \"', parameters('vmSpec').adminUserName, '\" \"', parameters('clusterSpec').highAvailability, '\" \"', parameters('vmSpec').adminPassword, '\" \"', parameters('cmUsername'), '\" \"', parameters('cmPassword'), '\" \"', parameters('emailAddress'), '\" \"', parameters('businessPhone'), '\" \"', parameters('firstName'), '\" \"', parameters('lastName'), '\" \"', parameters('jobRole'), '\" \"', parameters('jobFunction'), '\" \"', parameters('company'), '\" \"', parameters('installCDH'), '\" \"', parameters('vmSpec').vmSize, '\" >> /home/$ADMINUSER/bootstrap-cloudera.log 2>&1')]"
         }
       }
     }


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
Remove items for 2.0 handler

### Description of the change
VMExtension:
"publisher": "Microsoft.Azure.Extensions",
"type": "CustomScript",
"typeHandlerVersion": "2.0"

Doesn't allow items, therefore need to remove them.
