### PR TITLE
Update bigchaindb installation script

### DIFF
--- a/blockchain/scripts/bigchaindb.sh
+++ b/blockchain/scripts/bigchaindb.sh
@@ -9,7 +9,7 @@ sudo cp /etc/rethinkdb/default.conf.sample /etc/rethinkdb/instances.d/instance1.
 
 sudo /etc/init.d/rethinkdb restart
 
-sudo apt-get -y install g++ python3-dev
+sudo apt-get -y install g++ python3-dev libffi-dev
 
 sudo apt-get -y install python3-setuptools
 sudo easy_install3 pip


### PR DESCRIPTION
The next release of BigchainDB (0.7) will require the installation of `libffi-dev` (an Ubuntu package), so I added that to the `blockchain/scripts/bigchaindb.sh` installation script. (The current version doesn't need it `libffi-dev` but installing it won't hurt.)

For more background on why `libffi-dev` will be needed by BigchainDB 0.7, see https://github.com/bigchaindb/bigchaindb/pull/698