### PR TITLE
Update devops templates with better error handling

### DIFF
--- a/101-jenkins-with-SSH-public-key/azuredeploy.json
+++ b/101-jenkins-with-SSH-public-key/azuredeploy.json
@@ -36,7 +36,7 @@
     "vNetAddressPrefixes": "10.0.0.0/16",
     "sNetAddressPrefixes": "10.0.0.0/24",
     "vmPrivateIP": "10.0.0.5",
-    "_artifactsLocation": "https://raw.githubusercontent.com/azure/azure-devops-utils/v0.11.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.12.0/",
     "_extensionScript": "install_jenkins.sh",
     "_artifactsLocationSasToken": ""
   },

--- a/101-jenkins-with-SSH-public-key/metadata.json
+++ b/101-jenkins-with-SSH-public-key/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy a secure Jenkins instance on a DS1_v2 size Linux Ubuntu 14.04 LTS VM using an SSH public key for authentication.",
   "summary": "This template allows you to deploy a secure Jenkins instance on a DS1_v2 size Linux Ubuntu 14.04 LTS VM using an SSH public key for authentication.",
   "githubUsername": "azure-devops",
-  "dateUpdated": "2017-05-01"
+  "dateUpdated": "2017-05-03"
 }

--- a/101-jenkins/azuredeploy.json
+++ b/101-jenkins/azuredeploy.json
@@ -36,7 +36,7 @@
     "vNetAddressPrefixes": "10.0.0.0/16",
     "sNetAddressPrefixes": "10.0.0.0/24",
     "vmPrivateIP": "10.0.0.5",
-    "_artifactsLocation": "https://raw.githubusercontent.com/azure/azure-devops-utils/v0.11.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.12.0/",
     "_extensionScript": "install_jenkins.sh",
     "_artifactsLocationSasToken": ""
   },

--- a/101-jenkins/metadata.json
+++ b/101-jenkins/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy a secure Jenkins instance on a DS1_v2 size Linux Ubuntu 14.04 LTS VM.",
   "summary": "This template allows you to deploy a secure Jenkins instance on a DS1_v2 size Linux Ubuntu 14.04 LTS VM.",
   "githubUsername": "azure-devops",
-  "dateUpdated": "2017-05-01"
+  "dateUpdated": "2017-05-03"
 }

--- a/101-spinnaker/azuredeploy.json
+++ b/101-spinnaker/azuredeploy.json
@@ -32,7 +32,7 @@
     "vmName": "[concat(variables('resourcePrefix'), 'VM')]",
     "vmExtensionName": "[concat(variables('resourcePrefix'), 'Init')]",
     "virtualNetworkName": "[concat(variables('resourcePrefix'), 'VNET')]",
-    "_artifactsLocation": "https://raw.githubusercontent.com/azure/azure-devops-utils/v0.8.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.12.0/",
     "_artifactsLocationSasToken": ""
   },
   "resources": [

--- a/101-spinnaker/metadata.json
+++ b/101-spinnaker/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM. This will deploy a D3_v2 size VM in the resource group location and return the FQDN of the VM. You will have to manually configure the instance to target a deployment environment.",
   "summary": "This template deploys an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM, with no configuration.",
   "githubUsername": "azure-devops",
-  "dateUpdated": "2017-04-25"
+  "dateUpdated": "2017-05-03"
 }

--- a/201-jenkins-acr/azuredeploy.json
+++ b/201-jenkins-acr/azuredeploy.json
@@ -54,7 +54,7 @@
     "vmExtensionName": "[concat(variables('resourcePrefix'), 'Init')]",
     "virtualNetworkName": "[concat(variables('resourcePrefix'), 'VNET')]",
     "frontEndNSGName": "[concat(variables('resourcePrefix'), 'NSG')]",
-    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.11.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.12.0/",
     "_extensionScript": "201-jenkins-acr.sh",
     "_artifactsLocationSasToken": ""
   },

--- a/201-jenkins-acr/metadata.json
+++ b/201-jenkins-acr/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM and an Azure Container Registry. It also includes an optional ACR pipeline.",
   "summary": "This template allows you to deploy an instance of Jenkins on a DS1_v2 size Linux Ubuntu 14.04 LTS VM and an Azure Container Registry. It also includes an optional ACR pipeline.",
   "githubUsername": "azure-devops",
-  "dateUpdated": "2017-05-01"
+  "dateUpdated": "2017-05-03"
 }

--- a/201-spinnaker-acr-k8s/azuredeploy.json
+++ b/201-spinnaker-acr-k8s/azuredeploy.json
@@ -65,7 +65,6 @@
   "variables": {
     "resourcePrefix": "spinnaker",
     "kubernetesName": "[concat('containerservice-', resourceGroup().name)]",
-    "kubernetesMasterCount": 1,
     "storageAccountName": "[concat(variables('resourcePrefix'), uniquestring(resourceGroup().id))]",
     "OSDiskName": "[concat(variables('resourcePrefix'), 'OSDisk')]",
     "nicName": "[concat(variables('resourcePrefix'), 'VMNic')]",
@@ -79,7 +78,7 @@
     "acrStorageAccountName": "[concat('registry', uniquestring(resourceGroup().id))]",
     "kubernetesDnsPrefix": "[concat('k8s', uniquestring(resourceGroup().id))]",
     "pipelinePort": "8000",
-    "_artifactsLocation": "https://raw.githubusercontent.com/azure/azure-devops-utils/v0.8.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.12.0/",
     "_extensionScript": "201-spinnaker-acr-k8s.sh",
     "_artifactsLocationSasToken": ""
   },
@@ -94,7 +93,7 @@
           "orchestratorType": "Kubernetes"
         },
         "masterProfile": {
-          "count": "[variables('kubernetesMasterCount')]",
+          "count": 1,
           "dnsPrefix": "[concat(variables('kubernetesDnsPrefix'),'mgmt')]"
         },
         "agentPoolProfiles": [
@@ -271,7 +270,7 @@
               ]
             },
             "protectedSettings": {
-              "commandToExecute": "[concat('./', variables('_extensionScript'),' -ai \"', parameters('servicePrincipalAppId'), '\" -ak \"', parameters('servicePrincipalAppKey'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -un \"', parameters('adminUsername'), '\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -mc \"', variables('kubernetesMasterCount'), '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value, '\" -acr \"', reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrPrefix'))).loginServer, '\" -ikp $(expr \"', parameters('kubernetesPipeline'), '\" == \"Include\") -prg \"', parameters('pipelineRegistry'), '\" -prp \"', parameters('pipelineRepository'), '\" -pp \"', variables('pipelinePort'), '\" -al \"', variables('_artifactsLocation'), '\" -st \"', variables('_artifactsLocationSasToken'), '\"')]"
+              "commandToExecute": "[concat('./', variables('_extensionScript'),' -ai \"', parameters('servicePrincipalAppId'), '\" -ak \"', parameters('servicePrincipalAppKey'), '\" -si \"', subscription().subscriptionId, '\" -ti \"', subscription().tenantId, '\" -un \"', parameters('adminUsername'), '\" -rg \"', resourceGroup().name, '\" -mf \"', reference(resourceId('Microsoft.ContainerService/containerServices', variables('kubernetesName'))).masterProfile.fqdn, '\" -san \"', variables('storageAccountName'), '\" -sak \"', listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2016-01-01').keys[0].value, '\" -acr \"', reference(resourceId('Microsoft.ContainerRegistry/registries', variables('acrPrefix'))).loginServer, '\" -ikp $(expr \"', parameters('kubernetesPipeline'), '\" == \"Include\") -prg \"', parameters('pipelineRegistry'), '\" -prp \"', parameters('pipelineRepository'), '\" -pp \"', variables('pipelinePort'), '\" -al \"', variables('_artifactsLocation'), '\" -st \"', variables('_artifactsLocationSasToken'), '\"')]"
             }
           }
         }

--- a/201-spinnaker-acr-k8s/metadata.json
+++ b/201-spinnaker-acr-k8s/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM automatically configured to target a Kubernetes cluster. This will deploy a D3_v2 size VM and a Kubernetes cluster in the resource group location and return the FQDN of both. It will also create an Azure Container Registry and return the full registry name.",
   "summary": "This template deploys an instance of Spinnaker on a Linux Ubuntu 14.04 LTS VM, targeting Kubernetes.",
   "githubUsername": "azure-devops",
-  "dateUpdated": "2017-04-25"
+  "dateUpdated": "2017-05-03"
 }

--- a/301-jenkins-acr-spinnaker-k8s/azuredeploy.json
+++ b/301-jenkins-acr-spinnaker-k8s/azuredeploy.json
@@ -65,7 +65,7 @@
     "kubernetesMasterCount": 1,
     "kubernetesDnsPrefix": "[concat('k8s', uniquestring(resourceGroup().id))]",
     "pipelinePort": "8000",
-    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.11.0/",
+    "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.12.0/",
     "_extensionScript": "301-jenkins-acr-spinnaker-k8s.sh",
     "_artifactsLocationSasToken": ""
   },

--- a/301-jenkins-acr-spinnaker-k8s/metadata.json
+++ b/301-jenkins-acr-spinnaker-k8s/metadata.json
@@ -4,5 +4,5 @@
   "description": "This template allows you to deploy and configure a DevOps pipeline from an Azure Container Registry to a Kubernetes cluster. It deploys an instance of Jenkins and Spinnaker on a D3_v2 size Linux Ubuntu 14.04 LTS VM.",
   "summary": "This template allows you to deploy and configure a DevOps pipeline from an Azure Container Registry to a Kubernetes cluster. It deploys an instance of Jenkins and Spinnaker on a D3_v2 size Linux Ubuntu 14.04 LTS VM.",
   "githubUsername": "azure-devops",
-  "dateUpdated": "2017-05-01"
+  "dateUpdated": "2017-05-03"
 }


### PR DESCRIPTION
Now they will fail if sub scripts fail
The spinnaker scripts are also updated to use az cli 2.0

I've run a CI test on all the templates and they look good. Obviously I'll wait to merge this until after I do a release of the utils repo