### PR TITLE
Added Service Bus Topic Subscription w/ SQL Filter template

### DIFF
--- a/101-servicebus-topic-subscription-sqlfilter/README.md
+++ b/101-servicebus-topic-subscription-sqlfilter/README.md
@@ -1,0 +1,7 @@
+# Create a Service Bus Namespace
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-servicebus-topic-subscription%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+This template creates a Service Bus Namespace and Topic with a Subscription to catch all messages.

--- a/101-servicebus-topic-subscription-sqlfilter/README.md
+++ b/101-servicebus-topic-subscription-sqlfilter/README.md
@@ -1,6 +1,6 @@
 # Create a Service Bus Namespace
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-servicebus-topic-subscription%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-servicebus-topic-subscription-sqlfilter%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 

--- a/101-servicebus-topic-subscription-sqlfilter/README.md
+++ b/101-servicebus-topic-subscription-sqlfilter/README.md
@@ -4,4 +4,4 @@
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
 
-This template creates a Service Bus Namespace and Topic with a Subscription to catch all messages.
+This template creates a Service Bus Namespace and Topic with a Subscription using a SQL Filter to define what messages will be directed to or received by the Subscription.

--- a/101-servicebus-topic-subscription-sqlfilter/README.md
+++ b/101-servicebus-topic-subscription-sqlfilter/README.md
@@ -1,4 +1,4 @@
-# Create a Service Bus Namespace
+# Create a Service Bus Namespace and Topic with a Subscription using a SQL Filter
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-servicebus-topic-subscription-sqlfilter%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>

--- a/101-servicebus-topic-subscription-sqlfilter/azuredeploy.json
+++ b/101-servicebus-topic-subscription-sqlfilter/azuredeploy.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "serviceBusNamespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Service Bus Namespace"
+      }
+    },
+    "serviceBusTopicName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Service Bus Topic"
+      }
+    },
+    "serviceBusTopicSubscriptionName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Service Bus Topic Subscription"
+      }
+    },
+	"serviceBusTopicSubscriptionSqlFilter": {
+      "type": "string",
+      "metadata": {
+        "description": "The SQL Filter of the Service Bus Topic Subscription"
+      }
+    }
+  },
+  "variables": {
+    "sbVersion": "2015-08-01"
+  },
+  "resources": [
+    {
+      "apiVersion": "[variables('sbVersion')]",
+      "name": "[parameters('serviceBusNamespaceName')]",
+      "type": "Microsoft.ServiceBus/namespaces",
+      "location": "[resourceGroup().location]",
+      "properties": {
+      },
+      "resources": [
+        {
+            "apiVersion": "[variables('sbVersion')]",
+            "name": "[parameters('serviceBusTopicName')]",
+            "type": "Topics",
+            "dependsOn": [
+                "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
+            ],
+            "properties": {
+                "path": "[parameters('serviceBusTopicName')]"
+            },
+            "resources": [
+                {
+                    "apiVersion": "[variables('sbVersion')]",
+                    "name": "[parameters('serviceBusTopicSubscriptionName')]",
+                    "type": "Subscriptions",
+                    "dependsOn": [
+                        "[parameters('serviceBusTopicName')]"
+                    ],
+                    "properties": {
+                    },
+                    "resources": [{
+						"apiVersion": "[variables('sbVersion')]",
+						"name": "[concat(parameters('serviceBusTopicSubscriptionName'), '-filter')]",
+						"type": "Rules",
+						"dependsOn": [
+							"[parameters('serviceBusTopicSubscriptionName')]"
+						],
+						"properties": {
+							"filter": {
+								"sqlExpression": "[parameters('serviceBusTopicSubscriptionSqlFilter')]"
+							}
+						}
+					}]
+                }
+            ]
+        }
+      ]
+    }
+  ],
+  "outputs": {
+  }
+}

--- a/101-servicebus-topic-subscription-sqlfilter/azuredeploy.json
+++ b/101-servicebus-topic-subscription-sqlfilter/azuredeploy.json
@@ -1,83 +1,82 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "serviceBusNamespaceName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the Service Bus Namespace"
-      }
-    },
-    "serviceBusTopicName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the Service Bus Topic"
-      }
-    },
-    "serviceBusTopicSubscriptionName": {
-      "type": "string",
-      "metadata": {
-        "description": "Name of the Service Bus Topic Subscription"
-      }
-    },
-	"serviceBusTopicSubscriptionSqlFilter": {
-      "type": "string",
-      "metadata": {
-        "description": "The SQL Filter of the Service Bus Topic Subscription"
-      }
-    }
-  },
-  "variables": {
-    "sbVersion": "2015-08-01"
-  },
-  "resources": [
-    {
-      "apiVersion": "[variables('sbVersion')]",
-      "name": "[parameters('serviceBusNamespaceName')]",
-      "type": "Microsoft.ServiceBus/namespaces",
-      "location": "[resourceGroup().location]",
-      "properties": {
-      },
-      "resources": [
-        {
-            "apiVersion": "[variables('sbVersion')]",
-            "name": "[parameters('serviceBusTopicName')]",
-            "type": "Topics",
-            "dependsOn": [
-                "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
-            ],
-            "properties": {
-                "path": "[parameters('serviceBusTopicName')]"
-            },
-            "resources": [
-                {
-                    "apiVersion": "[variables('sbVersion')]",
-                    "name": "[parameters('serviceBusTopicSubscriptionName')]",
-                    "type": "Subscriptions",
-                    "dependsOn": [
-                        "[parameters('serviceBusTopicName')]"
-                    ],
-                    "properties": {
-                    },
-                    "resources": [{
-						"apiVersion": "[variables('sbVersion')]",
-						"name": "[concat(parameters('serviceBusTopicSubscriptionName'), '-filter')]",
-						"type": "Rules",
-						"dependsOn": [
-							"[parameters('serviceBusTopicSubscriptionName')]"
-						],
-						"properties": {
-							"filter": {
-								"sqlExpression": "[parameters('serviceBusTopicSubscriptionSqlFilter')]"
-							}
-						}
-					}]
-                }
-            ]
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "serviceBusNamespaceName": {
+        "type": "string",
+        "metadata": {
+          "description": "Name of the Service Bus Namespace"
         }
-      ]
+      },
+      "serviceBusTopicName": {
+        "type": "string",
+        "metadata": {
+          "description": "Name of the Service Bus Topic"
+        }
+      },
+      "serviceBusTopicSubscriptionName": {
+        "type": "string",
+        "metadata": {
+          "description": "Name of the Service Bus Topic Subscription"
+        }
+      },
+      "serviceBusTopicSubscriptionSqlFilter": {
+        "type": "string",
+        "metadata": {
+          "description": "The SQL Filter of the Service Bus Topic Subscription"
+        }
+      }
+    },
+    "variables": {
+    },
+    "resources": [
+      {
+        "apiVersion": "2017-04-01",
+        "name": "[parameters('serviceBusNamespaceName')]",
+        "type": "Microsoft.ServiceBus/namespaces",
+        "location": "[resourceGroup().location]",
+        "properties": {
+        },
+        "resources": [
+          {
+              "apiVersion": "2017-04-01",
+              "name": "[parameters('serviceBusTopicName')]",
+              "type": "topics",
+              "dependsOn": [
+                  "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
+              ],
+              "properties": {
+                  "path": "[parameters('serviceBusTopicName')]"
+              },
+              "resources": [
+                  {
+                      "apiVersion": "2017-04-01",
+                      "name": "[parameters('serviceBusTopicSubscriptionName')]",
+                      "type": "subscriptions",
+                      "dependsOn": [
+                          "[parameters('serviceBusTopicName')]"
+                      ],
+                      "properties": {
+                      },
+                      "resources": [{
+                          "apiVersion": "2017-04-01",
+                          "name": "[concat(parameters('serviceBusTopicSubscriptionName'), '-filter')]",
+                          "type": "Rules",
+                          "dependsOn": [
+                              "[parameters('serviceBusTopicSubscriptionName')]"
+                          ],
+                          "properties": {
+                              "filter": {
+                                  "sqlExpression": "[parameters('serviceBusTopicSubscriptionSqlFilter')]"
+                              }
+                          }
+                      }]
+                  }
+              ]
+          }
+        ]
+      }
+    ],
+    "outputs": {
     }
-  ],
-  "outputs": {
   }
-}

--- a/101-servicebus-topic-subscription-sqlfilter/azuredeploy.parameters.json
+++ b/101-servicebus-topic-subscription-sqlfilter/azuredeploy.parameters.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "serviceBusNamespaceName": {
+            "value": "GEN-UNIQUE"
+        },
+        "serviceBusTopicName": {
+            "value": "GEN-UNIQUE"
+        },
+        "serviceBusTopicSubscriptionName": {
+            "value": "GEN-UNIQUE"
+        },
+		"serviceBusTopicSubscriptionSqlFilter": {
+			"value": "[property-name] = 'value'"
+		}
+    }
+}

--- a/101-servicebus-topic-subscription-sqlfilter/azuredeploy.parameters.json
+++ b/101-servicebus-topic-subscription-sqlfilter/azuredeploy.parameters.json
@@ -11,8 +11,8 @@
         "serviceBusTopicSubscriptionName": {
             "value": "GEN-UNIQUE"
         },
-		"serviceBusTopicSubscriptionSqlFilter": {
-			"value": "[property-name] = 'value'"
-		}
+        "serviceBusTopicSubscriptionSqlFilter": {
+             "value": "[property-name] = 'value'"
+        }
     }
 }

--- a/101-servicebus-topic-subscription-sqlfilter/metadata.json
+++ b/101-servicebus-topic-subscription-sqlfilter/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Create a Service Bus Topic with Subscription and SQL Filter",
+  "description": "This template creates a Service Bus Namespace and Topic with a Subscription using a SQL Filter expression to recieve only the messages that match the defined SQL Filter Expression.",
+  "summary": "This template creates a Service Bus Namespace and Topic with a Subscription that has a SQL Filter defined.",
+  "githubUsername": "crpietschmann",
+  "dateUpdated": "2017-06-23"
+}


### PR DESCRIPTION
This ARM Template is a further addition to a previous one I submitted that extends it to add the ability to set up a SQL Filter on the Azure Service Bus Topic Subscription that gets created. This is something that isn't documented ANYWHERE, but I was able to figure it out, so I thought I'd share it in the quick-start-templates project so it can help others too. :)