### PR TITLE
fix the use of the 'vmSize' parameter

### DIFF
--- a/rds-deployment-ha-gateway/azuredeploy.json
+++ b/rds-deployment-ha-gateway/azuredeploy.json
@@ -89,11 +89,11 @@
       },
       "defaultValue": "2016-Datacenter"
     },
-    "rdshVmSize": {
+    "vmSize": {
       "type": "string",
       "defaultValue": "Standard_D2",
       "metadata": {
-        "description": "The size of the RDSH VMs"
+        "description": "Size for the new RD Gateway VMs"
       }
     },
     "existingVnet": {
@@ -305,9 +305,8 @@
         "[concat('Microsoft.Network/networkInterfaces/gw-',copyindex(),'-nic')]"
       ],
       "properties": {
-
         "hardwareProfile": {
-          "vmSize": "Standard_A4"
+          "vmSize": "[parameters('vmSize')]"
         },
         "availabilitySet": {
           "id": "[resourceId('Microsoft.Compute/availabilitySets', 'gw-availabilityset')]"


### PR DESCRIPTION
rds-templates: [Issue #16](https://github.com/mmarch/rds-templates/issues/16)

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.
