### PR TITLE
Iwooden bootnode diagscript

### DIFF
--- a/ethereum-consortium-blockchain-network/nested/vmExtension.json
+++ b/ethereum-consortium-blockchain-network/nested/vmExtension.json
@@ -91,36 +91,6 @@
       }
     },
     {
-      "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(parameters('txVMNamePrefix'), copyIndex(), '/diagscript')]",
-      "apiVersion": "[variables('apiVersionVirtualMachinesExtensions')]",
-      "location": "[parameters('location')]",
-      "copy": {
-        "name": "txNodesDiagLoop",
-        "count": "[parameters('numTXNodes')]"
-      },
-      "properties": {
-        "publisher": "Microsoft.OSTCExtensions",
-        "type": "LinuxDiagnostic",
-        "typeHandlerVersion": "2.3",
-        "autoUpgradeMinorVersion": true,
-        "settings": {
-           "perfCfg":[
-              {
-                "query":"SELECT UsedMemory,AvailableMemory FROM SCX_MemoryStatisticalInformation","table":"Memory"
-              },
-              {
-                "query":"SELECT PercentIdleTime,PercentProcessorTime,PercentIOWaitTime FROM SCX_ProcessorStatisticalInformation WHERE IsAggregate = TRUE","table":"CPU"
-              }
-            ]
-        },
-        "protectedSettings": {
-          "storageAccountName": "[parameters('metricsStorageAcctName')]",
-          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('metricsStorageAcctName')), parameters('apiVersionStorageAccounts')).keys[0].value]"
-        }
-      }
-    },
-    {
       "apiVersion": "[variables('apiVersionVirtualMachinesExtensions')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('mnVMNamePrefix'), copyIndex(), '/newuserscript')]",
@@ -141,36 +111,6 @@
         },
         "protectedSettings": {
           "commandToExecute": "[concat('/bin/bash configure-geth.sh \"', parameters('adminUsername'), '\" \"', parameters('ethereumAccountPsswd'), '\" \"', parameters('ethereumAccountPassphrase'), '\" \"', parameters('artifactsLocationURL'), '\" \"', parameters('ethereumNetworkID'), '\" \"', variables('maxPeers'), '\" \"', variables('mnNode'), '\" \"', parameters('gethIPCPort'), '\" \"', parameters('numBootNodes'), '\" \"', parameters('numMNNodes'), '\" \"', parameters('mnVMNamePrefix'), '\" \"', copyIndex(), '\"')]"
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(parameters('mnVMNamePrefix'), copyIndex(), '/diagscript')]",
-      "apiVersion": "[variables('apiVersionVirtualMachinesExtensions')]",
-      "location": "[parameters('location')]",
-      "copy": {
-        "name": "mnNodesDiagLoop",
-        "count": "[parameters('numMNNodes')]"
-      },
-      "properties": {
-        "publisher": "Microsoft.OSTCExtensions",
-        "type": "LinuxDiagnostic",
-        "typeHandlerVersion": "2.3",
-        "autoUpgradeMinorVersion": true,
-        "settings": {
-          "perfCfg":[
-             {
-               "query":"SELECT UsedMemory,AvailableMemory FROM SCX_MemoryStatisticalInformation","table":"Memory"
-             },
-             {
-               "query":"SELECT PercentIdleTime,PercentProcessorTime,PercentIOWaitTime FROM SCX_ProcessorStatisticalInformation WHERE IsAggregate = TRUE","table":"CPU"
-             }
-           ]
-        },
-        "protectedSettings": {
-          "storageAccountName": "[parameters('metricsStorageAcctName')]",
-          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('metricsStorageAcctName')), parameters('apiVersionStorageAccounts')).keys[0].value]"
         }
       }
     }

--- a/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
+++ b/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
@@ -188,7 +188,7 @@ fi
 ##########################################
 # Setup rc.local for service start on boot
 ##########################################
-echo "sudo -u $AZUREUSER /bin/bash $HOMEDIR/start-private-blockchain.sh $GETH_CFG_FILE_PATH $PASSWD" | sudo tee /etc/rc.local 2>&1 1>/dev/null
+echo -e '#!/bin/bash' "\nsudo -u $AZUREUSER /bin/bash $HOMEDIR/start-private-blockchain.sh $GETH_CFG_FILE_PATH $PASSWD" | sudo tee /etc/rc.local 2>&1 1>/dev/null
 if [ $? -ne 0 ]; then
 	exit 1;
 fi

--- a/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
+++ b/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
@@ -157,7 +157,7 @@ BOOTNODE_URLS="";
 for i in `seq 0 $(($NUM_BOOT_NODES - 1))`; do
 	BOOTNODE_URLS="${BOOTNODE_URLS}enode://${NODE_IDS[$i]}@#${MN_NODE_PREFIX}${i}#:${GETH_IPC_PORT}";
   if [ $i -lt $(($NUM_BOOT_NODES - 1)) ]; then
-  	BOOTNODE_URLS="${BOOTNODE_URLS},";
+  	BOOTNODE_URLS="${BOOTNODE_URLS} --bootnodes ";
   fi
 done
 
@@ -188,7 +188,7 @@ fi
 ##########################################
 # Setup rc.local for service start on boot
 ##########################################
-echo -e '#!/bin/bash' "\nsudo -u $AZUREUSER /bin/bash $HOMEDIR/start-private-blockchain.sh $GETH_CFG_FILE_PATH $PASSWD" | sudo tee /etc/rc.local 2>&1 1>/dev/null
+echo "sudo -u $AZUREUSER /bin/bash $HOMEDIR/start-private-blockchain.sh $GETH_CFG_FILE_PATH $PASSWD" | sudo tee /etc/rc.local 2>&1 1>/dev/null
 if [ $? -ne 0 ]; then
 	exit 1;
 fi


### PR DESCRIPTION
### Changelog

* Workaround for go-ethereum bootnode string handling - for more details see [here](https://github.com/ethereum/go-ethereum/issues/3547).
* Remove diagscript VM extension - we were seeing several provisioning errors with this extension, so we are removing it for now, with full OMS support coming in a later release for proper monitoring.

