### PR TITLE
PowerShell approach missing access policy change

### DIFF
--- a/openshift-origin-rhel/README.md
+++ b/openshift-origin-rhel/README.md
@@ -27,11 +27,12 @@ From a Linux or Mac, you can just use the ssh-keygen command.
 
 You will need to create a Key Vault to store your SSH Private Key that will then be used as part of the deployment.
 
-1. Create KeyVault using Powershell <br/>
+1. Create Key Vault using Powershell <br/>
   a.  Create new resource group: New-AzureRMResourceGroup -Name 'ResourceGroupName' -Location 'West US'<br/>
   b.  Create key vault: New-AzureRmKeyVault -VaultName 'KeyVaultName' -ResourceGroup 'ResourceGroupName' -Location 'West US'<br/>
   c.  Create variable with sshPrivateKey: $securesecret = ConvertTo-SecureString -String '[copy ssh Private Key here - including line feeds]' -AsPlainText -Force<br/>
   d.  Create Secret: Set-AzureKeyVaultSecret -Name 'SecretName' -SecretValue $securesecret -VaultName 'KeyVaultName'<br/>
+  e.  Enable the Key Vault for Template Deployments: Set-AzureRmKeyVaultAccessPolicy -VaultName 'KeyVaultName' -ResourceGroupName 'ResourceGroupName' -EnabledForTemplateDeployment
 
 2. Create Key Vault using Azure CLI - must be run from a Linux machine (can use Azure CLI container from Docker for Windows) or Mac<br/>
   a.  Create new Resource Group: azure group create \<name\> \<location\> <br/>
@@ -40,7 +41,7 @@ You will need to create a Key Vault to store your SSH Private Key that will then
          Ex: [azure keyvault create -u KeyVaultName -g ResourceGroupName -l 'East US'] <br/>
   c.  Create Secret: azure keyvault secret set -u \<vault-name\> -s \<secret-name\> --file \<private-key-file-name\><br/>
          Ex: [azure keyvault secret set -u KeyVaultName -s SecretName --file ~/.ssh/id_rsa <br/>
-  d.  Enable the Keyvvault for Template Deployment: azure keyvault set-policy -u \<vault-name\> --enabled-for-template-deployment true <br/>
+  d.  Enable the Key Vault for Template Deployments: azure keyvault set-policy -u \<vault-name\> --enabled-for-template-deployment true <br/>
          Ex: [azure keyvault set-policy -u KeyVaultName --enabled-for-template-deployment true] <br/>
 
 ### azuredeploy.Parameters.json File Explained


### PR DESCRIPTION
### Contributing guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog
*
*
*
*
*

### Description of the change
The PowerShell approach was missing a step to change the key vault access policy in order to allow for template deployments.