### PR TITLE
Update function templates to use newer storage api version

### DIFF
--- a/101-function-app-create-dedicated/azuredeploy.json
+++ b/101-function-app-create-dedicated/azuredeploy.json
@@ -58,6 +58,7 @@
             "name": "[variables('storageAccountName')]",
             "apiVersion": "2016-12-01",
             "location": "[resourceGroup().location]",
+            "kind": "Storage",
             "sku": {
                 "name": "[parameters('storageAccountType')]"
             }

--- a/101-function-app-create-dedicated/azuredeploy.json
+++ b/101-function-app-create-dedicated/azuredeploy.json
@@ -56,10 +56,10 @@
         {
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
-            "apiVersion": "2015-06-15",
+            "apiVersion": "2016-12-01",
             "location": "[resourceGroup().location]",
-            "properties": {
-                "accountType": "[parameters('storageAccountType')]"
+            "sku": {
+                "name": "[parameters('storageAccountType')]"
             }
         },
         {

--- a/101-function-app-create-dynamic/azuredeploy.json
+++ b/101-function-app-create-dynamic/azuredeploy.json
@@ -32,10 +32,10 @@
         {
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
-            "apiVersion": "2015-06-15",
+            "apiVersion": "2016-12-01",
             "location": "[resourceGroup().location]",
-            "properties": {
-                "accountType": "[parameters('storageAccountType')]"
+            "sku": {
+                "name": "[parameters('storageAccountType')]"
             }
         },
         {

--- a/101-function-app-create-dynamic/azuredeploy.json
+++ b/101-function-app-create-dynamic/azuredeploy.json
@@ -34,6 +34,7 @@
             "name": "[variables('storageAccountName')]",
             "apiVersion": "2016-12-01",
             "location": "[resourceGroup().location]",
+            "kind": "Storage",
             "sku": {
                 "name": "[parameters('storageAccountType')]"
             }


### PR DESCRIPTION
This resolves a problem that can occur when rerunning the functions templates multiple times.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Updated 101-function-app-create-dedicated/azuredeploy.json to use new storage api version
* Updated 101-function-app-create-dynamic/azuredeploy.json to use new storage api version


