### PR TITLE
Use Ubuntu 16.04 LTS in the Openchain template

### DIFF
--- a/openchain-blockchain-coinprism/azuredeploy.json
+++ b/openchain-blockchain-coinprism/azuredeploy.json
@@ -89,7 +89,7 @@
     "apiVersion": "2015-06-15",
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
-    "ubuntuOSVersion": "16.04.0-LTS",
+    "ubuntuOSVersion": "16.04-LTS",
     "osDiskName": "openchain-osdisk",
     "nsgName": "SecurityGroup",
     "nicName": "NIC",

--- a/openchain-blockchain-coinprism/azuredeploy.json
+++ b/openchain-blockchain-coinprism/azuredeploy.json
@@ -89,7 +89,7 @@
     "apiVersion": "2015-06-15",
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
-    "ubuntuOSVersion": "14.04.2-LTS",
+    "ubuntuOSVersion": "16.04.0-LTS",
     "osDiskName": "openchain-osdisk",
     "nsgName": "SecurityGroup",
     "nicName": "NIC",


### PR DESCRIPTION
### Changelog

* Use Ubuntu 16.04 LTS instead of Ubuntu 14.04 LTS for the Openchain template