### PR TITLE
Minor init.sh fixes for bigchaindb-on-ubuntu

### DIFF
--- a/bigchaindb-on-ubuntu/scripts/init.sh
+++ b/bigchaindb-on-ubuntu/scripts/init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 
 . /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
 wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -

--- a/bigchaindb-on-ubuntu/scripts/init.sh
+++ b/bigchaindb-on-ubuntu/scripts/init.sh
@@ -1,6 +1,6 @@
 #!/bin/sh 
 
-source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
+. /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
 wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -
 sudo apt-get -y update
 sudo apt-get -y install rethinkdb

--- a/bigchaindb-on-ubuntu/scripts/init.sh
+++ b/bigchaindb-on-ubuntu/scripts/init.sh
@@ -14,4 +14,4 @@ sudo apt-get -y install python3-setuptools
 sudo easy_install3 pip
 sudo pip3 install --upgrade pip wheel setuptools
 
-sudo pip install bigchaindb
+sudo pip3 install bigchaindb

--- a/bigchaindb-on-ubuntu/scripts/init.sh
+++ b/bigchaindb-on-ubuntu/scripts/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/bin/sh 
 
 source /etc/lsb-release && echo "deb http://download.rethinkdb.com/apt $DISTRIB_CODENAME main" | sudo tee /etc/apt/sources.list.d/rethinkdb.list
 wget -qO- https://download.rethinkdb.com/apt/pubkey.gpg | sudo apt-key add -


### PR DESCRIPTION
There were some minor problems with the `init.sh` script for `bigchaindb-on-ubuntu`. This pull request fixes them:

1. The first line was `#!/bin/bash` but it seems the Azure Linux Agent runs `sh` regardless, so I changed that first line to `#!/bin/sh`
2. The line `source /etc/lsb-release && ...` wasn't working because `source` doesn't work with `sh`. The word `source` was replaced with just `.`
3. The last line was changed from `sudo pip install bigchaindb` to `sudo pip3 install bigchaindb`. This may not have been necessary but it seemed like a good idea to be explicit about which version of pip we want to use.