### PR TITLE
Change Spinnaker template to 'azure-devops' as author

### DIFF
--- a/101-spinnaker/metadata.json
+++ b/101-spinnaker/metadata.json
@@ -3,6 +3,6 @@
   "icon": "ubuntu",
   "description": "This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM. This will deploy a D3_v2 size VM in the resource group location and return the FQDN of the VM. You will have to manually configure the instance to target a deployment environment.",
   "summary": "This template deploys an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM, with no configuration.",
-  "githubUsername": "EricJizbaMSFT",
+  "githubUsername": "azure-devops",
   "dateUpdated": "2017-04-19"
 }


### PR DESCRIPTION
This is a test to see if [this](https://azure.microsoft.com/en-us/resources/templates/) will handle organizations as the author