### PR TITLE
Add Spinnaker to Kubernetes template

### DIFF
--- a/spinnaker-vm-to-kubernetes/README.md
+++ b/spinnaker-vm-to-kubernetes/README.md
@@ -1,0 +1,81 @@
+# Host Spinnaker in an Azure VM targeting Kubernetes
+
+<a href="https://aka.ms/azspindeployk8sqs" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+<a href="https://aka.ms/azspinvizk8sqs" target="_blank">
+    <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+
+This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM automatically configured to target a Kubernetes cluster. This will deploy a D2_v2 size VM and a Kubernetes cluster in the resource group location and return the FQDN of both.
+
+## A. Deploy Spinnaker VM
+1. Click the "Deploy to Azure" button. If you don't have an Azure subscription, you can follow instructions to signup for a free trial.
+1. Enter a valid name for the Spinnaker VM and Kubernetes cluster, as well as a user name and [ssh public key](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys) that you will use to login remotely to both.
+1. Create a [service principal](https://docs.microsoft.com/en-us/azure/container-service/container-service-kubernetes-service-principal#create-a-service-principal-in-azure-active-directory) for your Kubernetes cluster and enter the client id and key.
+
+## B. Setup SSH port forwarding
+You need to setup port forwarding to view the Spinnaker UI on your local machine.
+
+### If you are using Windows:
+1. Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+1. Launch Putty and navigate to Change Settings > SSH > Tunnels
+1. In the Options controlling SSH port forwarding window, enter 8084 for Source port. Then enter 127.0.0.1:8084 for the Destination. Click Add.
+1. Repeat this process for ports: 8087 and 9000, until you have all three listed in the text box for Forward ports.
+1. Click Open to establish the connection.
+
+### If you are using Linux or Mac:
+1. Add this to your ~/.ssh/config
+  ```
+  Host spinnaker-start
+    HostName <Public DNS name of instance you just created>
+    IdentityFile <Path to your key file>
+    ControlMaster yes
+    ControlPath ~/.ssh/spinnaker-tunnel.ctl
+    RequestTTY no
+    LocalForward 9000 127.0.0.1:9000
+    LocalForward 8084 127.0.0.1:8084
+    LocalForward 8087 127.0.0.1:8087
+    User <User name>
+
+  Host spinnaker-stop
+    HostName <Public DNS name of instance you just created>
+    IdentityFile <Path to your key file>
+    ControlPath ~/.ssh/spinnaker-tunnel.ctl
+    RequestTTY no
+  ```
+1. Create a spinnaker-tunnel.sh file with the following content and give it execute permission using `chmod +x spinnaker-tunnel.sh`
+  ```
+  #!/bin/bash
+
+  socket=$HOME/.ssh/spinnaker-tunnel.ctl
+
+  if [ "$1" == "start" ]; then
+    if [ ! \( -e ${socket} \) ]; then
+      echo "Starting tunnel to Spinnaker..."
+      ssh -f -N spinnaker-start && echo "Done."
+    else
+      echo "Tunnel to Spinnaker running."
+    fi
+  fi
+
+  if [ "$1" == "stop" ]; then
+    if [ \( -e ${socket} \) ]; then
+      echo "Stopping tunnel to Spinnaker..."
+      ssh -O "exit" spinnaker-stop && echo "Done."
+    else
+      echo "Tunnel to Spinnaker stopped."
+    fi
+  fi
+  ```
+1. Call `./spinnaker-tunnel.sh start` to start your tunnel
+1. Call `./spinnaker-tunnel.sh stop` to stop your tunnel
+
+## C. Connect to Spinnaker
+
+1. After you have started your tunnel, navigate to `http://localhost:9000/` on your local machine.
+1. Follow steps [here](http://www.spinnaker.io/docs/kubernetes-source-to-prod) to deploy a sample pipeline. The kubeconfig file has already been copied over to your Spinnaker instance, and it has been configured to use the [docker repository](https://hub.docker.com/r/lwander/spin-kub-demo/) in the example.
+1. Check the [Troubleshooting Guide](http://www.spinnaker.io/docs/troubleshooting-guide) if you have any issues.
+
+## Questions/Comments? azdevopspub@microsoft.com

--- a/spinnaker-vm-to-kubernetes/azuredeploy.json
+++ b/spinnaker-vm-to-kubernetes/azuredeploy.json
@@ -1,0 +1,279 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "User name for the Virtual Machine."
+      }
+    },
+    "sshPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Configure all linux machines with the SSH public key string.  Your key should include three parts, for example 'ssh-rsa AAAAB...snip...UcyupgH azureuser@linuxvm'"
+      }
+    },
+    "spinnakerDnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Public IP used to access the Spinnaker Virtual Machine."
+      }
+    },
+    "kubernetesDnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Public IP used to access the Kubernetes cluster targeted for deployment."
+      }
+    },
+    "servicePrincipalClientId": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Service Principal Client ID (also called App ID) used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
+      }
+    },
+    "servicePrincipalClientSecret": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Service Principal secret used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
+      }
+    },
+    "_artifactsLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+      },
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/spinnaker-vm-to-kubernetes/scripts/"
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+      },
+      "defaultValue": ""
+    }
+  },
+  "variables": {
+    "resourcePrefix": "spinnaker",
+    "kubernetesName": "[concat('containerservice-', resourceGroup().name)]",
+    "kubernetesMasterCount": 1,
+    "storageAccountName": "[concat(variables('resourcePrefix'), uniquestring(resourceGroup().id))]",
+    "OSDiskName": "[concat(variables('resourcePrefix'), 'OSDisk')]",
+    "nicName": "[concat(variables('resourcePrefix'), 'VMNic')]",
+    "subnetName": "[concat(variables('resourcePrefix'), 'Subnet')]",
+    "publicIPAddressName": "[concat(variables('resourcePrefix'), 'PublicIP')]",
+    "vmStorageAccountContainerName": "vhds",
+    "vmName": "[concat(variables('resourcePrefix'), 'VM')]",
+    "virtualNetworkName": "[concat(variables('resourcePrefix'), 'VNET')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-09-30",
+      "type": "Microsoft.ContainerService/containerServices",
+      "location": "[resourceGroup().location]",
+      "name": "[variables('kubernetesName')]",
+      "properties": {
+        "orchestratorProfile": {
+          "orchestratorType": "Kubernetes"
+        },
+        "masterProfile": {
+          "count": "[variables('kubernetesMasterCount')]",
+          "dnsPrefix": "[concat(parameters('kubernetesDnsLabelPrefix'),'mgmt')]"
+        },
+        "agentPoolProfiles": [
+          {
+            "name": "agentpools",
+            "count": 1,
+            "vmSize": "Standard_D2_v2",
+            "dnsPrefix": "[concat(parameters('kubernetesDnsLabelPrefix'),'agents')]"
+          }
+        ],
+        "linuxProfile": {
+          "adminUsername": "[parameters('adminUsername')]",
+          "ssh": {
+            "publicKeys": [
+              {
+                "keyData": "[parameters('sshPublicKey')]"
+              }
+            ]
+          }
+        },
+        "servicePrincipalProfile": {
+          "ClientId": "[parameters('servicePrincipalClientId')]",
+          "Secret": "[parameters('servicePrincipalClientSecret')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "2016-01-01",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "Storage",
+      "properties": {}
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('spinnakerDnsLabelPrefix')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.0.0/24"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')),'/subnets/',variables('subnetName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2016-03-30",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "Standard_D2_v2"
+        },
+        "osProfile": {
+          "computerName": "[variables('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": "true",
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "[concat('/home/',parameters('adminUserName'),'/.ssh/authorized_keys')]",
+                  "keyData": "[parameters('sshPublicKey')]"
+                }
+              ]
+            }
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "Canonical",
+            "offer": "UbuntuServer",
+            "sku": "14.04.5-LTS",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').primaryEndpoints.blob, variables('vmStorageAccountContainerName'), '/', variables('OSDiskName'), '.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').primaryEndpoints.blob)]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmName'), '/downloadinitscript')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))]",
+        "[resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": [
+            "[concat(parameters('_artifactsLocation'), 'set_spinnaker.sh', parameters('_artifactsLocationSasToken'))]"
+          ]
+        },
+        "protectedSettings": {
+          "commandToExecute": "[concat('./set_spinnaker.sh', ' ', parameters('servicePrincipalClientId'), ' ', parameters('servicePrincipalClientSecret'), ' ', subscription().tenantId, ' ', parameters('adminUsername'), ' ', resourceGroup().name, ' ', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, ' ', variables('kubernetesMasterCount'), ' ', parameters('_artifactsLocation'), ' ', parameters('_artifactsLocationSasToken'))]"
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "spinnakerFQDN": {
+      "type": "string",
+      "value": "[reference(variables('publicIPAddressName')).dnsSettings.fqdn]"
+    },
+    "spinnakerSsh": {
+      "type": "string",
+      "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+    },
+    "kubernetesMasterFQDN": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn]"
+    },
+    "kubernetesMasterSsh": {
+      "type": "string",
+      "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn)]"
+    }
+  }
+}

--- a/spinnaker-vm-to-kubernetes/azuredeploy.json
+++ b/spinnaker-vm-to-kubernetes/azuredeploy.json
@@ -185,7 +185,7 @@
       ],
       "properties": {
         "hardwareProfile": {
-          "vmSize": "Standard_D2_v2"
+          "vmSize": "Standard_D3_v2"
         },
         "osProfile": {
           "computerName": "[variables('vmName')]",

--- a/spinnaker-vm-to-kubernetes/azuredeploy.parameters.json
+++ b/spinnaker-vm-to-kubernetes/azuredeploy.parameters.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "value": "GEN-USERNAME"
+    },
+    "sshPublicKey": {
+      "value": "GEN-SSH-PUB-KEY"
+    },
+    "spinnakerDnsLabelPrefix": {
+      "value": "GEN-UNIQUE"
+    },
+    "kubernetesDnsLabelPrefix": {
+      "value": "GEN-UNIQUE"
+    },
+    "servicePrincipalClientId": {
+      "value": "GEN-UNIQUE-18"
+    },
+    "servicePrincipalClientSecret": {
+      "value": "GEN-PASSWORD"
+    }
+  }
+}

--- a/spinnaker-vm-to-kubernetes/metadata.json
+++ b/spinnaker-vm-to-kubernetes/metadata.json
@@ -1,0 +1,8 @@
+{
+  "itemDisplayName": "Deploy Spinnaker on a Linux VM targeting Kubernetes",
+  "icon": "ubuntu",
+  "description": "This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM automatically configured to target a Kubernetes cluster. This will deploy a D2_v2 size VM and a Kubernetes cluster in the resource group location and return the FQDN of both.",
+  "summary": "This template deploys an instance of Spinnaker on a Linux Ubuntu 14.05 LTS VM, targeting Kubernetes.",
+  "githubUsername": "EricJizbaMSFT",
+  "dateUpdated": "2017-01-26"
+}

--- a/spinnaker-vm-to-kubernetes/scripts/add_temp_user.sh
+++ b/spinnaker-vm-to-kubernetes/scripts/add_temp_user.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+admin_user_name=$1
+temp_user_name=$2
+temp_public_key=$3
+
+# Add user
+sudo useradd $temp_user_name --create-home
+
+# Add public key
+sudo mkdir /home/$temp_user_name/.ssh
+echo $temp_public_key | sudo tee -a /home/$temp_user_name/.ssh/authorized_keys
+
+# Copy kube config file and give user permission to access
+sudo mkdir /home/$temp_user_name/.kube
+sudo cp /home/$admin_user_name/.kube/config /home/$temp_user_name/.kube/config
+sudo chown $temp_user_name /home/$temp_user_name/.kube/config

--- a/spinnaker-vm-to-kubernetes/scripts/remove_temp_user.sh
+++ b/spinnaker-vm-to-kubernetes/scripts/remove_temp_user.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+temp_user_name=$1
+
+sudo userdel -r $temp_user_name

--- a/spinnaker-vm-to-kubernetes/scripts/set_spinnaker.sh
+++ b/spinnaker-vm-to-kubernetes/scripts/set_spinnaker.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+client_id=$1
+client_secret=$2
+tenant_id=$3
+admin_user_name=$4
+resource_group=$5
+master_fqdn=$6
+master_count=$7
+artifacts_location=$8
+artifacts_location_sas_token=$9
+
+#Install Spinnaker
+curl --silent https://raw.githubusercontent.com/spinnaker/spinnaker/master/InstallSpinnaker.sh | sudo bash -s -- --quiet
+
+# Install Azure cli
+curl -sL https://deb.nodesource.com/setup_4.x | sudo -E bash -
+sudo apt-get -y install nodejs
+sudo npm install -g azure-cli
+
+# Login to azure cli using service principal
+azure telemetry --disable
+azure login --service-principal -u $client_id -p $client_secret --tenant $tenant_id
+
+# Setup temporary credentials to access kubernetes master vms
+temp_user_name=$(uuidgen | sed 's/-//g')
+temp_key_path=$(mktemp -d)/temp_key
+ssh-keygen -t rsa -N "" -f $temp_key_path -V "+1d"
+temp_pub_key=$(cat ${temp_key_path}.pub)
+
+# Get the unique suffix used for kubernetes vms
+kubernetes_suffix=$(azure group deployment list $resource_group --json | grep -A 2 'nameSuffix\|masterFQDN' | grep 'value' | \
+  grep -A 1 $master_fqdn | tail -n 1 | cut -d '"' -f 4)
+
+# Enable temporary credentials on every kubernetes master vm (since we don't know which vm will be used when we scp)
+for (( i=0; i<$master_count; i++ ))
+do
+  master_vm="k8s-master-${kubernetes_suffix}-$i"
+  azure vm extension set $resource_group $master_vm CustomScript Microsoft.Azure.Extensions 2.0 --auto-upgrade-minor-version \
+    --public-config "{\"fileUris\": [\"${artifacts_location}add_temp_user.sh${artifacts_location_sas_token}\"], \"commandToExecute\": \"./add_temp_user.sh $admin_user_name $temp_user_name '$temp_pub_key'\"}"
+done
+
+# Copy kube config over from master kubernetes cluster and mark readable
+sudo mkdir /home/spinnaker/.kube
+sudo scp -o StrictHostKeyChecking=no -i $temp_key_path $temp_user_name@$master_fqdn:/home/$temp_user_name/.kube/config /home/spinnaker/.kube/config
+sudo chmod +r /home/spinnaker/.kube/config
+
+# Remove temporary credentials on every kubernetes master vm
+for (( i=0; i<$master_count; i++ ))
+do
+  master_vm="k8s-master-${kubernetes_suffix}-$i"
+  azure vm extension set $resource_group $master_vm CustomScript Microsoft.Azure.Extensions 2.0 --auto-upgrade-minor-version \
+    --public-config "{\"fileUris\": [\"${artifacts_location}remove_temp_user.sh${artifacts_location_sas_token}\"], \"commandToExecute\": \"./remove_temp_user.sh $temp_user_name\"}"
+done
+
+# Delete temp key on spinnaker vm
+rm $temp_key_path
+rm ${temp_key_path}.pub
+
+# Configure Spinnaker for Kubernetes
+sudo sed -i 's|SPINNAKER_KUBERNETES_ENABLED:false|SPINNAKER_KUBERNETES_ENABLED:true|' /opt/spinnaker/config/spinnaker-local.yml
+sudo sed -i 's|SPINNAKER_DOCKER_REPOSITORY:|SPINNAKER_DOCKER_REPOSITORY:lwander/spin-kub-demo|' /opt/spinnaker/config/spinnaker-local.yml
+
+# Restart spinnaker so that config changes take effect
+sudo service spinnaker restart
+
+# Restart cassandra to avoid front50 connection issue
+sudo service cassandra restart


### PR DESCRIPTION
This spins up a linux vm and a kubernetes cluster.  It installs Spinnaker on the vm and configures it to target Kubernetes.

The most complex part is getting the kube config file (used to authenticate) from the kubernetes cluster to the spinnaker vm. I use the service principal and azure cli to give a temp user access to the kubernetes master vms, then scp the file to the spinnaker vm.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*Add Spinnaker to Kubernetes template

