### PR TITLE
Updates to bigchaindb-on-ubuntu

### DIFF
--- a/bigchaindb-on-ubuntu/azuredeploy.json
+++ b/bigchaindb-on-ubuntu/azuredeploy.json
@@ -191,6 +191,19 @@
                             "priority": 1020,
                             "direction": "Inbound"
                         }
+                    },
+                    {
+                        "name": "bigchaindb-http",
+                        "properties": {
+                            "protocol": "Tcp",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "9984",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 100,
+                            "direction": "Inbound"
+                        }
                     }
                 ]
             },

--- a/bigchaindb-on-ubuntu/azuredeploy.json
+++ b/bigchaindb-on-ubuntu/azuredeploy.json
@@ -180,7 +180,7 @@
                         }
                     },
                     {
-                        "name": "bigchaindb",
+                        "name": "intra-rethinkdb",
                         "properties": {
                             "protocol": "*",
                             "sourcePortRange": "*",

--- a/bigchaindb-on-ubuntu/azuredeploy.json
+++ b/bigchaindb-on-ubuntu/azuredeploy.json
@@ -204,6 +204,19 @@
                             "priority": 100,
                             "direction": "Inbound"
                         }
+                    },
+                    {
+                        "name": "rethinkdb-web-admin",
+                        "properties": {
+                            "protocol": "Tcp",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "8080",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 2000,
+                            "direction": "Inbound"
+                        }
                     }
                 ]
             },

--- a/bigchaindb-on-ubuntu/scripts/init.sh
+++ b/bigchaindb-on-ubuntu/scripts/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash 
 
-echo "deb http://download.rethinkdb.com/apt trusty main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
+source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
 wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get -y update
 sudo apt-get -y install rethinkdb

--- a/bigchaindb-on-ubuntu/scripts/init.sh
+++ b/bigchaindb-on-ubuntu/scripts/init.sh
@@ -5,9 +5,7 @@ wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get -y update
 sudo apt-get -y install rethinkdb
 
-sudo cp /etc/rethinkdb/default.conf.sample /etc/rethinkdb/instances.d/instance1.conf
-
-sudo /etc/init.d/rethinkdb restart
+rethinkdb --bind all
 
 sudo apt-get -y install make
 sudo apt-get -y install g++ python3-dev libffi-dev

--- a/bigchaindb-on-ubuntu/scripts/init.sh
+++ b/bigchaindb-on-ubuntu/scripts/init.sh
@@ -5,7 +5,7 @@ wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get -y update
 sudo apt-get -y install rethinkdb
 
-rethinkdb --bind all
+rethinkdb --bind all --daemon
 
 sudo apt-get -y install make
 sudo apt-get -y install g++ python3-dev libffi-dev


### PR DESCRIPTION
### Changelog

* Updated the command-line command to prepare for RethinkDB installation (to be Ubuntu version-independent), based on https://www.rethinkdb.com/docs/install/ubuntu/
* Simplified the command to run RethinkDB, and included an option to bind all: `rethinkdb --bind all`
* Renamed the existing inbound security group rule for port 29015 as "intra-rethinkdb"
* Added new inbound security group rule for port 9984 (the BigchainDB HTTP API port)
* Added new inbound security group rule for port 8080 (the RethinkDB web admin port)
