### PR TITLE
Supports multiple images/vm creation

### DIFF
--- a/201-vm-winrm-windows/ConfigureWinRM.ps1
+++ b/201-vm-winrm-windows/ConfigureWinRM.ps1
@@ -38,6 +38,27 @@ function Delete-WinRMListener
     }
 }
 
+function Create-Certificate
+{
+    param(
+        [string]$hostname
+    )
+
+    # makecert ocassionally produces negative serial numbers
+	# which golang tls/crypto <1.6.1 cannot handle
+	# https://github.com/golang/go/issues/8265
+    $serial = Get-Random
+    .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e 01/01/2022 -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12 -# $serial
+    $thumbprint=(Get-ChildItem cert:\Localmachine\my | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
+
+    if(-not $thumbprint)
+    {
+        throw "Failed to create the test certificate."
+    }
+
+    return $thumbprint
+}
+
 function Configure-WinRMHttpsListener
 {
     param([string] $HostName,
@@ -47,21 +68,19 @@ function Configure-WinRMHttpsListener
     Delete-WinRMListener
 
     # Create a test certificate
-    $thumbprint = (Get-ChildItem cert:\LocalMachine\My | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
+    $cert = (Get-ChildItem cert:\LocalMachine\My | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1)
+    $thumbprint = $cert.Thumbprint
     if(-not $thumbprint)
     {
-	# makecert ocassionally produces negative serial numbers
-	# which golang tls/crypto <1.6.1 cannot handle
-	# https://github.com/golang/go/issues/8265
-        $serial = Get-Random
-        .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e 01/01/2022 -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12 -# $serial
-        $thumbprint=(Get-ChildItem cert:\Localmachine\my | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
-
-        if(-not $thumbprint)
-        {
-            throw "Failed to create the test certificate."
-        }
-    }    
+	    $thumbprint = Create-Certificate -hostname $HostName
+    }
+    elseif (-not $cert.PrivateKey)
+    {
+        # The private key is missing - could have been sysprepped
+        # Delete the certificate
+        Remove-Item Cert:\LocalMachine\My\$thumbprint -DeleteKey -Force
+        $thumbprint = Create-Certificate -hostname $HostName
+    }
 
     $response = cmd.exe /c .\winrmconf.cmd $hostname $thumbprint
 }

--- a/201-vm-winrm-windows/ConfigureWinRM.ps1
+++ b/201-vm-winrm-windows/ConfigureWinRM.ps1
@@ -48,7 +48,7 @@ function Create-Certificate
 	# which golang tls/crypto <1.6.1 cannot handle
 	# https://github.com/golang/go/issues/8265
     $serial = Get-Random
-    .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e 01/01/2022 -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12 -# $serial
+    .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e 01/01/2022 -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12 -# $serial 2>&1 | Out-Null
 
     $thumbprint=(Get-ChildItem cert:\Localmachine\my | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
 
@@ -56,6 +56,8 @@ function Create-Certificate
     {
         throw "Failed to create the test certificate."
     }
+
+    return $thumbprint
 }
 
 function Configure-WinRMHttpsListener
@@ -71,16 +73,14 @@ function Configure-WinRMHttpsListener
     $thumbprint = $cert.Thumbprint
     if(-not $thumbprint)
     {
-	    Create-Certificate -hostname $HostName
-        $thumbprint=(Get-ChildItem cert:\Localmachine\my | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
+	    $thumbprint = Create-Certificate -hostname $HostName
     }
     elseif (-not $cert.PrivateKey)
     {
         # The private key is missing - could have been sysprepped
         # Delete the certificate
         Remove-Item Cert:\LocalMachine\My\$thumbprint -Force
-        Create-Certificate -hostname $HostName
-        $thumbprint=(Get-ChildItem cert:\Localmachine\my | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
+        $thumbprint = Create-Certificate -hostname $HostName
     }
 
     $response = cmd.exe /c .\winrmconf.cmd $hostname $thumbprint


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

**My scenario**

* Added support for using this multiple times when imaging/creating VMs.  This fails is you run it, then sysprep the machine and try to run it again.  This PR fixes it.

