### PR TITLE
Update to GA ACR for devops templates

### DIFF
--- a/201-jenkins-acr/azuredeploy.json
+++ b/201-jenkins-acr/azuredeploy.json
@@ -94,10 +94,13 @@
       "name": "[variables('acrName')]",
       "type": "Microsoft.ContainerRegistry/registries",
       "location": "[resourceGroup().location]",
-      "apiVersion": "2016-06-27-preview",
+      "apiVersion": "2017-03-01",
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts', variables('acrStorageAccountName'))]"
       ],
+      "sku": {
+        "name": "Basic"
+      },
       "properties": {
         "adminUserEnabled": false,
         "storageAccount": {

--- a/201-jenkins-acr/metadata.json
+++ b/201-jenkins-acr/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM and an Azure Container Registry. It also includes an optional ACR pipeline.",
   "summary": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM and an Azure Container Registry. It also includes an optional ACR pipeline.",
   "githubUsername": "clguimanMSFT",
-  "dateUpdated": "2017-04-14"
+  "dateUpdated": "2017-04-18"
 }

--- a/201-spinnaker-acr-k8s/azuredeploy.json
+++ b/201-spinnaker-acr-k8s/azuredeploy.json
@@ -274,10 +274,13 @@
       "name": "[variables('acrPrefix')]",
       "type": "Microsoft.ContainerRegistry/registries",
       "location": "[resourceGroup().location]",
-      "apiVersion": "2016-06-27-preview",
+      "apiVersion": "2017-03-01",
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts', variables('acrStorageAccountName'))]"
       ],
+      "sku": {
+        "name": "Basic"
+      },
       "properties": {
         "adminUserEnabled": false,
         "storageAccount": {

--- a/201-spinnaker-acr-k8s/metadata.json
+++ b/201-spinnaker-acr-k8s/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM automatically configured to target a Kubernetes cluster. This will deploy a D3_v2 size VM and a Kubernetes cluster in the resource group location and return the FQDN of both. It will also create an Azure Container Registry and return the full registry name.",
   "summary": "This template deploys an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM, targeting Kubernetes.",
   "githubUsername": "EricJizbaMSFT",
-  "dateUpdated": "2017-04-03"
+  "dateUpdated": "2017-04-18"
 }

--- a/301-jenkins-acr-spinnaker-k8s/azuredeploy.json
+++ b/301-jenkins-acr-spinnaker-k8s/azuredeploy.json
@@ -105,10 +105,13 @@
       "name": "[variables('acrName')]",
       "type": "Microsoft.ContainerRegistry/registries",
       "location": "[resourceGroup().location]",
-      "apiVersion": "2016-06-27-preview",
+      "apiVersion": "2017-03-01",
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts', variables('acrStorageAccountName'))]"
       ],
+      "sku": {
+        "name": "Basic"
+      },
       "properties": {
         "adminUserEnabled": false,
         "storageAccount": {

--- a/301-jenkins-acr-spinnaker-k8s/metadata.json
+++ b/301-jenkins-acr-spinnaker-k8s/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy and configure a DevOps pipeline from an Azure Container Registry to a Kubernetes cluster. It deploys an instance of Jenkins and Spinnaker on a D3_v2 size Linux Ubuntu 14.04 LTS VM.",
   "summary": "This template allows you to deploy and configure a DevOps pipeline from an Azure Container Registry to a Kubernetes cluster. It deploys an instance of Jenkins and Spinnaker on a D3_v2 size Linux Ubuntu 14.04 LTS VM.",
   "githubUsername": "EricJizbaMSFT",
-  "dateUpdated": "2017-04-14"
+  "dateUpdated": "2017-04-18"
 }


### PR DESCRIPTION
Original PR by @mekenthompson here: https://github.com/Azure/azure-quickstart-templates/pull/3316, but he had some issues with rebasing/formatting. I've applied the original commit to all three of our templates that use ACR. Thanks for the contribution Ken! (I've listed you as the author for this commit)