### PR TITLE
Remove redundant args in creating service principal

### DIFF
--- a/201-jenkins-acr/README.md
+++ b/201-jenkins-acr/README.md
@@ -18,7 +18,7 @@ You can optionally include a basic Jenkins pipeline that will checkout a user-pr
     ```bash
     az login
     az account set --subscription <Subscription ID>
-    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/<Subscription ID>" --name "Spinnaker"
+    az ad sp create-for-rbac --name "Spinnaker"
     ```
     > NOTE: You can run `az account list` after you login to get a list of subscription IDs for your account.
 1. Enter a public git repository. The repository must have a Dockerfile in its root.

--- a/201-spinnaker-acr-k8s/README.md
+++ b/201-spinnaker-acr-k8s/README.md
@@ -18,7 +18,7 @@ This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14
     ```bash
     az login
     az account set --subscription <Subscription ID>
-    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/<Subscription ID>" --name "Spinnaker"
+    az ad sp create-for-rbac --name "Spinnaker"
     ```
     > NOTE: You can run `az account list` after you login to get a list of subscription IDs for your account.
 

--- a/301-jenkins-acr-spinnaker-k8s/README.md
+++ b/301-jenkins-acr-spinnaker-k8s/README.md
@@ -20,7 +20,7 @@ The Jenkins instance will include a basic pipeline that checks out a user-provid
     ```bash
     az login
     az account set --subscription <Subscription ID>
-    az ad sp create-for-rbac --role="Contributor" --scopes="/subscriptions/<Subscription ID>" --name "Spinnaker"
+    az ad sp create-for-rbac --name "Spinnaker"
     ```
     > NOTE: You can run `az account list` after you login to get a list of subscription IDs for your account.
 1. Leave the git repository as the [sample app](https://github.com/azure-devops/spin-kub-demo) or change it to target your own app's repository. The repo must have a Dockerfile in its root.


### PR DESCRIPTION
The command already defaults to 'Contributor' and scoped to the current subscription

See here for more info: https://docs.microsoft.com/en-us/cli/azure/ad/sp#create-for-rbac