### PR TITLE
Iwooden test

### DIFF
--- a/ethereum-consortium-blockchain-network/azuredeploy.json
+++ b/ethereum-consortium-blockchain-network/azuredeploy.json
@@ -183,7 +183,7 @@
     "maxVMsPerStorageAcct": 20,
     "mnStorageAcctCount": "[add(div(variables('numMNNodes'), variables('maxVMsPerStorageAcct')), 1)]",
     "mnStorageAcctNames": [
-      "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn0')],
+      "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn0')]",
       "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn1')]",
       "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn2')]",
       "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn3')]",

--- a/ethereum-consortium-blockchain-network/azuredeploy.json
+++ b/ethereum-consortium-blockchain-network/azuredeploy.json
@@ -183,7 +183,7 @@
     "maxVMsPerStorageAcct": 20,
     "mnStorageAcctCount": "[add(div(variables('numMNNodes'), variables('maxVMsPerStorageAcct')), 1)]",
     "mnStorageAcctNames": [
-      "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn0')]",
+      "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn0')],
       "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn1')]",
       "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn2')]",
       "[concat(uniqueString(resourceGroup().id, variables('namingInfix')), 'mn3')]",

--- a/ethereum-consortium-blockchain-network/scripts/configure-geth.sh
+++ b/ethereum-consortium-blockchain-network/scripts/configure-geth.sh
@@ -26,7 +26,7 @@ sudo -u $AZUREUSER /bin/bash -c "wget -N ${ARTIFACTS_URL_PREFIX}/scripts/configu
 # Initiate loop for error checking
 ##################################
 for LOOPCOUNT in `seq 1 5`; do
-	sudo -u $AZUREUSER /bin/bash /home/$AZUREUSER/configure-geth-azureuser.sh $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${11} ${12} ${13} ${14} >> $CONFIG_LOG_FILE_PATH 2>&1;
+	sudo -u $AZUREUSER /bin/bash /home/$AZUREUSER/configure-geth-azureuser.sh "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9" "${10}" "${11}" "${12}" "${13}" "${14}" >> $CONFIG_LOG_FILE_PATH 2>&1;
 	if [ $? -ne 0 ]; then
 		echo "Command failed on try $LOOPCOUNT, retrying..." >> $CONFIG_LOG_FILE_PATH;
 		sleep 5;


### PR DESCRIPTION
Changelog:
1. Ethereuem passphrases with spaces would break the template. By wrapping parameters in quotes as we pass them from the parent script, we ensure that they are parsed correctly.