### PR TITLE
update to 101-nic-publicip-dns-vnet

### DIFF
--- a/101-nic-publicip-dns-vnet/azuredeploy.json
+++ b/101-nic-publicip-dns-vnet/azuredeploy.json
@@ -83,13 +83,17 @@
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
       "properties": {
         "ipConfigurations": [
           {
             "name": "ipconfig1",
             "properties": {
+              "publicIPAddress": {
+                "id": "[resourceId ('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+              },
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
                 "id": "[variables('subnetRef')]"

--- a/101-nic-publicip-dns-vnet/metadata.json
+++ b/101-nic-publicip-dns-vnet/metadata.json
@@ -2,6 +2,6 @@
   "itemDisplayName": "Network Interface with Public IP Address",
   "description": "This template allows you to create a Network Inerface in a Virtual Network referencing a Public IP Address.",
   "summary": "Network Interface in a Virtual Network with Public IP Address",
-  "githubUsername": "mahthi",
-  "dateUpdated": "2015-12-21"
+  "githubUsername": "rachelye",
+  "dateUpdated": "2017-03-07"
 }


### PR DESCRIPTION
Hello,
submitting a minor change to 101-nic-publicip-dns-vnet, the template created a NIC and a PublicIP resources, but the PublicIP wasn't associated with the NIC. Fixed this issue.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [v ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

