### PR TITLE
 201-key-vault-secret-create | propsoing secureObject wrapper for array 

### DIFF
--- a/201-key-vault-secret-create/README.md
+++ b/201-key-vault-secret-create/README.md
@@ -7,7 +7,7 @@
 
 This template helps you to create a Key Vault. It allows to create and set multiple access policies and Secrets while creating the Vault. If you are new to [Key Vault check this out](https://azure.microsoft.com/en-us/services/key-vault/). A full walk through of this template is available [here](http://www.rahulpnath.com/blog/managing-azure-key-vault-using-azure-resource-manager-arm-templates/).
 
-Instead of using an array for the secret creation, this template wraps the array in a [secureObject](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates#parameters).
+Instead of just using an array for the secret creation, this template wraps an array in a [secureObject](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates#parameters).
 Using a secureObject instead of an array type means that the values you pass, cannot be read back in the portal after the deployment. 
 
 Tags: Azure Key Vault, Key Vault, Secrets

--- a/201-key-vault-secret-create/README.md
+++ b/201-key-vault-secret-create/README.md
@@ -7,4 +7,7 @@
 
 This template helps you to create a Key Vault. It allows to create and set multiple access policies and Secrets while creating the Vault. If you are new to [Key Vault check this out](https://azure.microsoft.com/en-us/services/key-vault/). A full walk through of this template is available [here](http://www.rahulpnath.com/blog/managing-azure-key-vault-using-azure-resource-manager-arm-templates/).
 
+Instead of using an array for the secret creation, this template wraps the array in a [secureObject](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates#parameters).
+Using a secureObject instead of an array type means that the values you pass, cannot be read back in the portal after the deployment. 
+
 Tags: Azure Key Vault, Key Vault, Secrets

--- a/201-key-vault-secret-create/azuredeploy.json
+++ b/201-key-vault-secret-create/azuredeploy.json
@@ -53,7 +53,7 @@
                 "description": "Specifies if the vault is enabled for volume encryption"
             }
         },
-        "secureObject": {
+        "secretsObject": {
             "type": "secureObject",
             "defaultValue": "{}",
             "metadata": {
@@ -84,17 +84,17 @@
         },
         {
             "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(parameters('keyVaultName'), '/', parameters('secureObject').secrets[copyIndex()].secretName)]",
+            "name": "[concat(parameters('keyVaultName'), '/', parameters('secretsObject').secrets[copyIndex()].secretName)]",
             "apiVersion": "2015-06-01",
             "properties": {
-                "value": "[parameters('secureObject').secrets[copyIndex()].secretValue]"
+                "value": "[parameters('secretsObject').secrets[copyIndex()].secretValue]"
             },
             "dependsOn": [
                 "[concat('Microsoft.KeyVault/vaults/', parameters('keyVaultName'))]"
             ],
             "copy": {
                 "name": "secretsCopy",
-                "count": "[length(parameters('secureObject').secrets)]"
+                "count": "[length(parameters('secretsObject').secrets)]"
             }
         }
     ]

--- a/201-key-vault-secret-create/azuredeploy.json
+++ b/201-key-vault-secret-create/azuredeploy.json
@@ -54,10 +54,10 @@
             }
         },
         "secrets": {
-            "type": "array",
+            "type": "secureObject",
             "defaultValue": "{}",
             "metadata": {
-                "description": "all secrets {\"secretName\":\"\",\"secretValue\":\"\"}"
+                "description": "all secrets {\"secretName\":\"\",\"secretValue\":\"\"} wrapped in a secure object"
             }
         }
     },
@@ -84,17 +84,17 @@
         },
         {
             "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(parameters('keyVaultName'), '/', parameters('secrets')[copyIndex()].secretName)]",
+            "name": "[concat(parameters('keyVaultName'), '/', parameters('secrets').array[copyIndex()].secretName)]",
             "apiVersion": "2015-06-01",
             "properties": {
-                "value": "[parameters('secrets')[copyIndex()].secretValue]"
+                "value": "[parameters('secrets').array[copyIndex()].secretValue]"
             },
             "dependsOn": [
                 "[concat('Microsoft.KeyVault/vaults/', parameters('keyVaultName'))]"
             ],
             "copy": {
                 "name": "secretsCopy",
-                "count": "[length(parameters('secrets'))]"
+                "count": "[length(parameters('secrets').array)]"
             }
         }
     ]

--- a/201-key-vault-secret-create/azuredeploy.json
+++ b/201-key-vault-secret-create/azuredeploy.json
@@ -53,7 +53,7 @@
                 "description": "Specifies if the vault is enabled for volume encryption"
             }
         },
-        "secrets": {
+        "secureObject": {
             "type": "secureObject",
             "defaultValue": "{}",
             "metadata": {
@@ -84,17 +84,17 @@
         },
         {
             "type": "Microsoft.KeyVault/vaults/secrets",
-            "name": "[concat(parameters('keyVaultName'), '/', parameters('secrets').array[copyIndex()].secretName)]",
+            "name": "[concat(parameters('keyVaultName'), '/', parameters('secureObject').secrets[copyIndex()].secretName)]",
             "apiVersion": "2015-06-01",
             "properties": {
-                "value": "[parameters('secrets').array[copyIndex()].secretValue]"
+                "value": "[parameters('secureObject').secrets[copyIndex()].secretValue]"
             },
             "dependsOn": [
                 "[concat('Microsoft.KeyVault/vaults/', parameters('keyVaultName'))]"
             ],
             "copy": {
                 "name": "secretsCopy",
-                "count": "[length(parameters('secrets').array)]"
+                "count": "[length(parameters('secureObject').secrets)]"
             }
         }
     ]

--- a/201-key-vault-secret-create/azuredeploy.parameters.json
+++ b/201-key-vault-secret-create/azuredeploy.parameters.json
@@ -29,16 +29,18 @@
                 ]
             },
             "secrets": {
-                "value": [
-                    {
-                        "secretName": "exampleSecret1",
-                        "secretValue": "secretVaule1"
-                    },
-                    {
-                        "secretName": "exampleSecret2",
-                        "secretValue": "secretValue2"
-                    }
-                ]
+                "value": {
+					"array": [						
+						{
+							"secretName": "exampleSecret1",
+							"secretValue": "secretVaule1"
+						},
+						{
+							"secretName": "exampleSecret2",
+							"secretValue": "secretValue2"
+						}
+					]
+				}
             }
         }
     }

--- a/201-key-vault-secret-create/azuredeploy.parameters.json
+++ b/201-key-vault-secret-create/azuredeploy.parameters.json
@@ -28,9 +28,9 @@
                     }
                 ]
             },
-            "secrets": {
+            "secureObject": {
                 "value": {
-					"array": [						
+					"secrets": [						
 						{
 							"secretName": "exampleSecret1",
 							"secretValue": "secretVaule1"


### PR DESCRIPTION
adding secureObject wrapper to align more with ARM templating recommendations: https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-authoring-templates#parameters

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

[x] Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* changed variable input to secureObject rather than array
* added object wrapper around array
* changed reference expressions in template to support wrapper
* using a secureObject prevents other users from seeing the secrets in the portal after the deployment

### Screenshots of the difference

Before: (everyone can see the secrets)
<img width="450" alt="secret-value-before-wrapper" src="https://user-images.githubusercontent.com/9444698/27787380-73d9f344-5fdc-11e7-9681-786ac287a3ea.PNG">

After: (secrets hidden)
<img width="450" alt="using-secret-wrapper" src="https://user-images.githubusercontent.com/9444698/27787379-73d91b68-5fdc-11e7-95d9-60b987d4df5a.PNG">


