### PR TITLE
Changed location of Tomcat Connector to use the Apache archive site (…

### DIFF
--- a/vsts-tomcat-redhat-vm/scripts/tomcat-setup-redhat.sh
+++ b/vsts-tomcat-redhat-vm/scripts/tomcat-setup-redhat.sh
@@ -15,7 +15,7 @@ yum install -y gcc >> /home/$1/install.out.txt 2>&1
 yum install -y gcc-c++ >> /home/$1/install.out.txt 2>&1
 yum install -y httpd-devel >> /home/$1/install.out.txt 2>&1
 cd /home/$1
-wget http://www-us.apache.org/dist/tomcat/tomcat-connectors/jk/tomcat-connectors-1.2.41-src.tar.gz >> /home/$1/install.out.txt 2>&1
+wget http://archive.apache.org/dist/tomcat/tomcat-connectors/jk/tomcat-connectors-1.2.41-src.tar.gz >> /home/$1/install.out.txt 2>&1
 tar xvfz tomcat-connectors-1.2.41-src.tar.gz >> /home/$1/install.out.txt 2>&1
 cd /home/$1/tomcat-connectors-1.2.41-src/native/
 ./configure --with-apxs=/usr/bin/apxs >> /home/$1/install.out.txt 2>&1


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
* Changed the default download location for Apache2 Tomcat Connectors package from "live" site to "archive" site so this should future proof the script (which is now broken)
*
*
*
*

### Description of the change
…instead of live)