### PR TITLE
Change default VM Size and remove "Windows" from VM name

### DIFF
--- a/101-vm-simple-linux/README.md
+++ b/101-vm-simple-linux/README.md
@@ -1,4 +1,4 @@
-# Very simple deployment of an Linux VM
+# Very simple deployment of a Linux VM
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-vm-simple-linux%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
@@ -8,4 +8,4 @@
 </a>
 
 
-This template allows you to deploy a simple Linux VM using a few different options for the Ubuntu Linux version, using the latest patched version. This will deploy a D1 size VM in the resource group location and return the FQDN of the VM.
+This template allows you to deploy a simple Linux VM using a few different options for the Ubuntu Linux version, using the latest patched version. This will deploy a A1 size VM in the resource group location and return the FQDN of the VM.

--- a/101-vm-simple-linux/azuredeploy.json
+++ b/101-vm-simple-linux/azuredeploy.json
@@ -49,7 +49,7 @@
     "publicIPAddressType": "Dynamic",
     "vmStorageAccountContainerName": "vhds",
     "vmName": "MyUbuntuVM",
-    "vmSize": "Standard_D1",
+    "vmSize": "Standard_A1",
     "virtualNetworkName": "MyVNET",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"

--- a/101-vm-simple-linux/metadata.json
+++ b/101-vm-simple-linux/metadata.json
@@ -1,8 +1,8 @@
 {
   "itemDisplayName": "Deploy a simple Linux VM",
-  "icon": "Ubuntu",
+  "icon": "ubuntu",
   "description": "This template allows you to deploy a simple Linux VM using a few different options for the Ubuntu version, using the latest patched version. This will deploy a A1 size VM in the resource group location and return the FQDN of the VM.",
   "summary": "This template takes a minimum amount of parameters and deploys a Linux VM, using the latest patched version.",
   "githubUsername": "bmoore-msft",
-  "dateUpdated": "2016-12-14"
+  "dateUpdated": "2016-12-15"
 }

--- a/101-vm-simple-linux/metadata.json
+++ b/101-vm-simple-linux/metadata.json
@@ -1,8 +1,8 @@
 {
   "itemDisplayName": "Deploy a simple Linux VM",
   "icon": "Ubuntu",
-  "description": "This template allows you to deploy a simple Linux VM using a few different options for the Ubuntu version, using the latest patched version. This will deploy a D1 szie VM in the resource group location and return the FQDN of the VM.",
+  "description": "This template allows you to deploy a simple Linux VM using a few different options for the Ubuntu version, using the latest patched version. This will deploy a A1 size VM in the resource group location and return the FQDN of the VM.",
   "summary": "This template takes a minimum amount of parameters and deploys a Linux VM, using the latest patched version.",
   "githubUsername": "bmoore-msft",
-  "dateUpdated": "2016-09-20"
+  "dateUpdated": "2016-12-14"
 }

--- a/101-vm-simple-windows/README.md
+++ b/101-vm-simple-windows/README.md
@@ -1,4 +1,4 @@
-# Very simple deployment of an Windows VM
+# Very simple deployment of a Windows VM
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-vm-simple-windows%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
@@ -7,4 +7,4 @@
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy a D1 size VM in the resource group location and return the fully qualified domain name of the VM.
+This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy a A2 size VM in the resource group location and return the fully qualified domain name of the VM.

--- a/101-vm-simple-windows/azuredeploy.json
+++ b/101-vm-simple-windows/azuredeploy.json
@@ -43,7 +43,7 @@
     "subnetName": "Subnet",
     "subnetPrefix": "10.0.0.0/24",
     "publicIPAddressName": "myPublicIP",
-    "vmName": "SimpleWindowsVM",
+    "vmName": "SimpleWinVM",
     "virtualNetworkName": "MyVNET",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
   },

--- a/101-vm-simple-windows/azuredeploy.json
+++ b/101-vm-simple-windows/azuredeploy.json
@@ -129,7 +129,7 @@
       ],
       "properties": {
         "hardwareProfile": {
-          "vmSize": "Standard_D1"
+          "vmSize": "Standard_A2"
         },
         "osProfile": {
           "computerName": "[variables('vmName')]",

--- a/101-vm-simple-windows/metadata.json
+++ b/101-vm-simple-windows/metadata.json
@@ -1,8 +1,8 @@
 {
   "itemDisplayName": "Deploy a simple Windows VM",
   "icon": "windowsVM",
-  "description": "This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy a D1 size VM in the resource group location and return the FQDN of the VM.",
+  "description": "This template allows you to deploy a simple Windows VM using a few different options for the Windows version, using the latest patched version. This will deploy a A2 size VM in the resource group location and return the FQDN of the VM.",
   "summary": "This template takes a minimum amount of parameters and deploys a Windows VM, using the latest patched version.",
   "githubUsername": "bmoore-msft",
-  "dateUpdated": "2016-09-20"
+  "dateUpdated": "2016-12-14"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Change the VM Size for '101-vm-simple-windows' to Standard_A2 because A2 are available in all the region while D1 is not.
* Change the VM Size for '101-vm-simple-linux' to Standard_A1 because A1 are available in all the region while D1 is not.
* For '101-vm-simple-windows', change the name of the VM from 'SimpleWindowsVM' to 'SimpleWinVM' because "Windows" is a trademark and can't be used for the name of a VM

