### PR TITLE
Update 101-vsts-cloudtest-rig to fix VM deployment error

### DIFF
--- a/101-vsts-cloudloadtest-rig/azuredeploy.json
+++ b/101-vsts-cloudloadtest-rig/azuredeploy.json
@@ -155,7 +155,8 @@
          "name":"[concat(variables('vmName'), 'i',copyIndex())]",
          "location":"[resourceGroup().location]",
          "dependsOn":[
-            "[concat('Microsoft.Network/networkInterfaces/', concat(variables('nicName'), 'i', copyIndex()))]"
+            "[concat('Microsoft.Network/networkInterfaces/', concat(variables('nicName'), 'i', copyIndex()))]",
+            "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]"
          ],
          "properties":{
             "hardwareProfile":{


### PR DESCRIPTION
Added in a dependsOn declaration for the storage account in the virtual machine.

This fixes a deployment error that happens when the storage account isn't immediately created (e.g. taking up to 20 minutes to create to the storage account) and forces the VM to be created after the storage account has successfully been created.

Currently if the storage account isn't created immediately the deployment fails because the virtual machine requires it.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

