### PR TITLE
Update Example Bosh Manifest

### DIFF
--- a/bosh-setup/manifests/single-vm-cf.yml
+++ b/bosh-setup/manifests/single-vm-cf.yml
@@ -224,7 +224,15 @@ jobs:
       scim:
         userids_enabled: true
         users:
-        - admin|REPLACE_WITH_PASSWORD|scim.write,scim.read,openid,cloud_controller.admin,doppler.firehose,routing.router_groups.read
+        - name: admin
+          password: REPLACE_WITH_PASSWORD
+          groups:
+            - scim.write
+            - scim.read
+            - openid
+            - cloud_controller.admin
+            - doppler.firehose
+            - routing.router_groups.read
       port: 8082
     uaadb:
       address: 10.0.16.5
@@ -726,7 +734,17 @@ properties:
     scim:
       userids_enabled: true
       users:
-      - admin|REPLACE_WITH_PASSWORD|scim.write,scim.read,openid,cloud_controller.admin,clients.read,clients.write,doppler.firehose,routing.router_groups.read
+      - name: admin
+        password: REPLACE_WITH_PASSWORD
+        groups:
+          - scim.write
+          - scim.read
+          - openid
+          - cloud_controller.admin
+          - clients.read
+          - clients.write
+          - doppler.firehose
+          - routing.router_groups.read
     clients:
       cc-service-dashboards:
         authorities: clients.read,clients.write,clients.admin


### PR DESCRIPTION
The single-vm-cf.yml example Bosh manifest uses an old format for
setting UAA users, which causes the manifest to be incompatible with
cf-mysql-release.

This commit updates the users information to the newer and compatible
format.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Update example manifest in bosh-setup to use new UAA users format.
