### PR TITLE
Minor fixes to DevOps readmes

### DIFF
--- a/101-jenkins-with-SSH-public-key/README.md
+++ b/101-jenkins-with-SSH-public-key/README.md
@@ -17,7 +17,7 @@ This template allows you to host an instance of Jenkins on a DS1_v2 size Linux U
 ## B. Setup SSH port forwarding
 **By default the Jenkins instance is using the http protocol and listens on port 8080. Users shouldn't authenticate over unsecured protocols!**
 
-You need to setup port forwarding to view the Jenkins UI on your local machine.
+You need to setup port forwarding to view the Jenkins UI on your local machine. If you do not know the full DNS name of your instance, go to the Portal and find it in the deployment outputs here: `Resource Groups > {Resource Group Name} > Deployments > {Deployment Name, usually 'Microsoft.Template'} > Outputs`
 
 ### If you are using Windows:
 Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).

--- a/101-jenkins/README.md
+++ b/101-jenkins/README.md
@@ -17,7 +17,7 @@ This template allows you to host an instance of Jenkins on a DS1_v2 size Linux U
 ## B. Setup SSH port forwarding
 **By default the Jenkins instance is using the http protocol and listens on port 8080. Users shouldn't authenticate over unsecured protocols!**
 
-You need to setup port forwarding to view the Jenkins UI on your local machine.
+You need to setup port forwarding to view the Jenkins UI on your local machine. If you do not know the full DNS name of your instance, go to the Portal and find it in the deployment outputs here: `Resource Groups > {Resource Group Name} > Deployments > {Deployment Name, usually 'Microsoft.Template'} > Outputs`
 
 ### If you are using Windows:
 Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).

--- a/101-spinnaker/README.md
+++ b/101-spinnaker/README.md
@@ -50,7 +50,7 @@ ssh -i <path to private key file> -L 9000:localhost:9000 -L 8084:localhost:8084 
 
 ## E. Connect to Spinnaker
 
-1. After you have started your tunnel, navigate to `http://localhost:9000/` on your local machine.
+1. After you have started your tunnel, navigate to http://localhost:9000/ on your local machine.
 1. Check the [Troubleshooting Guide](http://www.spinnaker.io/docs/troubleshooting-guide) if you have any issues.
 
 ## Questions/Comments? azdevopspub@microsoft.com

--- a/101-spinnaker/README.md
+++ b/101-spinnaker/README.md
@@ -24,7 +24,7 @@ In Azure, Spinnaker can target a Kubernetes cluster or VM Scale Sets.
 - To target VM Scale Sets, follow instructions [here](http://www.spinnaker.io/v1.0/docs/target-deployment-configuration#section-azure) to configure Spinnaker.
 
 ## D. Setup SSH port forwarding
-Once you have configured Spinnaker, you need to setup port forwarding to view the Spinnaker UI on your local machine.
+Once you have configured Spinnaker, you need to setup port forwarding to view the Spinnaker UI on your local machine. If you do not know the full DNS name of your instance, go to the Portal and find it in the deployment outputs here: `Resource Groups > {Resource Group Name} > Deployments > {Deployment Name, usually 'Microsoft.Template'} > Outputs`
 
 ### If you are using Windows:
 Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).

--- a/201-jenkins-acr/README.md
+++ b/201-jenkins-acr/README.md
@@ -26,7 +26,7 @@ You can optionally include a basic Jenkins pipeline that will checkout a user-pr
 ## B. Setup SSH port forwarding
 **By default the Jenkins instance is using the http protocol and listens on port 8080. Users shouldn't authenticate over unsecured protocols!**
 
-You need to setup port forwarding to view the Jenkins UI on your local machine.
+You need to setup port forwarding to view the Jenkins UI on your local machine. If you do not know the full DNS name of your instance, go to the Portal and find it in the deployment outputs here: `Resource Groups > {Resource Group Name} > Deployments > {Deployment Name, usually 'Microsoft.Template'} > Outputs`
 
 ### If you are using Windows:
 Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).

--- a/201-spinnaker-acr-k8s/README.md
+++ b/201-spinnaker-acr-k8s/README.md
@@ -23,7 +23,7 @@ This template allows you to deploy an instance of Spinnaker on a Linux Ubuntu 14
     > NOTE: You can run `az account list` after you login to get a list of subscription IDs for your account.
 
 ## B. Setup SSH port forwarding
-You need to setup port forwarding to view the Spinnaker UI on your local machine.
+You need to setup port forwarding to view the Spinnaker UI on your local machine. If you do not know the full DNS name of your instance, go to the Portal and find it in the deployment outputs here: `Resource Groups > {Resource Group Name} > Deployments > {Deployment Name, usually 'Microsoft.Template'} > Outputs`
 
 ### If you are using Windows:
 Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).

--- a/201-spinnaker-acr-k8s/README.md
+++ b/201-spinnaker-acr-k8s/README.md
@@ -45,11 +45,11 @@ Run this command:
 ```bash
 ssh -i <path to private key file> -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8001:localhost:8001 <User name>@<Public DNS name of instance you just created>
 ```
-> NOTE: Port 9000 and 8084 correspond to Spinnaker's deck and gate services, respectively. Port 8001 is used to view the dashboard for your Kubernetes cluster - just run `kubectl proxy` on the VM before navigating to http://localhost:8001 on your local machine.
+> NOTE: Port 9000 and 8084 correspond to Spinnaker's deck and gate services, respectively. Port 8001 is used to view the dashboard for your Kubernetes cluster - just run `kubectl proxy` on the VM before navigating to http://localhost:8001/ui on your local machine.
 
 ## C. Connect to Spinnaker
 
-1. After you have started your tunnel, navigate to `http://localhost:9000/` on your local machine.
+1. After you have started your tunnel, navigate to http://localhost:9000/ on your local machine.
 1. If you included a Kubernetes Pipeline when creating the template, navigate to 'Applications -> {Application Name} -> Pipelines' to see your pipeline. Follow steps [here](http://www.spinnaker.io/docs/kubernetes-source-to-prod#section-1-create-a-spinnaker-application) to create a pipeline manually.
 1. You can trigger the pipeline by pushing an image with a new tag to the configured repository or simply clicking 'Start Manual Execution' and selecting an existing tag.
   1. By default, Spinnaker has been targeted to use the [repository](https://hub.docker.com/r/lwander/spin-kub-demo/) in the sample pipeline. Follow steps [here](http://www.spinnaker.io/v1.0/docs/target-deployment-configuration#section-docker-registry) to target different repositories.

--- a/301-jenkins-acr-spinnaker-k8s/README.md
+++ b/301-jenkins-acr-spinnaker-k8s/README.md
@@ -29,7 +29,7 @@ The Jenkins instance will include a basic pipeline that checks out a user-provid
 ## C. Setup SSH port forwarding
 **By default the Jenkins instance is using the http protocol and listens on port 8080. Users shouldn't authenticate over unsecured protocols!**
 
-You need to setup port forwarding to view the Jenkins and Spinnaker UI on your local machine.
+You need to setup port forwarding to view the Jenkins and Spinnaker UI on your local machine. If you do not know the full DNS name of your instance, go to the Portal and find it in the deployment outputs here: `Resource Groups > {Resource Group Name} > Deployments > {Deployment Name, usually 'Microsoft.Template'} > Outputs`
 
 ### If you are using Windows:
 Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).

--- a/301-jenkins-acr-spinnaker-k8s/README.md
+++ b/301-jenkins-acr-spinnaker-k8s/README.md
@@ -51,7 +51,7 @@ Run this command:
 ```bash
 ssh -i <path to private key file> -L 8080:localhost:8080 -L 9000:localhost:9000 -L 8084:localhost:8084 -L 8001:localhost:8001 <User name>@<Public DNS name of instance you just created>
 ```
-> NOTE: Port 8080 corresponds to your Jenkins instance. Port 9000 and 8084 correspond to Spinnaker's deck and gate services, respectively. Port 8001 is used to view the dashboard for your Kubernetes cluster - just run `kubectl proxy` on the VM before navigating to http://localhost:8001 on your local machine.
+> NOTE: Port 8080 corresponds to your Jenkins instance. Port 9000 and 8084 correspond to Spinnaker's deck and gate services, respectively. Port 8001 is used to view the dashboard for your Kubernetes cluster - just run `kubectl proxy` on the VM before navigating to http://localhost:8001/ui on your local machine.
 
 ## D. Connect to Jenkins
 
@@ -62,7 +62,7 @@ ssh -i <path to private key file> -L 8080:localhost:8080 -L 9000:localhost:9000 
 
 ## E. Connect to Spinnaker
 
-1. After you have started your tunnel, navigate to `http://localhost:9000/` on your local machine.
+1. After you have started your tunnel, navigate to http://localhost:9000/ on your local machine.
 1. Navigate to 'Applications -> {Application Name} -> Pipelines' to see your pipeline. Follow steps [here](http://www.spinnaker.io/docs/kubernetes-source-to-prod#section-1-create-a-spinnaker-application) to create a pipeline manually.
 1. Check the [Troubleshooting Guide](http://www.spinnaker.io/docs/troubleshooting-guide) if you have any issues.
 

--- a/301-jenkins-aptly-spinnaker-vmss/README.md
+++ b/301-jenkins-aptly-spinnaker-vmss/README.md
@@ -35,7 +35,7 @@ Deploying from the command line
 ## C. Setup SSH port forwarding
 **By default the Jenkins instance is using the http protocol and listens on port 8080. Users shouldn't authenticate over unsecured protocols!**
 
-You need to setup port forwarding to view the Jenkins and Spinnaker UI on your local machine.
+You need to setup port forwarding to view the Jenkins and Spinnaker UI on your local machine. If you do not know the full DNS name of your instance, go to the Portal and find it in the deployment outputs here: `Resource Groups > {Resource Group Name} > Deployments > {Deployment Name, usually 'Microsoft.Template'} > Outputs`
 
 ### If you are using Windows:
 Install Putty or use any bash shell for Windows (if using a bash shell, follow the instructions for Linux or Mac).

--- a/301-jenkins-aptly-spinnaker-vmss/README.md
+++ b/301-jenkins-aptly-spinnaker-vmss/README.md
@@ -61,14 +61,14 @@ ssh -i <path to private key file> -L 8080:localhost:8080 -L 9000:localhost:9000 
 
 ## D. Connect to Jenkins
 
-1. After you have started your tunnel, navigate to `http://localhost:8080/` on your local machine.
+1. After you have started your tunnel, navigate to http://localhost:8080/ on your local machine.
 1. The instance should already be unlocked and your first account setup. Login with the credentials you specified when deploying the template.
 1. Your Jenkins instance is now ready to use! You can access a read-only view by going to http://< Public DNS name of instance you just created >.
 1. Go to http://aka.ms/azjenkinsagents if you want to build/CI from this Jenkins master using Azure VM agents.
 
 ## E. Connect to Spinnaker 
 
-1. After you have started your tunnel, navigate to `http://localhost:9000/` on your local machine.
+1. After you have started your tunnel, navigate to http://localhost:9000/ on your local machine.
 1. Documention to create a sample pipeline is forthcoming.
 
 ## Questions/Comments? azdevopspub@microsoft.com


### PR DESCRIPTION
* Fix k8s dashboard URL (it has to have 'ui' at the end)
* Make some of the localhost URLs clickable
* Add note on how to find the deployment outputs for DevOps templates