### PR TITLE
These new templates enable Capture to ADLS as destination

### DIFF
--- a/201-eventhubs-create-namespace-and-enable-capture-for-adls/README.md
+++ b/201-eventhubs-create-namespace-and-enable-capture-for-adls/README.md
@@ -1,0 +1,13 @@
+# 201-eventhubs-create-namespace-and-enable-capture-for-adls
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-eventhubs-create-namespace-and-enable-capture-for-adls%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-eventhubs-create-namespace-and-enable-capture-for-adls%2Fazuredeploy.json" target="_blank">
+    <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+For information about using this template, see [Create an Event Hubs namespace with Event Hub and enable Capture using an ARM template](http://azure.microsoft.com/documentation/articles/event-hubs-create-event-hub-and-enable-capture/)
+Azure Event Hubs Capture enables you to automatically deliver the streaming data in your Event Hubs to a Blob storage of your choice with the added flexibility to specify a time or size interval of your choosing.
+Setting up Capture is quick, there are no administrative costs to run it, and it scales automatically with your Event Hubs Throughput Units. Event Hubs Capture is the easiest way to load streaming data into Azure and allows you to focus on data processing rather than data capture. You will need to specify you existing storage resource id and your container to enable archiving to it.

--- a/201-eventhubs-create-namespace-and-enable-capture-for-adls/azuredeploy.json
+++ b/201-eventhubs-create-namespace-and-enable-capture-for-adls/azuredeploy.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2014-04-01-preview/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "eventHubNamespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the EventHub namespace"
+      }
+    },
+    "eventHubName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Event Hub"
+      }
+    },
+    "messageRetentionInDays": {
+      "type": "int",
+      "defaultValue": 1,
+      "minValue": 1,
+      "maxValue": 7,
+      "metadata": {
+        "description": "How long to retain the data in Event Hub"
+      }
+    },
+    "partitionCount": {
+      "type": "int",
+      "defaultValue": 4,
+      "minValue": 2,
+      "maxValue": 32,
+      "metadata": {
+        "description": "Number of partitions chosen"
+      }
+    },
+    "captureEnabled": {
+      "type": "string",
+      "defaultValue": "true",
+      "allowedValues": [
+        "false",
+        "true"
+      ],
+      "metadata": {
+        "description": "Enable or disable the Capture feature for your Event Hub"
+      }
+    },
+    "captureEncodingFormat": {
+      "type": "string",
+      "defaultValue": "Avro",
+      "allowedValues": [
+        "Avro"
+      ],
+      "metadata": {
+        "description": "The encoding format Eventhub capture serializes the EventData when archiving to your storage"
+      }
+    },
+    "captureTime": {
+      "type": "int",
+      "defaultValue": 300,
+      "minValue": 60,
+      "maxValue": 900,
+      "metadata": {
+        "description": "the time window in seconds for the archival"
+      }
+    },
+    "captureSize": {
+      "type": "int",
+      "defaultValue": 314572800,
+      "minValue": 10485760,
+      "maxValue": 524288000,
+      "metadata": {
+        "description": "the size window in bytes for evetn hub capture"
+      }
+    },
+   
+    "captureNameFormat": {
+      "type": "string",
+	  "defaultValue": "{Namespace}/{EventHub}/{PartitionId}/{Year}/{Month}/{Day}/{Hour}/{Minute}/{Second}",
+      "metadata": {
+        "description": "A Capture Name Format must contain {Namespace}, {EventHub}, {PartitionId}, {Year}, {Month}, {Day}, {Hour}, {Minute} and {Second} fields. These can be arranged in any order with or without delimeters. E.g.  Prod_{EventHub}/{Namespace}\\{PartitionId}_{Year}_{Month}/{Day}/{Hour}/{Minute}/{Second}"
+      }
+    }
+  },
+  "subscriptionId": {
+            "type": "string",
+            "metadata": {
+                "description": "Subscription Id of both Data Lake Store and Event Hub namespace"
+            }
+        },
+        "dataLakeAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Data Lake Store name"
+            }
+        },
+        "dataLakeFolderPath": {
+            "type": "string",
+            "metadata": {
+                "description": "Destination archive folder path"
+            }
+        },
+  "variables": {
+    "defaultSASKeyName": "RootManageSharedAccessKey",
+    "authRuleResourceId": "[resourceId('Microsoft.EventHub/namespaces/authorizationRules', parameters('eventHubNamespaceName'), variables('defaultSASKeyName'))]",
+	"ehVersion": "2017-04-01"
+  },
+  "resources": [
+        {
+            "apiVersion": "2015-08-01",
+            "name": "[parameters('namespaceName')]",
+            "type": "Microsoft.EventHub/Namespaces",
+            "location": "[variables('location')]",
+            "sku": {
+                "name": "Standard",
+                "tier": "Standard"
+            },
+            "resources": [
+                {
+                    "apiVersion": "2015-08-01",
+                    "name": "[parameters('eventHubName')]",
+                    "type": "EventHubs",
+                    "dependsOn": [
+                        "[concat('Microsoft.EventHub/namespaces/', parameters('namespaceName'))]"
+                    ],
+                    "properties": {
+                        "path": "[parameters('eventHubName')]",
+                        "ArchiveDescription": {
+                            "enabled": "true",
+                            "encoding": "[parameters('archiveEncodingFormat')]",
+                            "intervalInSeconds": "[parameters('archiveTime')]",
+                            "sizeLimitInBytes": "[parameters('archiveSize')]",
+                            "destination": {
+                                "name": "EventHubArchive.AzureDataLake",
+                                "properties": {
+                                    "DataLakeSubscriptionId": "[parameters('subscriptionId')]",
+                                    "DataLakeAccountName": "[parameters('dataLakeAccountName')]",
+                                    "DataLakeFolderPath": "[parameters('dataLakeFolderPath')]",
+                                    "ArchiveNameFormat": "[parameters('captureNameFormat')]"
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    }
+  ],
+  "outputs": {
+    "NamespaceConnectionString": {
+      "type": "string",
+      "value": "[listkeys(variables('authRuleResourceId'), variables('ehVersion')).primaryConnectionString]"
+    },
+    "SharedAccessPolicyPrimaryKey": {
+      "type": "string",
+      "value": "[listkeys(variables('authRuleResourceId'), variables('ehVersion')).primaryKey]"
+    }
+  }
+}

--- a/201-eventhubs-create-namespace-and-enable-capture-for-adls/azuredeploy.parameters.json
+++ b/201-eventhubs-create-namespace-and-enable-capture-for-adls/azuredeploy.parameters.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "eventHubNamespaceName": {
+      "value": "GEN-UNIQUE"
+    },
+    "eventHubName": {
+      "value": "GEN-UNIQUE"
+    },
+    "messageRetentionInDays": {
+      "value": 1
+    },
+    "partitionCount": {
+      "value": 2
+    },
+    "captureEnabled": {
+      "value": "true"
+    },
+    "captureEncodingFormat": {
+      "value": "Avro"
+    },
+    "captureTime": {
+      "value": 300
+    },
+    "captureSize": {
+      "value": 314572800
+    },
+    "destinationStorageAccountResourceId": {
+      "value": "GEN-UNIQUE"
+    },
+    "blobContainerName": {
+      "value": "GEN-UNIQUE"
+    },
+    "captureNameFormat": {
+      "value": "GEN-UNIQUE"
+    },
+	"subscriptionId": {
+	 "value": "GEN-UNIQUE"
+	},
+	"dataLakeAccountName": {
+	 "value": "GEN-UNIQUE"
+	},
+	"dataLakeFolderPath": {
+	 "value":"GEN-UNIQUE"
+	}
+  }
+}

--- a/201-eventhubs-create-namespace-and-enable-capture-for-adls/metadata.json
+++ b/201-eventhubs-create-namespace-and-enable-capture-for-adls/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Create EventHubs with Capture enabled",
+  "description": "This template enables you to deploy a EventHubs namespace with an event hub and enabling Capture on it",
+  "summary": "Creates a EventHubs namespace, an Event Hub with Capture enabled on it for Azure Data Lake Store as destination. Existing data lake store under the same subscription Id, details are to be specified in the template.",
+  "githubUsername": "ShubhaVijayasarathy",
+  "dateUpdated": "2017-08-03"
+}

--- a/201-eventhubs-create-namespace-and-enable-capture/metadata.json
+++ b/201-eventhubs-create-namespace-and-enable-capture/metadata.json
@@ -1,7 +1,7 @@
 {
-  "itemDisplayName": "Create EventHubs with Archive enabled",
-  "description": "This template enables you to deploy a EventHubs namespace with an Event Huh enabling Archive on it",
-  "summary": "Creates a EventHubs namespace, an Event Hub with Archive enabled on it. Existing storage account resource id and container details are to be specified in the template.",
+  "itemDisplayName": "Create EventHubs with Capture enabled",
+  "description": "This template enables you to deploy a EventHubs namespace with an event hub and enabling Capture on it",
+  "summary": "Creates a EventHubs namespace, an Event Hub with Capture enabled on it for Azure Storage as destination. Existing storage account resource id and container details are to be specified in the template.",
   "githubUsername": "v-ajnava",
   "dateUpdated": "2017-06-22"
 }


### PR DESCRIPTION
Enabling Event Hubs Capture to ADLS as a new destination

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

