### PR TITLE
fixed deploy to azure & visualize links

### DIFF
--- a/101-data-factory-hive-transformation/README.md
+++ b/101-data-factory-hive-transformation/README.md
@@ -15,10 +15,10 @@ This sample creates a data factory with a data pipeline that processes data by r
     - hiveScriptFolder is the name of the folder that contains the hive query (HQL) file. For the tutorial, it is **script**.  
     - hiveScriptFile is the name of the hive script file (HQL). For the sample, it is **partitionweblogs.hql**. 
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-data-factory-blob-to-sql%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-data-factory-hive-transformation%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-data-factory-blob-to-sql%2Fazuredeploy.json" target="_blank">
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-data-factory-hive-transformation%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
Fixed the "Deploy to Azure" and "Visualize" links to point to the right folder. 