### PR TITLE
Fix rc.local reboot functionality

### DIFF
--- a/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
+++ b/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
@@ -188,7 +188,7 @@ fi
 ##########################################
 # Setup rc.local for service start on boot
 ##########################################
-echo "sudo -u $AZUREUSER /bin/bash $HOMEDIR/start-private-blockchain.sh $GETH_CFG_FILE_PATH $PASSWD" | sudo tee /etc/rc.local 2>&1 1>/dev/null
+echo -e '#!/bin/bash' "\nsudo -u $AZUREUSER /bin/bash $HOMEDIR/start-private-blockchain.sh $GETH_CFG_FILE_PATH $PASSWD" | sudo tee /etc/rc.local 2>&1 1>/dev/null
 if [ $? -ne 0 ]; then
 	exit 1;
 fi


### PR DESCRIPTION
This change fixes an issue with starting the blockchain services on VM reboot. In some linux configurations, the /etc/rc.local file will not execute properly unless it has the #!/bin/bash shebang on top.

With this change, rebooting the VMs will cause the blockchain services (geth and nodejs) to start properly in all linux configurations.

