### PR TITLE
Fix for encrypting multiple servers at the same time

### DIFF
--- a/201-encrypt-running-windows-vm/azuredeploy.json
+++ b/201-encrypt-running-windows-vm/azuredeploy.json
@@ -100,7 +100,7 @@
       }
     },
     {
-      "name": "updatevm",
+      "name": "[concat('updatevm-',parameters('vmName'))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2015-01-01",
       "dependsOn": [


### PR DESCRIPTION
in current version of the json the name of the linked template is static updatevm causing error (template already running) if you want to encrypt multiple servers at the same time.
the small change suggested here solves the issue by giving every encryption task a more "unique" name

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

