### PR TITLE
vertx-openjdk-apache-mysql-on-ubuntu: Updated azuredeploy.parameters.json to use GEN values

### DIFF
--- a/vertx-openjdk-apache-mysql-on-ubuntu/azuredeploy.parameters.json
+++ b/vertx-openjdk-apache-mysql-on-ubuntu/azuredeploy.parameters.json
@@ -1,22 +1,21 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "newStorageAccountName": {
-      "value": "changeme"
-    },
-    "adminUsername": {
-      "value": "changeme"
-    },
-    "dnsNameForPublicIP": {
-      "value": "changeme"
-    },
-    "vmName": {
-      "value": "changeme"
-    },
-    "adminPassword": {
-      "value": "changeme"
-      }
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "newStorageAccountName": {
+            "value": "GEN-UNIQUE-10"
+        },
+        "adminUsername": {
+            "value": "GEN-UNIQUE-8"
+        },
+        "dnsNameForPublicIP": {
+            "value": "GEN-UNIQUE-11"
+        },
+        "vmName": {
+            "value": "GEN-UNIQUE-8"
+        },
+        "adminPassword": {
+            "value": "GEN-PASSWORD"
+        }
     }
-  }
-
+}


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

