### PR TITLE
Update ssh port forwarding instructions if using a password

### DIFF
--- a/101-jenkins/README.md
+++ b/101-jenkins/README.md
@@ -30,7 +30,6 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
     ```
     Host jenkins-start
       HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
       ControlMaster yes
       ControlPath ~/.ssh/jenkins-tunnel.ctl
       RequestTTY no
@@ -39,7 +38,6 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
 
     Host jenkins-stop
       HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
       ControlPath ~/.ssh/jenkins-tunnel.ctl
       RequestTTY no
     ```

--- a/201-jenkins-acr/README.md
+++ b/201-jenkins-acr/README.md
@@ -39,7 +39,6 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
     ```
     Host jenkins-start
       HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
       ControlMaster yes
       ControlPath ~/.ssh/jenkins-tunnel.ctl
       RequestTTY no
@@ -48,7 +47,6 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
 
     Host jenkins-stop
       HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
       ControlPath ~/.ssh/jenkins-tunnel.ctl
       RequestTTY no
     ```

--- a/azure-jenkins/README.md
+++ b/azure-jenkins/README.md
@@ -30,7 +30,6 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
     ```
     Host jenkins-start
       HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
       ControlMaster yes
       ControlPath ~/.ssh/jenkins-tunnel.ctl
       RequestTTY no
@@ -39,7 +38,6 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
 
     Host jenkins-stop
       HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
       ControlPath ~/.ssh/jenkins-tunnel.ctl
       RequestTTY no
     ```


### PR DESCRIPTION
The templates that use a password shouldn't ask for a key file when doing ssh port forwarding