### PR TITLE
Update WebAndGwFarmAdd_PostConfig1.1.ps1

### DIFF
--- a/rds-deployment-ha-gateway/Scripts/WebAndGwFarmAdd_PostConfig1.1.ps1
+++ b/rds-deployment-ha-gateway/Scripts/WebAndGwFarmAdd_PostConfig1.1.ps1
@@ -48,10 +48,6 @@ configuration RDWebAccessdeployment
    
     $localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName
     
-    $DomainNetbios = $domainName.Split('.') | select -First 1
-    $username = $adminCreds.UserName -split '\\' | select -last 1
-    $domainCreds = New-Object System.Management.Automation.PSCredential ("$DomainNetbios\$username", $adminCreds.Password)
-
     if (-not $connectionBroker)   { $connectionBroker = $localhost }
     if (-not $webAccessServer)    { $webAccessServer  = $localhost }
 
@@ -74,7 +70,7 @@ configuration RDWebAccessdeployment
             GatewayExternalFqdn = $externalFqdn
             ConnectionBroker = $BrokerServer
 
-            PsDscRunAsCredential = $domainCreds
+            PsDscRunAsCredential = $adminCreds
         }
     
     }
@@ -134,11 +130,7 @@ configuration RDGatewaydeployment
     Import-DscResource -ModuleName xActiveDirectory, xComputerManagement, xRemoteDesktopSessionHost
    
     $localhost = [System.Net.Dns]::GetHostByName((hostname)).HostName
-    
-    $DomainNetbios = $domainName.Split('.') | select -First 1
-    $username = $adminCreds.UserName -split '\\' | select -last 1
-    $domainCreds = New-Object System.Management.Automation.PSCredential ("$DomainNetbios\$username", $adminCreds.Password)
-
+ 
     if (-not $connectionBroker)   { $connectionBroker = $localhost }
     if (-not $webAccessServer)    { $webAccessServer  = $localhost }
 
@@ -161,7 +153,7 @@ configuration RDGatewaydeployment
             GatewayExternalFqdn = $externalFqdn
             ConnectionBroker = $BrokerServer
 
-            PsDscRunAsCredential = $domainCreds
+            PsDscRunAsCredential = $adminCreds
         }
     
     }


### PR DESCRIPTION
Added a fix for the issue where the script fails if the AD NetBios Name does not match the first part of the AD Domain Name.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

