### PR TITLE
etherum-consortium-blockchain: Removed dependency that is breaking deployment

### DIFF
--- a/ethereum-consortium-blockchain-network/azuredeploy.json
+++ b/ethereum-consortium-blockchain-network/azuredeploy.json
@@ -42,7 +42,7 @@
     },
     "ethereumNetworkID": {
       "type": "int",
-      "defaultValue": 10101010,
+      "defaultValue": 72,
       "metadata": {
         "description": "Private Ethereum network ID to which to connect (max 9 digit number)"
       },

--- a/ethereum-consortium-blockchain-network/azuredeploy.json
+++ b/ethereum-consortium-blockchain-network/azuredeploy.json
@@ -42,7 +42,7 @@
     },
     "ethereumNetworkID": {
       "type": "int",
-      "defaultValue": 72,
+      "defaultValue": 10101010,
       "metadata": {
         "description": "Private Ethereum network ID to which to connect (max 9 digit number)"
       },

--- a/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
+++ b/ethereum-consortium-blockchain-network/scripts/configure-geth-azureuser.sh
@@ -65,7 +65,7 @@ sleep 5;
 # Install packages
 ##################
 echo "===== Starting packages installation =====";
-sudo apt-get -y install npm=3.5.2-0ubuntu4 git=1:2.7.4-0ubuntu1 software-properties-common=0.96.20.6 || unsuccessful_exit "package install 1 failed";
+sudo apt-get -y install npm=3.5.2-0ubuntu4 git=1:2.7.4-0ubuntu1 || unsuccessful_exit "package install 1 failed";
 sudo update-alternatives --install /usr/bin/node nodejs /usr/bin/nodejs 100 || unsuccessful_exit "package install 2 failed";
 echo "===== Completed packages installation =====";
 
@@ -86,25 +86,8 @@ gpg --verify geth-alltools-linux-amd64-1.6.0-facc47cb.tar.gz.asc || unsuccessful
 tar xzf geth-alltools-linux-amd64-1.6.0-facc47cb.tar.gz || unsuccessful_exit "geth download unpack failed";
 
 # /usr/bin is in $PATH by default, we'll put our binaries there
-sudo cp geth-alltools-linux-amd64-1.6.0-facc47cb/* /usr/bin/ || nsuccessful_exit "copy of geth to /usr/bin failed";
-
-##############
-# Install geth
-##############
-wget https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.5.9-a07539fb.tar.gz || exit 1;
-wget https://gethstore.blob.core.windows.net/builds/geth-alltools-linux-amd64-1.5.9-a07539fb.tar.gz.asc || exit 1;
-
-# Import geth buildserver keys
-gpg --recv-keys --keyserver hkp://keys.gnupg.net F9585DE6 C2FF8BBF 9BA28146 7B9E2481 D2A67EAC || exit 1;
-
-# Validate signature
-gpg --verify geth-alltools-linux-amd64-1.5.9-a07539fb.tar.gz.asc || exit 1;
-
-# Unpack archive
-tar xzf geth-alltools-linux-amd64-1.5.9-a07539fb.tar.gz || exit 1;
-
-# /usr/bin is in $PATH by default, we'll put our binaries there
-sudo cp geth-alltools-linux-amd64-1.5.9-a07539fb/* /usr/bin/ || exit 1;
+sudo cp geth-alltools-linux-amd64-1.6.0-facc47cb/* /usr/bin/ || unsuccessful_exit "copy of geth to /usr/bin failed";
+echo "===== Completed geth installation =====";
 
 #############
 # Build node keys and node IDs


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog
* Removed software-properties-common dependency as its not needed and the version we were installing disappeared from the ubuntu package location.  This is causing deployments to fail.
* Also fixed a merge issue from the last merge where Ethereum client was being installed twice

