### PR TITLE
VMSS from Image with Existing VNet & AppGW

### DIFF
--- a/201-vmss-custom-image-existing-vnet-existing-app-gateway/README.md
+++ b/201-vmss-custom-image-existing-vnet-existing-app-gateway/README.md
@@ -1,0 +1,41 @@
+# VM Scale Set from a Managed Image connected to an existing Virtual Network and Application Gateway
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-vmss-custom-image-existing-vnet-existing-app-gateway%2Fazuredeploy.json" target="_blank">
+<img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-vmss-custom-image-existing-vnet-existing-app-gateway%2Fazuredeploy.json" target="_blank">
+<img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.png"/>
+</a>
+
+This template deploys a VM Scale Set based on a specified custom image (in the form of a Managed Image), connected to an existing subnet in an existing Virtual Network, and adds the instances to a specified existing Application Gateway Backend Pool. This is useful in cases where you might want to deploy multiple VM Scale Sets in the same Virtual Network, as well as configure the Application Gateway outside of this template, such as through the portal, which provides a more reliable experience for things like adding HTTPS listeners.
+
+`Tags: VM Scale Set, VMSS, Managed Disks, Managed Images, Custom Image`
+
+## Prerequisites
+
+To deploy this template, you will need:
+ * An existing Managed Image ([about Managed Images](https://docs.microsoft.com/en-us/azure/virtual-machines/virtual-machines-windows-capture-image-resource))
+ * An existing Virtual Network and subnet located in another Resource Group
+ * An existing Application Gateway and backend pool located in another Resource Group
+
+In the parameters, you will need to take note of:
+ * The name of the resource group containing the Managed Image
+ * The name of the Managed Image itself
+ * The name of the resource group containing the Virtual Network
+ * The name of the subnet inside the Virtual Network where the create VM Scale Set will connect to
+ * The name of the resource group containing the Application Gateway
+ * The name of the backend pool inside the Application Gateway which will be added with instances of the VM Scale SEt
+
+## Deployment steps
+
+You can click the "Deploy to Azure" button at the beginning of this document or follow the instructions for command line deployment using the scripts in the root of this repo.
+
+## Usage
+
+#### Connect
+
+To connect to individual instances of the VM Scale Set, utilize a jumpbox VM, that is, another VM that is located
+
+## Notes
+
+The OS of the VM Scale Set will follow whatever is defined in the custom image.

--- a/201-vmss-custom-image-existing-vnet-existing-app-gateway/azuredeploy.json
+++ b/201-vmss-custom-image-existing-vnet-existing-app-gateway/azuredeploy.json
@@ -1,0 +1,165 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmSku": {
+      "type": "string",
+      "defaultValue": "Standard_F2",
+      "metadata": {
+        "description": "Size of VMs in the VM Scale Set."
+      }
+    },
+    "vmssName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the VM Scale Set."
+      },
+      "maxLength": 61
+    },
+    "instanceCount": {
+      "type": "int",
+      "metadata": {
+        "description": "Initial number of VM instances (100 or less)."
+      },
+      "defaultValue": 2,
+      "maxValue": 100
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Admin username on all VMs."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin password on all VMs."
+      }
+    },
+    "upgradePolicy": {
+      "type": "string",
+      "defaultValue": "Manual",
+      "allowedValues": [
+        "Manual",
+        "Automatic"
+      ],
+      "metadata": {
+        "description": "The upgrade policy for the VM Scale Set, either Manual of Automatic."
+      }
+    },
+    "existingVirtualNetworkResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Resource Group which contains the existing Virtual Network that this VM Scale Set will be connected to."
+      }
+    },
+    "existingVirtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the existing Virtual Network that this VM Scale Set will be connected to."
+      }
+    },
+    "existingVirtualNetworkSubnet": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the existing subnet that this VM Scale Set will be connected to."
+      }
+    },
+    "existingManagedImageResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Resource Group containing the Image that instances of the VM Scale Set will be created from. Images can be created by capturing Azure VMs."
+      }
+    },
+    "existingManagedImageName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Image that instances of the VM Scale Set will be created from. Images can be created by capturing Azure VMs."
+      }
+    },
+    "existingAppGatewayResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Resource Group which contains the existing Application Gateway that will load-balance the instances of this VM Scale Set."
+      }
+    },
+    "existingAppGatewayName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the existing Application Gateway that will load-balance the instances of this VM Scale Set."
+      }
+    },
+    "existingAppGatewayBackendPoolName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Backend Pool in the existing Application Gateway that will load-balance the instances of this VM Scale Set."
+      },
+      "defaultValue": "appGatewayBackendPool"
+    }
+  },
+  "variables": {
+    "vmssName": "[toLower(substring(parameters('vmssName'), 0, 9))]",
+    "vnetId": "[resourceId(parameters('existingVirtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', parameters('existingVirtualNetworkName'))]",
+    "subnetId": "[concat(variables('vnetId'), '/subnets/', parameters('existingVirtualNetworkSubnet'))]",
+    "appGwId": "[resourceId(parameters('existingAppGatewayResourceGroup'), 'Microsoft.Network/applicationGateways', parameters('existingAppGatewayName'))]",
+    "appGwBePoolId": "[concat(variables('appGwId'), '/backendAddressPools/', parameters('existingAppGatewayBackendPoolName'))]",
+    "managedImageId": "[resourceId(parameters('existingManagedImageResourceGroup'), 'Microsoft.Compute/images', parameters('existingManagedImageName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "name": "[variables('vmssName')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2016-04-30-preview",
+      "sku": {
+        "name": "[parameters('vmSku')]",
+        "tier": "Standard",
+        "capacity": "[parameters('instanceCount')]"
+      },
+      "properties": {
+        "overprovision": true,
+	    	"singlePlacementGroup": false,
+        "upgradePolicy": {
+          "mode": "[parameters('upgradePolicy')]"
+        },
+        "virtualMachineProfile": {
+          "storageProfile": {
+            "imageReference": {
+              "id": "[variables('managedImageId')]"
+            }
+          },
+          "osProfile": {
+            "computerNamePrefix": "[variables('vmssName')]",
+			      "adminUsername": "[parameters('adminUsername')]",
+            "adminPassword": "[parameters('adminPassword')]"
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "nic",
+                "properties": {
+                  "primary": true,
+                  "ipConfigurations": [
+                    {
+                      "name": "ipconfig",
+                      "properties": {
+                        "subnet": {
+                          "id": "[variables('subnetId')]"
+                        },
+                        "ApplicationGatewayBackendAddressPools": [
+                          {
+                            "id": "[variables('appGwBePoolId')]"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/201-vmss-custom-image-existing-vnet-existing-app-gateway/azuredeploy.parameters.json
+++ b/201-vmss-custom-image-existing-vnet-existing-app-gateway/azuredeploy.parameters.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmSku": {
+      "value": "Standard_F2"
+    },
+    "vmssName": {
+      "value": "myvmss"
+    },
+    "instanceCount": {
+      "value": 2
+    },
+    "adminUsername": {
+      "value": "vmssadmin"
+    },
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "existingVirtualNetworkResourceGroup": {
+      "value": "Network-Group"
+    },
+    "existingVirtualNetworkName": {
+      "value": "Production-VNet"
+    },
+    "existingVirtualNetworkSubnet": {
+      "value": "default"
+    },
+    "existingManagedImageResourceGroup": {
+      "value": "ManagedImages-Group"
+    },
+    "existingManagedImageName": {
+      "value": "ubuntu1-image-20170310130221"
+    },
+    "existingAppGatewayResourceGroup": {
+      "value": "AppGateway-Group"
+    },
+    "existingAppGatewayName": {
+      "value": "Frontend-AppGW"
+    },
+    "existingAppGatewayBackendPoolName": {
+      "value": "appGatewayBackendPool"
+    }
+  }
+}

--- a/201-vmss-custom-image-existing-vnet-existing-app-gateway/metadata.json
+++ b/201-vmss-custom-image-existing-vnet-existing-app-gateway/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "VM Scale Set from a Managed Image connected to an existing Virtual Network and Application Gateway",
+  "description": "This template deploys a VM Scale Set based on an existing Managed Image, connected to an existing Virtual Network and existing Application Gateway Backend Pool.",
+  "summary": "This template deploys a VM Scale Set based on a specified custom image (in the form of a Managed Image), connected to an existing subnet in an existing Virtual Network, and adds the instances to a specified existing Application Gateway Backend Pool.",
+  "githubUsername": "andhikanugraha",
+  "dateUpdated": "2017-03-10"
+}


### PR DESCRIPTION
This template deploys a VM Scale Set based on a specified custom image (in the form of a Managed Image), connected to an existing subnet in an existing Virtual Network, and adds the instances to a specified existing Application Gateway Backend Pool. This is useful in cases where you might want to deploy multiple VM Scale Sets in the same Virtual Network, as well as configure the Application Gateway outside of this template, such as through the portal, which provides a more reliable experience for things like adding HTTPS listeners.