### PR TITLE
premium tear as allowed value for redis cache template

### DIFF
--- a/101-redis-cache/azuredeploy.json
+++ b/101-redis-cache/azuredeploy.json
@@ -12,7 +12,8 @@
       "type": "string",
       "allowedValues": [
         "Basic",
-        "Standard"
+        "Standard",
+        "Premium"
       ],
       "defaultValue": "Standard",
       "metadata": {
@@ -24,7 +25,11 @@
       "defaultValue": "C",
       "metadata": {
         "description": "The family for the sku."
-      }
+      },
+      "allowedValues": [
+        "C",
+        "P"
+      ]
     },
     "redisCacheCapacity": {
       "type": "int",


### PR DESCRIPTION
### Changelog
premium tear as allowed value for redis cache template.
this template 100% valid and can be deployed. I seen template with postfix Premium, but anyway..

