### PR TITLE
fixing deployment failure and adding azure provider flag set

### DIFF
--- a/spinnaker-jenkins-to-vmss/scripts/set_azure_spinnaker.sh
+++ b/spinnaker-jenkins-to-vmss/scripts/set_azure_spinnaker.sh
@@ -109,9 +109,12 @@ sudo printf "rosco.yml file has been updated\n"
 sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EB9B1D8886F44E2A
 sudo printf "apt-key done\n" 
 
+# Enable Azure provider in /etc/default/spinnaker
+sudo sed -i '/SPINNAKER_AZURE_ENABLED=false/s/.*/SPINNAKER_AZURE_ENABLED=true/' /etc/default/spinnaker
+
 # Removing debug file
 sudo rm -f $SED_FILE
 
 # rebooting the VM to avoid issues with front50
-sudo restart spinnaker 
+sudo service spinnaker restart
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

