### PR TITLE
fix openshift template

### DIFF
--- a/openshift-origin-rhel/scripts/masterPrep.sh
+++ b/openshift-origin-rhel/scripts/masterPrep.sh
@@ -7,7 +7,7 @@ yum -y update --exclude=WALinuxAgent
 yum -y install wget git net-tools bind-utils iptables-services bridge-utils bash-completion pyOpenSSL httpd-tools
 
 # Install the epel repo if not already present
-yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
 
 # Clean yum metadata and cache to make sure we see the latest packages available
 yum -y clean all

--- a/openshift-origin-rhel/scripts/nodePrep.sh
+++ b/openshift-origin-rhel/scripts/nodePrep.sh
@@ -7,7 +7,7 @@ yum -y update --exclude=WALinuxAgent
 yum -y install wget git net-tools bind-utils iptables-services bridge-utils bash-completion pyOpenSSL httpd-tools
 
 # Install the epel repo if not already present
-yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm
 
 # Clean yum metadata and cache to make sure we see the latest packages available
 yum -y clean all


### PR DESCRIPTION
Currently the openshift template doesn't work anymore because the URL of epel RPM is no more available, which prevents ansible installation

[https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm](https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-8.noarch.rpm) : KO, 404 Error

[https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm](https://dl.fedoraproject.org/pub/epel/7/x86_64/e/epel-release-7-9.noarch.rpm) : OK




### Changelog

* openshift-origin-rhel/scripts/masterPrep.sh
* openshift-origin-rhel/scripts/nodePrep.sh


