### PR TITLE
Use osType parameter for image properties

### DIFF
--- a/101-vm-from-user-image/azuredeploy.json
+++ b/101-vm-from-user-image/azuredeploy.json
@@ -108,7 +108,7 @@
       "properties": {
         "storageProfile": {
           "osDisk": {
-            "osType": "Windows",
+            "osType": "[parameters('osType')]",
             "osState": "Generalized",
             "blobUri": "[parameters('osDiskVhdUri')]",
             "storageAccountType": "Standard_LRS"


### PR DESCRIPTION
Current version has "Windows" hardcoded as the osType of the image. This causes the Linux VMs to not boot. To fix this bug, use osType parameter as the value of the osType of the managed image.
