### PR TITLE
disabling autoupgrade minor version for CSE

### DIFF
--- a/101-vsts-cloudloadtest-rig/azuredeploy.json
+++ b/101-vsts-cloudloadtest-rig/azuredeploy.json
@@ -248,7 +248,7 @@
                 "type": "CustomScriptExtension",
                 "forceUpdateTag": "[variables('sequenceVersion')]",
                 "typeHandlerVersion": "1.8",
-                "autoUpgradeMinorVersion": true,
+                "autoUpgradeMinorVersion": false,
                 "settings": {
                     "fileUris": [
                         "https://elsprodch2su1.blob.core.windows.net/ets-containerfor-loadagentresources/bootstrap/ManageVSTSCloudLoadAgent.ps1"

--- a/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.json
+++ b/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.json
@@ -216,7 +216,7 @@
                 "type": "CustomScriptExtension",
                 "forceUpdateTag": "[variables('sequenceVersion')]",
                 "typeHandlerVersion": "1.8",
-                "autoUpgradeMinorVersion": true,
+                "autoUpgradeMinorVersion": false,
                 "settings": {
                     "fileUris": [
                         "https://elsprodch2su1.blob.core.windows.net/ets-containerfor-loadagentresources/bootstrap/ManageVSTSCloudLoadAgent.ps1"


### PR DESCRIPTION
Disabling the upgrade based on minor versions in Custom Script Extension for CLT related ARM templates.