### PR TITLE
multiple local subnets

### DIFF
--- a/101-site-to-site-vpn-create/azuredeploy.json
+++ b/101-site-to-site-vpn-create/azuredeploy.json
@@ -28,8 +28,8 @@
             }
         },
         "localAddressPrefix": {
-            "type": "string",
-            "defaultValue": "192.168.0.0/16",
+            "type": "array",
+            "defaultValue": [ "192.168.0.0/16" , "172.16.0.0/12" ],
             "metadata": {
                 "description": "CIDR block representing the address space of the OnPremise VPN network's Subnet"
             }
@@ -123,9 +123,7 @@
         "location": "[resourceGroup().location]",
         "properties": {
           "localNetworkAddressSpace": {
-            "addressPrefixes": [
-              "[parameters('localAddressPrefix')]"
-            ]
+            "addressPrefixes": "[parameters('localAddressPrefix')]"
           },
           "gatewayIpAddress": "[parameters('localGatewayIpAddress')]"
         }

--- a/101-site-to-site-vpn-create/azuredeploy.parameters.json
+++ b/101-site-to-site-vpn-create/azuredeploy.parameters.json
@@ -12,7 +12,7 @@
             "value": "1.1.1.1"
         },
         "localAddressPrefix": {
-            "value": "192.168.0.0/16"
+            "value": [ "192.168.0.0/16", "172.16.0.0/12" ] 
         },
         "virtualNetworkName": {
             "value": "azureVnet"


### PR DESCRIPTION
Changed localAddressPrefix type from string to array to allow for more
local subnets over the vpn