### PR TITLE
Update certificates to prevent download errors

### DIFF
--- a/intel-lustre-clients-on-centos/lustre_client.sh
+++ b/intel-lustre-clients-on-centos/lustre_client.sh
@@ -108,6 +108,9 @@ install_lustre_centos66()
 	# Install wget and dstat
 	yum install -y wget dstat
 
+	# Update certificates to prevent wget download errors
+	yum update -y ca-certificates
+	
 	# Install pdsh since it is convenient for managing multiple client hosts later
 	# RHEL/CentOS 6 64-Bit ##
 	wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
@@ -153,6 +156,9 @@ install_lustre_centos70()
 	# Install wget and dstat
 	yum install -y wget dstat
 	
+	# Update certificates to prevent wget download errors
+	yum update -y ca-certificates
+	
 	# Download stable Lustre client source targeting specific CentOS 7.0 kernel
 	# This code will be used to create the RPM for the currently running kernel
 	wget https://downloads.hpdd.intel.com/public/lustre/lustre-2.7.0/el7/client/SRPMS/lustre-client-2.7.0-3.10.0_123.20.1.el7.x86_64.src.rpm
@@ -192,6 +198,9 @@ install_lustre_centos_hpc_65()
 	# Install wget and dstat
 	yum install -y wget dstat
 
+	# Update certificates to prevent wget download errors
+	yum update -y ca-certificates
+	
 	# Install pdsh since it is convenient for managing multiple client hosts later
 	# RHEL/CentOS 6 64-Bit ##
 	wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
@@ -242,6 +251,9 @@ install_lustre_centos_hpc_71()
 {
 	# Install wget and dstat
 	yum install -y wget dstat
+	
+	# Update certificates to prevent wget download errors
+	yum update -y ca-certificates
 	
 	# Download stable Lustre client source targeting specific CentOS 7.0 kernel
 	# This code will be used to create the RPM for the currently running kernel

--- a/intel-lustre-clients-vmss-centos/lustre_client.sh
+++ b/intel-lustre-clients-vmss-centos/lustre_client.sh
@@ -108,6 +108,9 @@ install_lustre_centos66()
 	# Install wget and dstat
 	yum install -y wget dstat
 
+	# Update certificates to prevent wget download errors
+	yum update -y ca-certificates
+	
 	# Install pdsh since it is convenient for managing multiple client hosts later
 	# RHEL/CentOS 6 64-Bit ##
 	wget http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
@@ -152,6 +155,9 @@ install_lustre_centos70()
 {
 	# Install wget and dstat
 	yum install -y wget dstat
+	
+	# Update certificates to prevent wget download errors
+	yum update -y ca-certificates
 	
 	# Download stable Lustre client source targeting specific CentOS 7.0 kernel
 	# This code will be used to create the RPM for the currently running kernel


### PR DESCRIPTION
Update root certificates to prevent download errors like ERROR: cannot
verify downloads.hpdd.intel.com's certificate, issued by
‘/C=US/ST=CA/L=Santa Clara/O=Intel Corporation/CN=Intel External Issuing
CA 6B’:
Unable to locally verify the issuer's authority.
To connect to downloads.hpdd.intel.com insecurely, use
`--no-check-certificate'.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog
Update root certificates to prevent download errors
*
*
*

