### PR TITLE
Update zookeeper version to 3.4.9

### DIFF
--- a/kafka-on-ubuntu/kafka-cluster-install.sh
+++ b/kafka-on-ubuntu/kafka-cluster-install.sh
@@ -157,22 +157,22 @@ install_zookeeper()
 {
 	mkdir -p /var/lib/zookeeper
 	cd /var/lib/zookeeper
-	wget "http://mirrors.ukfast.co.uk/sites/ftp.apache.org/zookeeper/stable/zookeeper-3.4.6.tar.gz"
-	tar -xvf "zookeeper-3.4.6.tar.gz"
+	wget "http://mirrors.ukfast.co.uk/sites/ftp.apache.org/zookeeper/stable/zookeeper-3.4.9.tar.gz"
+	tar -xvf "zookeeper-3.4.9.tar.gz"
 
-	touch zookeeper-3.4.6/conf/zoo.cfg
+	touch zookeeper-3.4.9/conf/zoo.cfg
 
-	echo "tickTime=2000" >> zookeeper-3.4.6/conf/zoo.cfg
-	echo "dataDir=/var/lib/zookeeper" >> zookeeper-3.4.6/conf/zoo.cfg
-	echo "clientPort=2181" >> zookeeper-3.4.6/conf/zoo.cfg
-	echo "initLimit=5" >> zookeeper-3.4.6/conf/zoo.cfg
-	echo "syncLimit=2" >> zookeeper-3.4.6/conf/zoo.cfg
+	echo "tickTime=2000" >> zookeeper-3.4.9/conf/zoo.cfg
+	echo "dataDir=/var/lib/zookeeper" >> zookeeper-3.4.9/conf/zoo.cfg
+	echo "clientPort=2181" >> zookeeper-3.4.9/conf/zoo.cfg
+	echo "initLimit=5" >> zookeeper-3.4.9/conf/zoo.cfg
+	echo "syncLimit=2" >> zookeeper-3.4.9/conf/zoo.cfg
 	# OLD Test echo "server.1=${ZOOKEEPER_IP_PREFIX}:2888:3888" >> zookeeper-3.4.6/conf/zoo.cfg
 	$(expand_ip_range_for_server_properties "${ZOOKEEPER_IP_PREFIX}-${INSTANCE_COUNT}")
 
 	echo $(($1+1)) >> /var/lib/zookeeper/myid
 
-	zookeeper-3.4.6/bin/zkServer.sh start
+	zookeeper-3.4.9/bin/zkServer.sh start
 }
 
 # Install kafka


### PR DESCRIPTION
3.4.6 is deprecated

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

