### PR TITLE
Use 'azureuser' instead of 'admin' by default for devops templates

### DIFF
--- a/101-jenkins-with-SSH-public-key/azuredeploy.parameters.json
+++ b/101-jenkins-with-SSH-public-key/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "admin"
+      "value": "azureuser"
     },
     "sshPublicKey": {
       "value": "GEN-SSH-PUB-KEY"

--- a/101-jenkins/azuredeploy.parameters.json
+++ b/101-jenkins/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "admin"
+      "value": "azureuser"
     },
     "adminPassword": {
       "value": "GEN-PASSWORD"

--- a/101-spinnaker/azuredeploy.parameters.json
+++ b/101-spinnaker/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "admin"
+      "value": "azureuser"
     },
     "sshPublicKey": {
       "value": "GEN-SSH-PUB-KEY"

--- a/201-jenkins-acr/azuredeploy.parameters.json
+++ b/201-jenkins-acr/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "admin"
+      "value": "azureuser"
     },
     "adminPassword": {
       "value": "GEN-PASSWORD"

--- a/201-spinnaker-acr-k8s/azuredeploy.parameters.json
+++ b/201-spinnaker-acr-k8s/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "admin"
+      "value": "azureuser"
     },
     "sshPublicKey": {
       "value": "GEN-SSH-PUB-KEY"

--- a/301-jenkins-acr-spinnaker-k8s/azuredeploy.parameters.json
+++ b/301-jenkins-acr-spinnaker-k8s/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "admin"
+      "value": "azureuser"
     },
     "sshPublicKey": {
       "value": "GEN-SSH-PUB-KEY"

--- a/azure-jenkins/azuredeploy.parameters.json
+++ b/azure-jenkins/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "admin"
+      "value": "azureuser"
     },
     "adminPassword": {
       "value": "GEN-PASSWORD"


### PR DESCRIPTION
'admin' is a reserved name and is thus invalid