### PR TITLE
Fixes incorrect reference to azure-cli 1.x in the 2.x script

### DIFF
--- a/az-group-deploy.sh
+++ b/az-group-deploy.sh
@@ -55,7 +55,7 @@ then
     if [[ -z $storageAccountName ]]
     then    
 
-        subscriptionId=$( azure account show --json | jq -r '.[0].id' )
+        subscriptionId=$( az account show -o json | jq -r '.id' )
         subscriptionId="${subscriptionId//-/}" 
         subscriptionId="${subscriptionId:0:19}"
         artifactsStorageAccountName="stage$subscriptionId"


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ X ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* The `az-group-deploy.sh` file is supposed to be compatible with the azure-cli 2.0, but still had a remaining reference to the `azure` cli 1.0 commands. I corrected the reference and modified behavior to work with it.
