### PR TITLE
Revert changes to azure-jenkins template

### DIFF
--- a/azure-jenkins/README.md
+++ b/azure-jenkins/README.md
@@ -38,13 +38,6 @@ Run this command:
 ssh -L 8080:localhost:8080 <User name>@<Public DNS name of instance you just created>
 ```
 
-If you see the following error: "bind:address is already in use", then you need to include the IP Address as follows:
-
-```
-ssh -L localhost:8080:<Public IP>:8080 <User name@<Public IP>
-```
-
-
 ## C. Configure Sample Jobs and Azure Active Directory configuration
 1. Once you are logged into the VM, run /opt/azure_jenkins_config/config_azure.sh and pick option 1 - "All of the below". This script will guide you to set up and configure the Azure Storage plugin to be used in the sample jobs to upload and download to Storage.
 It will also provide a Service Principal to access Azure resources from Jenkins.

--- a/azure-jenkins/azuredeploy.json
+++ b/azure-jenkins/azuredeploy.json
@@ -18,23 +18,22 @@
     "jenkinsDnsPrefix": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 11,
       "metadata": {
         "description": "Globally unique DNS Name for the Public IP used to access the Virtual Machine."
       }
     }
   },
   "variables": {
-    "resourcePrefix": "[parameters('jenkinsDnsPrefix')]",
-    "storageAccountName": "[concat(parameters('jenkinsDnsPrefix'), uniquestring(resourceGroup().id))]",
-    "OSDiskName": "[concat(parameters('jenkinsDnsPrefix'), 'OSDisk')]",
-    "nicName": "[concat(parameters('jenkinsDnsPrefix'), 'VMNic')]",
-    "subnetName": "[concat(parameters('jenkinsDnsPrefix'), 'Subnet')]",
-    "publicIPAddressName": "[concat(parameters('jenkinsDnsPrefix'), 'PublicIP')]",
+    "resourcePrefix": "jenkins",
+    "storageAccountName": "[concat(variables('resourcePrefix'), uniquestring(resourceGroup().id))]",
+    "OSDiskName": "[concat(variables('resourcePrefix'), 'OSDisk')]",
+    "nicName": "[concat(variables('resourcePrefix'), 'VMNic')]",
+    "subnetName": "[concat(variables('resourcePrefix'), 'Subnet')]",
+    "publicIPAddressName": "[concat(variables('resourcePrefix'), 'PublicIP')]",
     "vmStorageAccountContainerName": "vhds",
-    "vmName": "[concat(parameters('jenkinsDnsPrefix'), 'VM')]",
-    "virtualNetworkName": "[concat(parameters('jenkinsDnsPrefix'), 'VNET')]",
-    "frontEndNSGName": "[concat(parameters('jenkinsDnsPrefix'), 'NSG')]",
+    "vmName": "[concat(variables('resourcePrefix'), 'VM')]",
+    "virtualNetworkName": "[concat(variables('resourcePrefix'), 'VNET')]",
+    "frontEndNSGName": "[concat(variables('resourcePrefix'), 'NSG')]",
     "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/azure-jenkins/",
     "_artifactsLocationSasToken": ""
   },
@@ -83,20 +82,6 @@
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 100,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "http-rule",
-            "properties": {
-              "description": "Allow HTTP",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "8080",
-              "sourceAddressPrefix": "Internet",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 101,
               "direction": "Inbound"
             }
           }

--- a/azure-jenkins/azuredeploy.parameters.json
+++ b/azure-jenkins/azuredeploy.parameters.json
@@ -9,7 +9,7 @@
       "value": "GEN-PASSWORD"
     },
     "jenkinsDnsPrefix": {
-      "value": "GEN-UNIQUE-5"
+      "value": "GEN-UNIQUE"
     }
   }
 }


### PR DESCRIPTION
From commit 3a47045d5cb212907fdbba8314949e85448fc55a and 67b9bca3f2292ac3d310ce3e0235841afd48f5d1

These changes broke the template for a few reasons:
1. We don't want port 8080 exposed in the NSG because Jenkins uses "http" by default. If someone logs in to Jenkins over their public IP address, their password and other information could be stolen through a man-in-the-middle attack. The only secure way to log in is with ssh tunneling (until the Jenkins admin sets up https with their own certificate)
2. If the error says `bind:address is already in use`, that means something else is using that port on your local machine. The fix is to close whatever is using port 8080 on your localhost (maybe you have another ssh tunnel going in the background?) or to use a different port: `ssh -L 8082:localhost:8080 <User name>@<Public DNS name of instance you just created>`
3. The jenkinsDnsPrefix should not be used as the resource prefix for all resources because it has different naming constraints. For example a dns prefix can be up to 63 characters long and can contain hyphens, but a storage account name can only be up to 24 characters long and _cannot_ contain hyphens