### PR TITLE
Moved bigchaindb into alphabetical order in list

### DIFF
--- a/blockchain/README.md
+++ b/blockchain/README.md
@@ -9,6 +9,7 @@ This Microsoft Azure Resource Manager template deploys a single VM and allows yo
 
 Options for blockchain software include:
 
+- [bigchaindb](https://github.com/Azure/azure-quickstart-templates/blob/master/blockchain/details/bigchaindb.md)
 - [bitshares](https://github.com/Azure/azure-quickstart-templates/blob/master/blockchain/details/bitshares.md) (note: failed testing on 10/7/2016)
 - [bitswift](https://github.com/Azure/azure-quickstart-templates/blob/master/blockchain/details/bitswift.md)
 - [blocknet](https://github.com/Azure/azure-quickstart-templates/blob/master/blockchain/details/blocknet.md)
@@ -26,4 +27,3 @@ Options for blockchain software include:
 - [syscoin](https://github.com/Azure/azure-quickstart-templates/blob/master/blockchain/details/syscoin.md)
 - [vcash](https://github.com/Azure/azure-quickstart-templates/blob/master/blockchain/details/vcash.md)
 - [viacoin](https://github.com/Azure/azure-quickstart-templates/blob/master/blockchain/details/viacoin.md)
-- [bigchaindb](https://github.com/Azure/azure-quickstart-templates/blob/master/blockchain/details/bigchaindb.md)


### PR DESCRIPTION
In `blockchain/README.md`, the list of blockchains was in alphabetical order, but the most-recently-added one, `bigchaindb`, was just added to the end of the list. I moved it into alphabetical order with all the others.