### PR TITLE
Moving 'vmSize' to parameters to allow for user-specified size

### DIFF
--- a/docker-simple-on-ubuntu/azuredeploy.json
+++ b/docker-simple-on-ubuntu/azuredeploy.json
@@ -26,6 +26,13 @@
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }
     },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_F1",
+      "metadata": {
+        "description": "VM size for the Docker host."
+      }
+    },
     "ubuntuOSVersion": {
       "type": "string",
       "defaultValue": "14.04.4-LTS",
@@ -53,7 +60,6 @@
     "publicIPAddressType": "Dynamic",
     "vmStorageAccountContainerName": "vhds",
     "vmName": "MyDockerVM",
-    "vmSize": "Standard_F1",
     "virtualNetworkName": "MyVNETD",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
@@ -138,7 +144,7 @@
       ],
       "properties": {
         "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
+          "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
           "computerName": "[variables('vmName')]",


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog
These changes are in response to a user reporting problems deploying the template where the provided VM size was not available in their region / subscription.

* Moving `vmSize` from variables to parameter, keeping default value as `Standard_F1`
* Updating hardware profile properties to reflect parameter rather than variable