### PR TITLE
removed -u from example for consistency

### DIFF
--- a/1-CONTRIBUTION-GUIDE/README.md
+++ b/1-CONTRIBUTION-GUIDE/README.md
@@ -22,7 +22,7 @@ Simple execute the script and pass in the folder name of the sample you want to 
 .\Deploy-AzureResourceGroup.ps1 -ResourceGroupLocation 'eastus' -ArtifactsStagingDirectory '[foldername]'
 ```
 ```bash
-azure-group-deploy.sh -a [foldername] -l eastus -u
+azure-group-deploy.sh -a [foldername] -l eastus
 ```
 If the sample has artifacts that need to be "staged" for deployment (Configuration Scripts, Nested Templates, DSC Packages) then set the upload switch on the command.
 You can optionally specify a storage account to use, if so the storage account must already exist within the subscription.  If you don't want to specify a storage account

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Simply execute the script and pass in the folder name of the sample you want to 
 .\Deploy-AzureResourceGroup.ps1 -ResourceGroupLocation 'eastus' -ArtifactStagingDirectory '[foldername]'
 ```
 ```bash
-azure-group-deploy.sh -a [foldername] -l eastus -u
+azure-group-deploy.sh -a [foldername] -l eastus
 ```
 If the sample has artifacts that need to be "staged" for deployment (Configuration Scripts, Nested Templates, DSC Packages) then set the upload switch on the command.
 You can optionally specify a storage account to use, if so the storage account must already exist within the subscription.  If you don't want to specify a storage account


### PR DESCRIPTION
the sample for deploying via bash had the -u switch where the ps1 did not - so changed that to make the examples consistent in both cases
