### PR TITLE
Fix pip3 encoding issues

### DIFF
--- a/bigchaindb-on-ubuntu/scripts/init.sh
+++ b/bigchaindb-on-ubuntu/scripts/init.sh
@@ -9,8 +9,10 @@ rethinkdb --bind all --daemon
 
 sudo apt-get -y install make
 sudo apt-get -y install g++ python3-dev libffi-dev
-
 sudo apt-get -y install python3-setuptools
+
+export LANG="en_US.UTF-8"
+
 sudo easy_install3 pip
 sudo pip3 install --upgrade pip wheel setuptools
 


### PR DESCRIPTION
pip3 sometimes fails with encoding errors b/c the LANG environment variable is set to "POSIX" when the init.sh is executed, at VM provisioning time. This change forces LANG to UTF-8 to fix the issue.