### PR TITLE
Changed default VM size to D1_v2

### DIFF
--- a/ethereum-consortium-blockchain-network/azuredeploy.json
+++ b/ethereum-consortium-blockchain-network/azuredeploy.json
@@ -69,7 +69,7 @@
     },
     "mnNodeVMSize": {
       "type": "string",
-      "defaultValue": "Standard_D1",
+      "defaultValue": "Standard_D1_v2",
       "allowedValues": [
         "Standard_A1",
         "Standard_A2",
@@ -117,7 +117,7 @@
     },
     "txNodeVMSize": {
       "type": "string",
-      "defaultValue": "Standard_D1",
+      "defaultValue": "Standard_D1_v2",
       "allowedValues": [
         "Standard_A1",
         "Standard_A2",


### PR DESCRIPTION
### Changelog
* Changed default VM size to D1_v2

### Description of the change
This size is available in all regions including both Azure Gov regions.  D1 is not available in USGov Iowa so is not a good user experience for Azure Gov customers