### PR TITLE
Standardize devops template ssh commands

### DIFF
--- a/101-jenkins-with-SSH-public-key/README.md
+++ b/101-jenkins-with-SSH-public-key/README.md
@@ -20,9 +20,17 @@ This template allows you to host an instance of Jenkins on a DS1_v2 size Linux U
 You need to setup port forwarding to view the Jenkins UI on your local machine.
 
 ### If you are using Windows:
-1. Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+
+Run this command:
+```
+putty.exe -ssh -L 8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
+```
+
+Or follow these manual steps:
 1. Launch Putty and navigate to 'Connection > SSH > Tunnels'
 1. In the Options controlling SSH port forwarding window, enter 8080 for Source port. Then enter 127.0.0.1:8080 for the Destination. Click Add.
+1. Navigate to 'Connection > SSH > Auth' and enter your private key file for authentication. For more information on using ssh keys with Putty, see [here](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-ssh-from-windows#create-a-private-key-for-putty).
 1. Click Open to establish the connection.
 
 ### If you are using Linux or Mac:

--- a/101-jenkins-with-SSH-public-key/README.md
+++ b/101-jenkins-with-SSH-public-key/README.md
@@ -27,8 +27,8 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
 
 ### If you are using Linux or Mac:
 Run this command:
-```
-  ssh -L 127.0.0.1:8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
+```bash
+ssh -L 8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
 ```
 ## C. Connect to Jenkins
 

--- a/101-jenkins-with-SSH-public-key/azuredeploy.json
+++ b/101-jenkins-with-SSH-public-key/azuredeploy.json
@@ -242,7 +242,7 @@
     },
     "SSH": {
       "type": "string",
-      "value": "[concat('ssh -L 127.0.0.1:8080:localhost:8080 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+      "value": "[concat('ssh -L 8080:localhost:8080 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
     }
   }
 }

--- a/101-jenkins-with-SSH-public-key/metadata.json
+++ b/101-jenkins-with-SSH-public-key/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy a secure Jenkins instance on a DS1_v2 size Linux Ubuntu 14.04 LTS VM using an SSH public key for authentication.",
   "summary": "This template allows you to deploy a secure Jenkins instance on a DS1_v2 size Linux Ubuntu 14.04 LTS VM using an SSH public key for authentication.",
   "githubUsername": "clguimanMSFT",
-  "dateUpdated": "2017-04-14"
+  "dateUpdated": "2017-04-19"
 }

--- a/101-jenkins/README.md
+++ b/101-jenkins/README.md
@@ -20,7 +20,14 @@ This template allows you to host an instance of Jenkins on a DS1_v2 size Linux U
 You need to setup port forwarding to view the Jenkins UI on your local machine.
 
 ### If you are using Windows:
-1. Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+
+Run this command:
+```
+putty.exe -ssh -L 8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
+```
+
+Or follow these manual steps:
 1. Launch Putty and navigate to 'Connection > SSH > Tunnels'
 1. In the Options controlling SSH port forwarding window, enter 8080 for Source port. Then enter 127.0.0.1:8080 for the Destination. Click Add.
 1. Click Open to establish the connection.

--- a/101-jenkins/README.md
+++ b/101-jenkins/README.md
@@ -27,8 +27,8 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
 
 ### If you are using Linux or Mac:
 Run this command:
-```
-  ssh -L 127.0.0.1:8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
+```bash
+ssh -L 8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
 ```
 
 ## C. Connect to Jenkins

--- a/101-jenkins/azuredeploy.json
+++ b/101-jenkins/azuredeploy.json
@@ -232,7 +232,7 @@
     },
     "SSH": {
       "type": "string",
-      "value": "[concat('ssh -L 127.0.0.1:8080:localhost:8080 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+      "value": "[concat('ssh -L 8080:localhost:8080 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
     }
   }
 }

--- a/101-jenkins/metadata.json
+++ b/101-jenkins/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy a secure Jenkins instance on a DS1_v2 size Linux Ubuntu 14.04 LTS VM.",
   "summary": "This template allows you to deploy a secure Jenkins instance on a DS1_v2 size Linux Ubuntu 14.04 LTS VM.",
   "githubUsername": "clguimanMSFT",
-  "dateUpdated": "2017-04-14"
+  "dateUpdated": "2017-04-19"
 }

--- a/101-spinnaker/README.md
+++ b/101-spinnaker/README.md
@@ -33,52 +33,11 @@ Once you have configured Spinnaker, you need to setup port forwarding to view th
 4. Click Open to establish the connection.
 
 ### If you are using Linux or Mac:
-1. Add this to your ~/.ssh/config
-    ```
-    Host spinnaker-start
-      HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
-      ControlMaster yes
-      ControlPath ~/.ssh/spinnaker-tunnel.ctl
-      RequestTTY no
-      # Spinnaker/deck
-      LocalForward 9000 127.0.0.1:9000
-      # Spinnaker/gate
-      LocalForward 8084 127.0.0.1:8084
-      User <User name>
-
-    Host spinnaker-stop
-      HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
-      ControlPath ~/.ssh/spinnaker-tunnel.ctl
-      RequestTTY no
-    ```
-2. Create a spinnaker-tunnel.sh file with the following content and give it execute permission using `chmod +x spinnaker-tunnel.sh`
-    ```bash
-    #!/bin/bash
-
-    socket=$HOME/.ssh/spinnaker-tunnel.ctl
-
-    if [ "$1" == "start" ]; then
-      if [ ! \( -e ${socket} \) ]; then
-        echo "Starting tunnel to Spinnaker..."
-        ssh -f -N spinnaker-start && echo "Done."
-      else
-        echo "Tunnel to Spinnaker running."
-      fi
-    fi
-
-    if [ "$1" == "stop" ]; then
-      if [ \( -e ${socket} \) ]; then
-        echo "Stopping tunnel to Spinnaker..."
-        ssh -O "exit" spinnaker-stop && echo "Done."
-      else
-        echo "Tunnel to Spinnaker stopped."
-      fi
-    fi
-    ```
-3. Call `./spinnaker-tunnel.sh start` to start your tunnel
-4. Call `./spinnaker-tunnel.sh stop` to stop your tunnel
+Run this command:
+```bash
+ssh -L 9000:localhost:9000 -L 8084:localhost:8084 <User name>@<Public DNS name of instance you just created>
+```
+> NOTE: Port 9000 and 8084 correspond to Spinnaker's deck and gate services, respectively.
 
 ## E. Connect to Spinnaker
 

--- a/101-spinnaker/README.md
+++ b/101-spinnaker/README.md
@@ -11,7 +11,7 @@ This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14
 
 ## A. Deploy Spinnaker VM
 1. Click the "Deploy to Azure" button. If you don't have an Azure subscription, you can follow instructions to signup for a free trial.
-2. Enter a valid name for the VM, as well as a user name and [ssh public key](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys) that you will use to login remotely to the VM via SSH.
+1. Enter a valid name for the VM, as well as a user name and [ssh public key](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-mac-create-ssh-keys) that you will use to login remotely to the VM via SSH.
 
 ## B. Login remotely to the VM via SSH
 Once the VM has been deployed, note down the DNS Name generated in the Azure portal for the VM. To login:
@@ -27,10 +27,19 @@ In Azure, Spinnaker can target a Kubernetes cluster or VM Scale Sets.
 Once you have configured Spinnaker, you need to setup port forwarding to view the Spinnaker UI on your local machine.
 
 ### If you are using Windows:
+Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+
+Run this command:
+```
+putty.exe -ssh -L 9000:localhost:9000 -L 8084:localhost:8084 <User name>@<Public DNS name of instance you just created>
+```
+
+Or follow these manual steps:
 1. Launch Putty and navigate to Change Settings > SSH > Tunnels
-2. In the Options controlling SSH port forwarding window, enter 8084 for Source port. Then enter 127.0.0.1:8084 for the Destination. Click Add.
-3. Repeat this process for port 9000
-4. Click Open to establish the connection.
+1. In the Options controlling SSH port forwarding window, enter 8084 for Source port. Then enter 127.0.0.1:8084 for the Destination. Click Add.
+1. Repeat this process for port 9000
+1. Navigate to 'Connection > SSH > Auth' and enter your private key file for authentication. For more information on using ssh keys with Putty, see [here](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-ssh-from-windows#create-a-private-key-for-putty).
+1. Click Open to establish the connection.
 
 ### If you are using Linux or Mac:
 Run this command:
@@ -42,6 +51,6 @@ ssh -L 9000:localhost:9000 -L 8084:localhost:8084 <User name>@<Public DNS name o
 ## E. Connect to Spinnaker
 
 1. After you have started your tunnel, navigate to `http://localhost:9000/` on your local machine.
-2. Check the [Troubleshooting Guide](http://www.spinnaker.io/docs/troubleshooting-guide) if you have any issues.
+1. Check the [Troubleshooting Guide](http://www.spinnaker.io/docs/troubleshooting-guide) if you have any issues.
 
 ## Questions/Comments? azdevopspub@microsoft.com

--- a/101-spinnaker/azuredeploy.json
+++ b/101-spinnaker/azuredeploy.json
@@ -193,9 +193,9 @@
       "type": "string",
       "value": "[reference(variables('publicIPAddressName')).dnsSettings.fqdn]"
     },
-    "sshCommand": {
+    "SSH": {
       "type": "string",
-      "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+      "value": "[concat('ssh -L 9000:localhost:9000 -L 8084:localhost:8084 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
     }
   }
 }

--- a/101-spinnaker/metadata.json
+++ b/101-spinnaker/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM. This will deploy a D3_v2 size VM in the resource group location and return the FQDN of the VM. You will have to manually configure the instance to target a deployment environment.",
   "summary": "This template deploys an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM, with no configuration.",
   "githubUsername": "EricJizbaMSFT",
-  "dateUpdated": "2017-04-03"
+  "dateUpdated": "2017-04-19"
 }

--- a/201-jenkins-acr/README.md
+++ b/201-jenkins-acr/README.md
@@ -29,7 +29,14 @@ You can optionally include a basic Jenkins pipeline that will checkout a user-pr
 You need to setup port forwarding to view the Jenkins UI on your local machine.
 
 ### If you are using Windows:
-1. Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+
+Run this command:
+```
+putty.exe -ssh -L 8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
+```
+
+Or follow these manual steps:
 1. Launch Putty and navigate to 'Connection > SSH > Tunnels'
 1. In the Options controlling SSH port forwarding window, enter 8080 for Source port. Then enter 127.0.0.1:8080 for the Destination. Click Add.
 1. Click Open to establish the connection.

--- a/201-jenkins-acr/README.md
+++ b/201-jenkins-acr/README.md
@@ -36,8 +36,8 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
 
 ### If you are using Linux or Mac:
 Run this command:
-```
-  ssh -L 127.0.0.1:8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
+```bash
+ssh -L 8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
 ```
 
 ## C. Connect to Jenkins

--- a/201-jenkins-acr/azuredeploy.json
+++ b/201-jenkins-acr/azuredeploy.json
@@ -290,7 +290,7 @@
     },
     "SSH": {
       "type": "string",
-      "value": "[concat('ssh -L 127.0.0.1:8080:localhost:8080 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+      "value": "[concat('ssh -L 8080:localhost:8080 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
     },
     "azureContainerRegistryUrl": {
       "type": "string",

--- a/201-spinnaker-acr-k8s/README.md
+++ b/201-spinnaker-acr-k8s/README.md
@@ -26,7 +26,14 @@ This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14
 You need to setup port forwarding to view the Spinnaker UI on your local machine.
 
 ### If you are using Windows:
-1. Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+
+Run this command:
+```
+putty.exe -ssh -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8001:localhost:8001 <User name>@<Public DNS name of instance you just created>
+```
+
+Or follow these manual steps:
 1. Launch Putty and navigate to 'Connection > SSH > Tunnels'
 1. In the Options controlling SSH port forwarding window, enter 8084 for Source port. Then enter 127.0.0.1:8084 for the Destination. Click Add.
 1. Repeat this process for port 9000 and 8001.

--- a/201-spinnaker-acr-k8s/README.md
+++ b/201-spinnaker-acr-k8s/README.md
@@ -29,59 +29,16 @@ You need to setup port forwarding to view the Spinnaker UI on your local machine
 1. Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
 1. Launch Putty and navigate to 'Connection > SSH > Tunnels'
 1. In the Options controlling SSH port forwarding window, enter 8084 for Source port. Then enter 127.0.0.1:8084 for the Destination. Click Add.
-1. Repeat this process for ports: 8087 and 9000.
+1. Repeat this process for port 9000 and 8001.
 1. Navigate to 'Connection > SSH > Auth' and enter your private key file for authentication. For more information on using ssh keys with Putty, see [here](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-ssh-from-windows#create-a-private-key-for-putty).
 1. Click Open to establish the connection.
 
 ### If you are using Linux or Mac:
-1. Add this to your ~/.ssh/config
-    ```
-    Host spinnaker-start
-      HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
-      ControlMaster yes
-      ControlPath ~/.ssh/spinnaker-tunnel.ctl
-      RequestTTY no
-      # Spinnaker/deck
-      LocalForward 9000 127.0.0.1:9000
-      # Spinnaker/gate
-      LocalForward 8084 127.0.0.1:8084
-      # Default port if running 'kubectl proxy' on Spinnaker VM
-      LocalForward 8001 127.0.0.1:8001
-      User <User name>
-
-    Host spinnaker-stop
-      HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
-      ControlPath ~/.ssh/spinnaker-tunnel.ctl
-      RequestTTY no
-    ```
-1. Create a spinnaker-tunnel.sh file with the following content and give it execute permission using `chmod +x spinnaker-tunnel.sh`
-    ```bash
-    #!/bin/bash
-
-    socket=$HOME/.ssh/spinnaker-tunnel.ctl
-
-    if [ "$1" == "start" ]; then
-      if [ ! \( -e ${socket} \) ]; then
-        echo "Starting tunnel to Spinnaker..."
-        ssh -f -N spinnaker-start && echo "Done."
-      else
-        echo "Tunnel to Spinnaker running."
-      fi
-    fi
-
-    if [ "$1" == "stop" ]; then
-      if [ \( -e ${socket} \) ]; then
-        echo "Stopping tunnel to Spinnaker..."
-        ssh -O "exit" spinnaker-stop && echo "Done."
-      else
-        echo "Tunnel to Spinnaker stopped."
-      fi
-    fi
-    ```
-1. Call `./spinnaker-tunnel.sh start` to start your tunnel
-1. Call `./spinnaker-tunnel.sh stop` to stop your tunnel
+Run this command:
+```bash
+ssh -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8001:localhost:8001 <User name>@<Public DNS name of instance you just created>
+```
+> NOTE: Port 9000 and 8084 correspond to Spinnaker's deck and gate services, respectively. Port 8001 is used to view the dashboard for your Kubernetes cluster - just run `kubectl proxy` on the VM before navigating to http://localhost:8001 on your local machine.
 
 ## C. Connect to Spinnaker
 

--- a/201-spinnaker-acr-k8s/azuredeploy.json
+++ b/201-spinnaker-acr-k8s/azuredeploy.json
@@ -320,9 +320,9 @@
       "type": "string",
       "value": "[reference(variables('publicIPAddressName')).dnsSettings.fqdn]"
     },
-    "spinnakerSsh": {
+    "SSH": {
       "type": "string",
-      "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+      "value": "[concat('ssh -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8001:localhost:8001 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
     },
     "kubernetesMasterFQDN": {
       "type": "string",

--- a/301-jenkins-acr-spinnaker-k8s/README.md
+++ b/301-jenkins-acr-spinnaker-k8s/README.md
@@ -32,6 +32,21 @@ The Jenkins instance will include a basic pipeline that checks out a user-provid
 You need to setup port forwarding to view the Jenkins and Spinnaker UI on your local machine.
 
 ### If you are using Windows:
+Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+
+Run this command:
+```
+putty.exe -ssh -L 8080:localhost:8080 -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8001:localhost:8001 <User name>@<Public DNS name of instance you just created>
+```
+
+Or follow these manual steps:
+1. Launch Putty and navigate to 'Connection > SSH > Tunnels'
+1. In the Options controlling SSH port forwarding window, enter 8084 for Source port. Then enter 127.0.0.1:8084 for the Destination. Click Add.
+1. Repeat this process for port 8080, 9000 and 8001.
+1. Navigate to 'Connection > SSH > Auth' and enter your private key file for authentication. For more information on using ssh keys with Putty, see [here](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-linux-ssh-from-windows#create-a-private-key-for-putty).
+1. Click Open to establish the connection.
+
+### If you are using Linux or Mac:
 Run this command:
 ```bash
 ssh -L 8080:localhost:8080 -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8001:localhost:8001 <User name>@<Public DNS name of instance you just created>

--- a/301-jenkins-acr-spinnaker-k8s/README.md
+++ b/301-jenkins-acr-spinnaker-k8s/README.md
@@ -33,9 +33,10 @@ You need to setup port forwarding to view the Jenkins and Spinnaker UI on your l
 
 ### If you are using Windows:
 Run this command:
+```bash
+ssh -L 8080:localhost:8080 -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8001:localhost:8001 <User name>@<Public DNS name of instance you just created>
 ```
-  ssh -L 127.0.0.1:8080:localhost:8080 -L 127.0.0.1:9000:localhost:9000 -L 127.0.0.1:8084:localhost:8084 -L 127.0.0.1:8001:localhost:8001 <User name>@<Public DNS name of instance you just created>
-```
+> NOTE: Port 8080 corresponds to your Jenkins instance. Port 9000 and 8084 correspond to Spinnaker's deck and gate services, respectively. Port 8001 is used to view the dashboard for your Kubernetes cluster - just run `kubectl proxy` on the VM before navigating to http://localhost:8001 on your local machine.
 
 ## D. Connect to Jenkins
 

--- a/301-jenkins-acr-spinnaker-k8s/azuredeploy.json
+++ b/301-jenkins-acr-spinnaker-k8s/azuredeploy.json
@@ -353,7 +353,7 @@
     },
     "SSH": {
       "type": "string",
-      "value": "[concat('ssh -L 127.0.0.1:8080:localhost:8080 -L 127.0.0.1:9000:localhost:9000 -L 127.0.0.1:8084:localhost:8084 -L 127.0.0.1:8001:localhost:8001 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+      "value": "[concat('ssh -L 8080:localhost:8080 -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8001:localhost:8001 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
     },
     "azureContainerRegistryUrl": {
       "type": "string",

--- a/azure-jenkins/README.md
+++ b/azure-jenkins/README.md
@@ -20,7 +20,14 @@ This template allows you to create an instance of Azure Jenkins. Azure Jenkins i
 You need to setup port forwarding to view the Jenkins UI on your local machine.
 
 ### If you are using Windows:
-1. Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+
+Run this command:
+```
+putty.exe -ssh -L 8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
+```
+
+Or follow these manual steps:
 1. Launch Putty and navigate to 'Connection > SSH > Tunnels'
 1. In the Options controlling SSH port forwarding window, enter 8080 for Source port. Then enter 127.0.0.1:8080 for the Destination. Click Add.
 1. Click Open to establish the connection.

--- a/azure-jenkins/README.md
+++ b/azure-jenkins/README.md
@@ -26,47 +26,10 @@ You need to setup port forwarding to view the Jenkins UI on your local machine.
 1. Click Open to establish the connection.
 
 ### If you are using Linux or Mac:
-1. Add this to your ~/.ssh/config
-    ```
-    Host jenkins-start
-      HostName <Public DNS name of instance you just created>
-      ControlMaster yes
-      ControlPath ~/.ssh/jenkins-tunnel.ctl
-      RequestTTY no
-      LocalForward 8080 127.0.0.1:8080
-      User <User name>
-
-    Host jenkins-stop
-      HostName <Public DNS name of instance you just created>
-      ControlPath ~/.ssh/jenkins-tunnel.ctl
-      RequestTTY no
-    ```
-1. Create a jenkins-tunnel.sh file with the following content and give it execute permission using `chmod +x jenkins-tunnel.sh`
-    ```bash
-    #!/bin/bash
-
-    socket=$HOME/.ssh/jenkins-tunnel.ctl
-
-    if [ "$1" == "start" ]; then
-      if [ ! \( -e ${socket} \) ]; then
-        echo "Starting tunnel to Jenkins..."
-        ssh -f -N jenkins-start && echo "Done."
-      else
-        echo "Tunnel to Jenkins running."
-      fi
-    fi
-
-    if [ "$1" == "stop" ]; then
-      if [ \( -e ${socket} \) ]; then
-        echo "Stopping tunnel to Jenkins..."
-        ssh -O "exit" jenkins-stop && echo "Done."
-      else
-        echo "Tunnel to Jenkins stopped."
-      fi
-    fi
-    ```
-1. Call `./jenkins-tunnel.sh start` to start your tunnel
-1. Call `./jenkins-tunnel.sh stop` to stop your tunnel
+Run this command:
+```bash
+ssh -L 8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
+```
 
 ## C. Configure Sample Jobs and Azure Active Directory configuration
 1. Once you are logged into the VM, run /opt/azure_jenkins_config/config_azure.sh and pick option 1 - "All of the below". This script will guide you to set up and configure the Azure Storage plugin to be used in the sample jobs to upload and download to Storage.

--- a/azure-jenkins/azuredeploy.json
+++ b/azure-jenkins/azuredeploy.json
@@ -215,7 +215,7 @@
     },
     "SSH": {
       "type": "string",
-      "value": "[concat('ssh ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
+      "value": "[concat('ssh -L 8080:localhost:8080 ', parameters('adminUsername'), '@', reference(variables('publicIPAddressName')).dnsSettings.fqdn)]"
     }
   }
 }

--- a/azure-jenkins/metadata.json
+++ b/azure-jenkins/metadata.json
@@ -3,5 +3,5 @@
     "description": "This template will deploy an instance of the Jenkins CI tool configured to target the Azure platform onto a Linux VM in Azure",
     "summary": "Create a new Linux Ubuntu 14.04 LTS VM with Jenkins, Azure CLI installed to target Azure",
     "githubUsername": "arroyc",
-    "dateUpdated": "2017-04-14"
+    "dateUpdated": "2017-04-19"
 }

--- a/spinnaker-jenkins-to-vmss/README.md
+++ b/spinnaker-jenkins-to-vmss/README.md
@@ -52,52 +52,11 @@ You need to setup port forwarding to view the Spinnaker UI on your local machine
 1. Click Open to establish the connection.
 
 ### If you are using Linux or Mac:
-1. Add this to your ~/.ssh/config
-    ```
-    Host spinnaker-start
-      HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
-      ControlMaster yes
-      ControlPath ~/.ssh/spinnaker-tunnel.ctl
-      RequestTTY no
-      LocalForward 9000 127.0.0.1:9000
-      LocalForward 8084 127.0.0.1:8084
-      LocalForward 8087 127.0.0.1:8087
-      User <User name>
-
-    Host spinnaker-stop
-      HostName <Public DNS name of instance you just created>
-      IdentityFile <Path to your key file>
-      ControlPath ~/.ssh/spinnaker-tunnel.ctl
-      RequestTTY no
-    ```
-1. Create a spinnaker-tunnel.sh file with the following content and give it execute permission using `chmod +x spinnaker-tunnel.sh`
-    ```bash
-    #!/bin/bash
-
-    socket=$HOME/.ssh/spinnaker-tunnel.ctl
-
-    if [ "$1" == "start" ]; then
-      if [ ! \( -e ${socket} \) ]; then
-        echo "Starting tunnel to Spinnaker..."
-        ssh -f -N spinnaker-start && echo "Done."
-      else
-        echo "Tunnel to Spinnaker running."
-      fi
-    fi
-
-    if [ "$1" == "stop" ]; then
-      if [ \( -e ${socket} \) ]; then
-        echo "Stopping tunnel to Spinnaker..."
-        ssh -O "exit" spinnaker-stop && echo "Done."
-      else
-        echo "Tunnel to Spinnaker stopped."
-      fi
-    fi
-    ```
-1. Call `./spinnaker-tunnel.sh start` to start your tunnel
-1. Call `./spinnaker-tunnel.sh stop` to stop your tunnel
-
+Run this command:
+```bash
+ssh -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8087:localhost:8087 <User name>@<Public DNS name of instance you just created>
+```
+> NOTE: Port 9000, 8084, and 8087 correspond to Spinnaker's deck, gate and rosco services, respectively.
 
 ## E. Connect to Spinnaker 
 

--- a/spinnaker-jenkins-to-vmss/README.md
+++ b/spinnaker-jenkins-to-vmss/README.md
@@ -44,7 +44,14 @@ Deploying from the command line
 You need to setup port forwarding to view the Spinnaker UI on your local machine.
 
 ### If you are using Windows:
-1. Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).
+
+Run this command:
+```
+putty.exe -ssh -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8087:localhost:8087 <User name>@<Public DNS name of instance you just created>
+```
+
+Or follow these manual steps:
 1. Launch Putty and navigate to 'Connection > SSH > Tunnels'
 1. In the Options controlling SSH port forwarding window, enter 8084 for Source port. Then enter 127.0.0.1:8084 for the Destination. Click Add.
 1. Repeat this process for ports: 8087 and 9000, until you have all three listed in the text box for Forward ports.


### PR DESCRIPTION
Use one-liner instead of ssh-tunneling
Make the output variable the same name so we can use it for CI