### PR TITLE
Ethereum Consortium Network - OS upgrade, stability improvements

### DIFF
--- a/ethereum-consortium-blockchain-network/azuredeploy.json
+++ b/ethereum-consortium-blockchain-network/azuredeploy.json
@@ -275,7 +275,7 @@
     "ubuntuImage": {
       "publisher": "Canonical",
       "offer": "UbuntuServer",
-      "sku": "14.04.5-LTS",
+      "sku": "16.04.0-LTS",
       "version": "latest"
     },
     "artifactsLocationURL": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/ethereum-consortium-blockchain-network"

--- a/ethereum-consortium-blockchain-network/azuredeploy.json
+++ b/ethereum-consortium-blockchain-network/azuredeploy.json
@@ -156,6 +156,8 @@
     }
   },
   "variables": {
+    "location": "[resourceGroup().location]",
+    "artifactsLocationURL": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/ethereum-consortium-blockchain-network",
     "apiVersionDeployments": "2016-09-01",
     "apiVersionStorageAccounts": "2016-01-01",
     "apiVersionAvailabilitySets": "2016-03-30",
@@ -163,7 +165,7 @@
     "apiVersionNetworkInterfaces": "2016-09-01",
     "apiVersionVirtualMachines": "2016-03-30",
     "apiVersionVirtualNetworks": "2016-09-01",
-    "authType": "Password",
+    "authType": "password",
     "storageAccountType": "Standard_LRS",
     "namingInfix": "[toLower(substring(concat(parameters('namePrefix'), uniqueString(resourceGroup().id)), 0, 9))]",
     "availabilitySetName": "[concat(variables('namingInfix'), 'AvSet')]",
@@ -173,6 +175,10 @@
     "sshNATFrontEndStartingPort": 3000,
     "gethRPCPort": 8545,
     "gethIPCPort": 30303,
+    "loadBalancerName": "[concat(variables('namingInfix'), '-LB')]",
+    "loadBalancerBackendAddressPoolName": "LoadBalancerBackend1",
+    "loadBalancerInboundNatRuleNamePrefix": "SSH-VM",
+    "metricsStorageAcctName": "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'metrics')]",
     "numMNNodes": "[mul(parameters('numConsortiumMembers'), parameters('numMiningNodesPerMember'))]",
     "maxVMsPerStorageAcct": 20,
     "mnStorageAcctCount": "[add(div(variables('numMNNodes'), variables('maxVMsPerStorageAcct')), 1)]",
@@ -195,7 +201,7 @@
     "txNsgName": "[concat(variables('namingInfix'), 'TXNsg')]",
     "mnNsgName": "[concat(variables('namingInfix'), 'MNNsg')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "addressPrefix": "10.0.0.0/16",
+    "addressPrefix": "10.0.0.0/20",
     "mnSubnetNameArray": [
       "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'subnet-mn0')]",
       "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'subnet-mn1')]",
@@ -277,15 +283,14 @@
       "offer": "UbuntuServer",
       "sku": "16.04.0-LTS",
       "version": "latest"
-    },
-    "artifactsLocationURL": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/ethereum-consortium-blockchain-network"
+    }
   },
   "resources": [
     {
       "apiVersion": "[variables('apiVersionAvailabilitySets')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
-      "location": "[resourceGroup().location]",
+      "location": "[variables('location')]",
       "properties": {}
     },
     {
@@ -293,20 +298,24 @@
       "name": "loadBalancerLinkedTemplate",
       "type": "Microsoft.Resources/deployments",
       "properties": {
-        "mode": "incremental",
+        "mode": "Incremental",
         "templateLink": {
           "uri": "[concat(variables('artifactsLocationURL'), '/nested/loadBalancer.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
+          "loadBalancerName": {"value": "[variables('loadBalancerName')]"},
           "dnsHostName":{"value": "[variables('namingInfix')]"},
+          "loadBalancerBackendAddressPoolName":{"value": "[variables('loadBalancerBackendAddressPoolName')]"},
+          "loadBalancerInboundNatRuleNamePrefix":{"value": "[variables('loadBalancerInboundNatRuleNamePrefix')]"},
           "frontendPort1":{"value": "[variables('httpPort')]"},
           "backendPort1":{"value": "[variables('adminSitePort')]"},
           "frontendPort2":{"value": "[variables('gethRPCPort')]"},
           "backendPort2":{"value": "[variables('gethRPCPort')]"},
           "numInboundNATRules":{"value": "[parameters('numTXNodes')]"},
           "inboundNATRuleFrontendStartingPort":{"value": "[variables('sshNATFrontEndStartingPort')]"},
-          "inboundNATRuleBackendPort":{"value": "[variables('sshPort')]"}
+          "inboundNATRuleBackendPort":{"value": "[variables('sshPort')]"},
+          "location":{"value": "[variables('location')]"}
         }
       }
     },
@@ -314,7 +323,7 @@
       "apiVersion": "[variables('apiVersionNetworkSecurityGroups')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('mnNsgName')]",
-      "location": "[resourceGroup().location]",
+      "location": "[variables('location')]",
       "tags": {
         "displayName": "NSG - Mining (MN)"
       },
@@ -341,7 +350,7 @@
       "apiVersion": "[variables('apiVersionNetworkSecurityGroups')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('txNsgName')]",
-      "location": "[resourceGroup().location]",
+      "location": "[variables('location')]",
       "tags": {
         "displayName": "NSG - Transaction (TX)"
       },
@@ -410,7 +419,7 @@
       "apiVersion": "[variables('apiVersionVirtualNetworks')]",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
-      "location": "[resourceGroup().location]",
+      "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('txNsgName'))]",
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('mnNsgName'))]"
@@ -434,17 +443,18 @@
         "loadBalancerLinkedTemplate"
       ],
       "properties": {
-        "mode": "incremental",
+        "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('artifactsLocationURL'), '/nested/txVMAuth', variables('authType'), '.json')]",
+          "uri": "[concat(variables('artifactsLocationURL'), '/nested/txVMAuth', '-', variables('authType'), '.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
           "apiVersionVirtualMachines":{"value": "[variables('apiVersionVirtualMachines')]"},
           "apiVersionNetworkInterfaces":{"value": "[variables('apiVersionNetworkInterfaces')]"},
           "apiVersionStorageAccounts":{"value": "[variables('apiVersionStorageAccounts')]"},
-          "loadBalancerBackendAddressPoolId":{"value": "[reference('loadBalancerLinkedTemplate').outputs.backendAddressPoolID.value]"},
-          "loadBalancerInboundNatRuleIDprefix":{"value": "[reference('loadBalancerLinkedTemplate').outputs.inboundNatRuleIDprefix.value]"},
+          "loadBalancerName":{"value": "[variables('loadBalancerName')]"},
+          "loadBalancerBackendAddressPoolName":{"value": "[variables('loadBalancerBackendAddressPoolName')]"},
+          "loadBalancerInboundNatRuleNamePrefix":{"value": "[variables('loadBalancerInboundNatRuleNamePrefix')]"},
           "txSubnetRef":{"value": "[variables('txSubnetRef')]"},
           "txVMNamePrefix":{"value": "[variables('txVMNamePrefix')]"},
           "numTXNodes":{"value": "[parameters('numTXNodes')]"},
@@ -455,8 +465,10 @@
           "txNodeVMSize":{"value": "[parameters('txNodeVMSize')]"},
           "adminUsername":{"value": "[parameters('adminUsername')]"},
           "adminPassword":{"value": "[parameters('adminPassword')]"},
+          "adminSSHKey":{"value": ""},
           "ubuntuImage":{"value": "[variables('ubuntuImage')]"},
-          "namingInfix":{"value": "[variables('namingInfix')]"}
+          "namingInfix":{"value": "[variables('namingInfix')]"},
+          "location":{"value": "[variables('location')]"}
         }
       }
     },
@@ -468,9 +480,9 @@
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
       "properties": {
-        "mode": "incremental",
+        "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('artifactsLocationURL'), '/nested/mnVMAuth', variables('authType'), '.json')]",
+          "uri": "[concat(variables('artifactsLocationURL'), '/nested/mnVMAuth', '-', variables('authType'), '.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -488,8 +500,10 @@
           "mnNodeVMSize":{"value": "[parameters('mnNodeVMSize')]"},
           "adminUsername":{"value": "[parameters('adminUsername')]"},
           "adminPassword":{"value": "[parameters('adminPassword')]"},
+          "adminSSHKey":{"value": ""},
           "ubuntuImage":{"value": "[variables('ubuntuImage')]"},
-          "namingInfix":{"value": "[variables('namingInfix')]"}
+          "namingInfix":{"value": "[variables('namingInfix')]"},
+          "location":{"value": "[variables('location')]"}
         }
       }
     },
@@ -502,7 +516,7 @@
         "mnVMLinkedTemplate"
       ],
       "properties": {
-        "mode": "incremental",
+        "mode": "Incremental",
         "templateLink": {
           "uri": "[concat(variables('artifactsLocationURL'), '/nested/vmExtension.json')]",
           "contentVersion": "1.0.0.0"
@@ -510,7 +524,6 @@
         "parameters": {
           "numBootNodes":{"value": "[parameters('numConsortiumMembers')]"},
           "txVMNamePrefix":{"value": "[variables('txVMNamePrefix')]"},
-          "txStorageAcctName":{"value": "[variables('txStorageAcctName')]"},
           "numTXNodes":{"value": "[parameters('numTXNodes')]"},
           "mnVMNamePrefix":{"value": "[variables('mnVMNamePrefix')]"},
           "numMNNodes":{"value": "[variables('numMNNodes')]"},
@@ -520,7 +533,10 @@
           "ethereumAccountPassphrase": {"value": "[parameters('ethereumAccountPassphrase')]"},
           "ethereumNetworkID":{"value": "[parameters('ethereumNetworkID')]"},
           "gethIPCPort":{"value": "[variables('gethIPCPort')]"},
-          "adminSitePort":{"value": "[variables('adminSitePort')]"}
+          "adminSitePort":{"value": "[variables('adminSitePort')]"},
+          "metricsStorageAcctName":{"value": "[variables('metricsStorageAcctName')]"},
+          "apiVersionStorageAccounts":{"value": "[variables('apiVersionStorageAccounts')]"},
+          "location":{"value": "[variables('location')]"}
         }
       }
     }

--- a/ethereum-consortium-blockchain-network/nested/loadBalancer.json
+++ b/ethereum-consortium-blockchain-network/nested/loadBalancer.json
@@ -2,7 +2,16 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "loadBalancerName": {
+      "type": "string"
+    },
     "dnsHostName": {
+      "type": "string"
+    },
+    "loadBalancerBackendAddressPoolName": {
+      "type": "string"
+    },
+    "loadBalancerInboundNatRuleNamePrefix": {
       "type": "string"
     },
     "frontendPort1": {
@@ -25,28 +34,28 @@
     },
     "inboundNATRuleBackendPort": {
       "type": "int"
+    },
+    "location": {
+      "type": "string"
     }
   },
   "variables": {
     "apiVersionPublicIPAddresses": "2016-09-01",
     "apiVersionLoadBalancers": "2016-09-01",
     "apiVersionLoadBalanceInboundNATRules": "2016-09-01",
-    "lbName": "[concat(parameters('dnsHostName'), '-LB')]",
-    "lbID": "[resourceId('Microsoft.Network/loadBalancers',variables('lbName'))]",
+    "lbID": "[resourceId('Microsoft.Network/loadBalancers', parameters('loadBalancerName'))]",
     "lbPublicIPAddressName": "[concat(parameters('dnsHostName'), '-publicip')]",
     "lbFrontEndIpConfigName": "LoadBalancerFrontEnd",
     "lbFrontEndIPConfigID": "[concat(variables('lbID'),'/frontendIPConfigurations/',variables('lbFrontEndIpConfigName'))]",
-    "lbBackendAddressPoolName": "LoadBalancerBackend1",
-    "lbBackendAddressPoolID": "[concat(variables('lbID'), '/backendAddressPools/', variables('lbBackendAddressPoolName'))]",
-    "loadBalancerInboundNatRuleNamePart": "SSH-VM",
-    "loadBalancerInboundNatRuleIDprefix": "[concat(variables('lbID'),'/inboundNatRules/',variables('loadBalancerInboundNatRuleNamePart'))]"
+    "lbBackendAddressPoolID": "[concat(variables('lbID'), '/backendAddressPools/', parameters('loadBalancerBackendAddressPoolName'))]",
+    "loadBalancerInboundNatRuleIDprefix": "[concat(variables('lbID'),'/inboundNatRules/',parameters('loadBalancerInboundNatRuleNamePrefix'))]"
   },
   "resources": [
     {
       "apiVersion": "[variables('apiVersionPublicIPAddresses')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('lbPublicIPAddressName')]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -56,9 +65,9 @@
     },
     {
       "apiVersion": "[variables('apiVersionLoadBalancers')]",
-      "name": "[variables('lbName')]",
+      "name": "[parameters('loadBalancerName')]",
       "type": "Microsoft.Network/loadBalancers",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('lbPublicIPAddressName'))]"
       ],
@@ -75,7 +84,7 @@
         ],
         "backendAddressPools": [
           {
-            "name": "[variables('lbBackendAddressPoolName')]"
+            "name": "[parameters('loadBalancerBackendAddressPoolName')]"
           }
         ],
         "loadBalancingRules": [
@@ -88,7 +97,7 @@
               "backendAddressPool": {
                 "id": "[variables('lbBackendAddressPoolID')]"
               },
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "frontendPort": "[parameters('FrontendPort1')]",
               "backendPort": "[parameters('BackendPort1')]",
               "enableFloatingIP": false,
@@ -107,7 +116,7 @@
               "backendAddressPool": {
                 "id": "[variables('lbBackendAddressPoolID')]"
               },
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "frontendPort": "[parameters('FrontendPort2')]",
               "backendPort": "[parameters('BackendPort2')]",
               "enableFloatingIP": false,
@@ -122,7 +131,7 @@
           {
             "name": "lbProbe1",
             "properties": {
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "port": "[parameters('BackendPort1')]",
               "intervalInSeconds": 5,
               "numberOfProbes": 2
@@ -131,7 +140,7 @@
           {
             "name": "lbProbe2",
             "properties": {
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "port": "[parameters('BackendPort2')]",
               "intervalInSeconds": 5,
               "numberOfProbes": 2
@@ -143,14 +152,14 @@
     {
       "apiVersion": "[variables('apiVersionLoadBalanceInboundNATRules')]",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
-      "name": "[concat(variables('lbName'), '/', variables('loadBalancerInboundNatRuleNamePart'), copyIndex())]",
-      "location": "[resourceGroup().location]",
+      "name": "[concat(parameters('loadBalancerName'), '/', parameters('loadBalancerInboundNatRuleNamePrefix'), copyIndex())]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "lbNatLoop",
         "count": "[parameters('numInboundNATRules')]"
       },
       "dependsOn": [
-        "[concat('Microsoft.Network/loadBalancers/', variables('lbName'))]"
+        "[concat('Microsoft.Network/loadBalancers/', parameters('loadBalancerName'))]"
       ],
       "properties": {
         "frontendIPConfiguration": {
@@ -167,14 +176,6 @@
     "fqdn": {
       "type": "string",
       "value": "[reference(variables('lbPublicIPAddressName')).dnsSettings.fqdn]"
-    },
-    "backendAddressPoolID": {
-      "type": "string",
-      "value": "[variables('lbBackendAddressPoolID')]"
-    },
-    "inboundNatRuleIDprefix": {
-      "type": "string",
-      "value": "[variables('loadBalancerInboundNatRuleIDprefix')]"
     }
   }
 }

--- a/ethereum-consortium-blockchain-network/nested/mnVMAuth-password.json
+++ b/ethereum-consortium-blockchain-network/nested/mnVMAuth-password.json
@@ -44,7 +44,7 @@
     "adminPassword": {
       "type": "securestring"
     },
-    "sshKey": {
+    "adminSSHKey": {
       "type": "string"
     },
     "ubuntuImage": {
@@ -52,17 +52,17 @@
     },
     "namingInfix": {
       "type": "string"
+    },
+    "location": {
+      "type": "string"
     }
-  },
-  "variables": {
-    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]"
   },
   "resources": [
     {
       "apiVersion": "[parameters('apiVersionStorageAccounts')]",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('mnStorageAcctNames')[copyIndex()]]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "mnStorageLoop",
         "count": "[parameters('mnStorageAcctCount')]"
@@ -77,7 +77,7 @@
       "apiVersion": "[parameters('apiVersionNetworkInterfaces')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('mnNICPrefix'), copyindex())]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "mnNicLoop",
         "count": "[parameters('numMNNodes')]"
@@ -100,7 +100,7 @@
       "apiVersion": "[parameters('apiVersionVirtualMachines')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('mnVMNamePrefix'), copyIndex())]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "mnVMLoop",
         "count": "[parameters('numMNNodes')]"
@@ -116,17 +116,7 @@
         "osProfile": {
           "computerName": "[concat(parameters('mnVMNamePrefix'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
-          "linuxConfiguration": {
-            "disablePasswordAuthentication": "true",
-            "ssh": {
-              "publicKeys": [
-                {
-                  "path": "[variables('sshKeyPath')]",
-                  "keyData": "[parameters('sshKey')]"
-                }
-              ]
-            }
-          }
+          "adminPassword": "[parameters('adminPassword')]"
         },
         "storageProfile": {
           "imageReference": "[parameters('ubuntuImage')]",

--- a/ethereum-consortium-blockchain-network/nested/mnVMAuth-sshPublicKey.json
+++ b/ethereum-consortium-blockchain-network/nested/mnVMAuth-sshPublicKey.json
@@ -44,19 +44,28 @@
     "adminPassword": {
       "type": "securestring"
     },
+    "adminSSHKey": {
+      "type": "string"
+    },
     "ubuntuImage": {
       "type": "object"
     },
     "namingInfix": {
       "type": "string"
+    },
+    "location": {
+      "type": "string"
     }
+  },
+  "variables": {
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]"
   },
   "resources": [
     {
       "apiVersion": "[parameters('apiVersionStorageAccounts')]",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('mnStorageAcctNames')[copyIndex()]]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "mnStorageLoop",
         "count": "[parameters('mnStorageAcctCount')]"
@@ -71,7 +80,7 @@
       "apiVersion": "[parameters('apiVersionNetworkInterfaces')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('mnNICPrefix'), copyindex())]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "mnNicLoop",
         "count": "[parameters('numMNNodes')]"
@@ -94,7 +103,7 @@
       "apiVersion": "[parameters('apiVersionVirtualMachines')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('mnVMNamePrefix'), copyIndex())]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "mnVMLoop",
         "count": "[parameters('numMNNodes')]"
@@ -110,7 +119,17 @@
         "osProfile": {
           "computerName": "[concat(parameters('mnVMNamePrefix'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": "true",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "[variables('sshKeyPath')]",
+                  "keyData": "[parameters('adminSSHKey')]"
+                }
+              ]
+            }
+          }
         },
         "storageProfile": {
           "imageReference": "[parameters('ubuntuImage')]",

--- a/ethereum-consortium-blockchain-network/nested/txVMAuth-password.json
+++ b/ethereum-consortium-blockchain-network/nested/txVMAuth-password.json
@@ -11,10 +11,13 @@
     "apiVersionStorageAccounts": {
       "type": "string"
     },
-    "loadBalancerBackendAddressPoolId": {
+    "loadBalancerName": {
       "type": "string"
     },
-    "loadBalancerInboundNatRuleIDprefix": {
+    "loadBalancerBackendAddressPoolName": {
+      "type": "string"
+    },
+    "loadBalancerInboundNatRuleNamePrefix": {
       "type": "string"
     },
     "txSubnetRef": {
@@ -47,19 +50,30 @@
     "adminPassword": {
       "type": "securestring"
     },
+    "adminSSHKey": {
+      "type": "string"
+    },
     "ubuntuImage": {
       "type": "object"
     },
     "namingInfix": {
       "type": "string"
+    },
+    "location": {
+      "type": "string"
     }
+  },
+  "variables": {
+    "loadBalancerID": "[resourceId('Microsoft.Network/loadBalancers', parameters('loadBalancerName'))]",
+    "loadBalancerBackendAddressPoolID": "[concat(variables('loadBalancerID'), '/backendAddressPools/', parameters('loadBalancerBackendAddressPoolName'))]",
+    "loadBalancerInboundNatRuleIDprefix": "[concat(variables('loadBalancerID'),'/inboundNatRules/',parameters('loadBalancerInboundNatRuleNamePrefix'))]"
   },
   "resources": [
     {
       "apiVersion": "[parameters('apiVersionNetworkInterfaces')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('txNIPrefix'), copyindex())]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "txNicLoop",
         "count": "[parameters('numTXNodes')]"
@@ -75,12 +89,12 @@
               },
               "loadBalancerBackendAddressPools": [
                 {
-                  "id": "[parameters('loadBalancerBackendAddressPoolId')]"
+                  "id": "[variables('loadBalancerBackendAddressPoolID')]"
                 }
               ],
               "loadBalancerInboundNatRules": [
                 {
-                  "id": "[concat(parameters('loadBalancerInboundNatRuleIDprefix'), copyindex())]"
+                  "id": "[concat(variables('loadBalancerInboundNatRuleIDprefix'), copyindex())]"
                 }
               ]
             }
@@ -92,7 +106,7 @@
       "apiVersion": "[parameters('apiVersionStorageAccounts')]",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('txStorageAcctName')]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('storageAccountType')]"
       },
@@ -103,7 +117,7 @@
       "apiVersion": "[parameters('apiVersionVirtualMachines')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('txVMNamePrefix'), copyIndex())]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "txVMLoop",
         "count": "[parameters('numTXNodes')]"

--- a/ethereum-consortium-blockchain-network/nested/txVMAuth-sshPublicKey.json
+++ b/ethereum-consortium-blockchain-network/nested/txVMAuth-sshPublicKey.json
@@ -11,10 +11,13 @@
     "apiVersionStorageAccounts": {
       "type": "string"
     },
-    "loadBalancerBackendAddressPoolId": {
+    "loadBalancerName": {
       "type": "string"
     },
-    "loadBalancerInboundNatRuleIDprefix": {
+    "loadBalancerBackendAddressPoolName": {
+      "type": "string"
+    },
+    "loadBalancerInboundNatRuleNamePrefix": {
       "type": "string"
     },
     "txSubnetRef": {
@@ -47,7 +50,7 @@
     "adminPassword": {
       "type": "securestring"
     },
-    "sshKey": {
+    "adminSSHKey": {
       "type": "string"
     },
     "ubuntuImage": {
@@ -55,17 +58,23 @@
     },
     "namingInfix": {
       "type": "string"
+    },
+    "location": {
+      "type": "string"
     }
   },
   "variables": {
-    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]"
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+    "loadBalancerID": "[resourceId('Microsoft.Network/loadBalancers', parameters('loadBalancerName'))]",
+    "loadBalancerBackendAddressPoolID": "[concat(variables('loadBalancerID'), '/backendAddressPools/', parameters('loadBalancerBackendAddressPoolName'))]",
+    "loadBalancerInboundNatRuleIDprefix": "[concat(variables('loadBalancerID'),'/inboundNatRules/',parameters('loadBalancerInboundNatRuleNamePrefix'))]"
   },
   "resources": [
     {
       "apiVersion": "[parameters('apiVersionNetworkInterfaces')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('txNIPrefix'), copyindex())]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "txNicLoop",
         "count": "[parameters('numTXNodes')]"
@@ -81,12 +90,12 @@
               },
               "loadBalancerBackendAddressPools": [
                 {
-                  "id": "[parameters('loadBalancerBackendAddressPoolId')]"
+                  "id": "[variables('loadBalancerBackendAddressPoolID')]"
                 }
               ],
               "loadBalancerInboundNatRules": [
                 {
-                  "id": "[concat(parameters('loadBalancerInboundNatRuleIDprefix'), copyindex())]"
+                  "id": "[concat(variables('loadBalancerInboundNatRuleIDprefix'), copyindex())]"
                 }
               ]
             }
@@ -98,7 +107,7 @@
       "apiVersion": "[parameters('apiVersionStorageAccounts')]",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('txStorageAcctName')]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('storageAccountType')]"
       },
@@ -109,7 +118,7 @@
       "apiVersion": "[parameters('apiVersionVirtualMachines')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('txVMNamePrefix'), copyIndex())]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "txVMLoop",
         "count": "[parameters('numTXNodes')]"
@@ -134,7 +143,7 @@
               "publicKeys": [
                 {
                   "path": "[variables('sshKeyPath')]",
-                  "keyData": "[parameters('sshKey')]"
+                  "keyData": "[parameters('adminSSHKey')]"
                 }
               ]
             }

--- a/ethereum-consortium-blockchain-network/nested/vmExtension.json
+++ b/ethereum-consortium-blockchain-network/nested/vmExtension.json
@@ -8,9 +8,6 @@
     "txVMNamePrefix": {
       "type": "string"
     },
-    "txStorageAcctName": {
-      "type": "string"
-    },
     "numTXNodes": {
       "type": "int"
     },
@@ -40,6 +37,15 @@
     },
     "adminSitePort": {
       "type": "int"
+    },
+    "metricsStorageAcctName": {
+      "type": "string"
+    },
+    "apiVersionStorageAccounts": {
+      "type": "string"
+    },
+    "location": {
+      "type": "string"
     }
   },
   "variables": {
@@ -50,6 +56,17 @@
   },
   "resources": [
     {
+      "apiVersion": "[parameters('apiVersionStorageAccounts')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('metricsStorageAcctName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "Storage",
+      "properties": {}
+    },
+    {
       "apiVersion": "[variables('apiVersionVirtualMachinesExtensions')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('txVMNamePrefix'), copyIndex(), '/newuserscript')]",
@@ -57,7 +74,7 @@
         "name": "txNodesConfigLoop",
         "count": "[parameters('numTXNodes')]"
       },
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
         "type": "CustomScript",
@@ -77,7 +94,7 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('txVMNamePrefix'), copyIndex(), '/diagscript')]",
       "apiVersion": "[variables('apiVersionVirtualMachinesExtensions')]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "txNodesDiagLoop",
         "count": "[parameters('numTXNodes')]"
@@ -98,8 +115,8 @@
             ]
         },
         "protectedSettings": {
-          "storageAccountName": "[parameters('txStorageAcctName')]",
-          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('txStorageAcctName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+          "storageAccountName": "[parameters('metricsStorageAcctName')]",
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('metricsStorageAcctName')), parameters('apiVersionStorageAccounts')).keys[0].value]"
         }
       }
     },
@@ -111,7 +128,7 @@
         "name": "bootMNNodesConfigLoop",
         "count": "[parameters('numMNNodes')]"
       },
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
         "type": "CustomScript",
@@ -131,7 +148,7 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('mnVMNamePrefix'), copyIndex(), '/diagscript')]",
       "apiVersion": "[variables('apiVersionVirtualMachinesExtensions')]",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('location')]",
       "copy": {
         "name": "mnNodesDiagLoop",
         "count": "[parameters('numMNNodes')]"
@@ -152,8 +169,8 @@
            ]
         },
         "protectedSettings": {
-          "storageAccountName": "[parameters('txStorageAcctName')]",
-          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('txStorageAcctName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+          "storageAccountName": "[parameters('metricsStorageAcctName')]",
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('metricsStorageAcctName')), parameters('apiVersionStorageAccounts')).keys[0].value]"
         }
       }
     }

--- a/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
+++ b/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
@@ -70,12 +70,12 @@ for i in `seq 0 $(($NUM_BOOT_NODES - 1))`; do
 	setsid geth -nodekeyhex ${NODE_KEYS[$i]} > $HOMEDIR/tempbootnodeoutput 2>&1 &
 	while sleep 10; do
 		if [ -s $HOMEDIR/tempbootnodeoutput ]; then
+			killall geth;
 			NODE_IDS[$i]=`grep -Po '(?<=\/\/).*(?=@)' $HOMEDIR/tempbootnodeoutput`;
+			rm $HOMEDIR/tempbootnodeoutput;
 			if [ $? -ne 0 ]; then
 				exit 1;
 			fi
-			killall geth;
-			rm $HOMEDIR/tempbootnodeoutput;
 			break;
 		fi
 	done

--- a/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
+++ b/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
@@ -48,22 +48,16 @@ DIFFICULTY=`printf "0x%X" $(($DIFFICULTY_CONSTANT * $NUM_MN_NODES))`;
 ################
 # Update modules
 ################
-sudo add-apt-repository -y ppa:ethereum/ethereum;
-sudo apt-get -y update;
+sudo add-apt-repository -y ppa:ethereum/ethereum || exit 1;
+sudo apt-get -y update || exit 1;
+# To avoid intermittent issues with package DB staying locked when next apt-get runs
+sleep 5;
 
-##############
-# setup Nodejs
-##############
-sudo apt-get -y install npm;
-sudo update-alternatives --install /usr/bin/node nodejs /usr/bin/nodejs 100;
-
-############
-# Setup Geth
-############
-sudo apt-get -y install git;
-sudo apt-get -y install software-properties-common;
-sudo apt-get install -y ethereum;
-sudp apt-get install -y solc;
+##################
+# Install packages
+##################
+sudo apt-get -y install npm=3.5.2-0ubuntu4 git=1:2.7.4-0ubuntu1 software-properties-common=0.96.20.4 ethereum || exit 1;
+sudo update-alternatives --install /usr/bin/node nodejs /usr/bin/nodejs 100 || exit 1;
 
 #############
 # Build node keys and node IDs
@@ -73,15 +67,32 @@ declare -a NODE_IDS
 for i in `seq 0 $(($NUM_BOOT_NODES - 1))`; do
 	BOOT_NODE_HOSTNAME=$MN_NODE_PREFIX$i;
 	NODE_KEYS[$i]=`echo $BOOT_NODE_HOSTNAME | sha256sum | cut -d ' ' -f 1`;
-	bootnode -nodekeyhex ${NODE_KEYS[$i]} > $HOMEDIR/tempbootnodeoutput 2>&1 &
-	while sleep 1; do
+	setsid geth -nodekeyhex ${NODE_KEYS[$i]} > $HOMEDIR/tempbootnodeoutput 2>&1 &
+	while sleep 10; do
 		if [ -s $HOMEDIR/tempbootnodeoutput ]; then
 			NODE_IDS[$i]=`grep -Po '(?<=\/\/).*(?=@)' $HOMEDIR/tempbootnodeoutput`;
-			killall bootnode;
+			if [ $? -ne 0 ]; then
+				exit 1;
+			fi
+			killall geth;
 			rm $HOMEDIR/tempbootnodeoutput;
 			break;
 		fi
 	done
+done
+
+##################################
+# Check for empty node keys or IDs
+##################################
+for nodekey in "${NODE_KEYS[@]}"; do
+	if [ -z $nodekey ]; then
+		exit 1;
+	fi
+done
+for nodeid in "${NODE_IDS[@]}"; do
+	if [ -z $nodeid ]; then
+		exit 1;
+	fi
 done
 
 ##############################################
@@ -97,8 +108,8 @@ rm $HOMEDIR/priv_genesis.key;
 rm $PASSWD_FILE;
 
 cd $HOMEDIR
-wget -N ${ARTIFACTS_URL_PREFIX}/scripts/start-private-blockchain.sh;
-wget -N ${ARTIFACTS_URL_PREFIX}/genesis-template.json;
+wget -N ${ARTIFACTS_URL_PREFIX}/scripts/start-private-blockchain.sh || exit 1;
+wget -N ${ARTIFACTS_URL_PREFIX}/genesis-template.json || exit 1;
 # Place our calculated difficulty into genesis file
 sed s/#DIFFICULTY/$DIFFICULTY/ $HOMEDIR/genesis-template.json > $HOMEDIR/genesis-intermediate.json;
 sed s/#PREFUND_ADDRESS/$PREFUND_ADDRESS/ $HOMEDIR/genesis-intermediate.json > $HOMEDIR/genesis.json;
@@ -114,6 +125,9 @@ fi
 # Initialize geth
 #################
 geth --datadir $GETH_HOME -verbosity 6 init $GENESIS_FILE_PATH >> $GETH_LOG_FILE_PATH 2>&1;
+if [ $? -ne 0 ]; then
+	exit 1;
+fi
 echo "===== Completed geth initialization =====";
 
 #####################
@@ -122,17 +136,18 @@ echo "===== Completed geth initialization =====";
 if [ $NODE_TYPE -eq 0 ]; then # TX nodes only
   mkdir -p $ETHERADMIN_HOME/views/layouts;
   cd $ETHERADMIN_HOME/views/layouts;
-  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/main.handlebars;
+  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/main.handlebars || exit 1;
   cd $ETHERADMIN_HOME/views;
-  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/etheradmin.handlebars;
-  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/etherstartup.handlebars;
+  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/etheradmin.handlebars || exit 1;
+  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/etherstartup.handlebars || exit 1;
   cd $ETHERADMIN_HOME;
-  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/package.json;
-  npm install;
-  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/app.js;
+  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/package.json || exit 1;
+  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/npm-shrinkwrap.json || exit 1;
+  npm install || exit 1;
+  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/app.js || exit 1;
   mkdir $ETHERADMIN_HOME/public;
   cd $ETHERADMIN_HOME/public;
-  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/skeleton.css;
+  wget -N ${ARTIFACTS_URL_PREFIX}/scripts/etheradmin/skeleton.css || exit 1;
 fi
 
 #########################
@@ -143,7 +158,7 @@ for i in `seq 0 $(($NUM_BOOT_NODES - 1))`; do
 	BOOTNODE_URLS="${BOOTNODE_URLS}enode://${NODE_IDS[$i]}@#${MN_NODE_PREFIX}${i}#:${GETH_IPC_PORT}";
   if [ $i -lt $(($NUM_BOOT_NODES - 1)) ]; then
   	BOOTNODE_URLS="${BOOTNODE_URLS},";
-	fi
+  fi
 done
 
 ##################
@@ -174,10 +189,13 @@ fi
 # Setup rc.local for service start on boot
 ##########################################
 echo "sudo -u $AZUREUSER /bin/bash $HOMEDIR/start-private-blockchain.sh $GETH_CFG_FILE_PATH $PASSWD" | sudo tee /etc/rc.local 2>&1 1>/dev/null
+if [ $? -ne 0 ]; then
+	exit 1;
+fi
 
 ############
 # Start geth
 ############
-/bin/bash $HOMEDIR/start-private-blockchain.sh $GETH_CFG_FILE_PATH $PASSWD
-if [ $? -ne 0 ]; then echo "Previous command failed. Exiting"; exit $?; fi
-echo "===== Completed $0 =====";
+/bin/bash $HOMEDIR/start-private-blockchain.sh $GETH_CFG_FILE_PATH $PASSWD || exit 1;
+echo "Commands succeeded. Exiting";
+exit 0;

--- a/ethereum-consortium-blockchain-network/scripts/configure-geth.sh
+++ b/ethereum-consortium-blockchain-network/scripts/configure-geth.sh
@@ -21,6 +21,21 @@ CONFIG_LOG_FILE_PATH="$HOMEDIR/config.log";
 cd "/home/$AZUREUSER";
 
 sudo -u $AZUREUSER /bin/bash -c "wget -N ${ARTIFACTS_URL_PREFIX}/scripts/configure-geth-azureuser.sh";
-sudo -u $AZUREUSER /bin/bash /home/$AZUREUSER/configure-geth-azureuser.sh $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${11} ${12} ${13} ${14} >> $CONFIG_LOG_FILE_PATH 2>&1;
-echo "===== Completed $0 =====";
-exit $?;
+
+##################################
+# Initiate loop for error checking
+##################################
+for LOOPCOUNT in `seq 1 5`; do
+	sudo -u $AZUREUSER /bin/bash /home/$AZUREUSER/configure-geth-azureuser.sh $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${11} ${12} ${13} ${14} >> $CONFIG_LOG_FILE_PATH 2>&1;
+	if [ $? -ne 0 ]; then
+		echo "Command failed on try $LOOPCOUNT, retrying..." >> $CONFIG_LOG_FILE_PATH;
+		sleep 5;
+		continue;
+	else
+		echo "======== Deployment successful! ======== " >> $CONFIG_LOG_FILE_PATH;
+		exit 0;
+	fi
+done
+
+echo "One or more commands failed after 5 tries. Deployment failed." >> $CONFIG_LOG_FILE_PATH;
+exit 1

--- a/ethereum-consortium-blockchain-network/scripts/etheradmin/npm-shrinkwrap.json
+++ b/ethereum-consortium-blockchain-network/scripts/etheradmin/npm-shrinkwrap.json
@@ -1,0 +1,1015 @@
+{
+  "name": "etheradmin",
+  "version": "0.0.0",
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.3",
+      "from": "accepts@>=1.3.3 <1.4.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "from": "align-text@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "from": "amdefine@>=0.0.4",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+    },
+    "ansi-regex": {
+      "version": "2.0.0",
+      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "from": "array-flatten@1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+    },
+    "asap": {
+      "version": "2.0.5",
+      "from": "asap@>=2.0.3 <2.1.0",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.5.tgz"
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "from": "asn1@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "from": "assert-plus@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+    },
+    "assign": {
+      "version": "0.1.7",
+      "from": "assign@>=0.1.7",
+      "resolved": "https://registry.npmjs.org/assign/-/assign-0.1.7.tgz",
+      "dependencies": {
+        "fusing": {
+          "version": "0.4.0",
+          "from": "fusing@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.4.0.tgz"
+        }
+      }
+    },
+    "async": {
+      "version": "1.5.2",
+      "from": "async@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "from": "asynckit@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "from": "aws-sign2@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+    },
+    "aws4": {
+      "version": "1.5.0",
+      "from": "aws4@>=1.2.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+    },
+    "back": {
+      "version": "1.0.1",
+      "from": "back@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/back/-/back-1.0.1.tgz"
+    },
+    "balanced-match": {
+      "version": "0.4.2",
+      "from": "balanced-match@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+    },
+    "base64-url": {
+      "version": "1.3.3",
+      "from": "base64-url@1.3.3",
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.3.tgz"
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.0",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz"
+    },
+    "bignumber.js": {
+      "version": "2.0.7",
+      "from": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
+      "resolved": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2"
+    },
+    "body-parser": {
+      "version": "1.15.2",
+      "from": "body-parser@>=1.15.2 <1.16.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.15.2.tgz"
+    },
+    "boom": {
+      "version": "2.10.1",
+      "from": "boom@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+    },
+    "brace-expansion": {
+      "version": "1.1.6",
+      "from": "brace-expansion@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+    },
+    "bytes": {
+      "version": "2.4.0",
+      "from": "bytes@2.4.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+    },
+    "camelcase": {
+      "version": "1.2.1",
+      "from": "camelcase@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+    },
+    "caseless": {
+      "version": "0.11.0",
+      "from": "caseless@>=0.11.0 <0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "from": "center-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "from": "chalk@>=1.1.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "from": "cliui@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        }
+      }
+    },
+    "color": {
+      "version": "0.8.0",
+      "from": "color@>=0.8.0 <0.9.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz"
+    },
+    "color-convert": {
+      "version": "0.5.3",
+      "from": "color-convert@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz"
+    },
+    "color-name": {
+      "version": "1.1.1",
+      "from": "color-name@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz"
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "from": "color-string@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
+    },
+    "colornames": {
+      "version": "0.0.2",
+      "from": "colornames@0.0.2",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz"
+    },
+    "colorspace": {
+      "version": "1.0.1",
+      "from": "colorspace@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz"
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+    },
+    "commander": {
+      "version": "2.9.0",
+      "from": "commander@>=2.9.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz"
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+    },
+    "content-disposition": {
+      "version": "0.5.1",
+      "from": "content-disposition@0.5.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.1.tgz"
+    },
+    "content-type": {
+      "version": "1.0.2",
+      "from": "content-type@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "from": "cookie@0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "from": "cookie-signature@1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+    },
+    "crc": {
+      "version": "3.4.1",
+      "from": "crc@3.4.1",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.1.tgz"
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+    },
+    "crypto-js": {
+      "version": "3.1.8",
+      "from": "crypto-js@>=3.1.4 <4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz"
+    },
+    "dashdash": {
+      "version": "1.14.0",
+      "from": "dashdash@>=1.12.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "debug": {
+      "version": "2.2.0",
+      "from": "debug@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "from": "decamelize@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "from": "define-properties@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz"
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+    },
+    "depd": {
+      "version": "1.1.0",
+      "from": "depd@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "from": "destroy@>=1.0.4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+    },
+    "diagnostics": {
+      "version": "1.0.1",
+      "from": "diagnostics@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.0.1.tgz"
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "from": "ee-first@1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+    },
+    "emits": {
+      "version": "1.0.2",
+      "from": "emits@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz"
+    },
+    "enabled": {
+      "version": "1.0.2",
+      "from": "enabled@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz"
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "from": "encodeurl@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+    },
+    "env-variable": {
+      "version": "0.0.3",
+      "from": "env-variable@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz"
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "from": "escape-html@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+    },
+    "etag": {
+      "version": "1.7.0",
+      "from": "etag@>=1.7.0 <1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+    },
+    "eventemitter3": {
+      "version": "0.1.6",
+      "from": "eventemitter3@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
+    },
+    "express": {
+      "version": "4.14.0",
+      "from": "express@>=4.14.0 <4.15.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.14.0.tgz"
+    },
+    "express-handlebars": {
+      "version": "3.0.0",
+      "from": "express-handlebars@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-3.0.0.tgz"
+    },
+    "express-session": {
+      "version": "1.14.2",
+      "from": "express-session@>=1.14.1 <1.15.0",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.14.2.tgz"
+    },
+    "extend": {
+      "version": "3.0.0",
+      "from": "extend@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+    },
+    "extendible": {
+      "version": "0.1.1",
+      "from": "extendible@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz"
+    },
+    "extract-github": {
+      "version": "0.0.5",
+      "from": "extract-github@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/extract-github/-/extract-github-0.0.5.tgz"
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "from": "extsprintf@1.0.2",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+    },
+    "finalhandler": {
+      "version": "0.5.0",
+      "from": "finalhandler@0.5.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.0.tgz"
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "from": "foreach@>=2.0.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+    },
+    "form-data": {
+      "version": "2.1.2",
+      "from": "form-data@>=2.1.1 <2.2.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz"
+    },
+    "forwarded": {
+      "version": "0.1.0",
+      "from": "forwarded@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+    },
+    "fresh": {
+      "version": "0.3.0",
+      "from": "fresh@0.3.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+    },
+    "function-bind": {
+      "version": "1.1.0",
+      "from": "function-bind@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+    },
+    "fusing": {
+      "version": "0.2.3",
+      "from": "fusing@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/fusing/-/fusing-0.2.3.tgz"
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "from": "generate-function@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
+    },
+    "getpass": {
+      "version": "0.1.6",
+      "from": "getpass@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "githulk": {
+      "version": "0.0.7",
+      "from": "githulk@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/githulk/-/githulk-0.0.7.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "from": "debug@>=0.7.0 <0.8.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+        }
+      }
+    },
+    "glob": {
+      "version": "6.0.4",
+      "from": "glob@>=6.0.4 <7.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz"
+    },
+    "graceful-fs": {
+      "version": "4.1.10",
+      "from": "graceful-fs@>=4.1.2 <5.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.10.tgz"
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "from": "graceful-readlink@>=1.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+    },
+    "handlebars": {
+      "version": "4.0.6",
+      "from": "handlebars@>=4.0.5 <5.0.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz"
+    },
+    "har-validator": {
+      "version": "2.0.6",
+      "from": "har-validator@>=2.0.6 <2.1.0",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz"
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "from": "hawk@>=3.1.3 <3.2.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "from": "hoek@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+    },
+    "http-errors": {
+      "version": "1.5.0",
+      "from": "http-errors@>=1.5.0 <1.6.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.0.tgz"
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "from": "http-signature@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+    },
+    "iconv-lite": {
+      "version": "0.4.13",
+      "from": "iconv-lite@0.4.13",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+    },
+    "inherits": {
+      "version": "2.0.1",
+      "from": "inherits@2.0.1",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+    },
+    "ipaddr.js": {
+      "version": "1.1.1",
+      "from": "ipaddr.js@1.1.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.1.1.tgz"
+    },
+    "is-buffer": {
+      "version": "1.1.4",
+      "from": "is-buffer@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+    },
+    "is-my-json-valid": {
+      "version": "2.15.0",
+      "from": "is-my-json-valid@>=2.12.4 <3.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz"
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "from": "is-property@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "from": "isstream@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+    },
+    "jodid25519": {
+      "version": "1.0.2",
+      "from": "jodid25519@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+    },
+    "jsbn": {
+      "version": "0.1.0",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz"
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "from": "json-schema@0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+    },
+    "jsonpointer": {
+      "version": "4.0.0",
+      "from": "jsonpointer@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+    },
+    "jsprim": {
+      "version": "1.3.1",
+      "from": "jsprim@>=1.2.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
+    },
+    "kind-of": {
+      "version": "3.0.4",
+      "from": "kind-of@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.4.tgz"
+    },
+    "kuler": {
+      "version": "0.0.0",
+      "from": "kuler@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz"
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+    },
+    "licenses": {
+      "version": "0.0.20",
+      "from": "licenses@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/licenses/-/licenses-0.0.20.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.6.2",
+          "from": "async@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.6.2.tgz"
+        },
+        "debug": {
+          "version": "0.8.1",
+          "from": "debug@>=0.8.0 <0.9.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
+        }
+      }
+    },
+    "longest": {
+      "version": "1.0.1",
+      "from": "longest@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+    },
+    "mana": {
+      "version": "0.1.41",
+      "from": "mana@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/mana/-/mana-0.1.41.tgz",
+      "dependencies": {
+        "emits": {
+          "version": "3.0.0",
+          "from": "emits@>=3.0.0 <3.1.0",
+          "resolved": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz"
+        },
+        "eventemitter3": {
+          "version": "1.2.0",
+          "from": "eventemitter3@>=1.2.0 <1.3.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+        },
+        "fusing": {
+          "version": "1.0.0",
+          "from": "fusing@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/fusing/-/fusing-1.0.0.tgz"
+        }
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "from": "media-typer@0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "from": "merge-descriptors@1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+    },
+    "methods": {
+      "version": "1.1.2",
+      "from": "methods@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+    },
+    "millisecond": {
+      "version": "0.1.2",
+      "from": "millisecond@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz"
+    },
+    "mime": {
+      "version": "1.3.4",
+      "from": "mime@1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+    },
+    "mime-db": {
+      "version": "1.24.0",
+      "from": "mime-db@>=1.24.0 <1.25.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+    },
+    "mime-types": {
+      "version": "2.1.12",
+      "from": "mime-types@>=2.1.11 <2.2.0",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz"
+    },
+    "minimatch": {
+      "version": "3.0.3",
+      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+    },
+    "minimist": {
+      "version": "0.0.10",
+      "from": "minimist@>=0.0.1 <0.1.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+    },
+    "moment": {
+      "version": "2.15.2",
+      "from": "moment@>=2.15.1 <2.16.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.2.tgz"
+    },
+    "ms": {
+      "version": "0.7.1",
+      "from": "ms@0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "from": "negotiator@0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+    },
+    "node-uuid": {
+      "version": "1.4.7",
+      "from": "node-uuid@>=1.4.7 <1.5.0",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+    },
+    "npm-registry": {
+      "version": "0.1.13",
+      "from": "npm-registry@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/npm-registry/-/npm-registry-0.1.13.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "0.8.1",
+          "from": "debug@>=0.8.0 <0.9.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "from": "oauth-sign@>=0.8.1 <0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "from": "object-keys@>=1.0.10 <2.0.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+    },
+    "object.assign": {
+      "version": "4.0.4",
+      "from": "object.assign@>=4.0.3 <5.0.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz"
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "from": "on-finished@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "from": "on-headers@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+    },
+    "once": {
+      "version": "1.4.0",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "from": "optimist@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+    },
+    "parseurl": {
+      "version": "1.3.1",
+      "from": "parseurl@>=1.3.1 <1.4.0",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "from": "path-to-regexp@0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "from": "pinkie@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+    },
+    "predefine": {
+      "version": "0.1.2",
+      "from": "predefine@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz"
+    },
+    "promise": {
+      "version": "7.1.1",
+      "from": "promise@>=7.1.1 <7.2.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.1.1.tgz"
+    },
+    "proxy-addr": {
+      "version": "1.1.2",
+      "from": "proxy-addr@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.2.tgz"
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "from": "punycode@>=1.4.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+    },
+    "qs": {
+      "version": "6.2.0",
+      "from": "qs@6.2.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.0.tgz"
+    },
+    "random-bytes": {
+      "version": "1.0.0",
+      "from": "random-bytes@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz"
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "from": "range-parser@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+    },
+    "raw-body": {
+      "version": "2.1.7",
+      "from": "raw-body@>=2.1.7 <2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz"
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+    },
+    "request": {
+      "version": "2.78.0",
+      "from": "request@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "6.3.0",
+          "from": "qs@>=6.3.0 <6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+        }
+      }
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "from": "right-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+    },
+    "semver": {
+      "version": "2.2.1",
+      "from": "semver@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
+    },
+    "send": {
+      "version": "0.14.1",
+      "from": "send@0.14.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.14.1.tgz"
+    },
+    "serve-static": {
+      "version": "1.11.1",
+      "from": "serve-static@>=1.11.1 <1.12.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.11.1.tgz"
+    },
+    "setprototypeof": {
+      "version": "1.0.1",
+      "from": "setprototypeof@1.0.1",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.1.tgz"
+    },
+    "shrinkwrap": {
+      "version": "0.4.0",
+      "from": "shrinkwrap@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/shrinkwrap/-/shrinkwrap-0.4.0.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "0.8.1",
+          "from": "debug@>=0.8.0 <0.9.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.8.1.tgz"
+        }
+      }
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "from": "sntp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+    },
+    "source-map": {
+      "version": "0.4.4",
+      "from": "source-map@>=0.4.4 <0.5.0",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+    },
+    "sshpk": {
+      "version": "1.10.1",
+      "from": "sshpk@>=1.7.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "from": "statuses@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "from": "stringstream@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "from": "supports-color@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+    },
+    "text-hex": {
+      "version": "0.0.0",
+      "from": "text-hex@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz"
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "from": "tough-cookie@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+    },
+    "tunnel-agent": {
+      "version": "0.4.3",
+      "from": "tunnel-agent@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.14.3",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz"
+    },
+    "type-is": {
+      "version": "1.6.13",
+      "from": "type-is@>=1.6.13 <1.7.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.13.tgz"
+    },
+    "uglify-js": {
+      "version": "2.7.4",
+      "from": "uglify-js@>=2.6.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.4.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+    },
+    "uid-safe": {
+      "version": "2.1.3",
+      "from": "uid-safe@>=2.1.3 <2.2.0",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.3.tgz"
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "from": "unpipe@1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+    },
+    "utf8": {
+      "version": "2.1.2",
+      "from": "utf8@>=2.1.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz"
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "from": "utils-merge@1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+    },
+    "vary": {
+      "version": "1.1.0",
+      "from": "vary@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+    },
+    "verror": {
+      "version": "1.3.6",
+      "from": "verror@1.3.6",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+    },
+    "web3": {
+      "version": "0.17.0-beta",
+      "from": "web3@>=0.17.0-alpha <0.18.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-0.17.0-beta.tgz"
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "from": "window-size@0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "from": "wordwrap@>=0.0.2 <0.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "from": "xmlhttprequest@*",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz"
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "from": "xtend@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "from": "yargs@>=3.10.0 <3.11.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+    }
+  }
+}

--- a/ethereum-consortium-blockchain-network/scripts/etheradmin/package.json
+++ b/ethereum-consortium-blockchain-network/scripts/etheradmin/package.json
@@ -15,6 +15,7 @@
     "express-handlebars": "~3.0.0",
     "express-session": "~1.14.1",
     "moment": "~2.15.1",
-    "promise": "~7.1.1"
+    "promise": "~7.1.1",
+    "shrinkwrap": "^0.4.0"
   }
 }


### PR DESCRIPTION
### Contributing Guide
https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md

### Changelog

1. Updated Ubuntu version from 14.04.5-LTS to 16.04.0-LTS - necessary because the outdated 14.04.5-LTS version of NPM does not work with current NPM repos.
2. Updated loadBalancer linked template for increased modularity, along with additional minor changes to bring template more in line with the Azure Marketplace offering.
3. Updated configure-geth-azureuser script with error checking, compatibility with latest Ethereum release, and version locks for installed packages.
4. Updated npm with shrinkwrap for version locks on installed nodejs packages.

### Description of the change
These changes fix breaks that currently prevent NPM installs from succeeding and Ethereum node IDs from being generated, as well as providing more robust error checking, logging, and retry functionality.