### PR TITLE
Change name of SP in jenkins template README

### DIFF
--- a/201-jenkins-acr/README.md
+++ b/201-jenkins-acr/README.md
@@ -18,7 +18,7 @@ You can optionally include a basic Jenkins pipeline that will checkout a user-pr
     ```bash
     az login
     az account set --subscription <Subscription ID>
-    az ad sp create-for-rbac --name "Spinnaker"
+    az ad sp create-for-rbac --name "Jenkins"
     ```
     > NOTE: You can run `az account list` after you login to get a list of subscription IDs for your account.
 1. Enter a public git repository. The repository must have a Dockerfile in its root.


### PR DESCRIPTION
I noticed this Jenkins-only template was showing up when you searched for 'Spinnaker' on the Azure Quickstart page (https://azure.microsoft.com/resources/templates/ - also used for https://aka.ms/azspinnaker)