### PR TITLE
Refactor to use common install_jenkins script

### DIFF
--- a/101-jenkins-master-on-ubuntu/README.md
+++ b/101-jenkins-master-on-ubuntu/README.md
@@ -1,9 +1,9 @@
 # Azure hosted Jenkins Master on Ubuntu
 
-<a href="https://aka.ms/azdeployjenkinsonubuntu" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-jenkins-master-on-ubuntu%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-<a href="https://aka.ms/azvisualizejenkinsonubuntu" target="_blank">
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-jenkins-master-on-ubuntu%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 

--- a/101-jenkins-master-on-ubuntu/azuredeploy.json
+++ b/101-jenkins-master-on-ubuntu/azuredeploy.json
@@ -19,20 +19,6 @@
       "metadata": {
         "description": "Unique DNS Name for the Public IP used to access the Jenkins Virtual Machine."
       }
-    },
-    "_artifactsLocation": {
-      "type": "string",
-      "metadata": {
-        "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
-      },
-      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-jenkins-master-on-ubuntu/"
-    },
-    "_artifactsLocationSasToken": {
-      "type": "securestring",
-      "metadata": {
-        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
-      },
-      "defaultValue": ""
     }
   },
   "variables": {
@@ -47,7 +33,9 @@
     "virtualNetworkName": "[concat(variables('resourcePrefix'), 'VNET')]",
     "vmExtensionName": "initializeJenkins",
     "vmSize": "Standard_DS1_v2",
-    "frontEndNSGName": "jenkinsNSG"
+    "frontEndNSGName": "jenkinsNSG",
+    "_artifactsLocation": "https://raw.githubusercontent.com/azure/azure-devops-utils/v0.6.0/",
+    "_artifactsLocationSasToken": ""
   },
   "resources": [
     {
@@ -211,11 +199,11 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
-            "[concat(parameters('_artifactsLocation'), 'scripts/set_jenkins.sh', parameters('_artifactsLocationSasToken'))]"
+            "[concat(variables('_artifactsLocation'), 'jenkins/install_jenkins.sh', variables('_artifactsLocationSasToken'))]"
           ]
         },
         "protectedSettings": {
-          "commandToExecute": "./set_jenkins.sh"
+          "commandToExecute": "./install_jenkins.sh"
         }
       }
     }

--- a/101-jenkins-master-on-ubuntu/azuredeploy.parameters.json
+++ b/101-jenkins-master-on-ubuntu/azuredeploy.parameters.json
@@ -13,6 +13,6 @@
     },
     "vmSize": {
       "value": "Standard_DS1_v2"
-    },
+    }
   }
 }

--- a/101-jenkins-master-on-ubuntu/metadata.json
+++ b/101-jenkins-master-on-ubuntu/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM.",
   "summary": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM.",
   "githubUsername": "clguimanMSFT",
-  "dateUpdated": "2017-03-10"
+  "dateUpdated": "2017-03-29"
 }

--- a/101-jenkins-master-on-ubuntu/scripts/set_jenkins.sh
+++ b/101-jenkins-master-on-ubuntu/scripts/set_jenkins.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-wget -q -O - https://pkg.jenkins.io/debian/jenkins-ci.org.key | sudo apt-key add -
-sudo sh -c 'echo deb http://pkg.jenkins.io/debian-stable binary/ > /etc/apt/sources.list.d/jenkins.list'
-sudo apt-get update --yes
-sudo apt-get install jenkins --yes
-sudo apt-get install jenkins --yes

--- a/201-jenkins-to-azure-container-registry/azuredeploy.json
+++ b/201-jenkins-to-azure-container-registry/azuredeploy.json
@@ -54,7 +54,7 @@
     "virtualNetworkName": "[concat(variables('resourcePrefix'), 'VNET')]",
     "vmExtensionName": "initializeJenkins",
     "frontEndNSGName": "[concat(variables('resourcePrefix'), 'NSG')]",
-    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.5.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.6.0/",
     "_extensionScript": "201-jenkins-to-azure-container-registry.sh",
     "_artifactsLocationSasToken": ""
   },

--- a/201-jenkins-to-azure-container-registry/metadata.json
+++ b/201-jenkins-to-azure-container-registry/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM and an Azure Container Registry. It also includes an optional ACR pipeline.",
   "summary": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM and an Azure Container Registry. It also includes an optional ACR pipeline.",
   "githubUsername": "clguimanMSFT",
-  "dateUpdated": "2017-03-17"
+  "dateUpdated": "2017-03-29"
 }


### PR DESCRIPTION
It turns out the telemetry for templates is based on a hash of azuredeploy.json. I noticed these minor issues when using this template and wanted to fix ASAP so that telemetry is consistent going forward