### PR TITLE
Refactor DevOps Service Principal docs

### DIFF
--- a/101-jenkins-master-on-ubuntu/README.md
+++ b/101-jenkins-master-on-ubuntu/README.md
@@ -44,7 +44,7 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
     RequestTTY no
   ```
 1. Create a jenkins-tunnel.sh file with the following content and give it execute permission using `chmod +x jenkins-tunnel.sh`
-  ```
+  ```bash
   #!/bin/bash
 
   socket=$HOME/.ssh/jenkins-tunnel.ctl

--- a/201-jenkins-to-azure-container-registry/README.md
+++ b/201-jenkins-to-azure-container-registry/README.md
@@ -14,8 +14,13 @@ You can optionally include a basic Jenkins pipeline that will checkout a user-pr
 ## A. Deploy an Azure Container Registry and a Jenkins VM with an embedded Docker build and publish pipeline
 1. Click the "Deploy to Azure" button. If you don't have an Azure subscription, you can follow instructions to signup for a free trial.
 1. Enter the desired user name and password for the VM that's going to host the Jenkins instance. Also provide a DNS prefix for your VM.
-1. Create a [service principal](https://docs.microsoft.com/azure/container-service/container-service-kubernetes-service-principal#create-a-service-principal-in-azure-active-directory).
-1. Fill in the service principal client id and secret. These will be used by the Jenkins pipeline to push the built docker container.
+1. Enter the appId and appKey for your Service Principal (used by the Jenkins pipeline to push the built docker container). If you don't have a service principal, use the [Azure CLI 2.0](https://docs.microsoft.com/cli/azure/install-azure-cli) to create one (see [here](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli?toc=%2fazure%2fazure-resource-manager%2ftoc.json) for more details):
+  ```bash
+  az login
+  az account set --subscription <Subscription ID>
+  az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/<Subscription ID>" --name "Spinnaker"
+  ```
+  > NOTE: You can run `az account list` after you login to get a list of subscription IDs for your account.
 1. Enter a public git repository. The repository must have a Dockerfile in its root.
 
 ## B. Setup SSH port forwarding
@@ -48,7 +53,7 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
     RequestTTY no
   ```
 1. Create a jenkins-tunnel.sh file with the following content and give it execute permission using `chmod +x jenkins-tunnel.sh`
-  ```
+  ```bash
   #!/bin/bash
 
   socket=$HOME/.ssh/jenkins-tunnel.ctl

--- a/201-jenkins-to-azure-container-registry/azuredeploy.json
+++ b/201-jenkins-to-azure-container-registry/azuredeploy.json
@@ -20,16 +20,16 @@
         "description": "Unique DNS Name for the Public IP used to access the Jenkins Virtual Machine."
       }
     },
-    "servicePrincipalClientId": {
+    "servicePrincipalAppId": {
       "type": "string",
       "metadata": {
-        "description": "Service Principal Client ID (also called App ID) used by Jenkins to push the docker image to Azure Container Registry."
+        "description": "Service Principal App ID (also called Client ID) used by Jenkins to push the docker image to Azure Container Registry."
       }
     },
-    "servicePrincipalClientSecret": {
+    "servicePrincipalAppKey": {
       "type": "securestring",
       "metadata": {
-        "description": "Service Principal secret used by Jenkins to push the docker image to Azure Container Registry."
+        "description": "Service Principal App Key used by Jenkins to push the docker image to Azure Container Registry."
       }
     },
     "gitRepository": {
@@ -54,7 +54,7 @@
     "virtualNetworkName": "[concat(variables('resourcePrefix'), 'VNET')]",
     "vmExtensionName": "initializeJenkins",
     "frontEndNSGName": "[concat(variables('resourcePrefix'), 'NSG')]",
-    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.6.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.7.0/",
     "_extensionScript": "201-jenkins-to-azure-container-registry.sh",
     "_artifactsLocationSasToken": ""
   },
@@ -261,7 +261,7 @@
           ]
         },
         "protectedSettings": {
-          "commandToExecute": "[concat('./' , variables('_extensionScript'),' -u \"', parameters('adminUsername') , '\" -g \"', parameters('gitRepository') , '\" -r \"https://',reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrName'))).loginServer, '\" -ru \"', parameters('servicePrincipalClientId'), '\" -rp \"', parameters('servicePrincipalClientSecret'), '\" -al \"', variables('_artifactsLocation'), '\" -st \"', variables('_artifactsLocationSasToken'), '\"' )]"
+          "commandToExecute": "[concat('./' , variables('_extensionScript'),' -u \"', parameters('adminUsername') , '\" -g \"', parameters('gitRepository') , '\" -r \"https://',reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrName'))).loginServer, '\" -ru \"', parameters('servicePrincipalAppId'), '\" -rp \"', parameters('servicePrincipalAppKey'), '\" -al \"', variables('_artifactsLocation'), '\" -st \"', variables('_artifactsLocationSasToken'), '\"' )]"
         }
       }
     }

--- a/201-jenkins-to-azure-container-registry/azuredeploy.parameters.json
+++ b/201-jenkins-to-azure-container-registry/azuredeploy.parameters.json
@@ -11,14 +11,14 @@
     "jenkinsDnsLabelPrefix": {
       "value": "GEN-UNIQUE"
     },
-    "servicePrincipalClientId": {
+    "servicePrincipalAppId": {
       "value": "GEN-UNIQUE-18"
     },
-    "servicePrincipalClientSecret": {
+    "servicePrincipalAppKey": {
       "value": "GEN-PASSWORD"
     },
     "gitRepository": {
       "value": ""
-    },
+    }
   }
 }

--- a/201-jenkins-to-azure-container-registry/metadata.json
+++ b/201-jenkins-to-azure-container-registry/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM and an Azure Container Registry. It also includes an optional ACR pipeline.",
   "summary": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM and an Azure Container Registry. It also includes an optional ACR pipeline.",
   "githubUsername": "clguimanMSFT",
-  "dateUpdated": "2017-03-29"
+  "dateUpdated": "2017-03-30"
 }

--- a/301-jenkins-acr-spinnaker-k8s/README.md
+++ b/301-jenkins-acr-spinnaker-k8s/README.md
@@ -15,8 +15,14 @@ The Jenkins instance will include a basic pipeline that checks out a user-provid
 
 ## A. Deploy
 1. Click the "Deploy to Azure" button. If you don't have an Azure subscription, you can follow instructions to signup for a free trial.
-2. Enter a valid name for the VM, as well as a user name and [ssh public key](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys) that you will use to login remotely to the VM via SSH.
-1. Create a [service principal](https://docs.microsoft.com/azure/container-service/container-service-kubernetes-service-principal#create-a-service-principal-in-azure-active-directory) and enter the client id and key. This will be used to login to your ACR and by your Kubernetes cluster to dynamically manage resources.
+1. Enter a valid name for the VM, as well as a user name and [ssh public key](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys) that you will use to login remotely to the VM via SSH.
+1. Enter the appId and appKey for your Service Principal (used to access your ACR and by your Kubernetes cluster to dynamically manage resources). If you don't have a service principal, use the [Azure CLI 2.0](https://docs.microsoft.com/cli/azure/install-azure-cli) to create one (see [here](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli?toc=%2fazure%2fazure-resource-manager%2ftoc.json) for more details):
+  ```bash
+  az login
+  az account set --subscription <Subscription ID>
+  az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/<Subscription ID>" --name "Spinnaker"
+  ```
+  > NOTE: You can run `az account list` after you login to get a list of subscription IDs for your account.
 1. Leave the git repository as the [sample app](https://github.com/lwander/spin-kub-demo) or change it to target your own app's repository. The repo must have a Dockerfile in its root.
 1. Leave the docker repository as the sample name or change it to the name you desire. A repo with this name will be created in your ACR.
 
@@ -58,7 +64,7 @@ You need to setup port forwarding to view the Jenkins and Spinnaker UI on your l
     RequestTTY no
   ```
 1. Create a devops-tunnel.sh file with the following content and give it execute permission using `chmod +x devops-tunnel.sh`
-  ```
+  ```bash
   #!/bin/bash
 
   socket=$HOME/.ssh/devops-tunnel.ctl

--- a/301-jenkins-acr-spinnaker-k8s/azuredeploy.json
+++ b/301-jenkins-acr-spinnaker-k8s/azuredeploy.json
@@ -20,16 +20,16 @@
         "description": "Unique DNS Name for the Public IP used to access the combined Jenkins and Spinnaker Virtual Machine."
       }
     },
-    "servicePrincipalClientId": {
+    "servicePrincipalAppId": {
       "type": "string",
       "metadata": {
-        "description": "Service Principal Client ID (also called App ID) that has owner rights to the subscription used for this deployment. It is used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
+        "description": "Service Principal App ID (also called Client ID) that has contributor rights to the subscription used for this deployment. It is used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
       }
     },
-    "servicePrincipalClientSecret": {
+    "servicePrincipalAppKey": {
       "type": "securestring",
       "metadata": {
-        "description": "Service Principal secret that has owner rights to the subscription used for this deployment. It is used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
+        "description": "Service Principal App Key that has contributor rights to the subscription used for this deployment. It is used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
       }
     },
     "gitRepository": {
@@ -65,7 +65,7 @@
     "kubernetesMasterCount": 1,
     "kubernetesDnsLabelPrefix": "[concat('k8s', uniquestring(resourceGroup().id))]",
     "pipelinePort": "8000",
-    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.5.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.7.0/",
     "_extensionScript": "301-jenkins-acr-spinnaker-k8s.sh",
     "_artifactsLocationSasToken": ""
   },
@@ -294,8 +294,8 @@
           }
         },
         "servicePrincipalProfile": {
-          "ClientId": "[parameters('servicePrincipalClientId')]",
-          "Secret": "[parameters('servicePrincipalClientSecret')]"
+          "ClientId": "[parameters('servicePrincipalAppId')]",
+          "Secret": "[parameters('servicePrincipalAppKey')]"
         }
       }
     },
@@ -320,7 +320,7 @@
           ]
         },
         "protectedSettings": {
-          "commandToExecute": "[concat('./', variables('_extensionScript'), ' -ci \"', parameters('servicePrincipalClientId'), '\" -ck \"', parameters('servicePrincipalClientSecret'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -un \"', parameters('adminUsername'), '\" -gr \"', parameters('gitRepository') , '\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -mc \"', variables('kubernetesMasterCount'), '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value, '\" -acr \"', reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrName'))).loginServer, '\" -dr \"', parameters('dockerRepository') , '\" -pp \"', variables('pipelinePort'), '\" -al \"', variables('_artifactsLocation'), '\" -st \"', variables('_artifactsLocationSasToken'), '\"')]"
+          "commandToExecute": "[concat('./', variables('_extensionScript'), ' -ai \"', parameters('servicePrincipalAppId'), '\" -ak \"', parameters('servicePrincipalAppKey'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -un \"', parameters('adminUsername'), '\" -gr \"', parameters('gitRepository') , '\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -mc \"', variables('kubernetesMasterCount'), '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value, '\" -acr \"', reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrName'))).loginServer, '\" -dr \"', parameters('dockerRepository') , '\" -pp \"', variables('pipelinePort'), '\" -al \"', variables('_artifactsLocation'), '\" -st \"', variables('_artifactsLocationSasToken'), '\"')]"
         }
       }
     }

--- a/301-jenkins-acr-spinnaker-k8s/azuredeploy.parameters.json
+++ b/301-jenkins-acr-spinnaker-k8s/azuredeploy.parameters.json
@@ -11,10 +11,10 @@
     "dnsLabelPrefix": {
       "value": "GEN-UNIQUE"
     },
-    "servicePrincipalClientId": {
+    "servicePrincipalAppId": {
       "value": "GEN-UNIQUE-18"
     },
-    "servicePrincipalClientSecret": {
+    "servicePrincipalAppKey": {
       "value": "GEN-PASSWORD"
     }
   }

--- a/301-jenkins-acr-spinnaker-k8s/metadata.json
+++ b/301-jenkins-acr-spinnaker-k8s/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy and configure a DevOps pipeline from an Azure Container Registry to a Kubernetes cluster. It deploys an instance of Jenkins and Spinnaker on a D3_v2 size Linux Ubuntu 14.04 LTS VM.",
   "summary": "This template allows you to deploy and configure a DevOps pipeline from an Azure Container Registry to a Kubernetes cluster. It deploys an instance of Jenkins and Spinnaker on a D3_v2 size Linux Ubuntu 14.04 LTS VM.",
   "githubUsername": "EricJizbaMSFT",
-  "dateUpdated": "2017-03-17"
+  "dateUpdated": "2017-03-30"
 }

--- a/azure-jenkins/README.md
+++ b/azure-jenkins/README.md
@@ -44,7 +44,7 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
     RequestTTY no
   ```
 1. Create a jenkins-tunnel.sh file with the following content and give it execute permission using `chmod +x jenkins-tunnel.sh`
-  ```
+  ```bash
   #!/bin/bash
 
   socket=$HOME/.ssh/jenkins-tunnel.ctl

--- a/spinnaker-vm-simple/README.md
+++ b/spinnaker-vm-simple/README.md
@@ -54,7 +54,7 @@ Once you have configured Spinnaker, you need to setup port forwarding to view th
     RequestTTY no
   ```
 2. Create a spinnaker-tunnel.sh file with the following content and give it execute permission using `chmod +x spinnaker-tunnel.sh`
-  ```
+  ```bash
   #!/bin/bash
 
   socket=$HOME/.ssh/spinnaker-tunnel.ctl

--- a/spinnaker-vm-to-kubernetes/README.md
+++ b/spinnaker-vm-to-kubernetes/README.md
@@ -14,7 +14,13 @@ This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14
 ## A. Deploy Spinnaker VM
 1. Click the "Deploy to Azure" button. If you don't have an Azure subscription, you can follow instructions to signup for a free trial.
 1. Enter a valid name for the Spinnaker VM, a user name, and a [ssh public key](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys) that you will use to login remotely to both.
-1. Create a [service principal](https://docs.microsoft.com/azure/container-service/container-service-kubernetes-service-principal#create-a-service-principal-in-azure-active-directory) for your Kubernetes cluster and enter the client id and key.
+1. Enter the appId and appKey for your Service Principal (used to access your ACR and by your Kubernetes cluster to dynamically manage resources). If you don't have a service principal, use the [Azure CLI 2.0](https://docs.microsoft.com/cli/azure/install-azure-cli) to create one (see [here](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli?toc=%2fazure%2fazure-resource-manager%2ftoc.json) for more details):
+  ```bash
+  az login
+  az account set --subscription <Subscription ID>
+  az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/<Subscription ID>" --name "Spinnaker"
+  ```
+  > NOTE: You can run `az account list` after you login to get a list of subscription IDs for your account.
 
 ## B. Setup SSH port forwarding
 You need to setup port forwarding to view the Spinnaker UI on your local machine.
@@ -51,7 +57,7 @@ You need to setup port forwarding to view the Spinnaker UI on your local machine
     RequestTTY no
   ```
 1. Create a spinnaker-tunnel.sh file with the following content and give it execute permission using `chmod +x spinnaker-tunnel.sh`
-  ```
+  ```bash
   #!/bin/bash
 
   socket=$HOME/.ssh/spinnaker-tunnel.ctl

--- a/spinnaker-vm-to-kubernetes/azuredeploy.json
+++ b/spinnaker-vm-to-kubernetes/azuredeploy.json
@@ -20,16 +20,16 @@
         "description": "Unique DNS Name for the Public IP used to access the Spinnaker Virtual Machine."
       }
     },
-    "servicePrincipalClientId": {
+    "servicePrincipalAppId": {
       "type": "string",
       "metadata": {
-        "description": "Service Principal Client ID (also called App ID) that has owner rights to the subscription used for this deployment. It is used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
+        "description": "Service Principal App ID (also called Client ID) that has contributor rights to the subscription used for this deployment. It is used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
       }
     },
-    "servicePrincipalClientSecret": {
+    "servicePrincipalAppKey": {
       "type": "securestring",
       "metadata": {
-        "description": "Service Principal secret that has owner rights to the subscription used for this deployment. It is used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
+        "description": "Service Principal App Key that has contributor rights to the subscription used for this deployment. It is used by the Kubernetes cluster to dynamically manage resources (e.g. user-defined load balancers)."
       }
     },
     "kubernetesPipeline": {
@@ -79,7 +79,7 @@
     "acrStorageAccountName": "[concat('registry', uniquestring(resourceGroup().id))]",
     "kubernetesDnsLabelPrefix": "[concat('k8s', uniquestring(resourceGroup().id))]",
     "pipelinePort": "8000",
-    "_artifactsLocation": "https://raw.githubusercontent.com/azure/azure-devops-utils/v0.1.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/azure/azure-devops-utils/v0.7.0/",
     "_artifactsLocationSasToken": ""
   },
   "resources": [
@@ -115,8 +115,8 @@
           }
         },
         "servicePrincipalProfile": {
-          "ClientId": "[parameters('servicePrincipalClientId')]",
-          "Secret": "[parameters('servicePrincipalClientSecret')]"
+          "ClientId": "[parameters('servicePrincipalAppId')]",
+          "Secret": "[parameters('servicePrincipalAppKey')]"
         }
       }
     },
@@ -306,7 +306,7 @@
           ]
         },
         "protectedSettings": {
-          "commandToExecute": "[concat('./spinnaker_vm_to_kubernetes.sh', ' -ci \"', parameters('servicePrincipalClientId'), '\" -ck \"', parameters('servicePrincipalClientSecret'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -un \"', parameters('adminUsername'), '\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -mc \"', variables('kubernetesMasterCount'), '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value, '\" -acr \"', reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrPrefix'))).loginServer, '\" -ikp $(expr \"', parameters('kubernetesPipeline'), '\" == \"Include\") -prg \"', parameters('pipelineRegistry'), '\" -prp \"', parameters('pipelineRepository'), '\" -pp \"', variables('pipelinePort'), '\" -al \"', variables('_artifactsLocation'), '\" -st \"', variables('_artifactsLocationSasToken'), '\"')]"
+          "commandToExecute": "[concat('./spinnaker_vm_to_kubernetes.sh', ' -ai \"', parameters('servicePrincipalAppId'), '\" -ak \"', parameters('servicePrincipalAppKey'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -un \"', parameters('adminUsername'), '\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -mc \"', variables('kubernetesMasterCount'), '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value, '\" -acr \"', reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrPrefix'))).loginServer, '\" -ikp $(expr \"', parameters('kubernetesPipeline'), '\" == \"Include\") -prg \"', parameters('pipelineRegistry'), '\" -prp \"', parameters('pipelineRepository'), '\" -pp \"', variables('pipelinePort'), '\" -al \"', variables('_artifactsLocation'), '\" -st \"', variables('_artifactsLocationSasToken'), '\"')]"
         }
       }
     }

--- a/spinnaker-vm-to-kubernetes/azuredeploy.parameters.json
+++ b/spinnaker-vm-to-kubernetes/azuredeploy.parameters.json
@@ -11,10 +11,10 @@
     "spinnakerDnsLabelPrefix": {
       "value": "GEN-UNIQUE"
     },
-    "servicePrincipalClientId": {
+    "servicePrincipalAppId": {
       "value": "GEN-UNIQUE-18"
     },
-    "servicePrincipalClientSecret": {
+    "servicePrincipalAppKey": {
       "value": "GEN-PASSWORD"
     }
   }

--- a/spinnaker-vm-to-kubernetes/metadata.json
+++ b/spinnaker-vm-to-kubernetes/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM automatically configured to target a Kubernetes cluster. This will deploy a D3_v2 size VM and a Kubernetes cluster in the resource group location and return the FQDN of both. It will also create an Azure Container Registry and return the full registry name.",
   "summary": "This template deploys an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM, targeting Kubernetes.",
   "githubUsername": "EricJizbaMSFT",
-  "dateUpdated": "2017-03-09"
+  "dateUpdated": "2017-03-30"
 }


### PR DESCRIPTION
Explicitly describe steps for using the cli 2.0 and update to use 'app' rather than 'client' since that's what the cli and AAD stuff in the portal uses

I also tested/verified we only need contributor rights (not owner rights) for our scenarios.