### PR TITLE
Correcting apiversion

### DIFF
--- a/101-1vm-2nics-2subnets-1vnet/azuredeploy.json
+++ b/101-1vm-2nics-2subnets-1vnet/azuredeploy.json
@@ -50,7 +50,7 @@
         {
             "name": "[variables('virtualMachineName')]",
             "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2017-03-30",
+            "apiVersion": "2016-08-01",
             "location": "[resourceGroup().location]",
             "comments": "This is the virtual machine that you're building.",
             "dependsOn": [
@@ -109,7 +109,7 @@
         {
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('diagStorageAccountName')]",
-            "apiVersion": "2017-06-01",
+            "apiVersion": "2016-01-01",
             "location": "[resourceGroup().location]",
             "sku": {
                 "name": "[parameters('storageAccountType')]"

--- a/101-acsengine-swarmmode/azuredeploy.json
+++ b/101-acsengine-swarmmode/azuredeploy.json
@@ -750,7 +750,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "count": "[variables('agentStorageAccountsCount')]",
         "name": "vmLoopNode"
@@ -766,7 +766,7 @@
       "type": "Microsoft.Storage/storageAccounts"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "location": "[variables('location')]",
       "name": "[variables('agentIPAddressName')]",
       "properties": {
@@ -778,7 +778,7 @@
       "type": "Microsoft.Network/publicIPAddresses"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('agentIPAddressName'))]"
       ],
@@ -896,7 +896,7 @@
       "type": "Microsoft.Network/loadBalancers"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]",
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountPrefixes')[mod(add(0,variables('agentStorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('storageAccountPrefixes')[div(add(0,variables('agentStorageAccountOffset')),variables('storageAccountPrefixesCount'))],variables('agentAccountName'))]",
@@ -988,7 +988,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets"
     },
     {
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
@@ -1000,7 +1000,7 @@
       "type": "Microsoft.Storage/storageAccounts"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "location": "[variables('location')]",
       "name": "[variables('virtualNetworkName')]",
       "properties": {
@@ -1028,14 +1028,14 @@
       "type": "Microsoft.Network/virtualNetworks"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "location": "[variables('location')]",
       "name": "[variables('masterAvailabilitySet')]",
       "properties": {},
       "type": "Microsoft.Compute/availabilitySets"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "location": "[variables('location')]",
       "name": "[variables('masterPublicIPAddressName')]",
       "properties": {
@@ -1047,7 +1047,7 @@
       "type": "Microsoft.Network/publicIPAddresses"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('masterPublicIPAddressName'))]"
       ],
@@ -1073,7 +1073,7 @@
       "type": "Microsoft.Network/loadBalancers"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "copy": {
         "count": "[variables('masterCount')]",
         "name": "masterLbLoopNode"
@@ -1095,7 +1095,7 @@
       "type": "Microsoft.Network/loadBalancers/inboundNatRules"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "dependsOn": [
         "[variables('masterLbID')]"
       ],
@@ -1113,7 +1113,7 @@
       "type": "Microsoft.Network/loadBalancers/inboundNatRules"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "copy": {
         "count": "[variables('masterCount')]",
         "name": "nicLoopNode"
@@ -1149,7 +1149,7 @@
       "type": "Microsoft.Network/networkInterfaces"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "copy": {
         "count": "[variables('masterCount')]",
         "name": "vmLoopNode"
@@ -1214,7 +1214,7 @@
       "type": "Microsoft.Compute/virtualMachines"
     },
     {
-      "apiVersion": "[variables('apiVersionDefault')]",
+      "apiVersion": "2016-03-30",
       "copy": {
         "count": "[variables('masterCount')]",
         "name": "vmLoopNode"

--- a/101-application-gateway-create/azuredeploy.json
+++ b/101-application-gateway-create/azuredeploy.json
@@ -114,7 +114,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -135,7 +135,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[parameters('applicationGatewayName')]",
       "type": "Microsoft.Network/applicationGateways",
       "location": "[resourceGroup().location]",

--- a/101-application-gateway-public-ip-ssl-offload/azuredeploy.json
+++ b/101-application-gateway-public-ip-ssl-offload/azuredeploy.json
@@ -1,79 +1,79 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "addressPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/16",
-            "metadata": {
-                "description": "Address prefix for the Virtual Network"
-            }
-        },
-        "subnetPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/28",
-            "metadata": {
-                "description": "Subnet prefix"
-            }
-        },
-        "skuName": {
-            "type": "string",
-            "allowedValues": [
-                "Standard_Small",
-                "Standard_Medium",
-                "Standard_Large"
-            ],
-            "defaultValue": "Standard_Medium",
-            "metadata": {
-                "description": "Sku Name"
-            }
-        },
-        "capacity": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "Number of instances"
-            }
-        },
-        "backendIpAddress1": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Address for Backend Server 1"
-            }
-        },
-        "backendIpAddress2": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Address for Backend Server 2"
-            }
-        },
-        "certData": {
-            "type": "string",
-            "metadata": {
-                "description": "Base-64 encoded form of the .pfx file"
-            }
-        },
-        "certPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for .pfx certificate"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "addressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "Address prefix for the Virtual Network"
+      }
     },
-    "variables": {
-        "applicationGatewayName": "applicationGateway1",
-        "publicIPAddressName": "publicIp1",
-        "virtualNetworkName": "virtualNetwork1",
-        "subnetName": "appGatewaySubnet",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-        "publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
-        "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
-		"apiVersion": "2015-05-01-preview"
+    "subnetPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/28",
+      "metadata": {
+        "description": "Subnet prefix"
+      }
     },
+    "skuName": {
+      "type": "string",
+      "allowedValues": [
+        "Standard_Small",
+        "Standard_Medium",
+        "Standard_Large"
+      ],
+      "defaultValue": "Standard_Medium",
+      "metadata": {
+        "description": "Sku Name"
+      }
+    },
+    "capacity": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "Number of instances"
+      }
+    },
+    "backendIpAddress1": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 1"
+      }
+    },
+    "backendIpAddress2": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 2"
+      }
+    },
+    "certData": {
+      "type": "string",
+      "metadata": {
+        "description": "Base-64 encoded form of the .pfx file"
+      }
+    },
+    "certPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for .pfx certificate"
+      }
+    }
+  },
+  "variables": {
+    "applicationGatewayName": "applicationGateway1",
+    "publicIPAddressName": "publicIp1",
+    "virtualNetworkName": "virtualNetwork1",
+    "subnetName": "appGatewaySubnet",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
+    "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
+    "apiVersion": "2015-05-01-preview"
+  },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -82,7 +82,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -103,7 +103,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "name": "[variables('applicationGatewayName')]",
       "type": "Microsoft.Network/applicationGateways",
       "location": "[resourceGroup().location]",

--- a/101-application-gateway-public-ip/azuredeploy.json
+++ b/101-application-gateway-public-ip/azuredeploy.json
@@ -61,7 +61,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -70,7 +70,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -91,7 +91,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "name": "[variables('applicationGatewayName')]",
       "type": "Microsoft.Network/applicationGateways",
       "location": "[resourceGroup().location]",

--- a/101-application-gateway-redirect/azuredeploy.json
+++ b/101-application-gateway-redirect/azuredeploy.json
@@ -1,311 +1,349 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"virtualNetworkName": {
-			"type": "string",
-			"metadata": {
-				"description": "virtual network name"
-			}
-		},
-		"vnetAddressPrefix": {
-			"type": "string",
-			"defaultValue": "10.0.0.0/16",
-			"metadata": {
-				"description": "virtual network address range"
-			}
-		},
-		"subnetName": {
-			"type": "string",
-			"defaultValue": "subnet1",
-			"metadata": {
-				"description": "Subnet Name"
-			}
-		},
-		"subnetPrefix": {
-			"type": "string",
-			"defaultValue": "10.0.0.0/24",
-			"metadata": {
-				"description": "Subnet prefix"
-			}
-		},
-		"applicationGatewayName": {
-			"type": "string",
-			"defaultValue": "applicationGateway1",
-			"metadata": {
-				"description": "application gateway name"
-			}
-		},
-		"skuName": {
-			"type": "string",
-			"allowedValues": ["Standard_Small",
-			"Standard_Medium",
-			"Standard_Large"],
-			"defaultValue": "Standard_Medium",
-			"metadata": {
-				"description": "Sku Name"
-			}
-		},
-		"capacity": {
-			"type": "int",
-			"defaultValue": 2,
-			"metadata": {
-				"description": "application gateway instance count"
-			}
-		},
-		"backendIpAddress1": {
-			"type": "string",
-			"metadata": {
-				"description": "IP Address for Backend Server 1"
-			}
-		},
-		"backendIpAddress2": {
-			"type": "string",
-			"metadata": {
-				"description": "IP Address for Backend Server 2"
-			}
-		},
-		"pathMatch1": {
-			"type": "string",
-			"metadata": {
-				"description": "Path match string for Path Rule 1"
-			}
-		},
-		"certData": {
-			"type": "string",
-			"metadata": {
-				"description": "Base-64 encoded form of the .pfx file"
-			}
-		},
-		"certPassword": {
-			"type": "securestring",
-			"metadata": {
-				"description": "Password for .pfx certificate"
-			}
-		}
-	},
-	"variables": {
-		"publicIPAddressName": "[concat('publicIp',parameters('applicationGatewayName'))]",
-		"vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
-		"subnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetName'))]",
-		"publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
-		"applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',parameters('applicationGatewayName'))]",
-		"apiVersion": "2017-03-01"
-	},
-	"resources": [{
-		"apiVersion": "[variables('apiVersion')]",
-		"type": "Microsoft.Network/publicIPAddresses",
-		"name": "[variables('publicIPAddressName')]",
-		"location": "[resourceGroup().location]",
-		"properties": {
-			"publicIPAllocationMethod": "Dynamic"
-		}
-	},
-	{
-		"apiVersion": "[variables('apiVersion')]",
-		"type": "Microsoft.Network/virtualNetworks",
-		"name": "[parameters('virtualNetworkName')]",
-		"location": "[resourceGroup().location]",
-		"properties": {
-			"addressSpace": {
-				"addressPrefixes": ["[parameters('vnetAddressPrefix')]"]
-			},
-			"subnets": [{
-				"name": "[parameters('subnetName')]",
-				"properties": {
-					"addressPrefix": "[parameters('subnetPrefix')]"
-				}
-			}]
-		}
-	},
-	{
-		"apiVersion": "2017-04-01",
-		"name": "[parameters('applicationGatewayName')]",
-		"type": "Microsoft.Network/applicationGateways",
-		"location": "[resourceGroup().location]",
-		"dependsOn": ["[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]",
-		"[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"],
-		"properties": {
-			"sku": {
-				"name": "[parameters('skuName')]",
-				"tier": "Standard",
-				"capacity": "[parameters('capacity')]"
-			},
-			"sslCertificates": [{
-				"name": "appGatewaySslCert",
-				"properties": {
-					"data": "[parameters('certData')]",
-					"password": "[parameters('certPassword')]"
-				}
-			}],
-			"gatewayIPConfigurations": [{
-				"name": "appGatewayIpConfig",
-				"properties": {
-					"subnet": {
-						"id": "[variables('subnetRef')]"
-					}
-				}
-			}],
-			"frontendIPConfigurations": [{
-				"name": "appGatewayFrontendIP",
-				"properties": {
-					"PublicIPAddress": {
-						"id": "[variables('publicIPRef')]"
-					}
-				}
-			}],
-			"frontendPorts": [{
-				"name": "appGatewayFrontendHttpPort1",
-				"properties": {
-					"Port": 80
-				}
-			},
-			{
-				"name": "appGatewayFrontendHttpsPort1",
-				"properties": {
-					"Port": 443
-				}
-			},
-			{
-				"name": "appGatewayFrontendHttpPort2",
-				"properties": {
-					"Port": 8080
-				}
-			}],
-			"backendAddressPools": [{
-				"name": "appGatewayBackendPool1",
-				"properties": {
-					"BackendAddresses": [{
-						"IpAddress": "[parameters('backendIpAddress1')]"
-					}]
-				}
-			},
-			{
-				"name": "appGatewayBackendPool2",
-				"properties": {
-					"BackendAddresses": [{
-						"IpAddress": "[parameters('backendIpAddress2')]"
-					}]
-				}
-			}],
-			"backendHttpSettingsCollection": [{
-				"name": "appGatewayBackendHttpSettings",
-				"properties": {
-					"Port": 80,
-					"Protocol": "Http"
-				}
-			}],
-			"httpListeners": [{
-				"name": "appGatewayHttpListener1",
-				"properties": {
-					"FrontendIPConfiguration": {
-						"Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-					},
-					"FrontendPort": {
-						"Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendHttpPort1')]"
-					},
-					"Protocol": "Http"
-				}
-			},
-			{
-				"name": "appGatewayHttpsListener1",
-				"properties": {
-					"FrontendIPConfiguration": {
-						"Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-					},
-					"FrontendPort": {
-						"Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendHttpsPort1')]"
-					},
-					"Protocol": "Https",
-					"SslCertificate": {
-						"Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert')]"
-					}
-				}
-			},
-			{
-				"name": "appGatewayHttpListener2",
-				"properties": {
-					"FrontendIPConfiguration": {
-						"Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-					},
-					"FrontendPort": {
-						"Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendHttpPort2')]"
-					},
-					"Protocol": "Http"
-				}
-			}],
-			"redirectConfigurations": [{
-				"Name": "redirectConfig1",
-				"properties": {
-					"redirectType": "Temporary",
-					"targetListener": {
-						"id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpsListener1')]"
-					}
-				}
-			},
-			{
-				"Name": "redirectConfig2",
-				"properties": {
-					"redirectType": "Temporary",
-					"targetUrl": "http://www.bing.com"
-				}
-			}],
-			"urlPathMaps": [{
-				"name": "urlPathMap1",
-				"properties": {
-					"defaultRedirectConfiguration": {
-						"id": "[concat(variables('applicationGatewayID'), '/redirectConfigurations/redirectConfig2')]"
-					},
-					"pathRules": [{
-						"name": "pathRule1",
-						"properties": {
-							"paths": ["[parameters('pathMatch1')]"],
-							"redirectConfiguration": {
-								"id": "[concat(variables('applicationGatewayID'), '/redirectConfigurations/redirectConfig1')]"
-							}
-						}
-					}]
-				}
-			}],
-			"requestRoutingRules": [{
-				"Name": "rule1",
-				"properties": {
-					"RuleType": "Basic",
-					"httpListener": {
-						"id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener1')]"
-					},
-					"redirectConfiguration": {
-						"id": "[concat(variables('applicationGatewayID'), '/redirectConfigurations/redirectConfig1')]"
-					}
-				}
-			},
-			{
-				"Name": "rule2",
-				"properties": {
-					"RuleType": "Basic",
-					"httpListener": {
-						"id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpsListener1')]"
-					},
-					"backendAddressPool": {
-						"id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool1')]"
-					},
-					"backendHttpSettings": {
-						"id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
-					}
-				}
-			},
-			{
-				"Name": "rule3",
-				"properties": {
-					"RuleType": "PathBasedRouting",
-					"httpListener": {
-						"id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener2')]"
-					},
-					"urlPathMap": {
-						"id": "[concat(variables('applicationGatewayID'), '/urlPathMaps/urlPathMap1')]"
-					}
-				}
-			}]
-		}
-	}]
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "virtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "virtual network name"
+      }
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "virtual network address range"
+      }
+    },
+    "subnetName": {
+      "type": "string",
+      "defaultValue": "subnet1",
+      "metadata": {
+        "description": "Subnet Name"
+      }
+    },
+    "subnetPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/24",
+      "metadata": {
+        "description": "Subnet prefix"
+      }
+    },
+    "applicationGatewayName": {
+      "type": "string",
+      "defaultValue": "applicationGateway1",
+      "metadata": {
+        "description": "application gateway name"
+      }
+    },
+    "skuName": {
+      "type": "string",
+      "allowedValues": [
+        "Standard_Small",
+        "Standard_Medium",
+        "Standard_Large"
+      ],
+      "defaultValue": "Standard_Medium",
+      "metadata": {
+        "description": "Sku Name"
+      }
+    },
+    "capacity": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "application gateway instance count"
+      }
+    },
+    "backendIpAddress1": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 1"
+      }
+    },
+    "backendIpAddress2": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 2"
+      }
+    },
+    "pathMatch1": {
+      "type": "string",
+      "metadata": {
+        "description": "Path match string for Path Rule 1"
+      }
+    },
+    "certData": {
+      "type": "string",
+      "metadata": {
+        "description": "Base-64 encoded form of the .pfx file"
+      }
+    },
+    "certPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for .pfx certificate"
+      }
+    }
+  },
+  "variables": {
+    "publicIPAddressName": "[concat('publicIp',parameters('applicationGatewayName'))]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetName'))]",
+    "publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
+    "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',parameters('applicationGatewayName'))]",
+    "apiVersion": "2017-03-01"
+  },
+  "resources": [
+    {
+      "apiVersion": "2017-03-01",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2017-03-01",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('vnetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2017-04-01",
+      "name": "[parameters('applicationGatewayName')]",
+      "type": "Microsoft.Network/applicationGateways",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+      ],
+      "properties": {
+        "sku": {
+          "name": "[parameters('skuName')]",
+          "tier": "Standard",
+          "capacity": "[parameters('capacity')]"
+        },
+        "sslCertificates": [
+          {
+            "name": "appGatewaySslCert",
+            "properties": {
+              "data": "[parameters('certData')]",
+              "password": "[parameters('certPassword')]"
+            }
+          }
+        ],
+        "gatewayIPConfigurations": [
+          {
+            "name": "appGatewayIpConfig",
+            "properties": {
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ],
+        "frontendIPConfigurations": [
+          {
+            "name": "appGatewayFrontendIP",
+            "properties": {
+              "PublicIPAddress": {
+                "id": "[variables('publicIPRef')]"
+              }
+            }
+          }
+        ],
+        "frontendPorts": [
+          {
+            "name": "appGatewayFrontendHttpPort1",
+            "properties": {
+              "Port": 80
+            }
+          },
+          {
+            "name": "appGatewayFrontendHttpsPort1",
+            "properties": {
+              "Port": 443
+            }
+          },
+          {
+            "name": "appGatewayFrontendHttpPort2",
+            "properties": {
+              "Port": 8080
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "appGatewayBackendPool1",
+            "properties": {
+              "BackendAddresses": [
+                {
+                  "IpAddress": "[parameters('backendIpAddress1')]"
+                }
+              ]
+            }
+          },
+          {
+            "name": "appGatewayBackendPool2",
+            "properties": {
+              "BackendAddresses": [
+                {
+                  "IpAddress": "[parameters('backendIpAddress2')]"
+                }
+              ]
+            }
+          }
+        ],
+        "backendHttpSettingsCollection": [
+          {
+            "name": "appGatewayBackendHttpSettings",
+            "properties": {
+              "Port": 80,
+              "Protocol": "Http"
+            }
+          }
+        ],
+        "httpListeners": [
+          {
+            "name": "appGatewayHttpListener1",
+            "properties": {
+              "FrontendIPConfiguration": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+              },
+              "FrontendPort": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendHttpPort1')]"
+              },
+              "Protocol": "Http"
+            }
+          },
+          {
+            "name": "appGatewayHttpsListener1",
+            "properties": {
+              "FrontendIPConfiguration": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+              },
+              "FrontendPort": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendHttpsPort1')]"
+              },
+              "Protocol": "Https",
+              "SslCertificate": {
+                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert')]"
+              }
+            }
+          },
+          {
+            "name": "appGatewayHttpListener2",
+            "properties": {
+              "FrontendIPConfiguration": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+              },
+              "FrontendPort": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendHttpPort2')]"
+              },
+              "Protocol": "Http"
+            }
+          }
+        ],
+        "redirectConfigurations": [
+          {
+            "Name": "redirectConfig1",
+            "properties": {
+              "redirectType": "Temporary",
+              "targetListener": {
+                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpsListener1')]"
+              }
+            }
+          },
+          {
+            "Name": "redirectConfig2",
+            "properties": {
+              "redirectType": "Temporary",
+              "targetUrl": "http://www.bing.com"
+            }
+          }
+        ],
+        "urlPathMaps": [
+          {
+            "name": "urlPathMap1",
+            "properties": {
+              "defaultRedirectConfiguration": {
+                "id": "[concat(variables('applicationGatewayID'), '/redirectConfigurations/redirectConfig2')]"
+              },
+              "pathRules": [
+                {
+                  "name": "pathRule1",
+                  "properties": {
+                    "paths": [
+                      "[parameters('pathMatch1')]"
+                    ],
+                    "redirectConfiguration": {
+                      "id": "[concat(variables('applicationGatewayID'), '/redirectConfigurations/redirectConfig1')]"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "requestRoutingRules": [
+          {
+            "Name": "rule1",
+            "properties": {
+              "RuleType": "Basic",
+              "httpListener": {
+                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener1')]"
+              },
+              "redirectConfiguration": {
+                "id": "[concat(variables('applicationGatewayID'), '/redirectConfigurations/redirectConfig1')]"
+              }
+            }
+          },
+          {
+            "Name": "rule2",
+            "properties": {
+              "RuleType": "Basic",
+              "httpListener": {
+                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpsListener1')]"
+              },
+              "backendAddressPool": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool1')]"
+              },
+              "backendHttpSettings": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
+              }
+            }
+          },
+          {
+            "Name": "rule3",
+            "properties": {
+              "RuleType": "PathBasedRouting",
+              "httpListener": {
+                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener2')]"
+              },
+              "urlPathMap": {
+                "id": "[concat(variables('applicationGatewayID'), '/urlPathMaps/urlPathMap1')]"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/101-azure-relay-create-namespace/azuredeploy.json
+++ b/101-azure-relay-create-namespace/azuredeploy.json
@@ -1,40 +1,38 @@
 {
-   "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-   "contentVersion":"1.0.0.0",
-   "parameters":{
-      "name":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the Azure Relay namespace"
-         }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "name": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Azure Relay namespace"
       }
-   },
-   "variables":{
-      "location":"[resourceGroup().location]",
-      "apiVersion":"2016-07-01",
-      "defaultSASKeyName":"RootManageSharedAccessKey",
-      "defaultAuthRuleResourceId":"[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('name'), variables('defaultSASKeyName'))]"
-   },
-   "resources":[
-      {
-         "apiVersion":"[variables('apiVersion')]",
-         "name":"[parameters('name')]",
-         "type":"Microsoft.Relay/Namespaces",
-         "location":"[variables('location')]",
-         "kind":"Relay",
-         "properties":{
-
-         }
-      }
-   ],
-   "outputs":{
-      "NamespaceDefaultConnectionString":{
-         "type":"string",
-         "value":"[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
-      },
-      "DefaultSharedAccessPolicyPrimaryKey":{
-         "type":"string",
-         "value":"[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryKey]"
-      }
-   }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "apiVersion": "2016-07-01",
+    "defaultSASKeyName": "RootManageSharedAccessKey",
+    "defaultAuthRuleResourceId": "[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('name'), variables('defaultSASKeyName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-07-01",
+      "name": "[parameters('name')]",
+      "type": "Microsoft.Relay/Namespaces",
+      "location": "[variables('location')]",
+      "kind": "Relay",
+      "properties": {}
+    }
+  ],
+  "outputs": {
+    "NamespaceDefaultConnectionString": {
+      "type": "string",
+      "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
+    },
+    "DefaultSharedAccessPolicyPrimaryKey": {
+      "type": "string",
+      "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryKey]"
+    }
+  }
 }

--- a/101-data-lake-analytics/azuredeploy.json
+++ b/101-data-lake-analytics/azuredeploy.json
@@ -1,70 +1,72 @@
 {
-	"$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"adlAnalyticsName": {
-			"type": "string",
-			"metadata": {
-				"description": "The name of the Data Lake Analytics account to create."
-			}
-		},
-		"adlStoreName": {
-			"type": "string",
-			"metadata": {
-				"description": "The name of the Data Lake Store account to create."
-			}
-		},
-		"location": {
-			"type": "string",
-			"allowedValues": [
-				"East US 2",
-				"Central US",
-				"North Europe"
-			],
-			"defaultValue": "East US 2",
-			"metadata": {
-				"description": "The location in which the resources will be created."
-			}
-        	}
-	},
-	"variables": {
-		"adlsApiVersion": "2016-11-01",
-		"adlaApiVersion": "2016-11-01"
-	},
-	"resources": [{
-		"name": "[parameters('adlStoreName')]",
-		"type": "Microsoft.DataLakeStore/accounts",
-		"location": "[parameters('location')]",
-		"apiVersion": "[variables('adlsApiVersion')]",
-		"dependsOn": [],
-		"tags": {
-			
-		}
-	},
-	{
-		"name": "[parameters('adlAnalyticsName')]",
-		"type": "Microsoft.DataLakeAnalytics/accounts",
-		"location": "[parameters('location')]",
-		"apiVersion": "[variables('adlaApiVersion')]",
-		"dependsOn": ["[concat('Microsoft.DataLakeStore/accounts/', parameters('adlStoreName'))]"],
-		"tags": {
-			
-		},
-		"properties": {
-			"defaultDataLakeStoreAccount": "[parameters('adlStoreName')]",
-			"dataLakeStoreAccounts": [{
-				"name": "[parameters('adlStoreName')]"
-			}]
-		}
-	}],
-	"outputs": {
-		"adlAnalyticsAccount": {
-			"type": "object",
-			"value": "[reference(resourceId('Microsoft.DataLakeAnalytics/accounts',parameters('adlAnalyticsName')))]"
-		},
-		"adlStoreAccount": {
-			"type": "object",
-			"value": "[reference(resourceId('Microsoft.DataLakeStore/accounts',parameters('adlStoreName')))]"
-		}
-	}
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adlAnalyticsName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Data Lake Analytics account to create."
+      }
+    },
+    "adlStoreName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Data Lake Store account to create."
+      }
+    },
+    "location": {
+      "type": "string",
+      "allowedValues": [
+        "East US 2",
+        "Central US",
+        "North Europe"
+      ],
+      "defaultValue": "East US 2",
+      "metadata": {
+        "description": "The location in which the resources will be created."
+      }
+    }
+  },
+  "variables": {
+    "adlsApiVersion": "2016-11-01",
+    "adlaApiVersion": "2016-11-01"
+  },
+  "resources": [
+    {
+      "name": "[parameters('adlStoreName')]",
+      "type": "Microsoft.DataLakeStore/accounts",
+      "location": "[parameters('location')]",
+      "apiVersion": "2016-11-01",
+      "dependsOn": [],
+      "tags": {}
+    },
+    {
+      "name": "[parameters('adlAnalyticsName')]",
+      "type": "Microsoft.DataLakeAnalytics/accounts",
+      "location": "[parameters('location')]",
+      "apiVersion": "2016-11-01",
+      "dependsOn": [
+        "[concat('Microsoft.DataLakeStore/accounts/', parameters('adlStoreName'))]"
+      ],
+      "tags": {},
+      "properties": {
+        "defaultDataLakeStoreAccount": "[parameters('adlStoreName')]",
+        "dataLakeStoreAccounts": [
+          {
+            "name": "[parameters('adlStoreName')]"
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "adlAnalyticsAccount": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.DataLakeAnalytics/accounts',parameters('adlAnalyticsName')))]"
+    },
+    "adlStoreAccount": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.DataLakeStore/accounts',parameters('adlStoreName')))]"
+    }
+  }
 }

--- a/101-hdinsight-linux-ssh-publickey-metastore-vnet/azuredeploy.json
+++ b/101-hdinsight-linux-ssh-publickey-metastore-vnet/azuredeploy.json
@@ -1,137 +1,137 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "clusterName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the cluster to create."
-            }
-        },
-        "clusterVersion": {
-            "type": "string",
-            "defaultValue": "3.2",
-            "metadata": {
-                "description": "The HDInsight version to deploy."
-            }
-        },
-        "headNodeSize": {
-            "type": "string",
-            "defaultValue": "Standard_D3",
-            "metadata": {
-                "description": "The VM size of the head nodes."
-            }
-        },
-        "workerNodeSize": {
-            "type": "string",
-            "defaultValue": "Standard_D3",
-            "metadata": {
-                "description": "The VM size of the worker nodes."
-            }
-        },
-        "workerNodeCount": {
-            "type": "int",
-            "defaultValue": 4,
-            "metadata": {
-                "description": "The number of worker nodes in the cluster."
-            }
-        },
-        "clusterLoginUserName": {
-            "type": "string",
-            "defaultValue": "admin",
-            "metadata": {
-                "description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
-            }
-        },
-        "clusterLoginPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-            }
-        },
-        "sshUserName": {
-            "type": "string",
-            "metadata": {
-                "description": "These credentials can be used to remotely access the cluster."
-            }
-        },
-        "sshPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-            }
-        },
-        "existingClusterStorageResourceGroup": {
-            "type": "string",
-            "metadata": {
-                "description": "The resource group name of the storage account to use as the cluster's default storage."
-            }
-        },
-        "existingClusterStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the storage account to use as the cluster's default storage."
-            }
-        },
-        "newOrExistingClusterStorageContainerName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the storage container to use."
-            }
-        },
-        "existingHiveMetastoreServerName": {
-            "type": "string",
-            "metadata": {
-                "description": "The fully-qualified domain name of the SQL server to use for the external Hive metastore."
-            }
-        },
-        "existingHiveMetastoreDatabaseName": {
-            "type": "string",
-            "metadata": {
-                "description": "The external Hive metastore's existing SQL database."
-            }
-        },
-        "existingHiveMetastoreUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "The external Hive metastore's existing SQL server admin username."
-            }
-        },
-        "existingHiveMetastorePassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "The external Hive metastore's existing SQL server admin password."
-            }
-        },
-        "existingVirtualNetworkResourceGroup": {
-            "type": "string",
-            "metadata": {
-                "description": "The existing virtual network resource group name."
-            }
-        },
-        "existingVirtualNetworkName": {
-            "type": "string",
-            "metadata": {
-                "description": "The existing virtual network name."
-            }
-        },
-        "existingVirtualNetworkSubnetName": {
-            "type": "string",
-            "metadata": {
-                "description": "The existing virtual network subnet name."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the cluster to create."
+      }
     },
-    "variables": {
-        "defaultApiVersion": "2015-06-15",
-        "clusterApiVersion": "2015-03-01-preview"
+    "clusterVersion": {
+      "type": "string",
+      "defaultValue": "3.2",
+      "metadata": {
+        "description": "The HDInsight version to deploy."
+      }
     },
+    "headNodeSize": {
+      "type": "string",
+      "defaultValue": "Standard_D3",
+      "metadata": {
+        "description": "The VM size of the head nodes."
+      }
+    },
+    "workerNodeSize": {
+      "type": "string",
+      "defaultValue": "Standard_D3",
+      "metadata": {
+        "description": "The VM size of the worker nodes."
+      }
+    },
+    "workerNodeCount": {
+      "type": "int",
+      "defaultValue": 4,
+      "metadata": {
+        "description": "The number of worker nodes in the cluster."
+      }
+    },
+    "clusterLoginUserName": {
+      "type": "string",
+      "defaultValue": "admin",
+      "metadata": {
+        "description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
+      }
+    },
+    "clusterLoginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+      }
+    },
+    "sshUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "These credentials can be used to remotely access the cluster."
+      }
+    },
+    "sshPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+      }
+    },
+    "existingClusterStorageResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group name of the storage account to use as the cluster's default storage."
+      }
+    },
+    "existingClusterStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the storage account to use as the cluster's default storage."
+      }
+    },
+    "newOrExistingClusterStorageContainerName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the storage container to use."
+      }
+    },
+    "existingHiveMetastoreServerName": {
+      "type": "string",
+      "metadata": {
+        "description": "The fully-qualified domain name of the SQL server to use for the external Hive metastore."
+      }
+    },
+    "existingHiveMetastoreDatabaseName": {
+      "type": "string",
+      "metadata": {
+        "description": "The external Hive metastore's existing SQL database."
+      }
+    },
+    "existingHiveMetastoreUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The external Hive metastore's existing SQL server admin username."
+      }
+    },
+    "existingHiveMetastorePassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The external Hive metastore's existing SQL server admin password."
+      }
+    },
+    "existingVirtualNetworkResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The existing virtual network resource group name."
+      }
+    },
+    "existingVirtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "The existing virtual network name."
+      }
+    },
+    "existingVirtualNetworkSubnetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The existing virtual network subnet name."
+      }
+    }
+  },
+  "variables": {
+    "defaultApiVersion": "2015-06-15",
+    "clusterApiVersion": "2015-03-01-preview"
+  },
   "resources": [
     {
       "name": "[parameters('clusterName')]",
       "type": "Microsoft.HDInsight/clusters",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('clusterApiVersion')]",
+      "apiVersion": "2015-03-01-preview",
       "properties": {
         "clusterVersion": "[parameters('clusterVersion')]",
         "osType": "Linux",
@@ -210,10 +210,10 @@
       }
     }
   ],
-    "outputs": {
-        "cluster": {
-            "type": "object",
-            "value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
-        }
+  "outputs": {
+    "cluster": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
     }
+  }
 }

--- a/101-hdinsight-linux-ssh-publickey/azuredeploy.json
+++ b/101-hdinsight-linux-ssh-publickey/azuredeploy.json
@@ -1,55 +1,57 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"clusterType": {
-			"type": "string",
-			"allowedValues": ["hadoop",
-			"hbase",
-			"storm",
-			"spark"],
-			"metadata": {
-				"description": "The type of the HDInsight cluster to create."
-			}
-		},
-		"clusterName": {
-			"type": "string",
-			"metadata": {
-				"description": "The name of the HDInsight cluster to create."
-			}
-		},
-		"clusterLoginUserName": {
-			"type": "string",
-			"metadata": {
-				"description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
-			}
-		},
-		"clusterLoginPassword": {
-			"type": "securestring",
-			"metadata": {
-				"description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-			}
-		},
-		"sshUserName": {
-			"type": "string",
-			"metadata": {
-				"description": "These credentials can be used to remotely access the cluster."
-			}
-		},
-		"sshPublicKey": {
-			"type": "securestring",
-			"metadata": {
-				"description": "This field must be a valid SSH public key."
-			}
-		},
-		"clusterWorkerNodeCount": {
-			"type": "int",
-			"defaultValue": 4,
-			"metadata": {
-				"description": "The number of nodes in the HDInsight cluster."
-			}
-		}
-	},
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterType": {
+      "type": "string",
+      "allowedValues": [
+        "hadoop",
+        "hbase",
+        "storm",
+        "spark"
+      ],
+      "metadata": {
+        "description": "The type of the HDInsight cluster to create."
+      }
+    },
+    "clusterName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the HDInsight cluster to create."
+      }
+    },
+    "clusterLoginUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
+      }
+    },
+    "clusterLoginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+      }
+    },
+    "sshUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "These credentials can be used to remotely access the cluster."
+      }
+    },
+    "sshPublicKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "This field must be a valid SSH public key."
+      }
+    },
+    "clusterWorkerNodeCount": {
+      "type": "int",
+      "defaultValue": 4,
+      "metadata": {
+        "description": "The number of nodes in the HDInsight cluster."
+      }
+    }
+  },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id),'storage')]",
     "defaultApiVersion": "2015-05-01-preview",
@@ -60,11 +62,9 @@
       "name": "[variables('storageAccountName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('defaultApiVersion')]",
-      "dependsOn": [ ],
-      "tags": {
-
-      },
+      "apiVersion": "2015-05-01-preview",
+      "dependsOn": [],
+      "tags": {},
       "properties": {
         "accountType": "Standard_LRS"
       }
@@ -73,11 +73,11 @@
       "name": "[parameters('clusterName')]",
       "type": "Microsoft.HDInsight/clusters",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('clusterApiVersion')]",
-      "dependsOn": [ "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountName'))]" ],
-      "tags": {
-
-      },
+      "apiVersion": "2015-03-01-preview",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/',variables('storageAccountName'))]"
+      ],
+      "tags": {},
       "properties": {
         "clusterVersion": "3.5",
         "osType": "Linux",
@@ -146,10 +146,10 @@
       }
     }
   ],
-	"outputs": {
-		"cluster": {
-			"type": "object",
-			"value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
-		}
-	}
+  "outputs": {
+    "cluster": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
+    }
+  }
 }

--- a/101-internal-loadbalancer-create/azuredeploy.json
+++ b/101-internal-loadbalancer-create/azuredeploy.json
@@ -32,7 +32,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -53,7 +53,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -80,7 +80,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('loadBalancerName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",

--- a/101-iothub-with-consumergroup-create/azuredeploy.json
+++ b/101-iothub-with-consumergroup-create/azuredeploy.json
@@ -100,7 +100,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2016-02-03",
       "location": "[variables('location')]",
       "name": "[parameters('iotHubName')]",
       "properties": {
@@ -128,7 +128,7 @@
       "type": "Microsoft.Devices/iotHubs"
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2016-02-03",
       "dependsOn": [
         "[concat('Microsoft.Devices/iothubs/', parameters('iotHubName'))]"
       ],

--- a/101-jenkins-with-ssh-public-key/azuredeploy.json
+++ b/101-jenkins-with-ssh-public-key/azuredeploy.json
@@ -172,7 +172,7 @@
       }
     },
     {
-      "apiVersion": "2016-03-30",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",

--- a/101-loadbalancer-with-multivip/azuredeploy.json
+++ b/101-loadbalancer-with-multivip/azuredeploy.json
@@ -56,7 +56,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName1')]",
       "location": "[resourceGroup().location]",
@@ -68,7 +68,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName2')]",
       "location": "[resourceGroup().location]",
@@ -77,7 +77,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -98,7 +98,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -126,7 +126,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('loadBalancerName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",

--- a/101-loadbalancer-with-nat-rule/azuredeploy.json
+++ b/101-loadbalancer-with-nat-rule/azuredeploy.json
@@ -51,7 +51,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -63,7 +63,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -84,7 +84,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -117,7 +117,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('loadBalancerName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",

--- a/101-nic-publicip-dns-vnet/azuredeploy.json
+++ b/101-nic-publicip-dns-vnet/azuredeploy.json
@@ -45,7 +45,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -57,7 +57,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -78,7 +78,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",

--- a/101-point-to-site/azuredeploy.json
+++ b/101-point-to-site/azuredeploy.json
@@ -1,82 +1,82 @@
-{  
-   "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-   "contentVersion":"1.0.0.0",
-   "parameters":{  
-      "virtualNetworkName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"Name of the VNet."
-         }
-      },
-      "vnetAddressPrefix":{  
-         "type":"string",
-         "metadata":{  
-            "description":"Address space for the VNet."
-         }
-      },
-      "gatewaySubnetPrefix":{  
-         "type":"string",
-         "metadata":{  
-            "description":"The prefix for the GatewaySubnet where the VirtualNetworkGateway will be deployed. This must be at least /29."
-         }
-      },
-      "gatewayPublicIPName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"The name of the PublicIP attached to the VirtualNetworkGateway."
-         }
-      },
-      "gatewayName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"The name of the VirtualNetworkGateway."
-         }
-      },
-      "gatewaySku":{  
-         "type":"string",
-         "metadata":{  
-            "description":"The Sku of the Gateway. This must be one of Basic, Standard or HighPerformance."
-         }
-      },
-      "vpnClientAddressPoolPrefix":{  
-         "type":"string",
-         "metadata":{  
-            "description":"The IP address range from which VPN clients will receive an IP address when connected. Range specified must not overlap with on-premise network."
-         }
-      },
-      "clientRootCertName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"The name of the client root certificate used to authenticate VPN clients. This is a common name used to identify the root cert."
-         }
-      },
-      "clientRootCertData":{  
-         "type":"string",
-         "metadata":{  
-            "description":"Client root certificate data used to authenticate VPN clients."
-         }
-      },
-      "revokedCertName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"The name of revoked certificate, if any. This is a common name used to identify a given revoked certificate."
-         }
-      },
-      "revokedCertThumbprint":{  
-         "type":"string",
-         "metadata":{  
-            "description":"Thumbprint of the revoked certificate. This would revoke VPN client certificates matching this thumbprint from connecting to the VNet."
-         }
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "virtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the VNet."
       }
-   },
-   "variables":{  
-      "apiVersion":"2015-06-15",
-      "vnetID":"[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
-      "gatewaySubnetRef":"[concat(variables('vnetID'),'/subnets/','GatewaySubnet')]"
-   },
-   "resources":[
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address space for the VNet."
+      }
+    },
+    "gatewaySubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The prefix for the GatewaySubnet where the VirtualNetworkGateway will be deployed. This must be at least /29."
+      }
+    },
+    "gatewayPublicIPName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the PublicIP attached to the VirtualNetworkGateway."
+      }
+    },
+    "gatewayName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the VirtualNetworkGateway."
+      }
+    },
+    "gatewaySku": {
+      "type": "string",
+      "metadata": {
+        "description": "The Sku of the Gateway. This must be one of Basic, Standard or HighPerformance."
+      }
+    },
+    "vpnClientAddressPoolPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The IP address range from which VPN clients will receive an IP address when connected. Range specified must not overlap with on-premise network."
+      }
+    },
+    "clientRootCertName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the client root certificate used to authenticate VPN clients. This is a common name used to identify the root cert."
+      }
+    },
+    "clientRootCertData": {
+      "type": "string",
+      "metadata": {
+        "description": "Client root certificate data used to authenticate VPN clients."
+      }
+    },
+    "revokedCertName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of revoked certificate, if any. This is a common name used to identify a given revoked certificate."
+      }
+    },
+    "revokedCertThumbprint": {
+      "type": "string",
+      "metadata": {
+        "description": "Thumbprint of the revoked certificate. This would revoke VPN client certificates matching this thumbprint from connecting to the VNet."
+      }
+    }
+  },
+  "variables": {
+    "apiVersion": "2015-06-15",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+    "gatewaySubnetRef": "[concat(variables('vnetID'),'/subnets/','GatewaySubnet')]"
+  },
+  "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -97,7 +97,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('gatewayPublicIPName')]",
       "location": "[resourceGroup().location]",
@@ -106,7 +106,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworkGateways",
       "name": "[parameters('gatewayName')]",
       "location": "[resourceGroup().location]",
@@ -161,5 +161,5 @@
         }
       }
     }
-   ]
+  ]
 }

--- a/101-redis-cache/prereqs/prereq.azuredeploy.parameters.json
+++ b/101-redis-cache/prereqs/prereq.azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/101-security-group-create/azuredeploy.json
+++ b/101-security-group-create/azuredeploy.json
@@ -25,7 +25,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('networkSecurityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -49,7 +49,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",

--- a/101-servicebus-namespace/azuredeploy.json
+++ b/101-servicebus-namespace/azuredeploy.json
@@ -2,28 +2,25 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-      "serviceBusNamespaceName": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the Service Bus Namespace"
-            }
-        }
+    "serviceBusNamespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Service Bus Namespace"
+      }
+    }
   },
   "variables": {
-      "sbVersion": "2015-08-01"
+    "sbVersion": "2015-08-01"
   },
   "resources": [
     {
-      "apiVersion": "[variables('sbVersion')]",
+      "apiVersion": "2015-08-01",
       "name": "[parameters('serviceBusNamespaceName')]",
       "type": "Microsoft.ServiceBus/namespaces",
       "location": "[resourceGroup().location]",
-      "properties": {
-      },
-      "resources": [
-      ]
+      "properties": {},
+      "resources": []
     }
   ],
-  "outputs": {
-  }
+  "outputs": {}
 }

--- a/101-servicebus-queue/azuredeploy.json
+++ b/101-servicebus-queue/azuredeploy.json
@@ -20,28 +20,24 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('sbVersion')]",
+      "apiVersion": "2015-08-01",
       "name": "[parameters('serviceBusNamespaceName')]",
       "type": "Microsoft.ServiceBus/namespaces",
       "location": "[resourceGroup().location]",
-      "properties": {
-      },
+      "properties": {},
       "resources": [
         {
-            "apiVersion": "[variables('sbVersion')]",
-            "name": "[parameters('serviceBusQueueName')]",
-            "type": "Queues",
-            "dependsOn": [
-                "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
-            ],
-            "properties": {
-            },
-            "resources": [
-            ]
+          "apiVersion": "[variables('sbVersion')]",
+          "name": "[parameters('serviceBusQueueName')]",
+          "type": "Queues",
+          "dependsOn": [
+            "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
+          ],
+          "properties": {},
+          "resources": []
         }
       ]
     }
   ],
-  "outputs": {
-  }
+  "outputs": {}
 }

--- a/101-servicebus-topic-subscription/azuredeploy.json
+++ b/101-servicebus-topic-subscription/azuredeploy.json
@@ -26,41 +26,37 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('sbVersion')]",
+      "apiVersion": "2015-08-01",
       "name": "[parameters('serviceBusNamespaceName')]",
       "type": "Microsoft.ServiceBus/namespaces",
       "location": "[resourceGroup().location]",
-      "properties": {
-      },
+      "properties": {},
       "resources": [
         {
-            "apiVersion": "[variables('sbVersion')]",
-            "name": "[parameters('serviceBusTopicName')]",
-            "type": "Topics",
-            "dependsOn": [
-                "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
-            ],
-            "properties": {
-                "path": "[parameters('serviceBusTopicName')]"
-            },
-            "resources": [
-                {
-                    "apiVersion": "[variables('sbVersion')]",
-                    "name": "[parameters('serviceBusTopicSubscriptionName')]",
-                    "type": "Subscriptions",
-                    "dependsOn": [
-                        "[parameters('serviceBusTopicName')]"
-                    ],
-                    "properties": {
-                    },
-                    "resources": [
-                    ]
-                }
-            ]
+          "apiVersion": "[variables('sbVersion')]",
+          "name": "[parameters('serviceBusTopicName')]",
+          "type": "Topics",
+          "dependsOn": [
+            "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
+          ],
+          "properties": {
+            "path": "[parameters('serviceBusTopicName')]"
+          },
+          "resources": [
+            {
+              "apiVersion": "[variables('sbVersion')]",
+              "name": "[parameters('serviceBusTopicSubscriptionName')]",
+              "type": "Subscriptions",
+              "dependsOn": [
+                "[parameters('serviceBusTopicName')]"
+              ],
+              "properties": {},
+              "resources": []
+            }
+          ]
         }
       ]
     }
   ],
-  "outputs": {
-  }
+  "outputs": {}
 }

--- a/101-servicebus-topic/azuredeploy.json
+++ b/101-servicebus-topic/azuredeploy.json
@@ -20,29 +20,26 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('sbVersion')]",
+      "apiVersion": "2015-08-01",
       "name": "[parameters('serviceBusNamespaceName')]",
       "type": "Microsoft.ServiceBus/namespaces",
       "location": "[resourceGroup().location]",
-      "properties": {
-      },
+      "properties": {},
       "resources": [
         {
-            "apiVersion": "[variables('sbVersion')]",
-            "name": "[parameters('serviceBusTopicName')]",
-            "type": "Topics",
-            "dependsOn": [
-                "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
-            ],
-            "properties": {
-                "path": "[parameters('serviceBusTopicName')]"
-            },
-            "resources": [
-            ]
+          "apiVersion": "[variables('sbVersion')]",
+          "name": "[parameters('serviceBusTopicName')]",
+          "type": "Topics",
+          "dependsOn": [
+            "[concat('Microsoft.ServiceBus/namespaces/', parameters('serviceBusNamespaceName'))]"
+          ],
+          "properties": {
+            "path": "[parameters('serviceBusTopicName')]"
+          },
+          "resources": []
         }
       ]
     }
   ],
-  "outputs": {
-  }
+  "outputs": {}
 }

--- a/101-site-to-site-vpn-create/azuredeploy.json
+++ b/101-site-to-site-vpn-create/azuredeploy.json
@@ -1,221 +1,224 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "vpnType": {
-            "type": "string",
-            "metadata": {
-                "description": "Route based or policy based"
-            },
-            "defaultValue": "RouteBased",
-            "allowedValues": [
-                "RouteBased",
-                "PolicyBased"
-            ]
-        },
-        "localGatewayName": {
-            "type": "string",
-            "defaultValue": "localGateway",
-            "metadata": {
-                "description": "Arbitrary name for gateway resource representing "
-            }
-        },
-        "localGatewayIpAddress": {
-            "type": "string",
-            "defaultValue": "1.1.1.1",
-            "metadata": {
-                "description": "Public IP of your StrongSwan Instance"
-            }
-        },
-        "localAddressPrefix": {
-            "type": "array",
-            "defaultValue": [ "192.168.0.0/16" , "172.16.0.0/12" ],
-            "metadata": {
-                "description": "CIDR block representing the address space of the OnPremise VPN network's Subnet"
-            }
-        },
-        "virtualNetworkName": {
-            "type": "string",
-            "defaultValue": "azureVnet",
-            "metadata": {
-                "description": "Arbitrary name for the Azure Virtual Network"
-            }
-        },
-        "azureVNetAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.3.0.0/16",
-            "metadata": {
-                "description": "CIDR block representing the address space of the Azure VNet"
-            }
-        },
-        "subnetName": {
-            "type": "string",
-            "defaultValue": "Subnet1",
-            "metadata": {
-                "description": "Arbitrary name for the Azure Subnet"
-            }
-        },
-        "subnetPrefix": {
-            "type": "string",
-            "defaultValue": "10.3.1.0/24",
-            "metadata": {
-                "description": "CIDR block for VM subnet, subset of azureVNetAddressPrefix address space"
-            }
-        },
-        "gatewaySubnetPrefix": {
-            "type": "string",
-            "defaultValue": "10.3.200.0/29",
-            "metadata": {
-                "description": "CIDR block for gateway subnet, subset of azureVNetAddressPrefix address space"
-            }
-        },
-        "gatewayPublicIPName": {
-            "type": "string",
-            "defaultValue": "azureGatewayIP",
-            "metadata": {
-                "description": "Arbitrary name for public IP resource used for the new azure gateway"
-            }
-        },
-        "gatewayName": {
-            "type": "string",
-            "defaultValue": "azureGateway",
-            "metadata": {
-                "description": "Arbitrary name for the new gateway"
-            }
-        },
-        "gatewaySku":{  
-            "type":"string",
-            "defaultValue": "Basic",
-            "allowedValues": [
-                "Basic",
-                "Standard",
-                "HighPerformance"
-            ],
-            "metadata":{  
-                "description":"The Sku of the Gateway. This must be one of Basic, Standard or HighPerformance."
-            }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vpnType": {
+      "type": "string",
+      "metadata": {
+        "description": "Route based or policy based"
       },
-        "connectionName": {
-            "type": "string",
-            "defaultValue": "Azure2Other",
-            "metadata": {
-                "description": "Arbitrary name for the new connection between Azure VNet and other network"
-            }
-        },
-        "sharedKey": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Shared key (PSK) for IPSec tunnel"
-            }
-        }
+      "defaultValue": "RouteBased",
+      "allowedValues": [
+        "RouteBased",
+        "PolicyBased"
+      ]
     },
-    "variables": {
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-        "gatewaySubnetRef": "[concat(variables('vnetID'),'/subnets/','GatewaySubnet')]",
-        "api-version": "2015-06-15"
-    },
-    "resources": [
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/localNetworkGateways",
-        "name": "[parameters('localGatewayName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "localNetworkAddressSpace": {
-            "addressPrefixes": "[parameters('localAddressPrefix')]"
-          },
-          "gatewayIpAddress": "[parameters('localGatewayIpAddress')]"
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "name": "[parameters('connectionName')]",
-        "type": "Microsoft.Network/connections",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]",
-          "[concat('Microsoft.Network/localNetworkGateways/', parameters('localGatewayName'))]"
-        ],
-        "properties": {
-          "virtualNetworkGateway1": {
-            "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]"
-          },
-          "localNetworkGateway2": {
-            "id": "[resourceId('Microsoft.Network/localNetworkGateways', parameters('localGatewayName'))]"
-          },
-          "connectionType": "IPsec",
-          "routingWeight": 10,
-          "sharedKey": "[parameters('sharedKey')]"
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[parameters('virtualNetworkName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[parameters('azureVNetAddressPrefix')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[parameters('subnetName')]",
-              "properties": {
-                "addressPrefix": "[parameters('subnetPrefix')]"
-              }
-            },
-            {
-              "name": "GatewaySubnet",
-              "properties": {
-                "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[parameters('gatewayPublicIPName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "Dynamic"
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/virtualNetworkGateways",
-        "name": "[parameters('gatewayName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "[variables('gatewaySubnetRef')]"
-                },
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
-                }
-              },
-              "name": "vnetGatewayConfig"
-            }
-          ],
-          "sku": {
-            "name": "[parameters('gatewaySku')]",
-            "tier": "[parameters('gatewaySku')]"
-          },
-          "gatewayType": "Vpn",
-          "vpnType": "[parameters('vpnType')]",
-          "enableBgp": "false"
-        }
+    "localGatewayName": {
+      "type": "string",
+      "defaultValue": "localGateway",
+      "metadata": {
+        "description": "Arbitrary name for gateway resource representing "
       }
-    ]
+    },
+    "localGatewayIpAddress": {
+      "type": "string",
+      "defaultValue": "1.1.1.1",
+      "metadata": {
+        "description": "Public IP of your StrongSwan Instance"
+      }
+    },
+    "localAddressPrefix": {
+      "type": "array",
+      "defaultValue": [
+        "192.168.0.0/16",
+        "172.16.0.0/12"
+      ],
+      "metadata": {
+        "description": "CIDR block representing the address space of the OnPremise VPN network's Subnet"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "azureVnet",
+      "metadata": {
+        "description": "Arbitrary name for the Azure Virtual Network"
+      }
+    },
+    "azureVNetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.3.0.0/16",
+      "metadata": {
+        "description": "CIDR block representing the address space of the Azure VNet"
+      }
+    },
+    "subnetName": {
+      "type": "string",
+      "defaultValue": "Subnet1",
+      "metadata": {
+        "description": "Arbitrary name for the Azure Subnet"
+      }
+    },
+    "subnetPrefix": {
+      "type": "string",
+      "defaultValue": "10.3.1.0/24",
+      "metadata": {
+        "description": "CIDR block for VM subnet, subset of azureVNetAddressPrefix address space"
+      }
+    },
+    "gatewaySubnetPrefix": {
+      "type": "string",
+      "defaultValue": "10.3.200.0/29",
+      "metadata": {
+        "description": "CIDR block for gateway subnet, subset of azureVNetAddressPrefix address space"
+      }
+    },
+    "gatewayPublicIPName": {
+      "type": "string",
+      "defaultValue": "azureGatewayIP",
+      "metadata": {
+        "description": "Arbitrary name for public IP resource used for the new azure gateway"
+      }
+    },
+    "gatewayName": {
+      "type": "string",
+      "defaultValue": "azureGateway",
+      "metadata": {
+        "description": "Arbitrary name for the new gateway"
+      }
+    },
+    "gatewaySku": {
+      "type": "string",
+      "defaultValue": "Basic",
+      "allowedValues": [
+        "Basic",
+        "Standard",
+        "HighPerformance"
+      ],
+      "metadata": {
+        "description": "The Sku of the Gateway. This must be one of Basic, Standard or HighPerformance."
+      }
+    },
+    "connectionName": {
+      "type": "string",
+      "defaultValue": "Azure2Other",
+      "metadata": {
+        "description": "Arbitrary name for the new connection between Azure VNet and other network"
+      }
+    },
+    "sharedKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Shared key (PSK) for IPSec tunnel"
+      }
+    }
+  },
+  "variables": {
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+    "gatewaySubnetRef": "[concat(variables('vnetID'),'/subnets/','GatewaySubnet')]",
+    "api-version": "2015-06-15"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/localNetworkGateways",
+      "name": "[parameters('localGatewayName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "localNetworkAddressSpace": {
+          "addressPrefixes": "[parameters('localAddressPrefix')]"
+        },
+        "gatewayIpAddress": "[parameters('localGatewayIpAddress')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "name": "[parameters('connectionName')]",
+      "type": "Microsoft.Network/connections",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]",
+        "[concat('Microsoft.Network/localNetworkGateways/', parameters('localGatewayName'))]"
+      ],
+      "properties": {
+        "virtualNetworkGateway1": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]"
+        },
+        "localNetworkGateway2": {
+          "id": "[resourceId('Microsoft.Network/localNetworkGateways', parameters('localGatewayName'))]"
+        },
+        "connectionType": "IPsec",
+        "routingWeight": 10,
+        "sharedKey": "[parameters('sharedKey')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('azureVNetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetPrefix')]"
+            }
+          },
+          {
+            "name": "GatewaySubnet",
+            "properties": {
+              "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('gatewayPublicIPName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworkGateways",
+      "name": "[parameters('gatewayName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('gatewaySubnetRef')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
+              }
+            },
+            "name": "vnetGatewayConfig"
+          }
+        ],
+        "sku": {
+          "name": "[parameters('gatewaySku')]",
+          "tier": "[parameters('gatewaySku')]"
+        },
+        "gatewayType": "Vpn",
+        "vpnType": "[parameters('vpnType')]",
+        "enableBgp": "false"
+      }
+    }
+  ]
 }

--- a/101-subnet-add-vnet-existing/azuredeploy.json
+++ b/101-subnet-add-vnet-existing/azuredeploy.json
@@ -27,7 +27,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "name": "[concat(parameters('existingVNETName'), '/', parameters('newSubnetName'))]",
       "location": "[resourceGroup().location]",

--- a/101-subnet-add-vnet-existing/prereqs/prereq.azuredeploy.parameters.json
+++ b/101-subnet-add-vnet-existing/prereqs/prereq.azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {

--- a/101-traffic-manager-external-endpoint/azuredeploy.json
+++ b/101-traffic-manager-external-endpoint/azuredeploy.json
@@ -14,7 +14,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('tmApiVersion')]",
+      "apiVersion": "2015-11-01",
       "type": "Microsoft.Network/trafficManagerProfiles",
       "name": "ExternalEndpointExample",
       "location": "global",

--- a/101-vm-customdata/azuredeploy.json
+++ b/101-vm-customdata/azuredeploy.json
@@ -69,14 +69,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -88,7 +88,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",

--- a/101-vm-from-user-image/azuredeploy.json
+++ b/101-vm-from-user-image/azuredeploy.json
@@ -140,7 +140,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",

--- a/101-vm-linux-serial-output/azuredeploy.json
+++ b/101-vm-linux-serial-output/azuredeploy.json
@@ -46,14 +46,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -65,7 +65,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -86,7 +86,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",

--- a/101-vm-multiple-data-disk/azuredeploy.json
+++ b/101-vm-multiple-data-disk/azuredeploy.json
@@ -57,14 +57,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -76,7 +76,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -97,7 +97,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",

--- a/101-vm-secure-password/azuredeploy.json
+++ b/101-vm-secure-password/azuredeploy.json
@@ -57,14 +57,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -76,7 +76,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -97,7 +97,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",

--- a/101-vm-simple-rhel/azuredeploy.json
+++ b/101-vm-simple-rhel/azuredeploy.json
@@ -98,11 +98,13 @@
       }
     },
     {
-      "apiVersion": "[variables('computeResouresApiVersion')]",
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",
-      "tags": {"Tag1": "ManagedVM"},
+      "tags": {
+        "Tag1": "ManagedVM"
+      },
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],

--- a/101-vm-sshkey/azuredeploy.json
+++ b/101-vm-sshkey/azuredeploy.json
@@ -39,7 +39,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('networkSecurityGroupName')]",
       "location": "[variables('location')]",
@@ -63,7 +63,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[variables('location')]",
@@ -75,7 +75,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
@@ -95,14 +95,14 @@
               "addressPrefix": "[variables('subnet1Prefix')]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
-              }              
+              }
             }
           }
         ]
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[variables('location')]",
@@ -175,10 +175,10 @@
       }
     }
   ],
-    "outputs": {
+  "outputs": {
     "sshCommand": {
       "type": "string",
       "value": "[concat('ssh ', parameters('adminUsername'), '@', variables('uniqueDnsLabelPrefix'), '.', resourceGroup().location, '.cloudapp.azure.com')]"
-    } 
+    }
   }
 }

--- a/101-vm-tags/azuredeploy.json
+++ b/101-vm-tags/azuredeploy.json
@@ -76,7 +76,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "tags": {
         "Department": "[parameters('departmentName')]",
@@ -88,7 +88,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -105,7 +105,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -131,7 +131,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",

--- a/101-vm-user-image-data-disks/azuredeploy.json
+++ b/101-vm-user-image-data-disks/azuredeploy.json
@@ -102,7 +102,7 @@
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -114,7 +114,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -135,7 +135,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -161,7 +161,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",

--- a/101-vm-with-rdp-port/azuredeploy.json
+++ b/101-vm-with-rdp-port/azuredeploy.json
@@ -50,7 +50,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "publicIp",
       "location": "[resourceGroup().location]",
@@ -62,7 +62,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -71,7 +71,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -92,7 +92,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "loadBalancer",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -132,7 +132,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('vmName'),'-nic')]",
       "location": "[resourceGroup().location]",

--- a/101-vnet-two-subnets/azuredeploy.json
+++ b/101-vnet-two-subnets/azuredeploy.json
@@ -50,7 +50,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('vnetName')]",
       "location": "[resourceGroup().location]",

--- a/101-webappazure-oms-monitoring/azuredeploy.json
+++ b/101-webappazure-oms-monitoring/azuredeploy.json
@@ -84,7 +84,7 @@
     {
       "name": "[parameters('automationAccountName')]",
       "type": "Microsoft.Automation/automationAccounts",
-      "apiVersion": "[variables('aaApiVersion')]",
+      "apiVersion": "2015-10-31",
       "location": "[parameters('automationRegion')]",
       "properties": {
         "sku": {

--- a/201-1-vm-loadbalancer-2-nics/azuredeploy.json
+++ b/201-1-vm-loadbalancer-2-nics/azuredeploy.json
@@ -35,7 +35,7 @@
     }
   },
   "variables": {
-    "apiVersion" : "2015-06-15",
+    "apiVersion": "2015-06-15",
     "storageAccountType": "Standard_LRS",
     "addressPrefix": "10.0.0.0/16",
     "subnetName": "Subnet-1",
@@ -61,14 +61,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -80,7 +80,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('vnetName')]",
       "location": "[resourceGroup().location]",
@@ -101,7 +101,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nic1NamePrefix')]",
       "location": "[resourceGroup().location]",
@@ -134,7 +134,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nic2NamePrefix')]",
       "location": "[resourceGroup().location]",
@@ -156,7 +156,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -243,8 +243,8 @@
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
-             "enabled": "true",
-             "storageUri": "[concat('http://',tolower(parameters('storageAccountName')),'.blob.core.windows.net')]"
+            "enabled": "true",
+            "storageUri": "[concat('http://',tolower(parameters('storageAccountName')),'.blob.core.windows.net')]"
           }
         }
       }

--- a/201-application-gateway-multihosting/azuredeploy.json
+++ b/201-application-gateway-multihosting/azuredeploy.json
@@ -1,291 +1,291 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "vnetAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/16",
-            "metadata": {
-                "description": "Address prefix for the Virtual Network"
-            }
-        },
-        "subnetPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/28",
-            "metadata": {
-                "description": "Subnet prefix"
-            }
-        },
-        "skuName": {
-            "type": "string",
-            "allowedValues": [
-                "Standard_Small",
-                "Standard_Medium",
-                "Standard_Large"
-            ],
-            "defaultValue": "Standard_Medium",
-            "metadata": {
-                "description": "Sku Name"
-            }
-        },
-        "capacity": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "Number of instances"
-            }
-        },
-        "backendIpAddress1": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Address for Backend Server 1"
-            }
-        },
-        "backendIpAddress2": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Address for Backend Server 2"
-            }
-        },
-        "hostName1": {
-            "type": "string",
-            "metadata": {
-                "description": "HostName for listener 1"
-            }
-        },
-        "hostName2": {
-            "type": "string",
-            "metadata": {
-                "description": "HostName for listener 2"
-            }
-        },
-        "certData1": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Base-64 encoded form of the .pfx file"
-            }
-        },
-        "certPassword1": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for .pfx certificate"
-            }
-        },
-        "certData2": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Base-64 encoded form of the .pfx file"
-            }
-        },
-        "certPassword2": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for .pfx certificate"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "Address prefix for the Virtual Network"
+      }
     },
-    "variables": {
-        "applicationGatewayName": "applicationGateway1",
-        "publicIPAddressName": "publicIp1",
-        "virtualNetworkName": "virtualNetwork1",
-        "subnetName": "appGatewaySubnet",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-        "publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
-        "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
-        "apiVersion": "2015-06-15"
+    "subnetPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/28",
+      "metadata": {
+        "description": "Subnet prefix"
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[variables('publicIPAddressName')]",
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "publicIPAllocationMethod": "Dynamic"
-            }
+    "skuName": {
+      "type": "string",
+      "allowedValues": [
+        "Standard_Small",
+        "Standard_Medium",
+        "Standard_Large"
+      ],
+      "defaultValue": "Standard_Medium",
+      "metadata": {
+        "description": "Sku Name"
+      }
+    },
+    "capacity": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "Number of instances"
+      }
+    },
+    "backendIpAddress1": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 1"
+      }
+    },
+    "backendIpAddress2": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 2"
+      }
+    },
+    "hostName1": {
+      "type": "string",
+      "metadata": {
+        "description": "HostName for listener 1"
+      }
+    },
+    "hostName2": {
+      "type": "string",
+      "metadata": {
+        "description": "HostName for listener 2"
+      }
+    },
+    "certData1": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Base-64 encoded form of the .pfx file"
+      }
+    },
+    "certPassword1": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for .pfx certificate"
+      }
+    },
+    "certData2": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Base-64 encoded form of the .pfx file"
+      }
+    },
+    "certPassword2": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for .pfx certificate"
+      }
+    }
+  },
+  "variables": {
+    "applicationGatewayName": "applicationGateway1",
+    "publicIPAddressName": "publicIp1",
+    "virtualNetworkName": "virtualNetwork1",
+    "subnetName": "appGatewaySubnet",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
+    "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
+    "apiVersion": "2015-06-15"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('vnetAddressPrefix')]"
+          ]
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[variables('virtualNetworkName')]",
-            "location": "[resourceGroup().location]",
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
             "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[parameters('vnetAddressPrefix')]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('subnetName')]",
-                        "properties": {
-                            "addressPrefix": "[parameters('subnetPrefix')]"
-                        }
-                    }
-                ]
+              "addressPrefix": "[parameters('subnetPrefix')]"
             }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "name": "[variables('applicationGatewayName')]",
+      "type": "Microsoft.Network/applicationGateways",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+      ],
+      "properties": {
+        "sku": {
+          "name": "[parameters('skuName')]",
+          "tier": "Standard",
+          "capacity": "[parameters('capacity')]"
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "name": "[variables('applicationGatewayName')]",
-            "type": "Microsoft.Network/applicationGateways",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
-                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
-            ],
+        "sslCertificates": [
+          {
+            "name": "appGatewaySslCert1",
             "properties": {
-                "sku": {
-                    "name": "[parameters('skuName')]",
-                    "tier": "Standard",
-                    "capacity": "[parameters('capacity')]"
-                },
-                "sslCertificates": [
-                    {
-                        "name": "appGatewaySslCert1",
-                        "properties": {
-                            "data": "[parameters('certData1')]",
-                            "password": "[parameters('certPassword1')]"
-                        }
-                    },
-                    {
-                        "name": "appGatewaySslCert2",
-                        "properties": {
-                            "data": "[parameters('certData2')]",
-                            "password": "[parameters('certPassword2')]"
-                        }
-                    }
-                ],
-                "gatewayIPConfigurations": [
-                    {
-                        "name": "appGatewayIpConfig",
-                        "properties": {
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            }
-                        }
-                    }
-                ],
-                "frontendIPConfigurations": [
-                    {
-                        "name": "appGatewayFrontendIP",
-                        "properties": {
-                            "PublicIPAddress": {
-                                "id": "[variables('publicIPRef')]"
-                            }
-                        }
-                    }
-                ],
-                "frontendPorts": [
-                    {
-                        "name": "appGatewayFrontendPort",
-                        "properties": {
-                            "Port": 443
-                        }
-                    }
-                ],
-                "backendAddressPools": [
-                    {
-                        "name": "appGatewayBackendPool1",
-                        "properties": {
-                            "BackendAddresses": [
-                                {
-                                    "IpAddress": "[parameters('backendIpAddress1')]"
-                                }
-                            ]
-                        }
-                    },
-                    {
-                        "name": "appGatewayBackendPool2",
-                        "properties": {
-                            "BackendAddresses": [
-                                {
-                                    "IpAddress": "[parameters('backendIpAddress2')]"
-                                }
-                            ]
-                        }
-                    }
-                ],
-                "backendHttpSettingsCollection": [
-                    {
-                        "name": "appGatewayBackendHttpSettings",
-                        "properties": {
-                            "Port": 80,
-                            "Protocol": "Http",
-                            "CookieBasedAffinity": "Disabled"
-                        }
-                    }
-                ],
-                "httpListeners": [
-                    {
-                        "name": "appGatewayHttpListener1",
-                        "properties": {
-                            "FrontendIPConfiguration": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-                            },
-                            "FrontendPort": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
-                            },
-                            "Protocol": "Https",
-                            "SslCertificate": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert1')]"
-                            },
-                            "HostName": "[parameters('hostName1')]",
-                            "RequireServerNameIndication": "true"
-                        }
-                    },
-                    {
-                        "name": "appGatewayHttpListener2",
-                        "properties": {
-                            "FrontendIPConfiguration": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-                            },
-                            "FrontendPort": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
-                            },
-                            "Protocol": "Https",
-                            "SslCertificate": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert2')]"
-                            },
-                            "HostName": "[parameters('hostName2')]",
-                            "RequireServerNameIndication": "true"
-                        }
-                    }
-                ],
-                "requestRoutingRules": [
-                    {
-                        "Name": "rule1",
-                        "properties": {
-                            "RuleType": "Basic",
-                            "httpListener": {
-                                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener1')]"
-                            },
-                            "backendAddressPool": {
-                                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool1')]"
-                            },
-                            "backendHttpSettings": {
-                                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
-                            }
-                        }
-                    },
-                    {
-                        "Name": "rule2",
-                        "properties": {
-                            "RuleType": "Basic",
-                            "httpListener": {
-                                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener2')]"
-                            },
-                            "backendAddressPool": {
-                                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool2')]"
-                            },
-                            "backendHttpSettings": {
-                                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
-                            }
-                        }
-                    }
-                ]
+              "data": "[parameters('certData1')]",
+              "password": "[parameters('certPassword1')]"
             }
-        }
-    ]
+          },
+          {
+            "name": "appGatewaySslCert2",
+            "properties": {
+              "data": "[parameters('certData2')]",
+              "password": "[parameters('certPassword2')]"
+            }
+          }
+        ],
+        "gatewayIPConfigurations": [
+          {
+            "name": "appGatewayIpConfig",
+            "properties": {
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ],
+        "frontendIPConfigurations": [
+          {
+            "name": "appGatewayFrontendIP",
+            "properties": {
+              "PublicIPAddress": {
+                "id": "[variables('publicIPRef')]"
+              }
+            }
+          }
+        ],
+        "frontendPorts": [
+          {
+            "name": "appGatewayFrontendPort",
+            "properties": {
+              "Port": 443
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "appGatewayBackendPool1",
+            "properties": {
+              "BackendAddresses": [
+                {
+                  "IpAddress": "[parameters('backendIpAddress1')]"
+                }
+              ]
+            }
+          },
+          {
+            "name": "appGatewayBackendPool2",
+            "properties": {
+              "BackendAddresses": [
+                {
+                  "IpAddress": "[parameters('backendIpAddress2')]"
+                }
+              ]
+            }
+          }
+        ],
+        "backendHttpSettingsCollection": [
+          {
+            "name": "appGatewayBackendHttpSettings",
+            "properties": {
+              "Port": 80,
+              "Protocol": "Http",
+              "CookieBasedAffinity": "Disabled"
+            }
+          }
+        ],
+        "httpListeners": [
+          {
+            "name": "appGatewayHttpListener1",
+            "properties": {
+              "FrontendIPConfiguration": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+              },
+              "FrontendPort": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
+              },
+              "Protocol": "Https",
+              "SslCertificate": {
+                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert1')]"
+              },
+              "HostName": "[parameters('hostName1')]",
+              "RequireServerNameIndication": "true"
+            }
+          },
+          {
+            "name": "appGatewayHttpListener2",
+            "properties": {
+              "FrontendIPConfiguration": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+              },
+              "FrontendPort": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
+              },
+              "Protocol": "Https",
+              "SslCertificate": {
+                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert2')]"
+              },
+              "HostName": "[parameters('hostName2')]",
+              "RequireServerNameIndication": "true"
+            }
+          }
+        ],
+        "requestRoutingRules": [
+          {
+            "Name": "rule1",
+            "properties": {
+              "RuleType": "Basic",
+              "httpListener": {
+                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener1')]"
+              },
+              "backendAddressPool": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool1')]"
+              },
+              "backendHttpSettings": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
+              }
+            }
+          },
+          {
+            "Name": "rule2",
+            "properties": {
+              "RuleType": "Basic",
+              "httpListener": {
+                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener2')]"
+              },
+              "backendAddressPool": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool2')]"
+              },
+              "backendHttpSettings": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/201-application-gateway-sslpolicy-custom/azuredeploy.json
+++ b/201-application-gateway-sslpolicy-custom/azuredeploy.json
@@ -1,241 +1,241 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "addressPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/16",
-            "metadata": {
-                "description": "Address prefix for the Virtual Network"
-            }
-        },
-        "subnetPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/28",
-            "metadata": {
-                "description": "Subnet prefix"
-            }
-        },
-        "skuName": {
-            "type": "string",
-            "allowedValues": [
-                "Standard_Small",
-                "Standard_Medium",
-                "Standard_Large"
-            ],
-            "defaultValue": "Standard_Medium",
-            "metadata": {
-                "description": "Sku Name"
-            }
-        },
-        "capacity": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "Number of instances"
-            }
-        },
-        "backendIpAddress1": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Address for Backend Server 1"
-            }
-        },
-        "backendIpAddress2": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Address for Backend Server 2"
-            }
-        },
-        "certData": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Base-64 encoded form of the .pfx file"
-            }
-        },
-        "certPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for .pfx certificate"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "addressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "Address prefix for the Virtual Network"
+      }
     },
-    "variables": {
-        "applicationGatewayName": "applicationGateway1",
-        "publicIPAddressName": "publicIp1",
-        "virtualNetworkName": "virtualNetwork1",
-        "subnetName": "appGatewaySubnet",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-        "publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
-        "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
-        "apiVersion": "2017-06-01"
+    "subnetPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/28",
+      "metadata": {
+        "description": "Subnet prefix"
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[variables('publicIPAddressName')]",
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "publicIPAllocationMethod": "Dynamic"
-            }
+    "skuName": {
+      "type": "string",
+      "allowedValues": [
+        "Standard_Small",
+        "Standard_Medium",
+        "Standard_Large"
+      ],
+      "defaultValue": "Standard_Medium",
+      "metadata": {
+        "description": "Sku Name"
+      }
+    },
+    "capacity": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "Number of instances"
+      }
+    },
+    "backendIpAddress1": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 1"
+      }
+    },
+    "backendIpAddress2": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 2"
+      }
+    },
+    "certData": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Base-64 encoded form of the .pfx file"
+      }
+    },
+    "certPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for .pfx certificate"
+      }
+    }
+  },
+  "variables": {
+    "applicationGatewayName": "applicationGateway1",
+    "publicIPAddressName": "publicIp1",
+    "virtualNetworkName": "virtualNetwork1",
+    "subnetName": "appGatewaySubnet",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
+    "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
+    "apiVersion": "2017-06-01"
+  },
+  "resources": [
+    {
+      "apiVersion": "2017-06-01",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2017-06-01",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('addressPrefix')]"
+          ]
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[variables('virtualNetworkName')]",
-            "location": "[resourceGroup().location]",
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
             "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[parameters('addressPrefix')]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('subnetName')]",
-                        "properties": {
-                            "addressPrefix": "[parameters('subnetPrefix')]"
-                        }
-                    }
-                ]
+              "addressPrefix": "[parameters('subnetPrefix')]"
             }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2017-06-01",
+      "name": "[variables('applicationGatewayName')]",
+      "type": "Microsoft.Network/applicationGateways",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+      ],
+      "properties": {
+        "sku": {
+          "name": "[parameters('skuName')]",
+          "tier": "Standard",
+          "capacity": "[parameters('capacity')]"
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "name": "[variables('applicationGatewayName')]",
-            "type": "Microsoft.Network/applicationGateways",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
-                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
-            ],
+        "sslCertificates": [
+          {
+            "name": "appGatewaySslCert",
             "properties": {
-                "sku": {
-                    "name": "[parameters('skuName')]",
-                    "tier": "Standard",
-                    "capacity": "[parameters('capacity')]"
+              "data": "[parameters('certData')]",
+              "password": "[parameters('certPassword')]"
+            }
+          }
+        ],
+        "gatewayIPConfigurations": [
+          {
+            "name": "appGatewayIpConfig",
+            "properties": {
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ],
+        "frontendIPConfigurations": [
+          {
+            "name": "appGatewayFrontendIP",
+            "properties": {
+              "PublicIPAddress": {
+                "id": "[variables('publicIPRef')]"
+              }
+            }
+          }
+        ],
+        "frontendPorts": [
+          {
+            "name": "appGatewayFrontendPort",
+            "properties": {
+              "Port": 443
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "appGatewayBackendPool",
+            "properties": {
+              "BackendAddresses": [
+                {
+                  "IpAddress": "[parameters('backendIpAddress1')]"
                 },
-                "sslCertificates": [
-                    {
-                        "name": "appGatewaySslCert",
-                        "properties": {
-                            "data": "[parameters('certData')]",
-                            "password": "[parameters('certPassword')]"
-                        }
-                    }
-                ],
-                "gatewayIPConfigurations": [
-                    {
-                        "name": "appGatewayIpConfig",
-                        "properties": {
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            }
-                        }
-                    }
-                ],
-                "frontendIPConfigurations": [
-                    {
-                        "name": "appGatewayFrontendIP",
-                        "properties": {
-                            "PublicIPAddress": {
-                                "id": "[variables('publicIPRef')]"
-                            }
-                        }
-                    }
-                ],
-                "frontendPorts": [
-                    {
-                        "name": "appGatewayFrontendPort",
-                        "properties": {
-                            "Port": 443
-                        }
-                    }
-                ],
-                "backendAddressPools": [
-                    {
-                        "name": "appGatewayBackendPool",
-                        "properties": {
-                            "BackendAddresses": [
-                                {
-                                    "IpAddress": "[parameters('backendIpAddress1')]"
-                                },
-                                {
-                                    "IpAddress": "[parameters('backendIpAddress2')]"
-                                }
-                            ]
-                        }
-                    }
-                ],
-                "backendHttpSettingsCollection": [
-                    {
-                        "name": "appGatewayBackendHttpSettings",
-                        "properties": {
-                            "Port": 80,
-                            "Protocol": "Http",
-                            "CookieBasedAffinity": "Disabled"
-                        }
-                    }
-                ],
-                "httpListeners": [
-                    {
-                        "name": "appGatewayHttpListener",
-                        "properties": {
-                            "FrontendIPConfiguration": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-                            },
-                            "FrontendPort": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
-                            },
-                            "Protocol": "Https",
-                            "SslCertificate": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert')]"
-                            }
-                        }
-                    }
-                ],
-                "requestRoutingRules": [
-                    {
-                        "Name": "rule1",
-                        "properties": {
-                            "RuleType": "Basic",
-                            "httpListener": {
-                                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener')]"
-                            },
-                            "backendAddressPool": {
-                                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
-                            },
-                            "backendHttpSettings": {
-                                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
-                            }
-                        }
-                    }
-                ],
-                "sslPolicy":{
-                    "policyType":"Custom",
-                    "minProtocolVersion":"TLSv1_1",
-                    "cipherSuites":[
-                        "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-                        "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
-                        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
-                        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
-                        "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
-                        "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
-                        "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
-                        "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
-                        "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
-                        "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
-                        "TLS_RSA_WITH_AES_256_GCM_SHA384",
-                        "TLS_RSA_WITH_AES_128_GCM_SHA256",
-                        "TLS_RSA_WITH_AES_256_CBC_SHA256",
-                        "TLS_RSA_WITH_AES_128_CBC_SHA256",
-                        "TLS_RSA_WITH_AES_256_CBC_SHA",
-                        "TLS_RSA_WITH_AES_128_CBC_SHA"
-                    ]
+                {
+                  "IpAddress": "[parameters('backendIpAddress2')]"
                 }
+              ]
             }
+          }
+        ],
+        "backendHttpSettingsCollection": [
+          {
+            "name": "appGatewayBackendHttpSettings",
+            "properties": {
+              "Port": 80,
+              "Protocol": "Http",
+              "CookieBasedAffinity": "Disabled"
+            }
+          }
+        ],
+        "httpListeners": [
+          {
+            "name": "appGatewayHttpListener",
+            "properties": {
+              "FrontendIPConfiguration": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+              },
+              "FrontendPort": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
+              },
+              "Protocol": "Https",
+              "SslCertificate": {
+                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert')]"
+              }
+            }
+          }
+        ],
+        "requestRoutingRules": [
+          {
+            "Name": "rule1",
+            "properties": {
+              "RuleType": "Basic",
+              "httpListener": {
+                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener')]"
+              },
+              "backendAddressPool": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
+              },
+              "backendHttpSettings": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
+              }
+            }
+          }
+        ],
+        "sslPolicy": {
+          "policyType": "Custom",
+          "minProtocolVersion": "TLSv1_1",
+          "cipherSuites": [
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_RSA_WITH_AES_256_GCM_SHA384",
+            "TLS_RSA_WITH_AES_128_GCM_SHA256",
+            "TLS_RSA_WITH_AES_256_CBC_SHA256",
+            "TLS_RSA_WITH_AES_128_CBC_SHA256",
+            "TLS_RSA_WITH_AES_256_CBC_SHA",
+            "TLS_RSA_WITH_AES_128_CBC_SHA"
+          ]
         }
-    ]
+      }
+    }
+  ]
 }

--- a/201-application-gateway-sslpolicy-predefined/azuredeploy.json
+++ b/201-application-gateway-sslpolicy-predefined/azuredeploy.json
@@ -1,223 +1,223 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "addressPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/16",
-            "metadata": {
-                "description": "Address prefix for the Virtual Network"
-            }
-        },
-        "subnetPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/28",
-            "metadata": {
-                "description": "Subnet prefix"
-            }
-        },
-        "skuName": {
-            "type": "string",
-            "allowedValues": [
-                "Standard_Small",
-                "Standard_Medium",
-                "Standard_Large"
-            ],
-            "defaultValue": "Standard_Medium",
-            "metadata": {
-                "description": "Sku Name"
-            }
-        },
-        "capacity": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "Number of instances"
-            }
-        },
-        "backendIpAddress1": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Address for Backend Server 1"
-            }
-        },
-        "backendIpAddress2": {
-            "type": "string",
-            "metadata": {
-                "description": "IP Address for Backend Server 2"
-            }
-        },
-        "certData": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Base-64 encoded form of the .pfx file"
-            }
-        },
-        "certPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for .pfx certificate"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "addressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "Address prefix for the Virtual Network"
+      }
     },
-    "variables": {
-        "applicationGatewayName": "applicationGateway1",
-        "publicIPAddressName": "publicIp1",
-        "virtualNetworkName": "virtualNetwork1",
-        "subnetName": "appGatewaySubnet",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-        "publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
-        "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
-        "apiVersion": "2017-06-01"
+    "subnetPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/28",
+      "metadata": {
+        "description": "Subnet prefix"
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[variables('publicIPAddressName')]",
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "publicIPAllocationMethod": "Dynamic"
-            }
+    "skuName": {
+      "type": "string",
+      "allowedValues": [
+        "Standard_Small",
+        "Standard_Medium",
+        "Standard_Large"
+      ],
+      "defaultValue": "Standard_Medium",
+      "metadata": {
+        "description": "Sku Name"
+      }
+    },
+    "capacity": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "Number of instances"
+      }
+    },
+    "backendIpAddress1": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 1"
+      }
+    },
+    "backendIpAddress2": {
+      "type": "string",
+      "metadata": {
+        "description": "IP Address for Backend Server 2"
+      }
+    },
+    "certData": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Base-64 encoded form of the .pfx file"
+      }
+    },
+    "certPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for .pfx certificate"
+      }
+    }
+  },
+  "variables": {
+    "applicationGatewayName": "applicationGateway1",
+    "publicIPAddressName": "publicIp1",
+    "virtualNetworkName": "virtualNetwork1",
+    "subnetName": "appGatewaySubnet",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "publicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
+    "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
+    "apiVersion": "2017-06-01"
+  },
+  "resources": [
+    {
+      "apiVersion": "2017-06-01",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2017-06-01",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('addressPrefix')]"
+          ]
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[variables('virtualNetworkName')]",
-            "location": "[resourceGroup().location]",
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
             "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[parameters('addressPrefix')]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('subnetName')]",
-                        "properties": {
-                            "addressPrefix": "[parameters('subnetPrefix')]"
-                        }
-                    }
-                ]
+              "addressPrefix": "[parameters('subnetPrefix')]"
             }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2017-06-01",
+      "name": "[variables('applicationGatewayName')]",
+      "type": "Microsoft.Network/applicationGateways",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+      ],
+      "properties": {
+        "sku": {
+          "name": "[parameters('skuName')]",
+          "tier": "Standard",
+          "capacity": "[parameters('capacity')]"
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "name": "[variables('applicationGatewayName')]",
-            "type": "Microsoft.Network/applicationGateways",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
-                "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
-            ],
+        "sslCertificates": [
+          {
+            "name": "appGatewaySslCert",
             "properties": {
-                "sku": {
-                    "name": "[parameters('skuName')]",
-                    "tier": "Standard",
-                    "capacity": "[parameters('capacity')]"
+              "data": "[parameters('certData')]",
+              "password": "[parameters('certPassword')]"
+            }
+          }
+        ],
+        "gatewayIPConfigurations": [
+          {
+            "name": "appGatewayIpConfig",
+            "properties": {
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ],
+        "frontendIPConfigurations": [
+          {
+            "name": "appGatewayFrontendIP",
+            "properties": {
+              "PublicIPAddress": {
+                "id": "[variables('publicIPRef')]"
+              }
+            }
+          }
+        ],
+        "frontendPorts": [
+          {
+            "name": "appGatewayFrontendPort",
+            "properties": {
+              "Port": 443
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "appGatewayBackendPool",
+            "properties": {
+              "BackendAddresses": [
+                {
+                  "IpAddress": "[parameters('backendIpAddress1')]"
                 },
-                "sslCertificates": [
-                    {
-                        "name": "appGatewaySslCert",
-                        "properties": {
-                            "data": "[parameters('certData')]",
-                            "password": "[parameters('certPassword')]"
-                        }
-                    }
-                ],
-                "gatewayIPConfigurations": [
-                    {
-                        "name": "appGatewayIpConfig",
-                        "properties": {
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            }
-                        }
-                    }
-                ],
-                "frontendIPConfigurations": [
-                    {
-                        "name": "appGatewayFrontendIP",
-                        "properties": {
-                            "PublicIPAddress": {
-                                "id": "[variables('publicIPRef')]"
-                            }
-                        }
-                    }
-                ],
-                "frontendPorts": [
-                    {
-                        "name": "appGatewayFrontendPort",
-                        "properties": {
-                            "Port": 443
-                        }
-                    }
-                ],
-                "backendAddressPools": [
-                    {
-                        "name": "appGatewayBackendPool",
-                        "properties": {
-                            "BackendAddresses": [
-                                {
-                                    "IpAddress": "[parameters('backendIpAddress1')]"
-                                },
-                                {
-                                    "IpAddress": "[parameters('backendIpAddress2')]"
-                                }
-                            ]
-                        }
-                    }
-                ],
-                "backendHttpSettingsCollection": [
-                    {
-                        "name": "appGatewayBackendHttpSettings",
-                        "properties": {
-                            "Port": 80,
-                            "Protocol": "Http",
-                            "CookieBasedAffinity": "Disabled"
-                        }
-                    }
-                ],
-                "httpListeners": [
-                    {
-                        "name": "appGatewayHttpListener",
-                        "properties": {
-                            "FrontendIPConfiguration": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-                            },
-                            "FrontendPort": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
-                            },
-                            "Protocol": "Https",
-                            "SslCertificate": {
-                                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert')]"
-                            }
-                        }
-                    }
-                ],
-                "requestRoutingRules": [
-                    {
-                        "Name": "rule1",
-                        "properties": {
-                            "RuleType": "Basic",
-                            "httpListener": {
-                                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener')]"
-                            },
-                            "backendAddressPool": {
-                                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
-                            },
-                            "backendHttpSettings": {
-                                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
-                            }
-                        }
-                    }
-                ],
-                "sslPolicy":{
-                    "policyType":"Predefined",
-                    "policyName":"AppGwSslPolicy20170401"
+                {
+                  "IpAddress": "[parameters('backendIpAddress2')]"
                 }
+              ]
             }
+          }
+        ],
+        "backendHttpSettingsCollection": [
+          {
+            "name": "appGatewayBackendHttpSettings",
+            "properties": {
+              "Port": 80,
+              "Protocol": "Http",
+              "CookieBasedAffinity": "Disabled"
+            }
+          }
+        ],
+        "httpListeners": [
+          {
+            "name": "appGatewayHttpListener",
+            "properties": {
+              "FrontendIPConfiguration": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+              },
+              "FrontendPort": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
+              },
+              "Protocol": "Https",
+              "SslCertificate": {
+                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewaySslCert')]"
+              }
+            }
+          }
+        ],
+        "requestRoutingRules": [
+          {
+            "Name": "rule1",
+            "properties": {
+              "RuleType": "Basic",
+              "httpListener": {
+                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener')]"
+              },
+              "backendAddressPool": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
+              },
+              "backendHttpSettings": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
+              }
+            }
+          }
+        ],
+        "sslPolicy": {
+          "policyType": "Predefined",
+          "policyName": "AppGwSslPolicy20170401"
         }
-    ]
+      }
+    }
+  ]
 }

--- a/201-application-gateway-url-path-based-routing/azuredeploy.json
+++ b/201-application-gateway-url-path-based-routing/azuredeploy.json
@@ -81,7 +81,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -90,7 +90,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -111,7 +111,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('applicationGatewayName')]",
       "type": "Microsoft.Network/applicationGateways",
       "location": "[resourceGroup().location]",
@@ -151,10 +151,10 @@
             "properties": {
               "Port": 80
             }
-          }          
+          }
         ],
         "backendAddressPools": [
-        {
+          {
             "name": "appGatewayBackendPoolDefault",
             "properties": {
               "BackendAddresses": [
@@ -163,8 +163,8 @@
                 }
               ]
             }
-        },
-        {
+          },
+          {
             "name": "appGatewayBackendPool1",
             "properties": {
               "BackendAddresses": [

--- a/201-azure-relay-create-all-resources/azuredeploy.json
+++ b/201-azure-relay-create-all-resources/azuredeploy.json
@@ -1,87 +1,85 @@
 {
-   "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-   "contentVersion":"1.0.0.0",
-   "parameters":{
-      "namespaceName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the Azure Relay namespace"
-         }
-      },
-      "wcfRelayName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the WCF Relay"
-         }
-      },
-      "wcfRelayType":{
-         "type":"string",
-         "allowedValues":[
-            "NetTcp",
-            "Http"
-         ],
-         "metadata":{
-            "description":"WCF Relay Type. It could be any of the types: NetTcp/Http"
-         }
-      },
-      "hybridConnectionName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the HybridConnection"
-         }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "namespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Azure Relay namespace"
       }
-   },
-   "variables":{
-      "location":"[resourceGroup().location]",
-      "apiVersion":"2016-07-01",
-      "defaultSASKeyName":"RootManageSharedAccessKey",
-      "defaultAuthRuleResourceId":"[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('namespaceName'), variables('defaultSASKeyName'))]"
-   },
-   "resources":[
-      {
-         "apiVersion":"[variables('apiVersion')]",
-         "name":"[parameters('namespaceName')]",
-         "type":"Microsoft.Relay/Namespaces",
-         "location":"[variables('location')]",
-         "kind":"Relay",
-         "resources":[
-            {
-               "apiVersion":"[variables('apiVersion')]",
-               "name":"[parameters('wcfRelayName')]",
-               "type":"wcfRelays",
-               "dependsOn":[
-                  "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
-               ],
-               "properties":{
-                  "path":"[parameters('wcfRelayName')]",
-                  "relayType":"[parameters('wcfRelayType')]"
-               }
-            },
-            {
-               "apiVersion":"[variables('apiVersion')]",
-               "name":"[parameters('hybridConnectionName')]",
-               "type":"HybridConnections",
-               "dependsOn":[
-                  "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
-               ],
-               "properties":{
-                  "path":"[parameters('hybridConnectionName')]"
-               }
-            }
-         ],
-         "properties":{
-
-         }
+    },
+    "wcfRelayName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the WCF Relay"
       }
-   ],
-   "outputs":{
-      "NamespaceDefaultConnectionString":{
-         "type":"string",
-         "value":"[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
-      },
-      "DefaultSharedAccessPolicyPrimaryKey":{
-         "type":"string",
-         "value":"[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryKey]"
+    },
+    "wcfRelayType": {
+      "type": "string",
+      "allowedValues": [
+        "NetTcp",
+        "Http"
+      ],
+      "metadata": {
+        "description": "WCF Relay Type. It could be any of the types: NetTcp/Http"
       }
-   }
+    },
+    "hybridConnectionName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the HybridConnection"
+      }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "apiVersion": "2016-07-01",
+    "defaultSASKeyName": "RootManageSharedAccessKey",
+    "defaultAuthRuleResourceId": "[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('namespaceName'), variables('defaultSASKeyName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-07-01",
+      "name": "[parameters('namespaceName')]",
+      "type": "Microsoft.Relay/Namespaces",
+      "location": "[variables('location')]",
+      "kind": "Relay",
+      "resources": [
+        {
+          "apiVersion": "[variables('apiVersion')]",
+          "name": "[parameters('wcfRelayName')]",
+          "type": "wcfRelays",
+          "dependsOn": [
+            "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
+          ],
+          "properties": {
+            "path": "[parameters('wcfRelayName')]",
+            "relayType": "[parameters('wcfRelayType')]"
+          }
+        },
+        {
+          "apiVersion": "[variables('apiVersion')]",
+          "name": "[parameters('hybridConnectionName')]",
+          "type": "HybridConnections",
+          "dependsOn": [
+            "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
+          ],
+          "properties": {
+            "path": "[parameters('hybridConnectionName')]"
+          }
+        }
+      ],
+      "properties": {}
+    }
+  ],
+  "outputs": {
+    "NamespaceDefaultConnectionString": {
+      "type": "string",
+      "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
+    },
+    "DefaultSharedAccessPolicyPrimaryKey": {
+      "type": "string",
+      "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryKey]"
+    }
+  }
 }

--- a/201-azure-relay-create-hybridconnection/azuredeploy.json
+++ b/201-azure-relay-create-hybridconnection/azuredeploy.json
@@ -1,59 +1,57 @@
 {
-   "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-   "contentVersion":"1.0.0.0",
-   "parameters":{
-      "namespaceName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the Azure Relay namespace"
-         }
-      },
-      "hybridConnectionName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the HybridConnection"
-         }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "namespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Azure Relay namespace"
       }
-   },
-   "variables":{
-      "location":"[resourceGroup().location]",
-      "apiVersion":"2016-07-01",
-      "defaultSASKeyName":"RootManageSharedAccessKey",
-      "defaultAuthRuleResourceId":"[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('namespaceName'), variables('defaultSASKeyName'))]"
-   },
-   "resources":[
-      {
-         "apiVersion":"[variables('apiVersion')]",
-         "name":"[parameters('namespaceName')]",
-         "type":"Microsoft.Relay/Namespaces",
-         "location":"[variables('location')]",
-         "kind":"Relay",
-         "resources":[
-            {
-               "apiVersion":"[variables('apiVersion')]",
-               "name":"[parameters('hybridConnectionName')]",
-               "type":"HybridConnections",
-               "dependsOn":[
-                  "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
-               ],
-               "properties":{
-                  "path":"[parameters('hybridConnectionName')]"
-               }
-            }
-         ],
-         "properties":{
-
-         }
+    },
+    "hybridConnectionName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the HybridConnection"
       }
-   ],
-   "outputs":{
-      "NamespaceDefaultConnectionString":{
-         "type":"string",
-         "value":"[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
-      },
-      "DefaultSharedAccessPolicyPrimaryKey":{
-         "type":"string",
-         "value":"[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryKey]"
-      }
-   }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "apiVersion": "2016-07-01",
+    "defaultSASKeyName": "RootManageSharedAccessKey",
+    "defaultAuthRuleResourceId": "[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('namespaceName'), variables('defaultSASKeyName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-07-01",
+      "name": "[parameters('namespaceName')]",
+      "type": "Microsoft.Relay/Namespaces",
+      "location": "[variables('location')]",
+      "kind": "Relay",
+      "resources": [
+        {
+          "apiVersion": "[variables('apiVersion')]",
+          "name": "[parameters('hybridConnectionName')]",
+          "type": "HybridConnections",
+          "dependsOn": [
+            "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
+          ],
+          "properties": {
+            "path": "[parameters('hybridConnectionName')]"
+          }
+        }
+      ],
+      "properties": {}
+    }
+  ],
+  "outputs": {
+    "NamespaceDefaultConnectionString": {
+      "type": "string",
+      "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
+    },
+    "DefaultSharedAccessPolicyPrimaryKey": {
+      "type": "string",
+      "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryKey]"
+    }
+  }
 }

--- a/201-azure-relay-create-wcfrelay/azuredeploy.json
+++ b/201-azure-relay-create-wcfrelay/azuredeploy.json
@@ -1,70 +1,68 @@
 {
-   "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-   "contentVersion":"1.0.0.0",
-   "parameters":{
-      "namespaceName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the Azure Relay namespace"
-         }
-      },
-      "wcfRelayName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the WCF Relay"
-         }
-      },
-      "wcfRelayType":{
-         "type":"string",
-         "allowedValues":[
-            "NetTcp",
-            "Http"
-         ],
-         "metadata":{
-            "description":"WCF Relay Type. It could be any of the types: NetTcp/Http"
-         }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "namespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Azure Relay namespace"
       }
-   },
-   "variables":{
-      "location":"[resourceGroup().location]",
-      "apiVersion":"2016-07-01",
-      "defaultSASKeyName":"RootManageSharedAccessKey",
-      "defaultAuthRuleResourceId":"[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('namespaceName'), variables('defaultSASKeyName'))]"
-   },
-   "resources":[
-      {
-         "apiVersion":"[variables('apiVersion')]",
-         "name":"[parameters('namespaceName')]",
-         "type":"Microsoft.Relay/Namespaces",
-         "location":"[variables('location')]",
-         "kind":"Relay",
-         "resources":[
-            {
-               "apiVersion":"[variables('apiVersion')]",
-               "name":"[parameters('wcfRelayName')]",
-               "type":"wcfRelays",
-               "dependsOn":[
-                  "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
-               ],
-               "properties":{
-                  "path":"[parameters('wcfRelayName')]",
-                  "relayType":"[parameters('wcfRelayType')]"
-               }
-            }
-         ],
-         "properties":{
-
-         }
+    },
+    "wcfRelayName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the WCF Relay"
       }
-   ],
-   "outputs":{
-      "NamespaceDefaultConnectionString":{
-         "type":"string",
-         "value":"[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
-      },
-      "DefaultSharedAccessPolicyPrimaryKey":{
-         "type":"string",
-         "value":"[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryKey]"
+    },
+    "wcfRelayType": {
+      "type": "string",
+      "allowedValues": [
+        "NetTcp",
+        "Http"
+      ],
+      "metadata": {
+        "description": "WCF Relay Type. It could be any of the types: NetTcp/Http"
       }
-   }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "apiVersion": "2016-07-01",
+    "defaultSASKeyName": "RootManageSharedAccessKey",
+    "defaultAuthRuleResourceId": "[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('namespaceName'), variables('defaultSASKeyName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-07-01",
+      "name": "[parameters('namespaceName')]",
+      "type": "Microsoft.Relay/Namespaces",
+      "location": "[variables('location')]",
+      "kind": "Relay",
+      "resources": [
+        {
+          "apiVersion": "[variables('apiVersion')]",
+          "name": "[parameters('wcfRelayName')]",
+          "type": "wcfRelays",
+          "dependsOn": [
+            "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
+          ],
+          "properties": {
+            "path": "[parameters('wcfRelayName')]",
+            "relayType": "[parameters('wcfRelayType')]"
+          }
+        }
+      ],
+      "properties": {}
+    }
+  ],
+  "outputs": {
+    "NamespaceDefaultConnectionString": {
+      "type": "string",
+      "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
+    },
+    "DefaultSharedAccessPolicyPrimaryKey": {
+      "type": "string",
+      "value": "[listkeys(variables('defaultAuthRuleResourceId'), variables('apiVersion')).primaryKey]"
+    }
+  }
 }

--- a/201-cdn-customize/azuredeploy.json
+++ b/201-cdn-customize/azuredeploy.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "variables": {
-    "cdnApiVersion":"2015-06-01"
+    "cdnApiVersion": "2015-06-01"
   },
   "parameters": {
     "profileName": {
@@ -14,7 +14,10 @@
     "sku": {
       "type": "string",
       "defaultValue": "Standard",
-      "allowedValues": ["Standard","Premium"],
+      "allowedValues": [
+        "Standard",
+        "Premium"
+      ],
       "metadata": {
         "description": "Pricing tier of the CDN Profile."
       }
@@ -25,20 +28,20 @@
         "description": "Name of the CDN Endpoint."
       }
     },
-    "originHostHeader":{
+    "originHostHeader": {
       "type": "string",
       "metadata": {
         "description": "Host header that CDN edge node going to send to origin."
       }
     },
-    "isHttpAllowed":{
+    "isHttpAllowed": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
         "description": "Whether the HTTP traffic is allowed."
       }
     },
-    "isHttpsAllowed":{
+    "isHttpsAllowed": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
@@ -48,19 +51,29 @@
     "queryStringCachingBehavior": {
       "type": "string",
       "defaultValue": "IgnoreQueryString",
-      "allowedValues": ["IgnoreQueryString","BypassCaching","UseQueryString"],
+      "allowedValues": [
+        "IgnoreQueryString",
+        "BypassCaching",
+        "UseQueryString"
+      ],
       "metadata": {
         "description": "Query string caching behavior."
       }
     },
     "contentTypesToCompress": {
       "type": "array",
-      "defaultValue": [ "text/plain","text/html","text/css","application/x-javascript","text/javascript" ],
+      "defaultValue": [
+        "text/plain",
+        "text/html",
+        "text/css",
+        "application/x-javascript",
+        "text/javascript"
+      ],
       "metadata": {
         "description": "Content type that is compressed."
       }
     },
-    "isCompressionEnabled":{
+    "isCompressionEnabled": {
       "type": "bool",
       "defaultValue": true,
       "metadata": {
@@ -79,7 +92,7 @@
       "name": "[parameters('profileName')]",
       "type": "Microsoft.Cdn/profiles",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('cdnApiVersion')]",
+      "apiVersion": "2015-06-01",
       "properties": {
         "sku": {
           "name": "[parameters('sku')]"
@@ -87,7 +100,7 @@
       }
     },
     {
-      "apiVersion": "[variables('cdnApiVersion')]",
+      "apiVersion": "2015-06-01",
       "dependsOn": [
         "[concat('Microsoft.Cdn/profiles/', parameters('profileName'))]"
       ],

--- a/201-create-encrypted-managed-disk/CreateEncryptedManagedDisk-kek.json
+++ b/201-create-encrypted-managed-disk/CreateEncryptedManagedDisk-kek.json
@@ -1,83 +1,81 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "vhdUri": {
-            "type": "string",
-            "metadata": {
-               "description": "Storage VHD Uri"
-            }
-        },
-        "managedDiskName": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the managed disk to be copied"
-            }
-        },
-        "keyVaultResourceID": {
-            "type": "string",
-            "metadata": {
-                "description": "KeyVault resource id. Ex: /subscriptions/subscriptionid/resourceGroups/contosorg/providers/Microsoft.KeyVault/vaults/contosovault"
-            }
-        },
-        "keyVaultSecretUrl": {
-            "type": "string",
-            "metadata": {
-                "description": "KeyVault secret Url. Ex: https://contosovault.vault.azure.net/secrets/contososecret/e088818e865e48488cf363af16dea596"
-            }
-        },	
-        "kekUrl": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "KeyVault key encryption key Url. Ex: https://contosovault.vault.azure.net/keys/contosokek/562a4bb76b524a1493a6afe8e536ee78"
-            }
-        },
-        "kekVaultResourceID": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "KekVault resource id. Ex: /subscriptions/subscriptionid/resourceGroups/contosorg/providers/Microsoft.KeyVault/vaults/contosovault"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vhdUri": {
+      "type": "string",
+      "metadata": {
+        "description": "Storage VHD Uri"
+      }
     },
-    "variables": {
-        "location": "[resourceGroup().location]",
-        "computeResouresApiVersion" : "2016-04-30-preview",
-        "storageAccountType" : "Standard_LRS",
-        "diskSzie" : "128"
+    "managedDiskName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the managed disk to be copied"
+      }
     },
-    "resources": [
-      { 
-        "apiVersion": "[variables('computeResouresApiVersion')]",
-        "type": "Microsoft.Compute/disks",
-        "name": "[parameters('managedDiskName')]",
-        "location": "[variables('location')]",
-        "properties": 
-        { 
-            "creationData": 
-            {
-                "createOption": "Import",
-                "sourceUri": "[parameters('vhdUri')]" 
+    "keyVaultResourceID": {
+      "type": "string",
+      "metadata": {
+        "description": "KeyVault resource id. Ex: /subscriptions/subscriptionid/resourceGroups/contosorg/providers/Microsoft.KeyVault/vaults/contosovault"
+      }
+    },
+    "keyVaultSecretUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "KeyVault secret Url. Ex: https://contosovault.vault.azure.net/secrets/contososecret/e088818e865e48488cf363af16dea596"
+      }
+    },
+    "kekUrl": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "KeyVault key encryption key Url. Ex: https://contosovault.vault.azure.net/keys/contosokek/562a4bb76b524a1493a6afe8e536ee78"
+      }
+    },
+    "kekVaultResourceID": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "KekVault resource id. Ex: /subscriptions/subscriptionid/resourceGroups/contosorg/providers/Microsoft.KeyVault/vaults/contosovault"
+      }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "computeResouresApiVersion": "2016-04-30-preview",
+    "storageAccountType": "Standard_LRS",
+    "diskSzie": "128"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-04-30-preview",
+      "type": "Microsoft.Compute/disks",
+      "name": "[parameters('managedDiskName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "creationData": {
+          "createOption": "Import",
+          "sourceUri": "[parameters('vhdUri')]"
+        },
+        "accountType": "[variables('storageAccountType')]",
+        "diskSizeGB": "[variables('diskSzie')]",
+        "encryptionSettings": {
+          "enabled": true,
+          "diskEncryptionKey": {
+            "sourceVault": {
+              "id": "[parameters('keyVaultResourceID')]"
             },
-            "accountType": "[variables('storageAccountType')]",
-            "diskSizeGB": "[variables('diskSzie')]",
-            "encryptionSettings": {
-                "enabled": true,
-                "diskEncryptionKey": {
-                    "sourceVault": {
-                        "id": "[parameters('keyVaultResourceID')]"
-                    },
-                    "secretUrl": "[parameters('keyVaultSecretUrl')]"
-                },
-                "keyEncryptionKey": {
-                    "sourceVault": {
-                        "id": "[parameters('kekVaultResourceID')]"
-                    },
-                    "keyUrl": "[parameters('kekUrl')]"
-                }
-            }
+            "secretUrl": "[parameters('keyVaultSecretUrl')]"
+          },
+          "keyEncryptionKey": {
+            "sourceVault": {
+              "id": "[parameters('kekVaultResourceID')]"
+            },
+            "keyUrl": "[parameters('kekUrl')]"
+          }
         }
       }
-    ]
+    }
+  ]
 }

--- a/201-create-encrypted-managed-disk/CreateEncryptedManagedDisk-nokek.json
+++ b/201-create-encrypted-managed-disk/CreateEncryptedManagedDisk-nokek.json
@@ -1,77 +1,75 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "vhdUri": {
-            "type": "string",
-            "metadata": {
-               "description": "Storage VHD Uri"
-            }
-        },
-        "managedDiskName": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the managed disk to be copied"
-            }
-        },
-        "keyVaultResourceID": {
-            "type": "string",
-            "metadata": {
-                "description": "KeyVault resource id. Ex: /subscriptions/subscriptionid/resourceGroups/contosorg/providers/Microsoft.KeyVault/vaults/contosovault"
-            }
-        },
-        "keyVaultSecretUrl": {
-            "type": "string",
-            "metadata": {
-                "description": "KeyVault secret Url. Ex: https://contosovault.vault.azure.net/secrets/contososecret/e088818e865e48488cf363af16dea596"
-            }
-        },	
-        "kekUrl": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Ignore this. Not consumed"
-            }
-        },
-        "kekVaultResourceID": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Ignore this. Not consumed"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vhdUri": {
+      "type": "string",
+      "metadata": {
+        "description": "Storage VHD Uri"
+      }
     },
-    "variables": {
-        "location": "[resourceGroup().location]",
-        "computeResouresApiVersion" : "2016-04-30-preview",
-        "storageAccountType" : "Standard_LRS",
-        "diskSzie" : "128"
+    "managedDiskName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the managed disk to be copied"
+      }
     },
-    "resources": [
-      { 
-        "apiVersion": "[variables('computeResouresApiVersion')]",
-        "type": "Microsoft.Compute/disks",
-        "name": "[parameters('managedDiskName')]",
-        "location": "[variables('location')]",
-        "properties": 
-        { 
-            "creationData": 
-            {
-                "createOption": "Import",
-                "sourceUri": "[parameters('vhdUri')]" 
+    "keyVaultResourceID": {
+      "type": "string",
+      "metadata": {
+        "description": "KeyVault resource id. Ex: /subscriptions/subscriptionid/resourceGroups/contosorg/providers/Microsoft.KeyVault/vaults/contosovault"
+      }
+    },
+    "keyVaultSecretUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "KeyVault secret Url. Ex: https://contosovault.vault.azure.net/secrets/contososecret/e088818e865e48488cf363af16dea596"
+      }
+    },
+    "kekUrl": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Ignore this. Not consumed"
+      }
+    },
+    "kekVaultResourceID": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Ignore this. Not consumed"
+      }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "computeResouresApiVersion": "2016-04-30-preview",
+    "storageAccountType": "Standard_LRS",
+    "diskSzie": "128"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-04-30-preview",
+      "type": "Microsoft.Compute/disks",
+      "name": "[parameters('managedDiskName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "creationData": {
+          "createOption": "Import",
+          "sourceUri": "[parameters('vhdUri')]"
+        },
+        "accountType": "[variables('storageAccountType')]",
+        "diskSizeGB": "[variables('diskSzie')]",
+        "encryptionSettings": {
+          "enabled": true,
+          "diskEncryptionKey": {
+            "sourceVault": {
+              "id": "[parameters('keyVaultResourceID')]"
             },
-            "accountType": "[variables('storageAccountType')]",
-            "diskSizeGB": "[variables('diskSzie')]",
-            "encryptionSettings": {
-                "enabled": true,
-                "diskEncryptionKey": {
-                    "sourceVault": {
-                        "id": "[parameters('keyVaultResourceID')]"
-                    },
-                    "secretUrl": "[parameters('keyVaultSecretUrl')]"
-                }
-            }
+            "secretUrl": "[parameters('keyVaultSecretUrl')]"
+          }
         }
       }
-    ]
+    }
+  ]
 }

--- a/201-customscript-extension-azure-storage-on-ubuntu/azuredeploy.json
+++ b/201-customscript-extension-azure-storage-on-ubuntu/azuredeploy.json
@@ -90,14 +90,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -130,7 +130,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -156,7 +156,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -201,7 +201,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/', variables('extensionName'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/201-customscript-extension-public-storage-on-ubuntu/azuredeploy.json
+++ b/201-customscript-extension-public-storage-on-ubuntu/azuredeploy.json
@@ -80,7 +80,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -92,7 +92,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -113,7 +113,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -179,7 +179,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/installcustomscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/201-dsc-linux-azure-storage-on-ubuntu/azuredeploy.json
+++ b/201-dsc-linux-azure-storage-on-ubuntu/azuredeploy.json
@@ -1,259 +1,259 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "username": {
-            "type": "string",
-            "metadata": {
-                "description": "Username for the Virtual Machine."
-            }
-        },
-        "password": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for the Virtual Machine."
-            }
-        },
-        "newStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
-            }
-        },
-        "vmName": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the vm, will be used as DNS Name for the Public IP used to access the Virtual Machine."
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "metadata": {
-                "description": "VM size"
-            },
-            "allowedValues": [
-                "Standard_D1",
-                "Standard_D2",
-                "Standard_D3",
-                "Standard_D4",
-                "Standard_D11",
-                "Standard_D12",
-                "Standard_D13",
-                "Standard_D14"
-            ]
-        },
-        "ubuntuOSVersion": {
-            "type": "string",
-            "defaultValue": "14.04.3-LTS",
-            "metadata": {
-                "description": "The Ubuntu version"
-            },
-            "allowedValues": [
-                "14.04.3-LTS",
-                "12.04.5-LTS"
-            ]
-        },
-        "mode": {
-            "type": "string",
-            "defaultValue": "Push",
-            "metadata": {
-                "description": "The functional mode, push MOF configuration (Push), distribute MOF configuration (Pull), install custom DSC module (Install)"
-            },
-            "allowedValues": [
-                "Push",
-                "Pull",
-                "Install",
-                "Register"
-            ]
-        },
-        "storageAccountName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The name of the storage account that contains the MOF file/meta MOF file/resource ZIP file"
-            }
-        },
-        "storageAccountKey": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The key of the storage account that contains the MOF file/meta MOF file/resource ZIP file"
-            }
-        },
-        "fileUri": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The uri of the MOF file/Meta MOF file/resource ZIP file"
-            }
-        },
-        "registrationUrl": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The URL of the Azure Automation account"
-            }
-        },
-        "registrationKey": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The access key of the Azure Automation account"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "username": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
     },
-    "variables": {
-        "api-version": "2015-05-01-preview",
-        "virtualNetworkName": "vnet-dsc",
-        "nicName": "[parameters('vmName')]",
-        "publicIPAddressName": "[parameters('vmName')]",
-        "vnetAddressPrefix": "10.0.0.0/16",
-        "subnetName": "dsc",
-        "subnetPrefix": "10.0.0.0/24",
-        "publicIPAddressType": "Dynamic",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-        "vmStorageAccountContainerName": "vhds",
-        "storageAccountType": "Standard_LRS",
-        "imagePublisher": "Canonical",
-        "imageOffer": "UbuntuServer",
-        "OSDiskName": "osdiskfordsc"
+    "password": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
     },
-    "resources": [
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[parameters('newStorageAccountName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "accountType": "[variables('storageAccountType')]"
-        }
+    "newStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the vm, will be used as DNS Name for the Public IP used to access the Virtual Machine."
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "VM size"
       },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[variables('publicIPAddressName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-          "dnsSettings": {
-            "domainNameLabel": "[parameters('vmName')]"
-          }
-        }
+      "allowedValues": [
+        "Standard_D1",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14"
+      ]
+    },
+    "ubuntuOSVersion": {
+      "type": "string",
+      "defaultValue": "14.04.3-LTS",
+      "metadata": {
+        "description": "The Ubuntu version"
       },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[variables('virtualNetworkName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[variables('vnetAddressPrefix')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[variables('subnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('subnetPrefix')]"
-              }
-            }
-          ]
-        }
+      "allowedValues": [
+        "14.04.3-LTS",
+        "12.04.5-LTS"
+      ]
+    },
+    "mode": {
+      "type": "string",
+      "defaultValue": "Push",
+      "metadata": {
+        "description": "The functional mode, push MOF configuration (Push), distribute MOF configuration (Pull), install custom DSC module (Install)"
       },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[variables('nicName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfig1",
-              "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-                },
-                "subnet": {
-                  "id": "[variables('subnetRef')]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[parameters('vmName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-          "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-        ],
-        "properties": {
-          "hardwareProfile": {
-            "vmSize": "[parameters('vmSize')]"
-          },
-          "osProfile": {
-            "computerName": "[parameters('vmName')]",
-            "adminUsername": "[parameters('username')]",
-            "adminPassword": "[parameters('password')]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "[variables('imagePublisher')]",
-              "offer": "[variables('imageOffer')]",
-              "sku": "[parameters('ubuntuOSVersion')]",
-              "version": "latest"
-            },
-            "osDisk": {
-              "name": "osdisk1",
-              "vhd": {
-                "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-              },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
-            }
-          },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Compute/virtualMachines/extensions",
-        "name": "[concat(parameters('vmName'),'/enabledsc')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
-        ],
-        "properties": {
-          "publisher": "Microsoft.OSTCExtensions",
-          "type": "DSCForLinux",
-          "typeHandlerVersion": "2.0",
-          "settings": {
-            "Mode": "[parameters('mode')]",
-            "FileUri": "[parameters('fileUri')]"
-          },
-          "protectedSettings": {
-            "StorageAccountName": "[parameters('storageAccountName')]",
-            "StorageAccountKey": "[parameters('storageAccountKey')]",
-            "RegistrationUrl": "[parameters('registrationUrl')]",
-            "RegistrationKey": "[parameters('registrationKey')]"
-          }
+      "allowedValues": [
+        "Push",
+        "Pull",
+        "Install",
+        "Register"
+      ]
+    },
+    "storageAccountName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The name of the storage account that contains the MOF file/meta MOF file/resource ZIP file"
+      }
+    },
+    "storageAccountKey": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The key of the storage account that contains the MOF file/meta MOF file/resource ZIP file"
+      }
+    },
+    "fileUri": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The uri of the MOF file/Meta MOF file/resource ZIP file"
+      }
+    },
+    "registrationUrl": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The URL of the Azure Automation account"
+      }
+    },
+    "registrationKey": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The access key of the Azure Automation account"
+      }
+    }
+  },
+  "variables": {
+    "api-version": "2015-05-01-preview",
+    "virtualNetworkName": "vnet-dsc",
+    "nicName": "[parameters('vmName')]",
+    "publicIPAddressName": "[parameters('vmName')]",
+    "vnetAddressPrefix": "10.0.0.0/16",
+    "subnetName": "dsc",
+    "subnetPrefix": "10.0.0.0/24",
+    "publicIPAddressType": "Dynamic",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "vmStorageAccountContainerName": "vhds",
+    "storageAccountType": "Standard_LRS",
+    "imagePublisher": "Canonical",
+    "imageOffer": "UbuntuServer",
+    "OSDiskName": "osdiskfordsc"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('newStorageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('vmName')]"
         }
       }
-    ]
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('vmName')]",
+          "adminUsername": "[parameters('username')]",
+          "adminPassword": "[parameters('password')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('ubuntuOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk1",
+            "vhd": {
+              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmName'),'/enabledsc')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "DSCForLinux",
+        "typeHandlerVersion": "2.0",
+        "settings": {
+          "Mode": "[parameters('mode')]",
+          "FileUri": "[parameters('fileUri')]"
+        },
+        "protectedSettings": {
+          "StorageAccountName": "[parameters('storageAccountName')]",
+          "StorageAccountKey": "[parameters('storageAccountKey')]",
+          "RegistrationUrl": "[parameters('registrationUrl')]",
+          "RegistrationKey": "[parameters('registrationKey')]"
+        }
+      }
+    }
+  ]
 }

--- a/201-dsc-linux-public-storage-on-ubuntu/azuredeploy.json
+++ b/201-dsc-linux-public-storage-on-ubuntu/azuredeploy.json
@@ -1,243 +1,243 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "username": {
-            "type": "string",
-            "metadata": {
-                "description": "Username for the Virtual Machine."
-            }
-        },
-        "password": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for the Virtual Machine."
-            }
-        },
-        "newStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
-            }
-        },
-        "vmName": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the vm, will be used as DNS Name for the Public IP used to access the Virtual Machine."
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "metadata": {
-                "description": "VM size"
-            },
-            "allowedValues": [
-                "Standard_D1",
-                "Standard_D2",
-                "Standard_D3",
-                "Standard_D4",
-                "Standard_D11",
-                "Standard_D12",
-                "Standard_D13",
-                "Standard_D14"
-            ]
-        },
-        "ubuntuOSVersion": {
-            "type": "string",
-            "defaultValue": "14.04.3-LTS",
-            "metadata": {
-                "description": "The Ubuntu version"
-            },
-            "allowedValues": [
-                "14.04.3-LTS",
-                "12.04.5-LTS"
-            ]
-        },
-        "mode": {
-            "type": "string",
-            "defaultValue": "Push",
-            "metadata": {
-                "description": "The functional mode, push MOF configuration (Push), distribute MOF configuration (Pull), install custom DSC module (Install)"
-            },
-            "allowedValues": [
-                "Push",
-                "Pull",
-                "Install",
-                "Register"
-            ]
-        },
-        "fileUri": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The uri of the MOF file/Meta MOF file/resource ZIP file"
-            }
-        },
-        "registrationUrl": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The URL of the Azure Automation account"
-            }
-        },
-        "registrationKey": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "The access key of the Azure Automation account"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "username": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
     },
-    "variables": {
-        "api-version": "2015-05-01-preview",
-        "virtualNetworkName": "vnet-dsc",
-        "nicName": "[parameters('vmName')]",
-        "publicIPAddressName": "[parameters('vmName')]",
-        "vnetAddressPrefix": "10.0.0.0/16",
-        "subnetName": "dsc",
-        "subnetPrefix": "10.0.0.0/24",
-        "publicIPAddressType": "Dynamic",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-        "vmStorageAccountContainerName": "vhds",
-        "storageAccountType": "Standard_LRS",
-        "imagePublisher": "Canonical",
-        "imageOffer": "UbuntuServer",
-        "OSDiskName": "osdiskfordsc"
+    "password": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
     },
-    "resources": [
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[parameters('newStorageAccountName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "accountType": "[variables('storageAccountType')]"
-        }
+    "newStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the vm, will be used as DNS Name for the Public IP used to access the Virtual Machine."
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "VM size"
       },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[variables('publicIPAddressName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-          "dnsSettings": {
-            "domainNameLabel": "[parameters('vmName')]"
-          }
-        }
+      "allowedValues": [
+        "Standard_D1",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14"
+      ]
+    },
+    "ubuntuOSVersion": {
+      "type": "string",
+      "defaultValue": "14.04.3-LTS",
+      "metadata": {
+        "description": "The Ubuntu version"
       },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[variables('virtualNetworkName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[variables('vnetAddressPrefix')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[variables('subnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('subnetPrefix')]"
-              }
-            }
-          ]
-        }
+      "allowedValues": [
+        "14.04.3-LTS",
+        "12.04.5-LTS"
+      ]
+    },
+    "mode": {
+      "type": "string",
+      "defaultValue": "Push",
+      "metadata": {
+        "description": "The functional mode, push MOF configuration (Push), distribute MOF configuration (Pull), install custom DSC module (Install)"
       },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[variables('nicName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfig1",
-              "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-                },
-                "subnet": {
-                  "id": "[variables('subnetRef')]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[parameters('vmName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-          "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-        ],
-        "properties": {
-          "hardwareProfile": {
-            "vmSize": "[parameters('vmSize')]"
-          },
-          "osProfile": {
-            "computerName": "[parameters('vmName')]",
-            "adminUsername": "[parameters('username')]",
-            "adminPassword": "[parameters('password')]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "[variables('imagePublisher')]",
-              "offer": "[variables('imageOffer')]",
-              "sku": "[parameters('ubuntuOSVersion')]",
-              "version": "latest"
-            },
-            "osDisk": {
-              "name": "osdisk1",
-              "vhd": {
-                "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-              },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
-            }
-          },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Compute/virtualMachines/extensions",
-        "name": "[concat(parameters('vmName'),'/enabledsc')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
-        ],
-        "properties": {
-          "publisher": "Microsoft.OSTCExtensions",
-          "type": "DSCForLinux",
-          "typeHandlerVersion": "2.0",
-          "settings": {
-            "Mode": "[parameters('mode')]",
-            "FileUri": "[parameters('fileUri')]"
-          },
-          "protectedSettings": {
-            "RegistrationUrl": "[parameters('registrationUrl')]",
-            "RegistrationKey": "[parameters('registrationKey')]"
-          }
+      "allowedValues": [
+        "Push",
+        "Pull",
+        "Install",
+        "Register"
+      ]
+    },
+    "fileUri": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The uri of the MOF file/Meta MOF file/resource ZIP file"
+      }
+    },
+    "registrationUrl": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The URL of the Azure Automation account"
+      }
+    },
+    "registrationKey": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The access key of the Azure Automation account"
+      }
+    }
+  },
+  "variables": {
+    "api-version": "2015-05-01-preview",
+    "virtualNetworkName": "vnet-dsc",
+    "nicName": "[parameters('vmName')]",
+    "publicIPAddressName": "[parameters('vmName')]",
+    "vnetAddressPrefix": "10.0.0.0/16",
+    "subnetName": "dsc",
+    "subnetPrefix": "10.0.0.0/24",
+    "publicIPAddressType": "Dynamic",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "vmStorageAccountContainerName": "vhds",
+    "storageAccountType": "Standard_LRS",
+    "imagePublisher": "Canonical",
+    "imageOffer": "UbuntuServer",
+    "OSDiskName": "osdiskfordsc"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('newStorageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('vmName')]"
         }
       }
-    ]
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('vmName')]",
+          "adminUsername": "[parameters('username')]",
+          "adminPassword": "[parameters('password')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('ubuntuOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk1",
+            "vhd": {
+              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmName'),'/enabledsc')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "DSCForLinux",
+        "typeHandlerVersion": "2.0",
+        "settings": {
+          "Mode": "[parameters('mode')]",
+          "FileUri": "[parameters('fileUri')]"
+        },
+        "protectedSettings": {
+          "RegistrationUrl": "[parameters('registrationUrl')]",
+          "RegistrationKey": "[parameters('registrationKey')]"
+        }
+      }
+    }
+  ]
 }

--- a/201-extend-vnet-to-multi-vnet/azuredeploy.json
+++ b/201-extend-vnet-to-multi-vnet/azuredeploy.json
@@ -91,7 +91,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('newVnetName')]",
       "location": "[resourceGroup().location]",
@@ -118,7 +118,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('gatewayPublicIPName1')]",
       "location": "[parameters('existingVnetLocation')]",
@@ -127,7 +127,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('gatewayPublicIPName2')]",
       "location": "[resourceGroup().location]",
@@ -136,7 +136,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworkGateways",
       "name": "[variables('gatewayName1')]",
       "location": "[parameters('existingVnetLocation')]",
@@ -164,7 +164,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworkGateways",
       "name": "[variables('gatewayName2')]",
       "location": "[resourceGroup().location]",
@@ -194,7 +194,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/connections",
       "name": "[variables('connectionName1')]",
       "location": "[parameters('existingVnetLocation')]",
@@ -215,7 +215,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/connections",
       "name": "[variables('connectionName2')]",
       "location": "[resourceGroup().location]",

--- a/201-hdinsight-datalake-store-azure-storage/azuredeploy.json
+++ b/201-hdinsight-datalake-store-azure-storage/azuredeploy.json
@@ -1,208 +1,212 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"clusterType": {
-			"type": "string",
-			"allowedValues": ["hadoop",
-			"hbase",
-			"storm",
-			"spark"],
-			"metadata": {
-				"description": "The type of the HDInsight cluster to create."
-			}
-		},
-		"clusterName": {
-			"type": "string",
-			"metadata": {
-				"description": "The name of the HDInsight cluster to create."
-			}
-		},
-		"clusterLoginUserName": {
-			"type": "string",
-			"metadata": {
-				"description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
-			}
-		},
-		"clusterLoginPassword": {
-			"type": "securestring",
-			"metadata": {
-				"description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-			}
-		},
-		"sshUserName": {
-			"type": "string",
-			"metadata": {
-				"description": "These credentials can be used to remotely access the cluster."
-			}
-		},
-		"sshPassword": {
-			"type": "securestring",
-			"metadata": {
-				"description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-			}
-		},
-		"clusterStorageAccountName": {
-			"type": "string",
-			"metadata": {
-				"description": "The name of the Azure storage account to be created and be used as the cluster's primary storage."
-			}
-		},
-		"adlStoreName": {
-			"type": "string",
-			"metadata": {
-				"description": "The name of the Azure Data Lake Store account to be created and connected to the cluster."
-			}
-		},
-		"aadTenantId": {
-			"type": "string",
-			"metadata": {
-				"description": "The tenant ID (guid) of the Azure Active Directory (AAD) tenant where the service principal resides."
-			}
-		},
-		"servicePrincipalObjectId": {
-			"type": "string",
-			"metadata": {
-				"description": "The AAD object ID (guid) of the service principal that represents the HDInsight cluster. The service principal will be given permissions on the root folder of the Data Lake Store account."
-			}
-		},
-		"servicePrincipalApplicationId": {
-			"type": "string",
-			"metadata": {
-				"description": "The AAD application ID (guid) of the service principal that represents the HDInsight cluster. The service principal will be given permissions on the root folder of the Data Lake Store account."
-			}
-		},
-		"servicePrincipalCertificateContents": {
-			"type": "securestring",
-			"metadata": {
-				"description": "The base-64-encoded contents of the PFX certificate file that can be used to authenticate as the service principal that represents the HDInsight cluster."
-			}
-		},
-		"servicePrincipalCertificatePassword": {
-			"type": "securestring",
-			"metadata": {
-				"description": "The password securing the PFX certificate file that can be used to authenticate as the service principal that represents the HDInsight cluster."
-			}
-		},
-		"clusterWorkerNodeCount": {
-			"type": "int",
-			"defaultValue": 4,
-			"metadata": {
-				"description": "The number of nodes in the HDInsight cluster."
-			}
-		}
-	},
-	"variables": {
-		"defaultApiVersion": "2015-06-15",
-		"clusterApiVersion": "2015-03-01-preview",
-		"adlsApiVersion": "2015-10-01-preview"
-	},
-	"resources": [{
-		"name": "[parameters('adlStoreName')]",
-		"type": "Microsoft.DataLakeStore/accounts",
-		"location": "East US 2",
-		"apiVersion": "[variables('adlsApiVersion')]",
-		"dependsOn": [],
-		"tags": {
-			
-		},
-		"properties": {
-			"initialUser": "[parameters('servicePrincipalObjectId')]"
-		}
-	},
-	{
-		"name": "[parameters('clusterStorageAccountName')]",
-		"type": "Microsoft.Storage/storageAccounts",
-		"location": "East US 2",
-		"apiVersion": "[variables('defaultApiVersion')]",
-		"dependsOn": [],
-		"tags": {
-			
-		},
-		"properties": {
-			"accountType": "Standard_LRS"
-		}
-	},
-	{
-		"name": "[parameters('clusterName')]",
-		"type": "Microsoft.HDInsight/clusters",
-		"location": "East US 2",
-		"apiVersion": "[variables('clusterApiVersion')]",
-		"dependsOn": ["[concat('Microsoft.DataLakeStore/accounts/',parameters('adlStoreName'))]",
-		"[concat('Microsoft.Storage/storageAccounts/',parameters('clusterStorageAccountName'))]"],
-		"tags": {
-			
-		},
-		"properties": {
-			"clusterVersion": "3.2",
-			"osType": "Linux",
-			"clusterDefinition": {
-				"kind": "[parameters('clusterType')]",
-				"configurations": {
-					"gateway": {
-						"restAuthCredential.isEnabled": true,
-						"restAuthCredential.username": "[parameters('clusterLoginUserName')]",
-						"restAuthCredential.password": "[parameters('clusterLoginPassword')]"
-					},
-					"clusterIdentity": {
-						"clusterIdentity.applicationId": "[parameters('servicePrincipalApplicationId')]",
-						"clusterIdentity.certificate": "[parameters('servicePrincipalCertificateContents')]",
-						"clusterIdentity.certificatePassword": "[parameters('servicePrincipalCertificatePassword')]",
-						"clusterIdentity.aadTenantId": "[concat('https://login.windows.net/',parameters('aadTenantId'))]",
-						"clusterIdentity.resourceUri": "https://management.core.windows.net/"
-					}
-				}
-			},
-			"storageProfile": {
-				"storageaccounts": [{
-					"name": "[concat(parameters('clusterStorageAccountName'),'.blob.core.windows.net')]",
-					"isDefault": true,
-					"container": "[parameters('clusterName')]",
-					"key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
-				}]
-			},
-			"computeProfile": {
-				"roles": [{
-					"name": "headnode",
-					"targetInstanceCount": "2",
-					"hardwareProfile": {
-						"vmSize": "Standard_D3"
-					},
-					"osProfile": {
-						"linuxOperatingSystemProfile": {
-							"username": "[parameters('sshUserName')]",
-							"password": "[parameters('sshPassword')]"
-						}
-					}
-				},
-				{
-					"name": "workernode",
-					"targetInstanceCount": "[parameters('clusterWorkerNodeCount')]",
-					"hardwareProfile": {
-						"vmSize": "Standard_D3"
-					},
-					"osProfile": {
-						"linuxOperatingSystemProfile": {
-							"username": "[parameters('sshUserName')]",
-							"password": "[parameters('sshPassword')]"
-						}
-					}
-				}]
-			}
-		}
-	}],
-	"outputs": {
-		"adlStoreAccount": {
-			"type": "object",
-			"value": "[reference(resourceId('Microsoft.DataLakeStore/accounts',parameters('adlStoreName')))]"
-		},
-		"storageAccount": {
-			"type": "object",
-			"value": "[reference(resourceId('Microsoft.Storage/storageAccounts',parameters('clusterStorageAccountName')))]"
-		},
-		"cluster": {
-			"type": "object",
-			"value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
-		}
-	}
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterType": {
+      "type": "string",
+      "allowedValues": [
+        "hadoop",
+        "hbase",
+        "storm",
+        "spark"
+      ],
+      "metadata": {
+        "description": "The type of the HDInsight cluster to create."
+      }
+    },
+    "clusterName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the HDInsight cluster to create."
+      }
+    },
+    "clusterLoginUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
+      }
+    },
+    "clusterLoginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+      }
+    },
+    "sshUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "These credentials can be used to remotely access the cluster."
+      }
+    },
+    "sshPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+      }
+    },
+    "clusterStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure storage account to be created and be used as the cluster's primary storage."
+      }
+    },
+    "adlStoreName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure Data Lake Store account to be created and connected to the cluster."
+      }
+    },
+    "aadTenantId": {
+      "type": "string",
+      "metadata": {
+        "description": "The tenant ID (guid) of the Azure Active Directory (AAD) tenant where the service principal resides."
+      }
+    },
+    "servicePrincipalObjectId": {
+      "type": "string",
+      "metadata": {
+        "description": "The AAD object ID (guid) of the service principal that represents the HDInsight cluster. The service principal will be given permissions on the root folder of the Data Lake Store account."
+      }
+    },
+    "servicePrincipalApplicationId": {
+      "type": "string",
+      "metadata": {
+        "description": "The AAD application ID (guid) of the service principal that represents the HDInsight cluster. The service principal will be given permissions on the root folder of the Data Lake Store account."
+      }
+    },
+    "servicePrincipalCertificateContents": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The base-64-encoded contents of the PFX certificate file that can be used to authenticate as the service principal that represents the HDInsight cluster."
+      }
+    },
+    "servicePrincipalCertificatePassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password securing the PFX certificate file that can be used to authenticate as the service principal that represents the HDInsight cluster."
+      }
+    },
+    "clusterWorkerNodeCount": {
+      "type": "int",
+      "defaultValue": 4,
+      "metadata": {
+        "description": "The number of nodes in the HDInsight cluster."
+      }
+    }
+  },
+  "variables": {
+    "defaultApiVersion": "2015-06-15",
+    "clusterApiVersion": "2015-03-01-preview",
+    "adlsApiVersion": "2015-10-01-preview"
+  },
+  "resources": [
+    {
+      "name": "[parameters('adlStoreName')]",
+      "type": "Microsoft.DataLakeStore/accounts",
+      "location": "East US 2",
+      "apiVersion": "2015-10-01-preview",
+      "dependsOn": [],
+      "tags": {},
+      "properties": {
+        "initialUser": "[parameters('servicePrincipalObjectId')]"
+      }
+    },
+    {
+      "name": "[parameters('clusterStorageAccountName')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "location": "East US 2",
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
+      "tags": {},
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "name": "[parameters('clusterName')]",
+      "type": "Microsoft.HDInsight/clusters",
+      "location": "East US 2",
+      "apiVersion": "2015-03-01-preview",
+      "dependsOn": [
+        "[concat('Microsoft.DataLakeStore/accounts/',parameters('adlStoreName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/',parameters('clusterStorageAccountName'))]"
+      ],
+      "tags": {},
+      "properties": {
+        "clusterVersion": "3.2",
+        "osType": "Linux",
+        "clusterDefinition": {
+          "kind": "[parameters('clusterType')]",
+          "configurations": {
+            "gateway": {
+              "restAuthCredential.isEnabled": true,
+              "restAuthCredential.username": "[parameters('clusterLoginUserName')]",
+              "restAuthCredential.password": "[parameters('clusterLoginPassword')]"
+            },
+            "clusterIdentity": {
+              "clusterIdentity.applicationId": "[parameters('servicePrincipalApplicationId')]",
+              "clusterIdentity.certificate": "[parameters('servicePrincipalCertificateContents')]",
+              "clusterIdentity.certificatePassword": "[parameters('servicePrincipalCertificatePassword')]",
+              "clusterIdentity.aadTenantId": "[concat('https://login.windows.net/',parameters('aadTenantId'))]",
+              "clusterIdentity.resourceUri": "https://management.core.windows.net/"
+            }
+          }
+        },
+        "storageProfile": {
+          "storageaccounts": [
+            {
+              "name": "[concat(parameters('clusterStorageAccountName'),'.blob.core.windows.net')]",
+              "isDefault": true,
+              "container": "[parameters('clusterName')]",
+              "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
+            }
+          ]
+        },
+        "computeProfile": {
+          "roles": [
+            {
+              "name": "headnode",
+              "targetInstanceCount": "2",
+              "hardwareProfile": {
+                "vmSize": "Standard_D3"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('sshUserName')]",
+                  "password": "[parameters('sshPassword')]"
+                }
+              }
+            },
+            {
+              "name": "workernode",
+              "targetInstanceCount": "[parameters('clusterWorkerNodeCount')]",
+              "hardwareProfile": {
+                "vmSize": "Standard_D3"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('sshUserName')]",
+                  "password": "[parameters('sshPassword')]"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "adlStoreAccount": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.DataLakeStore/accounts',parameters('adlStoreName')))]"
+    },
+    "storageAccount": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.Storage/storageAccounts',parameters('clusterStorageAccountName')))]"
+    },
+    "cluster": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
+    }
+  }
 }

--- a/201-oms-extension-ubuntu-vm/azuredeploy.json
+++ b/201-oms-extension-ubuntu-vm/azuredeploy.json
@@ -26,12 +26,12 @@
         "description": "Password for the Virtual Machine."
       }
     },
-	"dnsLabelPrefix": {
-	   "type": "string",
-	   "metadata": {
-		  "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
-	   }
-	},
+    "dnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
     "ubuntuOSVersion": {
       "type": "string",
       "defaultValue": "14.04.2-LTS",
@@ -46,8 +46,8 @@
     }
   },
   "variables": {
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
     "OSDiskName": "osdiskforlinuxsimple",
@@ -69,14 +69,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -88,7 +88,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -177,15 +177,15 @@
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
-             "enabled": "true",
-             "storageUri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net')]"
+            "enabled": "true",
+            "storageUri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net')]"
           }
         }
       },
       "resources": [
         {
-		  "type": "Microsoft.Compute/virtualMachines/extensions",
-	      "name": "[concat(variables('vmName'), '/Microsoft.EnterpriseCloud.Monitoring')]",
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "[concat(variables('vmName'), '/Microsoft.EnterpriseCloud.Monitoring')]",
           "apiVersion": "[variables('apiVersion')]",
           "location": "[resourceGroup().location]",
           "dependsOn": [
@@ -193,14 +193,14 @@
           ],
           "properties": {
             "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-			"type": "OmsAgentForLinux",
+            "type": "OmsAgentForLinux",
             "typeHandlerVersion": "1.0",
             "autoUpgradeMinorVersion": true,
             "settings": {
-			  "workspaceId": "[parameters('workspaceId')]"
+              "workspaceId": "[parameters('workspaceId')]"
             },
             "protectedSettings": {
-			  "workspaceKey": "[parameters('workspaceKey')]"
+              "workspaceKey": "[parameters('workspaceKey')]"
             }
           }
         }

--- a/201-oms-extension-windows-vm/azuredeploy.json
+++ b/201-oms-extension-windows-vm/azuredeploy.json
@@ -14,12 +14,12 @@
         "description": "Password for the Virtual Machine."
       }
     },
-	"dnsLabelPrefix": {
-	   "type": "string",
-	   "metadata": {
-		  "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
-	   }
-	},
+    "dnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
     "workspaceName": {
       "type": "string",
       "metadata": {
@@ -41,8 +41,8 @@
     }
   },
   "variables": {
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
     "imagePublisher": "MicrosoftWindowsServer",
     "imageOffer": "WindowsServer",
     "OSDiskName": "osdiskforwindowssimple",
@@ -65,14 +65,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -84,7 +84,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -105,7 +105,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -173,8 +173,8 @@
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
-             "enabled": "true",
-             "storageUri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net')]"
+            "enabled": "true",
+            "storageUri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net')]"
           }
         }
       },
@@ -193,10 +193,10 @@
             "typeHandlerVersion": "1.0",
             "autoUpgradeMinorVersion": true,
             "settings": {
-			  "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName')), '2015-03-20').customerId]"
+              "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName')), '2015-03-20').customerId]"
             },
             "protectedSettings": {
-			  "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName')), '2015-03-20').primarySharedKey]"
+              "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName')), '2015-03-20').primarySharedKey]"
             }
           }
         }

--- a/201-ospatching-extension-on-ubuntu/azuredeploy.json
+++ b/201-ospatching-extension-on-ubuntu/azuredeploy.json
@@ -152,14 +152,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('newStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -171,7 +171,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -192,7 +192,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -218,7 +218,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -263,7 +263,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/installospatching')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
@@ -296,4 +296,3 @@
     }
   ]
 }
-

--- a/201-ospatching-extension-on-ubuntu/prereqs/prereq.azuredeploy.json
+++ b/201-ospatching-extension-on-ubuntu/prereqs/prereq.azuredeploy.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {},

--- a/201-ospatching-extension-on-ubuntu/prereqs/prereq.azuredeploy.parameters.json
+++ b/201-ospatching-extension-on-ubuntu/prereqs/prereq.azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/201-site-to-site-vpn/azuredeploy.json
+++ b/201-site-to-site-vpn/azuredeploy.json
@@ -1,380 +1,380 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "vpnType": {
-            "type": "String",
-            "metadata": {
-                "description": "Route based (Dynamic Gateway) or Policy based (Static Gateway)"
-            },
-            "defaultValue": "RouteBased",
-            "allowedValues": [
-                "RouteBased",
-                "PolicyBased"
-            ]
-        },
-        "localGatewayName": {
-            "type": "string",
-            "defaultValue": "localGateway",
-            "metadata": {
-                "description": "Arbitrary name for gateway resource representing your local/on-prem gateway"
-            }
-        },
-        "localGatewayIpAddress": {
-            "type": "string",
-            "metadata": {
-                "description": "Public IP of your local/on-prem gateway"
-            }
-        },
-        "localAddressPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "CIDR block representing the address space of your local/on-prem network's Subnet"
-            }
-        },
-        "virtualNetworkName": {
-            "type": "string",
-            "defaultValue": "azureVnet",
-            "metadata": {
-                "description": "Arbitrary name for the Azure Virtual Network"
-            }
-        },
-        "azureVNetAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.3.0.0/16",
-            "metadata": {
-                "description": "CIDR block representing the address space of the Azure VNet"
-            }
-        },
-        "subnetName": {
-            "type": "string",
-            "defaultValue": "Subnet1",
-            "metadata": {
-                "description": "Arbitrary name for the Azure Subnet"
-            }
-        },
-        "subnetPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "CIDR block for VM subnet, subset of azureVNetAddressPrefix address space"
-            }
-        },
-        "gatewaySubnetPrefix": {
-            "type": "string",
-            "defaultValue": "10.3.200.0/29",
-            "metadata": {
-                "description": "CIDR block for gateway subnet, subset of azureVNetAddressPrefix address space"
-            }
-        },
-        "gatewayPublicIPName": {
-            "type": "string",
-            "defaultValue": "azureGatewayIP",
-            "metadata": {
-                "description": "Arbitrary name for public IP resource used for the new azure gateway"
-            }
-        },
-        "gatewayName": {
-            "type": "string",
-            "defaultValue": "azureGateway",
-            "metadata": {
-                "description": "Arbitrary name for the new gateway"
-            }
-        },
-        "gatewaySku":{  
-            "type":"string",
-            "defaultValue": "Basic",
-            "allowedValues": [
-                "Basic",
-                "Standard",
-                "HighPerformance"
-            ],
-            "metadata":{  
-                "description":"The Sku of the Gateway. This must be one of Basic, Standard or HighPerformance."
-            }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vpnType": {
+      "type": "String",
+      "metadata": {
+        "description": "Route based (Dynamic Gateway) or Policy based (Static Gateway)"
       },
-        "connectionName": {
-            "type": "string",
-            "defaultValue": "Azure2Other",
-            "metadata": {
-                "description": "Arbitrary name for the new connection between Azure VNet and other network"
-            }
-        },
-        "sharedKey": {
-            "type": "string",
-            "metadata": {
-                "description": "Shared key (PSK) for IPSec tunnel"
-            }
-        },
-        "vmName": {
-            "type": "string",
-            "defaultValue": "node-1",
-            "metadata": {
-                "description": "Name of the sample VM to create"
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "defaultValue": "Standard_A1",
-            "allowedValues": [
-                "Standard_A1",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_A6",
-                "Standard_A7",
-                "Standard_A8",
-                "Standard_A9",
-                "Standard_A10",
-                "Standard_A11",
-                "Standard_D2",
-                "Standard_D3",
-                "Standard_D4",
-                "Standard_D11",
-                "Standard_D12",
-                "Standard_D13",
-                "Standard_D14"
-            ],
-            "metadata": {
-                "description": "Size of the Virtual Machine."
-            }
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Username for sample VM"
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "User password for sample VM"
-            }
-        },
-        "newStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "Storage Account Name for VM Disk"
-            }
-        },
-        "storageAccountType": {
-            "type": "string",
-            "allowedValues": [
-                "Standard_LRS",
-                "Standard_GRS",
-                "Standard_RAGRS",
-                "Premium_LRS"
-            ],
-            "metadata": {
-                "description": "The type of the Storage Account created"
-            },
-            "defaultValue": "Standard_LRS"
-        }
+      "defaultValue": "RouteBased",
+      "allowedValues": [
+        "RouteBased",
+        "PolicyBased"
+      ]
     },
-    "variables": {
-        "imagePublisher": "Canonical",
-        "imageOffer": "UbuntuServer",
-        "imageSKU": "14.04.2-LTS",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-        "gatewaySubnetRef": "[concat(variables('vnetID'),'/subnets/','GatewaySubnet')]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetName'))]",
-        "nicName": "[concat(parameters('vmName'), '-nic')]",
-        "vmStorageAccountContainerName": "vhds",
-        "OSDiskName": "osDisk",
-        "vmPublicIPName": "[concat(parameters('vmName'), '-publicIP')]",
-        "api-version": "2015-06-15",
-        "storage-api-version": "2015-05-01-preview"
+    "localGatewayName": {
+      "type": "string",
+      "defaultValue": "localGateway",
+      "metadata": {
+        "description": "Arbitrary name for gateway resource representing your local/on-prem gateway"
+      }
     },
-    "resources": [
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/localNetworkGateways",
-        "name": "[parameters('localGatewayName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "localNetworkAddressSpace": {
-            "addressPrefixes": [
-              "[parameters('localAddressPrefix')]"
-            ]
-          },
-          "gatewayIpAddress": "[parameters('localGatewayIpAddress')]"
-        }
+    "localGatewayIpAddress": {
+      "type": "string",
+      "metadata": {
+        "description": "Public IP of your local/on-prem gateway"
+      }
+    },
+    "localAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "CIDR block representing the address space of your local/on-prem network's Subnet"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "azureVnet",
+      "metadata": {
+        "description": "Arbitrary name for the Azure Virtual Network"
+      }
+    },
+    "azureVNetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.3.0.0/16",
+      "metadata": {
+        "description": "CIDR block representing the address space of the Azure VNet"
+      }
+    },
+    "subnetName": {
+      "type": "string",
+      "defaultValue": "Subnet1",
+      "metadata": {
+        "description": "Arbitrary name for the Azure Subnet"
+      }
+    },
+    "subnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "CIDR block for VM subnet, subset of azureVNetAddressPrefix address space"
+      }
+    },
+    "gatewaySubnetPrefix": {
+      "type": "string",
+      "defaultValue": "10.3.200.0/29",
+      "metadata": {
+        "description": "CIDR block for gateway subnet, subset of azureVNetAddressPrefix address space"
+      }
+    },
+    "gatewayPublicIPName": {
+      "type": "string",
+      "defaultValue": "azureGatewayIP",
+      "metadata": {
+        "description": "Arbitrary name for public IP resource used for the new azure gateway"
+      }
+    },
+    "gatewayName": {
+      "type": "string",
+      "defaultValue": "azureGateway",
+      "metadata": {
+        "description": "Arbitrary name for the new gateway"
+      }
+    },
+    "gatewaySku": {
+      "type": "string",
+      "defaultValue": "Basic",
+      "allowedValues": [
+        "Basic",
+        "Standard",
+        "HighPerformance"
+      ],
+      "metadata": {
+        "description": "The Sku of the Gateway. This must be one of Basic, Standard or HighPerformance."
+      }
+    },
+    "connectionName": {
+      "type": "string",
+      "defaultValue": "Azure2Other",
+      "metadata": {
+        "description": "Arbitrary name for the new connection between Azure VNet and other network"
+      }
+    },
+    "sharedKey": {
+      "type": "string",
+      "metadata": {
+        "description": "Shared key (PSK) for IPSec tunnel"
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "defaultValue": "node-1",
+      "metadata": {
+        "description": "Name of the sample VM to create"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_A1",
+      "allowedValues": [
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14"
+      ],
+      "metadata": {
+        "description": "Size of the Virtual Machine."
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for sample VM"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "User password for sample VM"
+      }
+    },
+    "newStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Storage Account Name for VM Disk"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_GRS",
+        "Standard_RAGRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "The type of the Storage Account created"
       },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "name": "[parameters('connectionName')]",
-        "type": "Microsoft.Network/connections",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]",
-          "[concat('Microsoft.Network/localNetworkGateways/', parameters('localGatewayName'))]"
-        ],
-        "properties": {
-          "virtualNetworkGateway1": {
-            "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]"
-          },
-          "localNetworkGateway2": {
-            "id": "[resourceId('Microsoft.Network/localNetworkGateways', parameters('localGatewayName'))]"
-          },
-          "connectionType": "IPsec",
-          "routingWeight": 10,
-          "sharedKey": "[parameters('sharedKey')]"
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[parameters('virtualNetworkName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[parameters('azureVNetAddressPrefix')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[parameters('subnetName')]",
-              "properties": {
-                "addressPrefix": "[parameters('subnetPrefix')]"
-              }
-            },
-            {
-              "name": "GatewaySubnet",
-              "properties": {
-                "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
-              }
-            }
+      "defaultValue": "Standard_LRS"
+    }
+  },
+  "variables": {
+    "imagePublisher": "Canonical",
+    "imageOffer": "UbuntuServer",
+    "imageSKU": "14.04.2-LTS",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+    "gatewaySubnetRef": "[concat(variables('vnetID'),'/subnets/','GatewaySubnet')]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('subnetName'))]",
+    "nicName": "[concat(parameters('vmName'), '-nic')]",
+    "vmStorageAccountContainerName": "vhds",
+    "OSDiskName": "osDisk",
+    "vmPublicIPName": "[concat(parameters('vmName'), '-publicIP')]",
+    "api-version": "2015-06-15",
+    "storage-api-version": "2015-05-01-preview"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/localNetworkGateways",
+      "name": "[parameters('localGatewayName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "localNetworkAddressSpace": {
+          "addressPrefixes": [
+            "[parameters('localAddressPrefix')]"
           ]
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[parameters('gatewayPublicIPName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "Dynamic"
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[variables('vmPublicIPName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "Dynamic"
-        }
-      },
-      {
-        "apiVersion": "[variables('storage-api-version')]",
-        "name": "[parameters('newStorageAccountName')]",
-        "location": "[resourceGroup().location]",
-        "type": "Microsoft.Storage/storageAccounts",
-        "properties": {
-          "accountType": "[parameters('storageAccountType')]"
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/virtualNetworkGateways",
-        "name": "[parameters('gatewayName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "[variables('gatewaySubnetRef')]"
-                },
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
-                }
-              },
-              "name": "vnetGatewayConfig"
-            }
-          ],
-          "sku": {
-            "name": "[parameters('gatewaySku')]",
-            "tier": "[parameters('gatewaySku')]"
-          },
-          "gatewayType": "Vpn",
-          "vpnType": "[parameters('vpnType')]",
-          "enableBgp": "false"
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[variables('nicName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('vmPublicIPName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]",
-          "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfig1",
-              "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('vmPublicIPName'))]"
-                },
-                "subnet": {
-                  "id": "[variables('subnetRef')]"
-                }
-              }
-            }
+        },
+        "gatewayIpAddress": "[parameters('localGatewayIpAddress')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "name": "[parameters('connectionName')]",
+      "type": "Microsoft.Network/connections",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]",
+        "[concat('Microsoft.Network/localNetworkGateways/', parameters('localGatewayName'))]"
+      ],
+      "properties": {
+        "virtualNetworkGateway1": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]"
+        },
+        "localNetworkGateway2": {
+          "id": "[resourceId('Microsoft.Network/localNetworkGateways', parameters('localGatewayName'))]"
+        },
+        "connectionType": "IPsec",
+        "routingWeight": 10,
+        "sharedKey": "[parameters('sharedKey')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('azureVNetAddressPrefix')]"
           ]
-        }
-      },
-      {
-        "apiVersion": "[variables('api-version')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[parameters('vmName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-          "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-        ],
-        "properties": {
-          "hardwareProfile": {
-            "vmSize": "[parameters('vmSize')]"
-          },
-          "osProfile": {
-            "computerName": "[parameters('vmName')]",
-            "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPassword')]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "[variables('imagePublisher')]",
-              "offer": "[variables('imageOffer')]",
-              "sku": "[variables('imageSKU')]",
-              "version": "latest"
-            },
-            "osDisk": {
-              "name": "osdisk1",
-              "vhd": {
-                "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-              },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetPrefix')]"
             }
           },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-              }
-            ]
+          {
+            "name": "GatewaySubnet",
+            "properties": {
+              "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
+            }
           }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('gatewayPublicIPName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('vmPublicIPName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "name": "[parameters('newStorageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "properties": {
+        "accountType": "[parameters('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworkGateways",
+      "name": "[parameters('gatewayName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('gatewaySubnetRef')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
+              }
+            },
+            "name": "vnetGatewayConfig"
+          }
+        ],
+        "sku": {
+          "name": "[parameters('gatewaySku')]",
+          "tier": "[parameters('gatewaySku')]"
+        },
+        "gatewayType": "Vpn",
+        "vpnType": "[parameters('vpnType')]",
+        "enableBgp": "false"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('vmPublicIPName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('vmPublicIPName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('imageSKU')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk1",
+            "vhd": {
+              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
         }
       }
-    ]
+    }
+  ]
 }

--- a/201-traffic-manager-vm/azuredeploy.json
+++ b/201-traffic-manager-vm/azuredeploy.json
@@ -59,7 +59,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "copy": {
@@ -75,7 +75,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -96,7 +96,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "copy": {
@@ -173,7 +173,7 @@
         "name": "extLoop",
         "count": "[variables('numVMs')]"
       },
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), copyIndex())]"
@@ -189,7 +189,7 @@
       }
     },
     {
-      "apiVersion": "[variables('tmApiVersion')]",
+      "apiVersion": "2015-11-01",
       "type": "Microsoft.Network/trafficManagerProfiles",
       "name": "VMEndpointExample",
       "location": "global",

--- a/201-userdefined-routes-appliance/azuredeploy.json
+++ b/201-userdefined-routes-appliance/azuredeploy.json
@@ -75,7 +75,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVer')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('uniqueDnsPrefixForVM'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -91,7 +91,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVer')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "DefaultNSG",
       "location": "[resourceGroup().location]",
@@ -117,7 +117,7 @@
     {
       "type": "Microsoft.Network/routeTables",
       "name": "[variables('routeTableName')]",
-      "apiVersion": "[variables('apiVer')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "routes": [
@@ -133,7 +133,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVer')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('VNetName')]",
       "location": "[resourceGroup().location]",
@@ -182,7 +182,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVer')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "Nic0",
       "location": "[resourceGroup().location]",
@@ -208,7 +208,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVer')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "Nic1",
       "location": "[resourceGroup().location]",
@@ -236,7 +236,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVer')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "Nic2",
       "location": "[resourceGroup().location]",

--- a/201-vm-domain-join/azuredeploy.json
+++ b/201-vm-domain-join/azuredeploy.json
@@ -85,7 +85,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPName')]",
       "location": "[resourceGroup().location]",
@@ -97,7 +97,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -106,7 +106,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -131,7 +131,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('dnsLabelPrefix')]",
       "location": "[resourceGroup().location]",
@@ -192,7 +192,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('dnsLabelPrefix'),'/joindomain')]",
       "location": "[resourceGroup().location]",

--- a/201-vm-monitoring-diagnostics-extension/azuredeploy.json
+++ b/201-vm-monitoring-diagnostics-extension/azuredeploy.json
@@ -38,18 +38,18 @@
         "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
       }
     },
-      "existingdiagnosticsStorageAccountName": {
-          "type": "string",
-          "metadata": {
+    "existingdiagnosticsStorageAccountName": {
+      "type": "string",
+      "metadata": {
         "description": "The name of an existing storage account to which diagnostics data will be transferred."
       }
-      },
-      "existingdiagnosticsStorageResourceGroup": {
-          "type": "string",
-          "metadata": {
+    },
+    "existingdiagnosticsStorageResourceGroup": {
+      "type": "string",
+      "metadata": {
         "description": "The resource group for the storage account specified in existingdiagnosticsStorageAccountName"
       }
-      }
+    }
   },
   "variables": {
     "apiVersion": "2015-06-15",
@@ -69,26 +69,26 @@
     "virtualNetworkName": "MyVNET",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-      "accountid": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/',parameters('existingdiagnosticsStorageResourceGroup'), '/providers/','Microsoft.Storage/storageAccounts/', parameters('existingdiagnosticsStorageAccountName'))]",
-      "wadlogs": "<WadCfg> <DiagnosticMonitorConfiguration overallQuotaInMB=\"4096\" xmlns=\"http://schemas.microsoft.com/ServiceHosting/2010/10/DiagnosticsConfiguration\"> <DiagnosticInfrastructureLogs scheduledTransferLogLevelFilter=\"Error\"/> <WindowsEventLog scheduledTransferPeriod=\"PT1M\" > <DataSource name=\"Application!*[System[(Level = 1 or Level = 2)]]\" /> <DataSource name=\"Security!*[System[(Level = 1 or Level = 2)]]\" /> <DataSource name=\"System!*[System[(Level = 1 or Level = 2)]]\" /></WindowsEventLog>",
-      "wadperfcounters1": "<PerformanceCounters scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Processor(_Total)\\% Processor Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"CPU utilization\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Processor(_Total)\\% Privileged Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Processor(_Total)\\% User Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Processor Information(_Total)\\Processor Frequency\" sampleRate=\"PT15S\" unit=\"Count\"><annotation displayName=\"CPU frequency\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\System\\Processes\" sampleRate=\"PT15S\" unit=\"Count\"><annotation displayName=\"Processes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Process(_Total)\\Thread Count\" sampleRate=\"PT15S\" unit=\"Count\"><annotation displayName=\"Threads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Process(_Total)\\Handle Count\" sampleRate=\"PT15S\" unit=\"Count\"><annotation displayName=\"Handles\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\% Committed Bytes In Use\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Memory usage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\Available Bytes\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\Committed Bytes\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory committed\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\Commit Limit\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory commit limit\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\% Disk Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Disk active time\" locale=\"en-us\"/></PerformanceCounterConfiguration>",
-      "wadperfcounters2": "<PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\% Disk Read Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Disk active read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\% Disk Write Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Disk active write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Transfers/sec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation displayName=\"Disk operations\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Reads/sec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation displayName=\"Disk read operations\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Writes/sec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation displayName=\"Disk write operations\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Bytes/sec\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation displayName=\"Disk speed\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Read Bytes/sec\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation displayName=\"Disk read speed\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Write Bytes/sec\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation displayName=\"Disk write speed\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\LogicalDisk(_Total)\\% Free Space\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Disk free space (percentage)\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>",
-      "wadcfgxstart": "[concat(variables('wadlogs'), variables('wadperfcounters1'), variables('wadperfcounters2'), '<Metrics resourceId=\"')]",
-      "wadmetricsresourceid": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name , '/providers/', 'Microsoft.Compute/virtualMachines/')]",
-      "wadcfgxend": "\"><MetricAggregation scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>"
+    "accountid": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/',parameters('existingdiagnosticsStorageResourceGroup'), '/providers/','Microsoft.Storage/storageAccounts/', parameters('existingdiagnosticsStorageAccountName'))]",
+    "wadlogs": "<WadCfg> <DiagnosticMonitorConfiguration overallQuotaInMB=\"4096\" xmlns=\"http://schemas.microsoft.com/ServiceHosting/2010/10/DiagnosticsConfiguration\"> <DiagnosticInfrastructureLogs scheduledTransferLogLevelFilter=\"Error\"/> <WindowsEventLog scheduledTransferPeriod=\"PT1M\" > <DataSource name=\"Application!*[System[(Level = 1 or Level = 2)]]\" /> <DataSource name=\"Security!*[System[(Level = 1 or Level = 2)]]\" /> <DataSource name=\"System!*[System[(Level = 1 or Level = 2)]]\" /></WindowsEventLog>",
+    "wadperfcounters1": "<PerformanceCounters scheduledTransferPeriod=\"PT1M\"><PerformanceCounterConfiguration counterSpecifier=\"\\Processor(_Total)\\% Processor Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"CPU utilization\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Processor(_Total)\\% Privileged Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"CPU privileged time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Processor(_Total)\\% User Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"CPU user time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Processor Information(_Total)\\Processor Frequency\" sampleRate=\"PT15S\" unit=\"Count\"><annotation displayName=\"CPU frequency\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\System\\Processes\" sampleRate=\"PT15S\" unit=\"Count\"><annotation displayName=\"Processes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Process(_Total)\\Thread Count\" sampleRate=\"PT15S\" unit=\"Count\"><annotation displayName=\"Threads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Process(_Total)\\Handle Count\" sampleRate=\"PT15S\" unit=\"Count\"><annotation displayName=\"Handles\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\% Committed Bytes In Use\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Memory usage\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\Available Bytes\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory available\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\Committed Bytes\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory committed\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\Memory\\Commit Limit\" sampleRate=\"PT15S\" unit=\"Bytes\"><annotation displayName=\"Memory commit limit\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\% Disk Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Disk active time\" locale=\"en-us\"/></PerformanceCounterConfiguration>",
+    "wadperfcounters2": "<PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\% Disk Read Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Disk active read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\% Disk Write Time\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Disk active write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Transfers/sec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation displayName=\"Disk operations\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Reads/sec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation displayName=\"Disk read operations\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Writes/sec\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation displayName=\"Disk write operations\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Bytes/sec\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation displayName=\"Disk speed\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Read Bytes/sec\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation displayName=\"Disk read speed\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk(_Total)\\Disk Write Bytes/sec\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation displayName=\"Disk write speed\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\LogicalDisk(_Total)\\% Free Space\" sampleRate=\"PT15S\" unit=\"Percent\"><annotation displayName=\"Disk free space (percentage)\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>",
+    "wadcfgxstart": "[concat(variables('wadlogs'), variables('wadperfcounters1'), variables('wadperfcounters2'), '<Metrics resourceId=\"')]",
+    "wadmetricsresourceid": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name , '/providers/', 'Microsoft.Compute/virtualMachines/')]",
+    "wadcfgxend": "\"><MetricAggregation scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>"
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('newStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -100,7 +100,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -121,7 +121,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -147,7 +147,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -225,4 +225,4 @@
       ]
     }
   ]
-    }
+}

--- a/201-vm-monitoring-diagnostics-extension/prereqs/prereq.azuredeploy.json
+++ b/201-vm-monitoring-diagnostics-extension/prereqs/prereq.azuredeploy.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/201-vm-monitoring-diagnostics-extension/prereqs/prereq.azuredeploy.parameters.json
+++ b/201-vm-monitoring-diagnostics-extension/prereqs/prereq.azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {

--- a/201-vm-multiple-nics-linux/azuredeploy.json
+++ b/201-vm-multiple-nics-linux/azuredeploy.json
@@ -22,7 +22,7 @@
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }
     },
-   "vmName": {
+    "vmName": {
       "type": "string",
       "defaultValue": "multinicvm",
       "metadata": {
@@ -78,41 +78,32 @@
   "variables": {
     "apiVersion": "2015-06-15",
     "location": "[resourceGroup().location]",
-
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'samultinic')]",
     "storageAccountType": "Standard_LRS",
-
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
-
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
-
     "nic1Name": "nic1",
     "nic2Name": "nic2",
-
     "vnetName": "vnet",
     "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]",
     "addressPrefix": "10.0.0.0/16",
-
     "subnet1Name": "Frontend",
     "subnet1Id": "[concat(variables('vnetId'), '/subnets/', variables('subnet1Name'))]",
     "subnet1Prefix": "10.0.1.0/24",
     "subnet1PrivateAddress": "10.0.1.5",
-
     "subnet2Name": "Web",
     "subnet2Id": "[concat(variables('vnetId'), '/subnets/', variables('subnet2Name'))]",
     "subnet2Prefix": "10.0.2.0/24",
     "subnet2PrivateAddress": "10.0.2.5",
-
     "publicIPAddressName": "[concat(uniquestring(resourceGroup().id), 'PublicIp')]",
     "publicIPAddressType": "Dynamic",
     "publicIPAddressId": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
-
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "name": "[variables('storageAccountName')]",
       "properties": {
@@ -121,7 +112,7 @@
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "name": "[variables('vnetName')]",
       "properties": {
@@ -148,7 +139,7 @@
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "name": "[variables('publicIPAddressName')]",
       "properties": {
@@ -161,7 +152,7 @@
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[variables('vnetId')]",
         "[variables('publicIPAddressId')]"
@@ -188,7 +179,7 @@
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[variables('vnetId')]"
       ],
@@ -278,6 +269,6 @@
     "sshCommand": {
       "type": "string",
       "value": "[concat('ssh ', parameters('adminUsername'), '@', parameters('vmName'), '.', resourceGroup().location, '.cloudapp.azure.com')]"
-    } 
+    }
   }
 }

--- a/201-vm-specialized-vhd-existing-vnet/azuredeploy.json
+++ b/201-vm-specialized-vhd-existing-vnet/azuredeploy.json
@@ -64,92 +64,101 @@
     "nicName": "[parameters('vmName')]",
     "publicIPAddressName": "[parameters('vmName')]"
   },
-  "resources": [{
-    "type": "Microsoft.Storage/storageAccounts",
-    "name": "[variables('diagStorageAccountName')]",
-    "apiVersion": "2016-01-01",
-    "location": "[resourceGroup().location]",
-    "sku": {
-      "name": "Standard_GRS"
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('diagStorageAccountName')]",
+      "apiVersion": "2016-01-01",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "kind": "Storage",
+      "properties": {}
     },
-    "kind": "Storage",
-    "properties": {}
-  }, {
-    "apiVersion": "[variables('api-version')]",
-    "type": "Microsoft.Network/publicIPAddresses",
-    "name": "[variables('publicIPAddressName')]",
-    "location": "[resourceGroup().location]",
-    "tags": {
-      "displayName": "PublicIPAddress"
-    },
-    "properties": {
-      "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-      "dnsSettings": {
-        "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "displayName": "PublicIPAddress"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+        }
       }
-    }
-  }, {
-    "apiVersion": "[variables('api-version')]",
-    "type": "Microsoft.Network/networkInterfaces",
-    "name": "[variables('nicName')]",
-    "location": "[resourceGroup().location]",
-    "dependsOn": [
-      "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
-    ],
-    "tags": {
-      "displayName": "NetworkInterface"
     },
-    "properties": {
-      "ipConfigurations": [{
-        "name": "ipconfig1",
-        "properties": {
-          "privateIPAllocationMethod": "Dynamic",
-          "publicIPAddress": {
-            "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-          },
-          "subnet": {
-            "id": "[variables('subnetRef')]"
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+      ],
+      "tags": {
+        "displayName": "NetworkInterface"
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "displayName": "VirtualMachine"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "storageProfile": {
+          "osDisk": {
+            "name": "[concat(parameters('vmName'))]",
+            "osType": "[parameters('osType')]",
+            "caching": "ReadWrite",
+            "vhd": {
+              "uri": "[parameters('osDiskVhdUri')]"
+            },
+            "createOption": "Attach"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('diagStorageAccountName')), '2016-01-01').primaryEndpoints.blob)]"
           }
         }
-      }]
-    }
-  }, {
-    "apiVersion": "[variables('api-version')]",
-    "type": "Microsoft.Compute/virtualMachines",
-    "name": "[parameters('vmName')]",
-    "location": "[resourceGroup().location]",
-    "tags": {
-      "displayName": "VirtualMachine"
-    },
-    "dependsOn": [
-      "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-    ],
-    "properties": {
-      "hardwareProfile": {
-        "vmSize": "[parameters('vmSize')]"
-      },
-      "storageProfile": {
-        "osDisk": {
-          "name": "[concat(parameters('vmName'))]",
-          "osType": "[parameters('osType')]",
-          "caching": "ReadWrite",
-          "vhd": {
-            "uri": "[parameters('osDiskVhdUri')]"
-          },
-          "createOption": "Attach"
-        }
-      },
-      "networkProfile": {
-        "networkInterfaces": [{
-          "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-        }]
-      },
-      "diagnosticsProfile": {
-        "bootDiagnostics": {
-          "enabled": "true",
-          "storageUri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('diagStorageAccountName')), '2016-01-01').primaryEndpoints.blob)]"
-        }
       }
     }
-  }]
+  ]
 }

--- a/201-vm-specialized-vhd/azuredeploy.json
+++ b/201-vm-specialized-vhd/azuredeploy.json
@@ -45,99 +45,111 @@
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
     "nicName": "specializedVMNic"
   },
-  "resources": [{
-    "type": "Microsoft.Storage/storageAccounts",
-    "name": "[variables('diagStorageAccountName')]",
-    "apiVersion": "2016-01-01",
-    "location": "[resourceGroup().location]",
-    "sku": {
-      "name": "Standard_GRS"
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('diagStorageAccountName')]",
+      "apiVersion": "2016-01-01",
+      "location": "[resourceGroup().location]",
+      "sku": {
+        "name": "Standard_GRS"
+      },
+      "kind": "Storage",
+      "properties": {}
     },
-    "kind": "Storage",
-    "properties": {}
-  }, {
-    "apiVersion": "[variables('api-version')]",
-    "type": "Microsoft.Network/virtualNetworks",
-    "name": "[variables('virtualNetworkName')]",
-    "location": "[resourceGroup().location]",
-    "properties": {
-      "addressSpace": {
-        "addressPrefixes": [
-          "[variables('addressPrefix')]"
-        ]
-      },
-      "subnets": [{
-        "name": "[variables('subnetName')]",
-        "properties": {
-          "addressPrefix": "[variables('subnetPrefix')]"
-        }
-      }]
-    }
-  }, {
-    "apiVersion": "[variables('api-version')]",
-    "type": "Microsoft.Network/networkInterfaces",
-    "name": "[variables('nicName')]",
-    "location": "[resourceGroup().location]",
-    "dependsOn": [
-      "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-      "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-    ],
-    "properties": {
-      "ipConfigurations": [{
-        "name": "ipconfig1",
-        "properties": {
-          "privateIPAllocationMethod": "Dynamic",
-          "publicIPAddress": {
-            "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-          },
-          "subnet": {
-            "id": "[variables('subnetRef')]"
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
           }
-        }
-      }]
-    }
-  }, {
-    "apiVersion": "[variables('api-version')]",
-    "type": "Microsoft.Network/publicIPAddresses",
-    "name": "[variables('publicIPAddressName')]",
-    "location": "[resourceGroup().location]",
-    "properties": {
-      "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
-    }
-  }, {
-    "apiVersion": "[variables('api-version')]",
-    "type": "Microsoft.Compute/virtualMachines",
-    "name": "[parameters('vmName')]",
-    "location": "[resourceGroup().location]",
-    "dependsOn": [
-      "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-    ],
-    "properties": {
-      "hardwareProfile": {
-        "vmSize": "[parameters('vmSize')]"
-      },
-      "storageProfile": {
-        "osDisk": {
-          "name": "[concat(parameters('vmName'),'-osDisk')]",
-          "osType": "[parameters('osType')]",
-          "caching": "ReadWrite",
-          "vhd": {
-            "uri": "[parameters('osDiskVhdUri')]"
-          },
-          "createOption": "Attach"
-        }
-      },
-      "networkProfile": {
-        "networkInterfaces": [{
-          "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
-        }]
-      },
-      "diagnosticsProfile": {
-        "bootDiagnostics": {
-          "enabled": "true",
-          "storageUri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('diagStorageAccountName')), '2016-01-01').primaryEndpoints.blob)]"
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "storageProfile": {
+          "osDisk": {
+            "name": "[concat(parameters('vmName'),'-osDisk')]",
+            "osType": "[parameters('osType')]",
+            "caching": "ReadWrite",
+            "vhd": {
+              "uri": "[parameters('osDiskVhdUri')]"
+            },
+            "createOption": "Attach"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('diagStorageAccountName')), '2016-01-01').primaryEndpoints.blob)]"
+          }
         }
       }
     }
-  }]
+  ]
 }

--- a/201-vm-winrm-lb-windows/azuredeploy.json
+++ b/201-vm-winrm-lb-windows/azuredeploy.json
@@ -97,7 +97,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('vnetName')]",
       "location": "[resourceGroup().location]",
@@ -130,7 +130,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('primaryNicNamePrefix'), copyindex())]",
       "location": "[resourceGroup().location]",
@@ -170,7 +170,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('secondaryNicNamePrefix'), copyindex())]",
       "location": "[resourceGroup().location]",
@@ -210,7 +210,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",

--- a/201-vm-winrm-windows/azuredeploy.json
+++ b/201-vm-winrm-windows/azuredeploy.json
@@ -87,7 +87,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -99,7 +99,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -120,7 +120,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",

--- a/201-vmaccess-on-ubuntu/azuredeploy.json
+++ b/201-vmaccess-on-ubuntu/azuredeploy.json
@@ -112,7 +112,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -121,7 +121,7 @@
       }
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -133,7 +133,7 @@
       }
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -154,7 +154,7 @@
       }
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -224,7 +224,7 @@
       }
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmName'),'/enablevmaccess')]",
       "location": "[resourceGroup().location]",
@@ -236,7 +236,7 @@
         "type": "VMAccessForLinux",
         "typeHandlerVersion": "1.4",
         "autoUpgradeMinorVersion": "true",
-        "settings": { },
+        "settings": {},
         "protectedSettings": {
           "username": "[parameters('userName')]",
           "password": "[parameters('password')]",

--- a/201-vmss-automation-dsc/azuredeploy.json
+++ b/201-vmss-automation-dsc/azuredeploy.json
@@ -1,618 +1,618 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "domainNamePrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "The public DNS name label for the service.  The pattern will follow: <domainNamePrefix>.<region>.cloudapp.azure.com"
-            }
-        },
-        "vmSku": {
-            "type": "string",
-            "defaultValue": "Standard_A2",
-            "metadata": {
-                "description": "VM size for the VM Scale Set + the mgmt VM"
-            }
-        },
-        "windowsOSVersion": {
-            "type": "string",
-            "defaultValue": "2012-R2-Datacenter",
-            "metadata": {
-                "description": "The Windows Server version for the VM. This will pick a fully patched image of this given Windows version"
-            }
-        },
-        "vmssName": {
-            "type": "string",
-            "metadata": {
-                "description": "String used as a base for naming resources (9 characters or less). A hash is prepended to this string for some resources, and resource-specific information is appended."
-            },
-            "maxLength": 9
-        },
-        "instanceCount": {
-            "type": "int",
-            "defaultValue": 5,
-            "metadata": {
-                "description": "Number of VM instances (100 or less)."
-            },
-            "maxValue": 100
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Admin username on all VMs."
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Admin password on all VMs."
-            }
-        },
-        "registrationKey": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Registration key to use to onboard to the Azure Automation DSC pull/reporting server"
-            }
-        },
-        "registrationUrl": {
-            "type": "string",
-            "metadata": {
-                "description": "Registration url of the Azure Automation DSC pull/reporting server"
-            }
-        },
-        "nodeConfigurationName": {
-            "type": "string",
-            "defaultValue": "MyService.webServer",
-            "metadata": {
-                "description": "The name of the node configuration, on the Azure Automation DSC pull server, that this node will be configured as"
-            }
-        },
-        "configurationMode": {
-            "type": "string",
-            "defaultValue": "ApplyAndAutoCorrect",
-            "allowedValues": [
-                "ApplyOnly",
-                "ApplyAndMonitor",
-                "ApplyAndAutoCorrect"
-            ],
-            "metadata": {
-                "description": "DSC agent (LCM) configuration mode setting. ApplyOnly, ApplyAndMonitor, or ApplyAndAutoCorrect"
-            }
-        },
-        "configurationModeFrequencyMins": {
-            "type": "int",
-            "defaultValue": 15,
-            "metadata": {
-                "description": "DSC agent (LCM) configuration mode frequency setting, in minutes"
-            }
-        },
-        "refreshFrequencyMins": {
-            "type": "int",
-            "defaultValue": 30,
-            "metadata": {
-                "description": "DSC agent (LCM) refresh frequency setting, in minutes"
-            }
-        },
-        "rebootNodeIfNeeded": {
-            "type": "bool",
-            "defaultValue": true,
-            "metadata": {
-                "description": "DSC agent (LCM) rebootNodeIfNeeded setting"
-            }
-        },
-        "actionAfterReboot": {
-            "type": "string",
-            "defaultValue": "ContinueConfiguration",
-            "allowedValues": [
-                "ContinueConfiguration",
-                "StopConfiguration"
-            ],
-            "metadata": {
-                "description": "DSC agent (LCM) actionAfterReboot setting. ContinueConfiguration or StopConfiguration"
-            }
-        },
-        "allowModuleOverwrite": {
-            "type": "bool",
-            "defaultValue": false,
-            "metadata": {
-                "description": "DSC agent (LCM) allowModuleOverwrite setting"
-            }
-        },
-        "timestamp": {
-            "type": "string",
-            "defaultValue": "MM/dd/yyyy H:mm:ss tt",
-            "metadata": {
-                "description": "The current datetime, as a string, to force the request to go through ARM even if all fields are the same as last ARM deployment of this template; example in parameters file is in MM/dd/yyyy H:mm:ss tt format"
-            }
-        },
-        "automationAccountName": {
-            "type": "string",
-            "defaultValue": "myAutomationAccount",
-            "metadata": {
-                "description": "The name of the Automation account to use.  Check the SKU and tags to make sure they match the existing account."
-            }
-        },
-        "automationRegionId": {
-            "type": "string",
-            "defaultValue": "East US 2",
-            "allowedValues": [
-                "Japan East",
-                "East US 2",
-                "West Europe",
-                "Southeast Asia",
-                "South Central US",
-                "Central India"
-            ],
-            "metadata": {
-                "description": "The region the Automation account is located in."
-            }
-        },
-        "configurationName": {
-            "type": "string",
-            "defaultValue": "MyService",
-            "metadata": {
-                "description": "The name of the DSC Configuration. The name must match the name in the URI."
-            }
-        },
-        "configurationURI": {
-            "type": "string",
-            "defaultValue": "https://raw.github.com/Azure/azure-quickstart-templates/master/201-vmss-automation-dsc/webServer.ps1",
-            "metadata": {
-                "description": "The URI for the DSC configuration "
-            }
-        },
-        "configurationDescription": {
-            "type": "string",
-            "defaultValue": "Web Server",
-            "metadata": {
-                "description": "The description of the configuration."
-            }
-        },
-        "jobid": {
-            "type": "string",
-            "metadata": {
-                "description": "The job id to compile the configuration"
-            }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "domainNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The public DNS name label for the service.  The pattern will follow: <domainNamePrefix>.<region>.cloudapp.azure.com"
+      }
+    },
+    "vmSku": {
+      "type": "string",
+      "defaultValue": "Standard_A2",
+      "metadata": {
+        "description": "VM size for the VM Scale Set + the mgmt VM"
+      }
+    },
+    "windowsOSVersion": {
+      "type": "string",
+      "defaultValue": "2012-R2-Datacenter",
+      "metadata": {
+        "description": "The Windows Server version for the VM. This will pick a fully patched image of this given Windows version"
+      }
+    },
+    "vmssName": {
+      "type": "string",
+      "metadata": {
+        "description": "String used as a base for naming resources (9 characters or less). A hash is prepended to this string for some resources, and resource-specific information is appended."
+      },
+      "maxLength": 9
+    },
+    "instanceCount": {
+      "type": "int",
+      "defaultValue": 5,
+      "metadata": {
+        "description": "Number of VM instances (100 or less)."
+      },
+      "maxValue": 100
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Admin username on all VMs."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin password on all VMs."
+      }
+    },
+    "registrationKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Registration key to use to onboard to the Azure Automation DSC pull/reporting server"
+      }
+    },
+    "registrationUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "Registration url of the Azure Automation DSC pull/reporting server"
+      }
+    },
+    "nodeConfigurationName": {
+      "type": "string",
+      "defaultValue": "MyService.webServer",
+      "metadata": {
+        "description": "The name of the node configuration, on the Azure Automation DSC pull server, that this node will be configured as"
+      }
+    },
+    "configurationMode": {
+      "type": "string",
+      "defaultValue": "ApplyAndAutoCorrect",
+      "allowedValues": [
+        "ApplyOnly",
+        "ApplyAndMonitor",
+        "ApplyAndAutoCorrect"
+      ],
+      "metadata": {
+        "description": "DSC agent (LCM) configuration mode setting. ApplyOnly, ApplyAndMonitor, or ApplyAndAutoCorrect"
+      }
+    },
+    "configurationModeFrequencyMins": {
+      "type": "int",
+      "defaultValue": 15,
+      "metadata": {
+        "description": "DSC agent (LCM) configuration mode frequency setting, in minutes"
+      }
+    },
+    "refreshFrequencyMins": {
+      "type": "int",
+      "defaultValue": 30,
+      "metadata": {
+        "description": "DSC agent (LCM) refresh frequency setting, in minutes"
+      }
+    },
+    "rebootNodeIfNeeded": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "DSC agent (LCM) rebootNodeIfNeeded setting"
+      }
+    },
+    "actionAfterReboot": {
+      "type": "string",
+      "defaultValue": "ContinueConfiguration",
+      "allowedValues": [
+        "ContinueConfiguration",
+        "StopConfiguration"
+      ],
+      "metadata": {
+        "description": "DSC agent (LCM) actionAfterReboot setting. ContinueConfiguration or StopConfiguration"
+      }
+    },
+    "allowModuleOverwrite": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "DSC agent (LCM) allowModuleOverwrite setting"
+      }
+    },
+    "timestamp": {
+      "type": "string",
+      "defaultValue": "MM/dd/yyyy H:mm:ss tt",
+      "metadata": {
+        "description": "The current datetime, as a string, to force the request to go through ARM even if all fields are the same as last ARM deployment of this template; example in parameters file is in MM/dd/yyyy H:mm:ss tt format"
+      }
+    },
+    "automationAccountName": {
+      "type": "string",
+      "defaultValue": "myAutomationAccount",
+      "metadata": {
+        "description": "The name of the Automation account to use.  Check the SKU and tags to make sure they match the existing account."
+      }
+    },
+    "automationRegionId": {
+      "type": "string",
+      "defaultValue": "East US 2",
+      "allowedValues": [
+        "Japan East",
+        "East US 2",
+        "West Europe",
+        "Southeast Asia",
+        "South Central US",
+        "Central India"
+      ],
+      "metadata": {
+        "description": "The region the Automation account is located in."
+      }
+    },
+    "configurationName": {
+      "type": "string",
+      "defaultValue": "MyService",
+      "metadata": {
+        "description": "The name of the DSC Configuration. The name must match the name in the URI."
+      }
+    },
+    "configurationURI": {
+      "type": "string",
+      "defaultValue": "https://raw.github.com/Azure/azure-quickstart-templates/master/201-vmss-automation-dsc/webServer.ps1",
+      "metadata": {
+        "description": "The URI for the DSC configuration "
+      }
+    },
+    "configurationDescription": {
+      "type": "string",
+      "defaultValue": "Web Server",
+      "metadata": {
+        "description": "The description of the configuration."
+      }
+    },
+    "jobid": {
+      "type": "string",
+      "metadata": {
+        "description": "The job id to compile the configuration"
+      }
+    }
+  },
+  "variables": {
+    "computeApi": "2017-03-30",
+    "networkApi": "2017-04-01",
+    "storageApi": "2015-06-15",
+    "insightsApi": "2015-04-01",
+    "automationApiVersion": "2015-10-31",
+    "storageAccountType": "Standard_LRS",
+    "saCount": 5,
+    "namingInfix": "[toLower(parameters('vmssName'))]",
+    "newStorageAccountSuffix": "[concat(variables('namingInfix'), 'sa')]",
+    "uniqueStringArray": [
+      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '0')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '1')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '2')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '3')))]",
+      "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '4')))]"
+    ],
+    "vhdContainerName": "[concat(variables('namingInfix'), 'vhd')]",
+    "osDiskName": "[concat(variables('namingInfix'), 'osdisk')]",
+    "virtualNetworkName": "[concat(variables('namingInfix'), 'vnet')]",
+    "virtualNetworkID": "[resourceId('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]",
+    "addressPrefix": "192.168.0.0/16",
+    "subnetName": "[concat(variables('namingInfix'), 'subnet')]",
+    "subnetID": "[concat(variables('virtualNetworkID'),'/subnets/',variables('subnetName'))]",
+    "subnetPrefix": "192.168.0.0/24",
+    "publicIPAddressName": "[concat(variables('namingInfix'), 'pip')]",
+    "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses/',variables('publicIPAddressName'))]",
+    "loadBalancerName": "[concat(variables('namingInfix'), 'loadBalancer')]",
+    "loadBalancerID": "[resourceId('Microsoft.Network/loadBalancers/',variables('loadBalancerName'))]",
+    "frontendIPConfigurationsName": "[concat(variables('loadBalancerName'), 'frontendIPConfigurations')]",
+    "frontEndIPConfigurationsID": "[concat(variables('loadBalancerID'),'/frontendIPConfigurations/',variables('frontendIPConfigurationsName'))]",
+    "loadBalancingRulesName": "[concat(variables('loadBalancerName'), 'loadBalancingRules')]",
+    "backendAddressPoolsName": "[concat(variables('loadBalancerName'), 'backendAddressPools')]",
+    "backendAddressPoolID": "[concat(variables('loadBalancerID'),'/backendAddressPools/',variables('backendAddressPoolsName'))]",
+    "httpProbeName": "[concat(variables('loadBalancerName'),'httpProbe')]",
+    "httpProbeID": "[concat(variables('loadBalancerID'),'/probes/',variables('httpProbeName'))]",
+    "httpProbeRequestPath": "/iisstart.htm",
+    "natRDPPoolName": "[concat(variables('loadBalancerName'), 'natRDP')]",
+    "natRDPPoolID": "[concat(variables('loadBalancerID'),'/inboundNatPools/',variables('natRDPPoolName'))]",
+    "natRDPStartPort": 50000,
+    "natRDPEndPort": 50119,
+    "natRDPBackendPort": 3389,
+    "natWinRMPoolName": "[concat(variables('loadBalancerName'), 'natWinRM')]",
+    "natWinRMPoolID": "[concat(variables('loadBalancerID'),'/inboundNatPools/',variables('natWinRMPoolName'))]",
+    "natWinRMStartPort": 51000,
+    "natWinRMEndPort": 51119,
+    "natWinRMBackendPort": 5896,
+    "nicName": "[concat(variables('namingInfix'), 'nic')]",
+    "ipConfigName": "[concat(variables('namingInfix'), 'ipconfig')]",
+    "osType": {
+      "publisher": "MicrosoftWindowsServer",
+      "offer": "WindowsServer",
+      "sku": "[parameters('windowsOSVersion')]",
+      "version": "latest"
+    },
+    "imageReference": "[variables('osType')]",
+    "automationPricingTier": "Free",
+    "dscOverwrite": "true",
+    "dscModules": {
+      "xNetworking": {
+        "moduleName": "xNetworking",
+        "moduleUri": "https://raw.github.com/Azure/azure-quickstart-templates/master/201-vmss-automation-dsc/xNetworking.zip"
+      }
+    },
+    "diagnosticsStorageAccountName": "[concat(variables('uniqueStringArray')[0], 'diagsa')]",
+    "diagnosticsStorageAccountResourceGroup": "[resourceGroup().name]",
+    "accountid": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',variables('diagnosticsStorageAccountResourceGroup'),'/providers/','Microsoft.Storage/storageAccounts/', variables('diagnosticsStorageAccountName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Automation/automationAccounts",
+      "name": "[parameters('automationAccountName')]",
+      "apiVersion": "2015-10-31",
+      "location": "[parameters('automationRegionId')]",
+      "dependsOn": [],
+      "tags": {},
+      "properties": {
+        "sku": {
+          "name": "[variables('automationPricingTier')]"
         }
-    },
-    "variables": {
-        "computeApi": "2017-03-30",
-        "networkApi": "2017-04-01",
-        "storageApi": "2015-06-15",
-        "insightsApi": "2015-04-01",
-        "automationApiVersion": "2015-10-31",
-        "storageAccountType": "Standard_LRS",
-        "saCount": 5,
-        "namingInfix": "[toLower(parameters('vmssName'))]",
-        "newStorageAccountSuffix": "[concat(variables('namingInfix'), 'sa')]",
-        "uniqueStringArray": [
-            "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '0')))]",
-            "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '1')))]",
-            "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '2')))]",
-            "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '3')))]",
-            "[concat(uniqueString(concat(resourceGroup().id, deployment().name, variables('newStorageAccountSuffix'), '4')))]"
-        ],
-        "vhdContainerName": "[concat(variables('namingInfix'), 'vhd')]",
-        "osDiskName": "[concat(variables('namingInfix'), 'osdisk')]",
-        "virtualNetworkName": "[concat(variables('namingInfix'), 'vnet')]",
-        "virtualNetworkID": "[resourceId('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]",
-        "addressPrefix": "192.168.0.0/16",
-        "subnetName": "[concat(variables('namingInfix'), 'subnet')]",
-        "subnetID": "[concat(variables('virtualNetworkID'),'/subnets/',variables('subnetName'))]",
-        "subnetPrefix": "192.168.0.0/24",
-        "publicIPAddressName": "[concat(variables('namingInfix'), 'pip')]",
-        "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses/',variables('publicIPAddressName'))]",
-        "loadBalancerName": "[concat(variables('namingInfix'), 'loadBalancer')]",
-        "loadBalancerID": "[resourceId('Microsoft.Network/loadBalancers/',variables('loadBalancerName'))]",
-        "frontendIPConfigurationsName": "[concat(variables('loadBalancerName'), 'frontendIPConfigurations')]",
-        "frontEndIPConfigurationsID": "[concat(variables('loadBalancerID'),'/frontendIPConfigurations/',variables('frontendIPConfigurationsName'))]",
-        "loadBalancingRulesName": "[concat(variables('loadBalancerName'), 'loadBalancingRules')]",
-        "backendAddressPoolsName":"[concat(variables('loadBalancerName'), 'backendAddressPools')]",
-        "backendAddressPoolID": "[concat(variables('loadBalancerID'),'/backendAddressPools/',variables('backendAddressPoolsName'))]",
-        "httpProbeName": "[concat(variables('loadBalancerName'),'httpProbe')]",
-        "httpProbeID": "[concat(variables('loadBalancerID'),'/probes/',variables('httpProbeName'))]",
-        "httpProbeRequestPath": "/iisstart.htm",
-        "natRDPPoolName": "[concat(variables('loadBalancerName'), 'natRDP')]",
-        "natRDPPoolID": "[concat(variables('loadBalancerID'),'/inboundNatPools/',variables('natRDPPoolName'))]",
-        "natRDPStartPort":50000,
-        "natRDPEndPort":50119,
-        "natRDPBackendPort":3389,
-        "natWinRMPoolName": "[concat(variables('loadBalancerName'), 'natWinRM')]",
-        "natWinRMPoolID": "[concat(variables('loadBalancerID'),'/inboundNatPools/',variables('natWinRMPoolName'))]",
-        "natWinRMStartPort":51000,
-        "natWinRMEndPort":51119,
-        "natWinRMBackendPort":5896,
-        "nicName": "[concat(variables('namingInfix'), 'nic')]",
-        "ipConfigName": "[concat(variables('namingInfix'), 'ipconfig')]",
-        "osType": {
-            "publisher": "MicrosoftWindowsServer",
-            "offer": "WindowsServer",
-            "sku": "[parameters('windowsOSVersion')]",
-            "version": "latest"
-        },
-        "imageReference": "[variables('osType')]",
-        "automationPricingTier": "Free",
-        "dscOverwrite": "true",
-        "dscModules": {
-            "xNetworking": {
-                "moduleName": "xNetworking",
-                "moduleUri": "https://raw.github.com/Azure/azure-quickstart-templates/master/201-vmss-automation-dsc/xNetworking.zip"
+      },
+      "resources": [
+        {
+          "name": "[concat(parameters('automationAccountName'), '/', variables('dscModules').xNetworking.ModuleName)]",
+          "type": "microsoft.automation/automationAccounts/Modules",
+          "apiVersion": "[variables('automationApiVersion')]",
+          "tags": {},
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'))]"
+          ],
+          "properties": {
+            "contentLink": {
+              "uri": "[variables('dscModules').xNetworking.ModuleUri]"
             }
+          }
         },
-        "diagnosticsStorageAccountName": "[concat(variables('uniqueStringArray')[0], 'diagsa')]",
-		"diagnosticsStorageAccountResourceGroup": "[resourceGroup().name]",
-		"accountid": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',variables('diagnosticsStorageAccountResourceGroup'),'/providers/','Microsoft.Storage/storageAccounts/', variables('diagnosticsStorageAccountName'))]"
-    },
-    "resources": [
-      {
-          "type": "Microsoft.Automation/automationAccounts",
-          "name": "[parameters('automationAccountName')]",
+        {
+          "name": "[parameters('configurationName')]",
+          "type": "Configurations",
           "apiVersion": "[variables('automationApiVersion')]",
           "location": "[parameters('automationRegionId')]",
-          "dependsOn": [],
           "tags": {},
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'))]"
+          ],
           "properties": {
-                "sku": {
-                    "name": "[variables('automationPricingTier')]"
-                }
-          },
-          "resources": [
-                {
-                    "name": "[concat(parameters('automationAccountName'), '/', variables('dscModules').xNetworking.ModuleName)]",
-                    "type": "microsoft.automation/automationAccounts/Modules",
-                    "apiVersion": "[variables('automationApiVersion')]",
-                    "tags": {},
-                    "dependsOn": [
-                        "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'))]"
-                    ],
-                    "properties": {
-                        "contentLink": {
-                            "uri": "[variables('dscModules').xNetworking.ModuleUri]"
-                        }
-                    }
-                },
-                {
-                    "name": "[parameters('configurationName')]",
-                    "type": "Configurations",
-                    "apiVersion": "[variables('automationApiVersion')]",
-                    "location": "[parameters('automationRegionId')]",
-                    "tags": {},
-                    "dependsOn": [
-                        "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'))]"
-                    ],
-                    "properties": {
-                        "logVerbose": "false",
-                        "description": "[parameters('configurationDescription')]",
-                        "state": "Published",
-                        "overwrite": "[variables('dscOverwrite')]",
-                        "Source": {
-                            "type": "uri",
-                            "Value": "[parameters('configurationURI')]"
-                        }
-                    }
-                },
-                {
-                    "name": "[parameters('jobid')]",
-                    "type": "Compilationjobs",
-                    "apiVersion": "[variables('automationApiVersion')]",
-                    "location": "parameters('automationRegionId')]",
-                    "tags": {},
-                    "dependsOn": [
-                        "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'))]",
-                        "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'),'/Modules/',variables('dscModules').xNetworking.ModuleName)]",
-                        "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'),'/Configurations/', parameters('configurationName'))]"
-                    ],
-                    "properties": {
-                        "configuration": {
-                            "name": "[parameters('configurationName')]"
-                        }
-                    }
-                }
-          ]
-      },
-      {
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[concat(variables('uniqueStringArray')[copyIndex()], variables('newStorageAccountSuffix'))]",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('storageApi')]",
-        "copy": {
-          "name": "storageLoop",
-          "count": "[variables('saCount')]"
-        },
-        "properties": {
-          "accountType": "[variables('storageAccountType')]"
-        }
-      },
-      {
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[variables('diagnosticsStorageAccountName')]",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('storageApi')]",
-        "properties": {
-          "accountType": "[variables('storageAccountType')]"
-        }
-      },
-      {
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[variables('virtualNetworkName')]",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('networkApi')]",
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[variables('addressPrefix')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[variables('subnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('subnetPrefix')]"
-              }
+            "logVerbose": "false",
+            "description": "[parameters('configurationDescription')]",
+            "state": "Published",
+            "overwrite": "[variables('dscOverwrite')]",
+            "Source": {
+              "type": "uri",
+              "Value": "[parameters('configurationURI')]"
             }
-          ]
-        }
-      },
-      {
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[variables('publicIPAddressName')]",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('networkApi')]",
-        "properties": {
-          "publicIPAllocationMethod": "Dynamic",
-          "dnsSettings": {
-            "domainNameLabel": "[parameters('domainNamePrefix')]"
+          }
+        },
+        {
+          "name": "[parameters('jobid')]",
+          "type": "Compilationjobs",
+          "apiVersion": "[variables('automationApiVersion')]",
+          "location": "parameters('automationRegionId')]",
+          "tags": {},
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'))]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'),'/Modules/',variables('dscModules').xNetworking.ModuleName)]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'),'/Configurations/', parameters('configurationName'))]"
+          ],
+          "properties": {
+            "configuration": {
+              "name": "[parameters('configurationName')]"
+            }
           }
         }
+      ]
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[concat(variables('uniqueStringArray')[copyIndex()], variables('newStorageAccountSuffix'))]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "copy": {
+        "name": "storageLoop",
+        "count": "[variables('saCount')]"
       },
-      {
-        "type": "Microsoft.Network/loadBalancers",
-        "name": "[variables('loadBalancerName')]",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('networkApi')]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
-        ],
-        "properties": {
-          "frontendIPConfigurations": [
-            {
-              "name": "[variables('frontendIPConfigurationsName')]",
-              "properties": {
-                "publicIPAddress": {
-                  "id": "[variables('publicIPAddressID')]"
-                }
-              }
-            }
-          ],
-          "backendAddressPools": [
-            {
-              "name": "[variables('backendAddressPoolsName')]"
-            }
-          ],
-          "loadBalancingRules": [
-            {
-              "name": "[variables('loadBalancingRulesName')]",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('frontEndIPConfigurationsID')]"
-                },
-                "backendAddressPool": {
-                  "id": "[variables('backendAddressPoolID')]"
-                },
-                "protocol": "tcp",
-                "frontendPort": 80,
-                "backendPort": 80,
-                "enableFloatingIP": false,
-                "idleTimeoutInMinutes": 5,
-                "probe": {
-                  "id": "[variables('httpProbeID')]"
-                }
-              }
-            }
-          ],
-          "probes": [
-            {
-              "name": "[variables('httpProbeName')]",
-              "properties": {
-                "protocol": "http",
-                "port": 80,
-                "intervalInSeconds": 5,
-                "numberOfProbes": 2,
-                "requestPath": "[variables('httpProbeRequestPath')]"
-              }
-            }
-          ],
-          "inboundNatPools": [
-            {
-              "name": "[variables('natRDPPoolName')]",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('frontEndIPConfigurationsID')]"
-                },
-                "protocol": "tcp",
-                "frontendPortRangeStart": "[variables('natRDPStartPort')]",
-                "frontendPortRangeEnd": "[variables('natRDPEndPort')]",
-                "backendPort": "[variables('natRDPBackendPort')]"
-              }
-            },
-            {
-              "name": "[variables('natWinRMPoolName')]",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('frontEndIPConfigurationsID')]"
-                },
-                "protocol": "tcp",
-                "frontendPortRangeStart": "[variables('natWinRMStartPort')]",
-                "frontendPortRangeEnd": "[variables('natWinRMEndPort')]",
-                "backendPort": "[variables('natWinRMBackendPort')]"
-              }
-            }
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('diagnosticsStorageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2017-04-01",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
           ]
-        }
-      },
-      {
-        "type": "Microsoft.Compute/virtualMachineScaleSets",
-        "name": "[variables('namingInfix')]",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('computeApi')]",
-        "dependsOn": [
-          "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'))]",
-          "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'),'/Modules/',variables('dscModules').xNetworking.ModuleName)]",
-          "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'),'/Configurations/', parameters('configurationName'))]",
-          "storageLoop",
-          "[concat('Microsoft.Storage/storageAccounts/', variables('diagnosticsStorageAccountName'))]",
-          "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-        ],
-        "sku": {
-          "name": "[parameters('vmSku')]",
-          "tier": "Standard",
-          "capacity": "[parameters('instanceCount')]"
         },
-        "properties": {
-          "overprovision": "true",
-          "upgradePolicy": {
-            "mode": "Manual"
-          },
-          "virtualMachineProfile": {
-            "storageProfile": {
-              "osDisk": {
-                "vhdContainers": [
-                  "[concat('https://', variables('uniqueStringArray')[0], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]",
-                  "[concat('https://', variables('uniqueStringArray')[1], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]",
-                  "[concat('https://', variables('uniqueStringArray')[2], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]",
-                  "[concat('https://', variables('uniqueStringArray')[3], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]",
-                  "[concat('https://', variables('uniqueStringArray')[4], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]"
-                ],
-                "name": "[variables('osDiskName')]",
-                "caching": "ReadOnly",
-                "createOption": "FromImage"
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2017-04-01",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('domainNamePrefix')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/loadBalancers",
+      "name": "[variables('loadBalancerName')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2017-04-01",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
+      ],
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "[variables('frontendIPConfigurationsName')]",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[variables('publicIPAddressID')]"
+              }
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "[variables('backendAddressPoolsName')]"
+          }
+        ],
+        "loadBalancingRules": [
+          {
+            "name": "[variables('loadBalancingRulesName')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('frontEndIPConfigurationsID')]"
               },
-              "imageReference": "[variables('imageReference')]"
+              "backendAddressPool": {
+                "id": "[variables('backendAddressPoolID')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "enableFloatingIP": false,
+              "idleTimeoutInMinutes": 5,
+              "probe": {
+                "id": "[variables('httpProbeID')]"
+              }
+            }
+          }
+        ],
+        "probes": [
+          {
+            "name": "[variables('httpProbeName')]",
+            "properties": {
+              "protocol": "http",
+              "port": 80,
+              "intervalInSeconds": 5,
+              "numberOfProbes": 2,
+              "requestPath": "[variables('httpProbeRequestPath')]"
+            }
+          }
+        ],
+        "inboundNatPools": [
+          {
+            "name": "[variables('natRDPPoolName')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('frontEndIPConfigurationsID')]"
+              },
+              "protocol": "tcp",
+              "frontendPortRangeStart": "[variables('natRDPStartPort')]",
+              "frontendPortRangeEnd": "[variables('natRDPEndPort')]",
+              "backendPort": "[variables('natRDPBackendPort')]"
+            }
+          },
+          {
+            "name": "[variables('natWinRMPoolName')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('frontEndIPConfigurationsID')]"
+              },
+              "protocol": "tcp",
+              "frontendPortRangeStart": "[variables('natWinRMStartPort')]",
+              "frontendPortRangeEnd": "[variables('natWinRMEndPort')]",
+              "backendPort": "[variables('natWinRMBackendPort')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "name": "[variables('namingInfix')]",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2017-03-30",
+      "dependsOn": [
+        "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'))]",
+        "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'),'/Modules/',variables('dscModules').xNetworking.ModuleName)]",
+        "[concat('Microsoft.Automation/automationAccounts/', parameters('automationAccountName'),'/Configurations/', parameters('configurationName'))]",
+        "storageLoop",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('diagnosticsStorageAccountName'))]",
+        "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "sku": {
+        "name": "[parameters('vmSku')]",
+        "tier": "Standard",
+        "capacity": "[parameters('instanceCount')]"
+      },
+      "properties": {
+        "overprovision": "true",
+        "upgradePolicy": {
+          "mode": "Manual"
+        },
+        "virtualMachineProfile": {
+          "storageProfile": {
+            "osDisk": {
+              "vhdContainers": [
+                "[concat('https://', variables('uniqueStringArray')[0], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]",
+                "[concat('https://', variables('uniqueStringArray')[1], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]",
+                "[concat('https://', variables('uniqueStringArray')[2], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]",
+                "[concat('https://', variables('uniqueStringArray')[3], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]",
+                "[concat('https://', variables('uniqueStringArray')[4], variables('newStorageAccountSuffix'), '.blob.core.windows.net/', variables('vhdContainerName'))]"
+              ],
+              "name": "[variables('osDiskName')]",
+              "caching": "ReadOnly",
+              "createOption": "FromImage"
             },
-            "extensionProfile": {
-              "extensions": [
-                {
-                  "name": "Microsoft.Powershell.DSC",
-                  "properties": {
-                    "publisher": "Microsoft.Powershell",
-                    "type": "DSC",
-                    "typeHandlerVersion": "2.19",
-                    "autoUpgradeMinorVersion": true,
-                    "protectedSettings": {
-                      "Items": {
-                        "registrationKeyPrivate": "[parameters('registrationKey')]"
-                      }
-                    },
-                    "settings": {
-                      "ModulesUrl": "https://raw.github.com/Azure/azure-quickstart-templates/master/201-vmss-automation-dsc/UpdateLCMforAAPull.zip",
-                      "SasToken": "",
-                      "ConfigurationFunction": "UpdateLCMforAAPull.ps1\\ConfigureLCMforAAPull",
-                      "Properties": [
-                        {
-                          "Name": "RegistrationKey",
-                          "Value": {
-                            "UserName": "PLACEHOLDER_DONOTUSE",
-                            "Password": "PrivateSettingsRef:registrationKeyPrivate"
-                          },
-                          "TypeName": "System.Management.Automation.PSCredential"
-                        },
-                        {
-                          "Name": "RegistrationUrl",
-                          "Value": "[parameters('registrationUrl')]",
-                          "TypeName": "System.String"
-                        },
-                        {
-                          "Name": "NodeConfigurationName",
-                          "Value": "[parameters('nodeConfigurationName')]",
-                          "TypeName": "System.String"
-                        },
-                        {
-                          "Name": "ConfigurationMode",
-                          "Value": "[parameters('configurationMode')]",
-                          "TypeName": "System.String"
-                        },
-                        {
-                          "Name": "ConfigurationModeFrequencyMins",
-                          "Value": "[parameters('configurationModeFrequencyMins')]",
-                          "TypeName": "System.Int32"
-                        },
-                        {
-                          "Name": "RefreshFrequencyMins",
-                          "Value": "[parameters('refreshFrequencyMins')]",
-                          "TypeName": "System.Int32"
-                        },
-                        {
-                          "Name": "RebootNodeIfNeeded",
-                          "Value": "[parameters('rebootNodeIfNeeded')]",
-                          "TypeName": "System.Boolean"
-                        },
-                        {
-                          "Name": "ActionAfterReboot",
-                          "Value": "[parameters('actionAfterReboot')]",
-                          "TypeName": "System.String"
-                        },
-                        {
-                          "Name": "AllowModuleOverwrite",
-                          "Value": "[parameters('allowModuleOverwrite')]",
-                          "TypeName": "System.Boolean"
-                        },
-                        {
-                          "Name": "Timestamp",
-                          "Value": "[parameters('timestamp')]",
-                          "TypeName": "System.String"
-                        }
-                      ]
+            "imageReference": "[variables('imageReference')]"
+          },
+          "extensionProfile": {
+            "extensions": [
+              {
+                "name": "Microsoft.Powershell.DSC",
+                "properties": {
+                  "publisher": "Microsoft.Powershell",
+                  "type": "DSC",
+                  "typeHandlerVersion": "2.19",
+                  "autoUpgradeMinorVersion": true,
+                  "protectedSettings": {
+                    "Items": {
+                      "registrationKeyPrivate": "[parameters('registrationKey')]"
                     }
-                  }
-                }
-              ]
-            },
-            "osProfile": {
-              "computerNamePrefix": "[variables('namingInfix')]",
-              "adminUsername": "[parameters('adminUsername')]",
-              "adminPassword": "[parameters('adminPassword')]"
-            },
-            "networkProfile": {
-              "networkInterfaceConfigurations": [
-                {
-                  "name": "[variables('nicName')]",
-                  "properties": {
-                    "primary": "true",
-                    "ipConfigurations": [
+                  },
+                  "settings": {
+                    "ModulesUrl": "https://raw.github.com/Azure/azure-quickstart-templates/master/201-vmss-automation-dsc/UpdateLCMforAAPull.zip",
+                    "SasToken": "",
+                    "ConfigurationFunction": "UpdateLCMforAAPull.ps1\\ConfigureLCMforAAPull",
+                    "Properties": [
                       {
-                        "name": "[variables('ipConfigName')]",
-                        "properties": {
-                          "subnet": {
-                            "id": "[variables('subnetID')]"
-                          },
-                          "loadBalancerBackendAddressPools": [
-                            {
-                              "id": "[variables('backendAddressPoolID')]"
-                            }
-                          ],
-                          "loadBalancerInboundNatPools": [
-                            {
-                              "id": "[variables('natRDPPoolID')]"
-                            },
-                            {
-                              "id": "[variables('natWinRMPoolID')]"
-                            }
-                          ]
-                        }
+                        "Name": "RegistrationKey",
+                        "Value": {
+                          "UserName": "PLACEHOLDER_DONOTUSE",
+                          "Password": "PrivateSettingsRef:registrationKeyPrivate"
+                        },
+                        "TypeName": "System.Management.Automation.PSCredential"
+                      },
+                      {
+                        "Name": "RegistrationUrl",
+                        "Value": "[parameters('registrationUrl')]",
+                        "TypeName": "System.String"
+                      },
+                      {
+                        "Name": "NodeConfigurationName",
+                        "Value": "[parameters('nodeConfigurationName')]",
+                        "TypeName": "System.String"
+                      },
+                      {
+                        "Name": "ConfigurationMode",
+                        "Value": "[parameters('configurationMode')]",
+                        "TypeName": "System.String"
+                      },
+                      {
+                        "Name": "ConfigurationModeFrequencyMins",
+                        "Value": "[parameters('configurationModeFrequencyMins')]",
+                        "TypeName": "System.Int32"
+                      },
+                      {
+                        "Name": "RefreshFrequencyMins",
+                        "Value": "[parameters('refreshFrequencyMins')]",
+                        "TypeName": "System.Int32"
+                      },
+                      {
+                        "Name": "RebootNodeIfNeeded",
+                        "Value": "[parameters('rebootNodeIfNeeded')]",
+                        "TypeName": "System.Boolean"
+                      },
+                      {
+                        "Name": "ActionAfterReboot",
+                        "Value": "[parameters('actionAfterReboot')]",
+                        "TypeName": "System.String"
+                      },
+                      {
+                        "Name": "AllowModuleOverwrite",
+                        "Value": "[parameters('allowModuleOverwrite')]",
+                        "TypeName": "System.Boolean"
+                      },
+                      {
+                        "Name": "Timestamp",
+                        "Value": "[parameters('timestamp')]",
+                        "TypeName": "System.String"
                       }
                     ]
                   }
                 }
-              ]
-            }
+              }
+            ]
+          },
+          "osProfile": {
+            "computerNamePrefix": "[variables('namingInfix')]",
+            "adminUsername": "[parameters('adminUsername')]",
+            "adminPassword": "[parameters('adminPassword')]"
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "[variables('nicName')]",
+                "properties": {
+                  "primary": "true",
+                  "ipConfigurations": [
+                    {
+                      "name": "[variables('ipConfigName')]",
+                      "properties": {
+                        "subnet": {
+                          "id": "[variables('subnetID')]"
+                        },
+                        "loadBalancerBackendAddressPools": [
+                          {
+                            "id": "[variables('backendAddressPoolID')]"
+                          }
+                        ],
+                        "loadBalancerInboundNatPools": [
+                          {
+                            "id": "[variables('natRDPPoolID')]"
+                          },
+                          {
+                            "id": "[variables('natWinRMPoolID')]"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
           }
         }
-      },
+      }
+    },
     {
       "type": "Microsoft.Insights/autoscaleSettings",
-      "apiVersion": "[variables('insightsApi')]",
+      "apiVersion": "2015-04-01",
       "name": "autoscalehost",
       "location": "[resourceGroup().location]",
       "dependsOn": [
@@ -641,7 +641,7 @@
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "GreaterThan",
-                  "threshold": 60.0
+                  "threshold": 60
                 },
                 "scaleAction": {
                   "direction": "Increase",
@@ -660,7 +660,7 @@
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "LessThan",
-                  "threshold": 30.0
+                  "threshold": 30
                 },
                 "scaleAction": {
                   "direction": "Decrease",
@@ -674,15 +674,15 @@
         ]
       }
     }
-    ],
-    "outputs": {
-		"fqdn": {
-			"value": "[reference(variables('publicIPAddressID'),providers('Microsoft.Network','publicIPAddresses').apiVersions[0]).dnsSettings.fqdn]",
-			"type": "string"
-		},
-		"ipaddress": {
-			"value": "[reference(variables('publicIPAddressID'),providers('Microsoft.Network','publicIPAddresses').apiVersions[0]).ipAddress]",
-			"type": "string"
-		}
-	}
+  ],
+  "outputs": {
+    "fqdn": {
+      "value": "[reference(variables('publicIPAddressID'),providers('Microsoft.Network','publicIPAddresses').apiVersions[0]).dnsSettings.fqdn]",
+      "type": "string"
+    },
+    "ipaddress": {
+      "value": "[reference(variables('publicIPAddressID'),providers('Microsoft.Network','publicIPAddresses').apiVersions[0]).ipAddress]",
+      "type": "string"
+    }
+  }
 }

--- a/201-vmss-azure-files-linux/azuredeploy.json
+++ b/201-vmss-azure-files-linux/azuredeploy.json
@@ -37,26 +37,26 @@
     },
     "storageAccountName": {
       "type": "string",
-            "metadata": {
+      "metadata": {
         "description": "Storage account name for Azure file share."
       }
     },
     "storageAccountKey": {
       "type": "securestring",
-            "metadata": {
+      "metadata": {
         "description": "Storage account key for Azure file share."
       }
     },
     "shareName": {
       "type": "string",
-            "metadata": {
+      "metadata": {
         "description": "Azure file share name."
       }
-    },    
+    },
     "mountpointPath": {
       "type": "string",
       "defaultValue": "/mnt/azurefiles",
-            "metadata": {
+      "metadata": {
         "description": "Path on VM to mount file share - will also link to user home dir."
       }
     }
@@ -95,7 +95,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -116,7 +116,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -128,7 +128,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -180,7 +180,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[parameters('vmssName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"

--- a/201-vmss-bottle-autoscale/azuredeploy.json
+++ b/201-vmss-bottle-autoscale/azuredeploy.json
@@ -70,7 +70,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -91,7 +91,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -103,7 +103,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -155,7 +155,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[parameters('vmssName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -241,7 +241,7 @@
     },
     {
       "type": "Microsoft.Insights/autoscaleSettings",
-      "apiVersion": "[variables('insightsApiVersion')]",
+      "apiVersion": "2015-04-01",
       "name": "autoscalehost",
       "location": "[variables('location')]",
       "dependsOn": [

--- a/201-vmss-custom-script-windows/azuredeploy.json
+++ b/201-vmss-custom-script-windows/azuredeploy.json
@@ -71,7 +71,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[parameters('vmssName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('vnetName'))]",
         "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]"
@@ -161,7 +161,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('vnetName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -182,7 +182,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -194,7 +194,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],

--- a/201-vmss-datascience/azuredeploy-ubuntu.json
+++ b/201-vmss-datascience/azuredeploy-ubuntu.json
@@ -44,9 +44,9 @@
       "product": "linux-data-science-vm-ubuntu"
     },
     "osType": {
-      "publisher": "microsoft-ads", 
+      "publisher": "microsoft-ads",
       "offer": "linux-data-science-vm-ubuntu",
-      "sku": "linuxdsvmubuntu", 
+      "sku": "linuxdsvmubuntu",
       "version": "latest"
     },
     "addressPrefix": "10.0.0.0/16",
@@ -74,7 +74,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -95,7 +95,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -107,7 +107,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -147,7 +147,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[parameters('vmssName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"

--- a/201-vmss-datascience/azuredeploy-windows.json
+++ b/201-vmss-datascience/azuredeploy-windows.json
@@ -44,9 +44,9 @@
       "product": "windows-data-science-vm"
     },
     "osType": {
-      "publisher": "microsoft-ads", 
+      "publisher": "microsoft-ads",
       "offer": "windows-data-science-vm",
-      "sku": "windows2016", 
+      "sku": "windows2016",
       "version": "latest"
     },
     "addressPrefix": "10.0.0.0/16",
@@ -74,7 +74,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -95,7 +95,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -107,7 +107,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -147,7 +147,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[parameters('vmssName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"

--- a/201-vmss-internal-loadbalancer/azuredeploy.json
+++ b/201-vmss-internal-loadbalancer/azuredeploy.json
@@ -93,7 +93,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -114,7 +114,7 @@
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('jumpBoxSAName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2015-06-15",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
@@ -123,7 +123,7 @@
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('jumpBoxNicName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -149,7 +149,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -161,7 +161,7 @@
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('jumpBoxName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('jumpBoxSAName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('jumpBoxNicName'))]"
@@ -205,7 +205,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
@@ -245,7 +245,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('namingInfix')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],

--- a/201-vmss-linux-jumpbox/azuredeploy.json
+++ b/201-vmss-linux-jumpbox/azuredeploy.json
@@ -84,7 +84,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -105,7 +105,7 @@
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('jumpBoxSAName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2015-06-15",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
@@ -114,7 +114,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -126,7 +126,7 @@
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('jumpBoxNicName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -152,7 +152,7 @@
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('jumpBoxName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('jumpBoxSAName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('jumpBoxNicName'))]"
@@ -196,7 +196,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('namingInfix')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],

--- a/201-vmss-linux-nat/azuredeploy.json
+++ b/201-vmss-linux-nat/azuredeploy.json
@@ -82,7 +82,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -103,7 +103,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -115,7 +115,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -155,7 +155,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('namingInfix')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -173,8 +173,8 @@
         "virtualMachineProfile": {
           "storageProfile": {
             "osDisk": {
-		"createOption": "FromImage",
-		"caching": "ReadWrite"
+              "createOption": "FromImage",
+              "caching": "ReadWrite"
             },
             "imageReference": "[variables('imageReference')]"
           },

--- a/201-vmss-public-ip-linux/azuredeploy.json
+++ b/201-vmss-public-ip-linux/azuredeploy.json
@@ -45,7 +45,8 @@
     "subnetName": "[concat(parameters('vmssName'), 'subnet')]",
     "loadBalancerName": "[concat(parameters('vmssName'), 'lb')]",
     "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]",
-    "lbID": "[resourceId('Microsoft.Network/loadBalancers',variables('loadBalancerName'))]",    "natPoolName": "[concat(parameters('vmssName'), 'natpool')]",
+    "lbID": "[resourceId('Microsoft.Network/loadBalancers',variables('loadBalancerName'))]",
+    "natPoolName": "[concat(parameters('vmssName'), 'natpool')]",
     "bePoolName": "[concat(parameters('vmssName'), 'bepool')]",
     "natStartPort": 50000,
     "natEndPort": 50120,
@@ -69,7 +70,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -90,7 +91,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -102,7 +103,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -142,7 +143,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[parameters('vmssName')]",
       "location": "[variables('location')]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"

--- a/201-vmss-ubuntu-app-gateway/azuredeploy.json
+++ b/201-vmss-ubuntu-app-gateway/azuredeploy.json
@@ -9,10 +9,10 @@
         "description": "Size of VMs in the VM Scale Set."
       }
     },
-    "vmssName":{
-      "type":"string",
-      "metadata":{
-        "description":"String used as a base for naming resources. Must be 3-57 characters in length and globally unique across Azure. A hash is prepended to this string for some resources, and resource-specific information is appended."
+    "vmssName": {
+      "type": "string",
+      "metadata": {
+        "description": "String used as a base for naming resources. Must be 3-57 characters in length and globally unique across Azure. A hash is prepended to this string for some resources, and resource-specific information is appended."
       },
       "maxLength": 57
     },
@@ -23,7 +23,7 @@
       },
       "maxValue": 1000
     },
-	  "adminUsername": {
+    "adminUsername": {
       "type": "string",
       "metadata": {
         "description": "Admin username on all VMs."
@@ -71,7 +71,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -98,7 +98,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('appGwPublicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic"
       }
@@ -107,7 +107,7 @@
       "type": "Microsoft.Network/applicationGateways",
       "name": "[variables('appGwName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
         "[concat('Microsoft.Network/publicIPAddresses/', variables('appGwPublicIPAddressName'))]"
@@ -199,7 +199,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('namingInfix')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
         "[concat('Microsoft.Network/applicationGateways/', variables('appGwName'))]"
@@ -211,7 +211,7 @@
       },
       "properties": {
         "overprovision": "true",
-	    	"singlePlacementGroup": "false",
+        "singlePlacementGroup": "false",
         "upgradePolicy": {
           "mode": "Automatic"
         },
@@ -221,12 +221,12 @@
               "caching": "ReadWrite",
               "createOption": "FromImage"
             },
-            "dataDisks": [ ],
+            "dataDisks": [],
             "imageReference": "[variables('imageReference')]"
           },
           "osProfile": {
             "computerNamePrefix": "[variables('namingInfix')]",
-			      "adminUsername": "[parameters('adminUsername')]",
+            "adminUsername": "[parameters('adminUsername')]",
             "adminPassword": "[parameters('adminPassword')]"
           },
           "networkProfile": {

--- a/201-vmss-ubuntu-autoscale/azuredeploy.json
+++ b/201-vmss-ubuntu-autoscale/azuredeploy.json
@@ -83,7 +83,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -104,7 +104,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -116,7 +116,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -156,7 +156,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('namingInfix')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -174,8 +174,8 @@
         "virtualMachineProfile": {
           "storageProfile": {
             "osDisk": {
-		"createOption": "FromImage",
-		"caching": "ReadWrite"
+              "createOption": "FromImage",
+              "caching": "ReadWrite"
             },
             "imageReference": "[variables('imageReference')]"
           },
@@ -219,7 +219,7 @@
     },
     {
       "type": "Microsoft.Insights/autoscaleSettings",
-      "apiVersion": "[variables('insightsApiVersion')]",
+      "apiVersion": "2015-04-01",
       "name": "autoscalewad",
       "location": "[resourceGroup().location]",
       "dependsOn": [
@@ -248,7 +248,7 @@
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "GreaterThan",
-                  "threshold": 60.0
+                  "threshold": 60
                 },
                 "scaleAction": {
                   "direction": "Increase",
@@ -267,7 +267,7 @@
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "LessThan",
-                  "threshold": 30.0
+                  "threshold": 30
                 },
                 "scaleAction": {
                   "direction": "Decrease",

--- a/201-vmss-windows-app-gateway/azuredeploy.json
+++ b/201-vmss-windows-app-gateway/azuredeploy.json
@@ -21,10 +21,10 @@
         "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
       }
     },
-    "vmssName":{
-      "type":"string",
-      "metadata":{
-        "description":"String used as a base for naming resources. Must be 3-57 characters in length and globally unique across Azure. A hash is prepended to this string for some resources, and resource-specific information is appended."
+    "vmssName": {
+      "type": "string",
+      "metadata": {
+        "description": "String used as a base for naming resources. Must be 3-57 characters in length and globally unique across Azure. A hash is prepended to this string for some resources, and resource-specific information is appended."
       },
       "maxLength": 57
     },
@@ -35,7 +35,7 @@
       },
       "maxValue": 1000
     },
-	  "adminUsername": {
+    "adminUsername": {
       "type": "string",
       "metadata": {
         "description": "Admin username on all VMs."
@@ -83,7 +83,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2016-03-30",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -110,7 +110,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('appGwPublicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2016-03-30",
       "properties": {
         "publicIPAllocationMethod": "Dynamic"
       }
@@ -119,7 +119,7 @@
       "type": "Microsoft.Network/applicationGateways",
       "name": "[variables('appGwName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2016-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
         "[concat('Microsoft.Network/publicIPAddresses/', variables('appGwPublicIPAddressName'))]"
@@ -211,7 +211,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('namingInfix')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2016-04-30-preview",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
         "[concat('Microsoft.Network/applicationGateways/', variables('appGwName'))]"
@@ -223,7 +223,7 @@
       },
       "properties": {
         "overprovision": "true",
-	    	"singlePlacementGroup": "false",
+        "singlePlacementGroup": "false",
         "upgradePolicy": {
           "mode": "Automatic"
         },
@@ -233,12 +233,12 @@
               "caching": "ReadWrite",
               "createOption": "FromImage"
             },
-            "dataDisks": [ ],
+            "dataDisks": [],
             "imageReference": "[variables('imageReference')]"
           },
           "osProfile": {
             "computerNamePrefix": "[variables('namingInfix')]",
-			      "adminUsername": "[parameters('adminUsername')]",
+            "adminUsername": "[parameters('adminUsername')]",
             "adminPassword": "[parameters('adminPassword')]"
           },
           "networkProfile": {

--- a/201-vmss-windows-autoscale/azuredeploy.json
+++ b/201-vmss-windows-autoscale/azuredeploy.json
@@ -84,7 +84,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -105,7 +105,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -117,7 +117,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -157,7 +157,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('namingInfix')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -175,8 +175,8 @@
         "virtualMachineProfile": {
           "storageProfile": {
             "osDisk": {
-		"createOption": "FromImage",
-		"caching": "ReadWrite"
+              "createOption": "FromImage",
+              "caching": "ReadWrite"
             },
             "imageReference": "[variables('imageReference')]"
           },
@@ -220,7 +220,7 @@
     },
     {
       "type": "Microsoft.Insights/autoscaleSettings",
-      "apiVersion": "[variables('insightsApiVersion')]",
+      "apiVersion": "2015-04-01",
       "name": "cpuautoscale",
       "location": "[resourceGroup().location]",
       "dependsOn": [

--- a/201-vmss-windows-customimage/azuredeploy.json
+++ b/201-vmss-windows-customimage/azuredeploy.json
@@ -125,7 +125,7 @@
   "resources": [
     {
       "type": "Microsoft.Compute/images",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "name": "[variables('imageName')]",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -140,7 +140,7 @@
       }
     },
     {
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -161,7 +161,7 @@
       }
     },
     {
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -173,7 +173,7 @@
       }
     },
     {
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -232,7 +232,7 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachineScaleSets",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "name": "[parameters('vmSSName')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [

--- a/201-vmss-windows-jumpbox/azuredeploy.json
+++ b/201-vmss-windows-jumpbox/azuredeploy.json
@@ -85,7 +85,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -106,7 +106,7 @@
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('jumpBoxSAName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2015-06-15",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
@@ -115,7 +115,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -127,7 +127,7 @@
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('jumpBoxNicName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
@@ -153,7 +153,7 @@
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('jumpBoxName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('jumpBoxSAName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('jumpBoxNicName'))]"
@@ -197,7 +197,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('namingInfix')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
@@ -214,8 +214,8 @@
         "virtualMachineProfile": {
           "storageProfile": {
             "osDisk": {
-		"createOption": "FromImage",
-		"caching": "ReadWrite"
+              "createOption": "FromImage",
+              "caching": "ReadWrite"
             },
             "imageReference": "[variables('imageReference')]"
           },

--- a/201-vmss-windows-nat/azuredeploy.json
+++ b/201-vmss-windows-nat/azuredeploy.json
@@ -95,7 +95,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -116,7 +116,7 @@
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('uniqueStringArray')[copyIndex()], variables('newStorageAccountSuffix'))]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "copy": {
         "name": "storageLoop",
         "count": "[variables('saCount')]"
@@ -131,7 +131,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -143,7 +143,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -183,7 +183,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('namingInfix')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "storageLoop",
         "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",

--- a/201-vnet-to-vnet/azuredeploy.json
+++ b/201-vnet-to-vnet/azuredeploy.json
@@ -1,303 +1,303 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location1": {
-            "type": "string",
-            "metadata": {
-                "description": "Location where first VNET, Gateway, PublicIP and Connection will be deployed."
-            }
-        },
-        "location2": {
-            "type": "string",
-            "metadata": {
-                "description": "Location where second VNET, Gateway, PublicIP and Connection will be deployed."
-            }
-        },
-        "virtualNetworkName1": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the first VNET."
-            }
-        },
-        "addressPrefix1": {
-            "type": "string",
-            "metadata": {
-                "description": "Address space for the first VNET."
-            }
-        },
-        "subnet1Name1": {
-            "type": "string",
-            "defaultValue": "Subnet-1",
-            "metadata": {
-                "description": "Name of the first subnet in the first VNET. Please note, an additional subnet called GatewaySubnet will be created where the VirtualNetworkGateway will be deployed. The name of that subnet must not be changed from GatewaySubnet."
-            }
-        },
-        "subnet1Prefix1": {
-            "type": "string",
-            "metadata": {
-                "description": "The prefix for the first subnet in the first VNET."
-            }
-        },
-        "gatewaySubnetPrefix1": {
-            "type": "string",
-            "metadata": {
-                "description": "The prefix for the GatewaySubnet where the first VirtualNetworkGateway will be deployed. This must be at least /29."
-            }
-        },
-        "gatewayPublicIPName1": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the PublicIP attached to the first VirtualNetworkGateway."
-            }
-        },
-        "gatewayName1": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the first VirtualNetworkGateway."
-            }
-        },
-        "connectionName1": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the first connection, connecting the first VirtualNetworkGateway to the second VirtualNetworkGateway."
-            }
-        },
-        "virtualNetworkName2": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the second VNET."
-            }
-        },
-        "addressPrefix2": {
-            "type": "string",
-            "metadata": {
-                "description": "Address space for the second VNET."
-            }
-        },
-        "subnet1Name2": {
-            "type": "string",
-            "defaultValue": "Subnet-1",
-            "metadata": {
-                "description": "Name of the first subnet in the second VNET. Please note, an additional subnet called GatewaySubnet will be created where the VirtualNetworkGateway will be deployed. The name of that subnet must not be changed from GatewaySubnet."
-            }
-        },
-        "subnet1Prefix2": {
-            "type": "string",
-            "metadata": {
-                "description": "The prefix for the first subnet in the second VNET."
-            }
-        },
-        "gatewaySubnetPrefix2": {
-            "type": "string",
-            "metadata": {
-                "description": "The prefix for the GatewaySubnet where the second VirtualNetworkGateway will be deployed. This must be at least /29."
-            }
-        },
-        "gatewayPublicIPName2": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the PublicIP attached to the second VirtualNetworkGateway."
-            }
-        },
-        "gatewayName2": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the second VirtualNetworkGateway."
-            }
-        },
-        "connectionName2": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the second connection, connecting the second VirtualNetworkGateway to the first VirtualNetworkGateway."
-            }
-        },
-        "sharedKey": {
-            "type": "string",
-            "metadata": {
-                "description": "The shared key used to establish connection between the two VirtualNetworkGateways."
-            }
-        }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location1": {
+      "type": "string",
+      "metadata": {
+        "description": "Location where first VNET, Gateway, PublicIP and Connection will be deployed."
+      }
     },
-    "variables": {
-        "apiVersion": "2015-05-01-preview",
-        "vnetID1": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName1'))]",
-        "gatewaySubnetRef1": "[concat(variables('vnetID1'),'/subnets/','GatewaySubnet')]",
-        "vnetID2": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName2'))]",
-        "gatewaySubnetRef2": "[concat(variables('vnetID2'),'/subnets/','GatewaySubnet')]"
+    "location2": {
+      "type": "string",
+      "metadata": {
+        "description": "Location where second VNET, Gateway, PublicIP and Connection will be deployed."
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[parameters('virtualNetworkName1')]",
-            "location": "[parameters('location1')]",
-            "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[parameters('addressPrefix1')]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[parameters('subnet1Name1')]",
-                        "properties": {
-                            "addressPrefix": "[parameters('subnet1Prefix1')]"
-                        }
-                    },
-                    {
-                        "name": "GatewaySubnet",
-                        "properties": {
-                            "addressPrefix": "[parameters('gatewaySubnetPrefix1')]"
-                        }
-                    }
-                ]
-            }
+    "virtualNetworkName1": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the first VNET."
+      }
+    },
+    "addressPrefix1": {
+      "type": "string",
+      "metadata": {
+        "description": "Address space for the first VNET."
+      }
+    },
+    "subnet1Name1": {
+      "type": "string",
+      "defaultValue": "Subnet-1",
+      "metadata": {
+        "description": "Name of the first subnet in the first VNET. Please note, an additional subnet called GatewaySubnet will be created where the VirtualNetworkGateway will be deployed. The name of that subnet must not be changed from GatewaySubnet."
+      }
+    },
+    "subnet1Prefix1": {
+      "type": "string",
+      "metadata": {
+        "description": "The prefix for the first subnet in the first VNET."
+      }
+    },
+    "gatewaySubnetPrefix1": {
+      "type": "string",
+      "metadata": {
+        "description": "The prefix for the GatewaySubnet where the first VirtualNetworkGateway will be deployed. This must be at least /29."
+      }
+    },
+    "gatewayPublicIPName1": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the PublicIP attached to the first VirtualNetworkGateway."
+      }
+    },
+    "gatewayName1": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the first VirtualNetworkGateway."
+      }
+    },
+    "connectionName1": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the first connection, connecting the first VirtualNetworkGateway to the second VirtualNetworkGateway."
+      }
+    },
+    "virtualNetworkName2": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the second VNET."
+      }
+    },
+    "addressPrefix2": {
+      "type": "string",
+      "metadata": {
+        "description": "Address space for the second VNET."
+      }
+    },
+    "subnet1Name2": {
+      "type": "string",
+      "defaultValue": "Subnet-1",
+      "metadata": {
+        "description": "Name of the first subnet in the second VNET. Please note, an additional subnet called GatewaySubnet will be created where the VirtualNetworkGateway will be deployed. The name of that subnet must not be changed from GatewaySubnet."
+      }
+    },
+    "subnet1Prefix2": {
+      "type": "string",
+      "metadata": {
+        "description": "The prefix for the first subnet in the second VNET."
+      }
+    },
+    "gatewaySubnetPrefix2": {
+      "type": "string",
+      "metadata": {
+        "description": "The prefix for the GatewaySubnet where the second VirtualNetworkGateway will be deployed. This must be at least /29."
+      }
+    },
+    "gatewayPublicIPName2": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the PublicIP attached to the second VirtualNetworkGateway."
+      }
+    },
+    "gatewayName2": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the second VirtualNetworkGateway."
+      }
+    },
+    "connectionName2": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the second connection, connecting the second VirtualNetworkGateway to the first VirtualNetworkGateway."
+      }
+    },
+    "sharedKey": {
+      "type": "string",
+      "metadata": {
+        "description": "The shared key used to establish connection between the two VirtualNetworkGateways."
+      }
+    }
+  },
+  "variables": {
+    "apiVersion": "2015-05-01-preview",
+    "vnetID1": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName1'))]",
+    "gatewaySubnetRef1": "[concat(variables('vnetID1'),'/subnets/','GatewaySubnet')]",
+    "vnetID2": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName2'))]",
+    "gatewaySubnetRef2": "[concat(variables('vnetID2'),'/subnets/','GatewaySubnet')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName1')]",
+      "location": "[parameters('location1')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('addressPrefix1')]"
+          ]
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[parameters('virtualNetworkName2')]",
-            "location": "[parameters('location2')]",
+        "subnets": [
+          {
+            "name": "[parameters('subnet1Name1')]",
             "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[parameters('addressPrefix2')]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[parameters('subnet1Name2')]",
-                        "properties": {
-                            "addressPrefix": "[parameters('subnet1Prefix2')]"
-                        }
-                    },
-                    {
-                        "name": "GatewaySubnet",
-                        "properties": {
-                            "addressPrefix": "[parameters('gatewaySubnetPrefix2')]"
-                        }
-                    }
-                ]
+              "addressPrefix": "[parameters('subnet1Prefix1')]"
             }
+          },
+          {
+            "name": "GatewaySubnet",
+            "properties": {
+              "addressPrefix": "[parameters('gatewaySubnetPrefix1')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName2')]",
+      "location": "[parameters('location2')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('addressPrefix2')]"
+          ]
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[parameters('gatewayPublicIPName1')]",
-            "location": "[parameters('location1')]",
+        "subnets": [
+          {
+            "name": "[parameters('subnet1Name2')]",
             "properties": {
-                "publicIPAllocationMethod": "Dynamic"
+              "addressPrefix": "[parameters('subnet1Prefix2')]"
             }
+          },
+          {
+            "name": "GatewaySubnet",
+            "properties": {
+              "addressPrefix": "[parameters('gatewaySubnetPrefix2')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('gatewayPublicIPName1')]",
+      "location": "[parameters('location1')]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('gatewayPublicIPName2')]",
+      "location": "[parameters('location2')]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworkGateways",
+      "name": "[parameters('gatewayName1')]",
+      "location": "[parameters('location1')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName1'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName1'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('gatewaySubnetRef1')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName1'))]"
+              }
+            },
+            "name": "vnetGatewayConfig1"
+          }
+        ],
+        "gatewayType": "Vpn",
+        "vpnType": "RouteBased",
+        "enableBgp": "false"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworkGateways",
+      "name": "[parameters('gatewayName2')]",
+      "location": "[parameters('location2')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName2'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName2'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('gatewaySubnetRef2')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName2'))]"
+              }
+            },
+            "name": "vnetGatewayConfig2"
+          }
+        ],
+        "gatewayType": "Vpn",
+        "vpnType": "RouteBased",
+        "enableBgp": "false"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/connections",
+      "name": "[parameters('connectionName1')]",
+      "location": "[parameters('location1')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName1'))]",
+        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName2'))]"
+      ],
+      "properties": {
+        "virtualNetworkGateway1": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName1'))]"
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[parameters('gatewayPublicIPName2')]",
-            "location": "[parameters('location2')]",
-            "properties": {
-                "publicIPAllocationMethod": "Dynamic"
-            }
+        "virtualNetworkGateway2": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName2'))]"
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/virtualNetworkGateways",
-            "name": "[parameters('gatewayName1')]",
-            "location": "[parameters('location1')]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName1'))]",
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName1'))]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "subnet": {
-                                "id": "[variables('gatewaySubnetRef1')]"
-                            },
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName1'))]"
-                            }
-                        },
-                        "name": "vnetGatewayConfig1"
-                    }
-                ],
-                "gatewayType": "Vpn",
-                "vpnType": "RouteBased",
-                "enableBgp": "false"
-            }
+        "connectionType": "Vnet2Vnet",
+        "routingWeight": 3,
+        "sharedKey": "[parameters('sharedKey')]"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/connections",
+      "name": "[parameters('connectionName2')]",
+      "location": "[parameters('location2')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName1'))]",
+        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName2'))]"
+      ],
+      "properties": {
+        "virtualNetworkGateway1": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName2'))]"
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/virtualNetworkGateways",
-            "name": "[parameters('gatewayName2')]",
-            "location": "[parameters('location2')]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName2'))]",
-                "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName2'))]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "subnet": {
-                                "id": "[variables('gatewaySubnetRef2')]"
-                            },
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName2'))]"
-                            }
-                        },
-                        "name": "vnetGatewayConfig2"
-                    }
-                ],
-                "gatewayType": "Vpn",
-                "vpnType": "RouteBased",
-                "enableBgp": "false"
-            }
+        "virtualNetworkGateway2": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName1'))]"
         },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/connections",
-            "name": "[parameters('connectionName1')]",
-            "location": "[parameters('location1')]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName1'))]",
-                "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName2'))]"
-            ],
-            "properties": {
-                "virtualNetworkGateway1": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName1'))]"
-                },
-                "virtualNetworkGateway2": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName2'))]"
-                },
-                "connectionType": "Vnet2Vnet",
-                "routingWeight": 3,
-                "sharedKey": "[parameters('sharedKey')]"
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/connections",
-            "name": "[parameters('connectionName2')]",
-            "location": "[parameters('location2')]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName1'))]",
-                "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName2'))]"
-            ],
-            "properties": {
-                "virtualNetworkGateway1": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName2'))]"
-                },
-                "virtualNetworkGateway2": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName1'))]"
-                },
-                "connectionType": "Vnet2Vnet",
-                "routingWeight": 3,
-                "sharedKey": "[parameters('sharedKey')]"
-            }
-        }
-    ]
+        "connectionType": "Vnet2Vnet",
+        "routingWeight": 3,
+        "sharedKey": "[parameters('sharedKey')]"
+      }
+    }
+  ]
 }

--- a/201-web-app-vm-dsc/azuredeploy.parameters.json
+++ b/201-web-app-vm-dsc/azuredeploy.parameters.json
@@ -1,5 +1,5 @@
-,{
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "newStorageAccountName": {

--- a/301-2fe-lb80-rdp-1be-nsg-rdp/azuredeploy.json
+++ b/301-2fe-lb80-rdp-1be-nsg-rdp/azuredeploy.json
@@ -41,7 +41,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "publicIp",
       "location": "[resourceGroup().location]",
@@ -53,7 +53,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "vmsqlIp",
       "location": "[resourceGroup().location]",
@@ -73,7 +73,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -82,7 +82,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "VNET",
       "location": "[resourceGroup().location]",
@@ -103,7 +103,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "loadBalancer",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -186,7 +186,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "vmsql",
       "location": "[resourceGroup().location]",
@@ -210,7 +210,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('vmName'),copyindex())]",
       "copy": {
@@ -247,7 +247,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicsql')]",
       "location": "[resourceGroup().location]",

--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
@@ -100,7 +100,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "publicIp",
       "location": "[resourceGroup().location]",
@@ -112,7 +112,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "vmsqlIp",
       "location": "[resourceGroup().location]",
@@ -132,7 +132,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountNameDiag')]",
       "location": "[resourceGroup().location]",
@@ -141,7 +141,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "VNET",
       "location": "[resourceGroup().location]",
@@ -162,7 +162,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "loadBalancer",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -245,7 +245,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "vmsql",
       "location": "[resourceGroup().location]",
@@ -269,7 +269,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('vmName'),copyindex())]",
       "copy": {
@@ -306,7 +306,7 @@
       }
     },
     {
-      "apiVersion": "[variables('ApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicsql')]",
       "location": "[resourceGroup().location]",

--- a/301-azure-relay-create-authrule-namespace-and-hybridconnection/azuredeploy.json
+++ b/301-azure-relay-create-authrule-namespace-and-hybridconnection/azuredeploy.json
@@ -1,109 +1,107 @@
 {
-   "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-   "contentVersion":"1.0.0.0",
-   "parameters":{
-      "namespaceName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the Azure Relay namespace"
-         }
-      },
-      "namespaceAuthorizationRuleName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the Namespace AuthorizationRule"
-         }
-      },
-      "hybridConnectionName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the HybridConnection"
-         }
-      },
-      "hybridConnectionAuthorizationRuleName":{
-         "type":"string",
-         "metadata":{
-            "description":"Name of the HybridConnection AuthorizationRule"
-         }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "namespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Azure Relay namespace"
       }
-   },
-   "variables":{
-      "location":"[resourceGroup().location]",
-      "apiVersion":"2016-07-01",
-      "namespaceAuthRuleName":"[concat(parameters('namespaceName'), concat('/', parameters('namespaceAuthorizationRuleName')))]",
-      "nsAuthorizationRuleResourceId":"[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('namespaceName'), parameters('namespaceAuthorizationRuleName'))]",
-      "hcAuthorizationRuleResourceId":"[resourceId('Microsoft.Relay/namespaces/HybridConnections/authorizationRules', parameters('namespaceName'), parameters('hybridConnectionName'), parameters('hybridConnectionAuthorizationRuleName'))]"
-   },
-   "resources":[
-      {
-         "apiVersion":"[variables('apiVersion')]",
-         "name":"[parameters('namespaceName')]",
-         "type":"Microsoft.Relay/Namespaces",
-         "location":"[variables('location')]",
-         "kind":"Relay",
-         "resources":[
+    },
+    "namespaceAuthorizationRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Namespace AuthorizationRule"
+      }
+    },
+    "hybridConnectionName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the HybridConnection"
+      }
+    },
+    "hybridConnectionAuthorizationRuleName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the HybridConnection AuthorizationRule"
+      }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "apiVersion": "2016-07-01",
+    "namespaceAuthRuleName": "[concat(parameters('namespaceName'), concat('/', parameters('namespaceAuthorizationRuleName')))]",
+    "nsAuthorizationRuleResourceId": "[resourceId('Microsoft.Relay/namespaces/authorizationRules', parameters('namespaceName'), parameters('namespaceAuthorizationRuleName'))]",
+    "hcAuthorizationRuleResourceId": "[resourceId('Microsoft.Relay/namespaces/HybridConnections/authorizationRules', parameters('namespaceName'), parameters('hybridConnectionName'), parameters('hybridConnectionAuthorizationRuleName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-07-01",
+      "name": "[parameters('namespaceName')]",
+      "type": "Microsoft.Relay/Namespaces",
+      "location": "[variables('location')]",
+      "kind": "Relay",
+      "resources": [
+        {
+          "apiVersion": "[variables('apiVersion')]",
+          "name": "[parameters('hybridConnectionName')]",
+          "type": "HybridConnections",
+          "dependsOn": [
+            "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
+          ],
+          "properties": {
+            "path": "[parameters('hybridConnectionName')]"
+          },
+          "resources": [
             {
-               "apiVersion":"[variables('apiVersion')]",
-               "name":"[parameters('hybridConnectionName')]",
-               "type":"HybridConnections",
-               "dependsOn":[
-                  "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
-               ],
-               "properties":{
-                  "path":"[parameters('hybridConnectionName')]"
-               },
-               "resources":[
-                  {
-                     "apiVersion":"[variables('apiVersion')]",
-                     "name":"[parameters('hybridConnectionAuthorizationRuleName')]",
-                     "type":"authorizationRules",
-                     "dependsOn":[
-                        "[parameters('hybridConnectionName')]"
-                     ],
-                     "properties":{
-                        "Rights":[
-                           "Listen"
-                        ]
-                     }
-                  }
-               ]
-            },
-            {
-               "apiVersion":"[variables('apiVersion')]",
-               "name":"[variables('namespaceAuthRuleName')]",
-               "type":"Microsoft.Relay/namespaces/authorizationRules",
-               "dependsOn":[
-                  "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
-               ],
-               "location":"[variables('location')]",
-               "properties":{
-                  "Rights":[
-                     "Send"
-                  ]
-               }
+              "apiVersion": "[variables('apiVersion')]",
+              "name": "[parameters('hybridConnectionAuthorizationRuleName')]",
+              "type": "authorizationRules",
+              "dependsOn": [
+                "[parameters('hybridConnectionName')]"
+              ],
+              "properties": {
+                "Rights": [
+                  "Listen"
+                ]
+              }
             }
-         ],
-         "properties":{
-
-         }
-      }
-   ],
-   "outputs":{
-      "NamespaceConnectionString":{
-         "type":"string",
-         "value":"[listkeys(variables('nsAuthorizationRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
-      },
-      "NamespaceSharedAccessPolicyPrimaryKey":{
-         "type":"string",
-         "value":"[listkeys(variables('nsAuthorizationRuleResourceId'), variables('apiVersion')).primaryKey]"
-      },
-      "HybridConnectionConnectionString":{
-         "type":"string",
-         "value":"[listkeys(variables('hcAuthorizationRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
-      },
-      "HybridConnectionSharedAccessPolicyPrimaryKey":{
-         "type":"string",
-         "value":"[listkeys(variables('hcAuthorizationRuleResourceId'), variables('apiVersion')).primaryKey]"
-      }
-   }
+          ]
+        },
+        {
+          "apiVersion": "[variables('apiVersion')]",
+          "name": "[variables('namespaceAuthRuleName')]",
+          "type": "Microsoft.Relay/namespaces/authorizationRules",
+          "dependsOn": [
+            "[concat('Microsoft.Relay/namespaces/', parameters('namespaceName'))]"
+          ],
+          "location": "[variables('location')]",
+          "properties": {
+            "Rights": [
+              "Send"
+            ]
+          }
+        }
+      ],
+      "properties": {}
+    }
+  ],
+  "outputs": {
+    "NamespaceConnectionString": {
+      "type": "string",
+      "value": "[listkeys(variables('nsAuthorizationRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
+    },
+    "NamespaceSharedAccessPolicyPrimaryKey": {
+      "type": "string",
+      "value": "[listkeys(variables('nsAuthorizationRuleResourceId'), variables('apiVersion')).primaryKey]"
+    },
+    "HybridConnectionConnectionString": {
+      "type": "string",
+      "value": "[listkeys(variables('hcAuthorizationRuleResourceId'), variables('apiVersion')).primaryConnectionString]"
+    },
+    "HybridConnectionSharedAccessPolicyPrimaryKey": {
+      "type": "string",
+      "value": "[listkeys(variables('hcAuthorizationRuleResourceId'), variables('apiVersion')).primaryKey]"
+    }
+  }
 }

--- a/301-dns-forwarder/azuredeploy.json
+++ b/301-dns-forwarder/azuredeploy.json
@@ -58,7 +58,7 @@
       "type": "Microsoft.Storage/StorageAccounts",
       "comments": "Storage account for the VHD files for the VMs",
       "name": "[parameters('storageAccName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "properties": {
         "accountType": "[variables('storType')]"
@@ -80,7 +80,7 @@
       "type": "Microsoft.Network/networkSecurityGroups",
       "comments": "An NSG to prevent inbound traffic other than SSH, set sourceAddressPrefix to restrict access further or block all together (or remove the public ip) and ssh in from another vm",
       "name": "[variables('nsgName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "properties": {
         "securityRules": [
@@ -105,7 +105,7 @@
       "type": "Microsoft.Network/virtualNetworks",
       "comments": "An example virtual network, for real scenarios add the DNS forwarder to your own vnet",
       "name": "[variables('vnetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "properties": {
         "addressSpace": {
@@ -127,7 +127,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "comments": "A public IP to allow us to SSH into the VM, not recommended for production DNS servers",
       "name": "[variables('pipName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "properties": {
         "publicIPAllocationMethod": "Dynamic"
@@ -137,7 +137,7 @@
       "type": "Microsoft.Network/networkInterfaces",
       "comments": "A single network interface on each DNS server",
       "name": "[variables('nicName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('pipName'))]",
@@ -218,7 +218,7 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "comments": "The shell script to install Bind9 and setup the ACL and forwarders.  If this step fails, check the logs in /var/log/waagent.log and /var/log/azure/* for details",
       "name": "[concat(parameters('vmName'),'/setupdnsfirewall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"

--- a/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
+++ b/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
@@ -19,25 +19,20 @@
         "description": "The Ubuntu version for the Drupal VM. This will pick a fully patched image of this given Ubuntu version. Allowed values are: 14.04.4-LTS."
       }
     },
-    
     "drupalAdminUser": {
       "type": "string",
       "defaultValue": "drupaladmin",
-      
       "metadata": {
         "description": "Admin User for the Drupal Installation"
       }
     },
-    
     "drupalAdminPassword": {
       "type": "securestring",
       "defaultValue": "Drupal Administrator Password",
-      
       "metadata": {
         "description": "The Ubuntu version for the Drupal VM. This will pick a fully patched image of this given Ubuntu version. Allowed values are: 15.10, 14.04.4-LTS."
       }
     },
-    
     "drupalVersion": {
       "type": "string",
       "defaultValue": "8.1.1",
@@ -48,7 +43,6 @@
         "description": "The Drupal Version to be installed"
       }
     },
-    
     "vmssName": {
       "type": "string",
       "metadata": {
@@ -84,16 +78,13 @@
         "description": "Admin password on all Drupal and gluster VMs."
       }
     },
-    
-    "drupalInstallationDatabaseName" : {
+    "drupalInstallationDatabaseName": {
       "type": "string",
       "defaultValue": "drupaldb",
-      
       "metadata": {
         "description": "The MySQL Database to which drupal will be installed"
       }
     },
-    
     "createNewMySQLServer": {
       "type": "string",
       "defaultValue": "yes",
@@ -105,7 +96,6 @@
         "description": "If Yes new MySQL server will be provisioned using the mysql replication template"
       }
     },
-    
     "existingMySqlFQDN": {
       "type": "string",
       "defaultValue": "onlyRequiredForExistingMySQL",
@@ -113,8 +103,6 @@
         "description": "Fully qualified domain name of the existing mysql server"
       }
     },
-    
-        
     "existingMysqlUser": {
       "type": "string",
       "defaultValue": "admin",
@@ -122,35 +110,30 @@
         "description": "mysql username. When creating New MySQL server using mysql replication template this will be admin."
       }
     },
-    
     "mysqlUserPassword": {
       "type": "securestring",
       "metadata": {
         "description": "mysql user password. For existing enter the existing password. In case of new MySQL server this will be the password for MySqL admin user"
       }
     },
-    
     "newMySqlDnsLabelPrefix": {
       "type": "string",
       "metadata": {
-      "description": "Required when creating new MySQL server, FQDN of server will be using dnsLabelPrefix.location.cloudapp.azure.com"
+        "description": "Required when creating new MySQL server, FQDN of server will be using dnsLabelPrefix.location.cloudapp.azure.com"
       }
     },
-
     "newMySqlVmUserName": {
       "type": "string",
       "metadata": {
         "description": "Required when creating new MySQL server. User name to ssh in to the MySQL VMs"
       }
     },
-    
     "newMySqlVmPassword": {
       "type": "securestring",
-        "metadata": {
+      "metadata": {
         "description": "Required when creating new MySQL server. Password to ssh in to the MySQL VMs"
       }
     },
-    
     "newMySqlVmSize": {
       "type": "string",
       "defaultValue": "Standard_D2",
@@ -158,7 +141,6 @@
         "description": "Required when creating new MySQL server. size for the mySql VMs"
       }
     },
-
     "dbCentosOSVersion": {
       "type": "string",
       "defaultValue": "6.6",
@@ -170,7 +152,6 @@
         "description": "Required when creating new MySQL server. VM OS version"
       }
     },
-
     "glusterTemplateLocation": {
       "type": "string",
       "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/gluster-file-system/",
@@ -278,7 +259,9 @@
     "storageAccountType": "Standard_LRS",
     "storageApiVersion": "2015-06-15",
     "templateAPIVersion": "2015-01-01",
-    "uniqueStringArray": ["[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '0')))]"],
+    "uniqueStringArray": [
+      "[concat(uniqueString(concat(resourceGroup().id, variables('newStorageAccountSuffix'), '0')))]"
+    ],
     "vhdContainerName": "[concat(variables('namingInfix'), 'vhd')]",
     "virtualNetworkName": "drupglusvnet",
     "wadcfgxend": "[concat('\"><MetricAggregation scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>')]",
@@ -289,12 +272,11 @@
     "wadperfcounters2": "<PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\BytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation displayName=\"Disk total bytes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\ReadBytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation displayName=\"Disk read guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\WriteBytesPerSecond\" sampleRate=\"PT15S\" unit=\"BytesPerSecond\"><annotation displayName=\"Disk write guest OS\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\TransfersPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation displayName=\"Disk transfers\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\ReadsPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation displayName=\"Disk reads\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\WritesPerSecond\" sampleRate=\"PT15S\" unit=\"CountPerSecond\"><annotation displayName=\"Disk writes\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\AverageReadTime\" sampleRate=\"PT15S\" unit=\"Seconds\"><annotation displayName=\"Disk read time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\AverageWriteTime\" sampleRate=\"PT15S\" unit=\"Seconds\"><annotation displayName=\"Disk write time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\AverageTransferTime\" sampleRate=\"PT15S\" unit=\"Seconds\"><annotation displayName=\"Disk transfer time\" locale=\"en-us\"/></PerformanceCounterConfiguration><PerformanceCounterConfiguration counterSpecifier=\"\\PhysicalDisk\\AverageDiskQueueLength\" sampleRate=\"PT15S\" unit=\"Count\"><annotation displayName=\"Disk queue length\" locale=\"en-us\"/></PerformanceCounterConfiguration></PerformanceCounters>"
   },
   "resources": [
-    
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('uniqueStringArray')[copyIndex()], variables('newStorageAccountSuffix'))]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "storageLoop",
         "count": "[variables('saCount')]"
@@ -307,7 +289,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -319,7 +301,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
         "gluster"
@@ -388,12 +370,10 @@
         ]
       }
     },
-
-    
     {
       "name": "mysql",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -401,41 +381,97 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "dnsName": { "value": "[parameters('newMySqlDnsLabelPrefix')]" },
-          "location": { "value": "[variables('location')]" },
-          "vmUserName": { "value": "[parameters('newMySqlVmUserName')]" },
-          "vmPassword": { "value": "[parameters('newMySqlVmPassword')]" },
-          "mysqlRootPassword": { "value": "[parameters('mysqlUserPassword')]" },
-          "mysqlReplicationPassword": { "value": "[variables('mysqlReplicationPassword')]" },
-          "mysqlProbePassword": { "value": "[variables('mysqlProbePassword')]" },
-          "vmSize": { "value": "[parameters('newMySqlVmSize')]" },
-          "storageAccountType": { "value": "[variables('storageAccountType')]" },
-          "virtualNetworkName": { "value": "[variables('mySqlVnetName')]" },
-          "vnetNewOrExisting": { "value": "new" },
-          "virtualNetworkExistingRGName": { "value": "" },
-          "dbSubnetName": { "value": "[variables('mySqlSubnetName')]" },
-          "vnetAddressPrefix": { "value": "[variables('mySqlVnetAddressPrefix')]" },
-          "dbSubnetAddressPrefix": { "value": "[variables('mySqlSubnetPrefix')]" },
-          "dbSubnetStartAddress": { "value": "[variables('dbSubnetStartAddress')]" },
-          "imagePublisher": { "value": "[variables('dbImagePublisher')]" },
-          "imageOffer": { "value": "[variables('dbOS')]" },
-          "imageSKU": { "value": "[parameters('dbCentosOSVersion')]" },
-          "mysqlFrontEndPort0": { "value": "[variables('mysqlFrontEndPort0')]" },
-          "mysqlFrontEndPort1": { "value": "[variables('mysqlFrontEndPort1')]" },
-          "sshNatRuleFrontEndPort0": { "value": "[variables('mysqlsshNatRuleFrontEndPort0')]" },
-          "sshNatRuleFrontEndPort1": { "value": "[variables('mysqlsshNatRuleFrontEndPort1')]" },
-          "mysqlProbePort0": { "value": "[variables('mysqlProbePort0')]" },
-          "mysqlProbePort1": { "value": "[variables('mysqlProbePort1')]" },
-          "artifactsPath": { "value": "[variables('mysqlTemplateLocation')]" },
-          "publicIPName": { "value": "[variables('mySqlpublicIPName')]" },
-          "storageAccountNamePrefix": { "value": "[variables('dbStorageAccountNamePrefix')]" }
+          "dnsName": {
+            "value": "[parameters('newMySqlDnsLabelPrefix')]"
+          },
+          "location": {
+            "value": "[variables('location')]"
+          },
+          "vmUserName": {
+            "value": "[parameters('newMySqlVmUserName')]"
+          },
+          "vmPassword": {
+            "value": "[parameters('newMySqlVmPassword')]"
+          },
+          "mysqlRootPassword": {
+            "value": "[parameters('mysqlUserPassword')]"
+          },
+          "mysqlReplicationPassword": {
+            "value": "[variables('mysqlReplicationPassword')]"
+          },
+          "mysqlProbePassword": {
+            "value": "[variables('mysqlProbePassword')]"
+          },
+          "vmSize": {
+            "value": "[parameters('newMySqlVmSize')]"
+          },
+          "storageAccountType": {
+            "value": "[variables('storageAccountType')]"
+          },
+          "virtualNetworkName": {
+            "value": "[variables('mySqlVnetName')]"
+          },
+          "vnetNewOrExisting": {
+            "value": "new"
+          },
+          "virtualNetworkExistingRGName": {
+            "value": ""
+          },
+          "dbSubnetName": {
+            "value": "[variables('mySqlSubnetName')]"
+          },
+          "vnetAddressPrefix": {
+            "value": "[variables('mySqlVnetAddressPrefix')]"
+          },
+          "dbSubnetAddressPrefix": {
+            "value": "[variables('mySqlSubnetPrefix')]"
+          },
+          "dbSubnetStartAddress": {
+            "value": "[variables('dbSubnetStartAddress')]"
+          },
+          "imagePublisher": {
+            "value": "[variables('dbImagePublisher')]"
+          },
+          "imageOffer": {
+            "value": "[variables('dbOS')]"
+          },
+          "imageSKU": {
+            "value": "[parameters('dbCentosOSVersion')]"
+          },
+          "mysqlFrontEndPort0": {
+            "value": "[variables('mysqlFrontEndPort0')]"
+          },
+          "mysqlFrontEndPort1": {
+            "value": "[variables('mysqlFrontEndPort1')]"
+          },
+          "sshNatRuleFrontEndPort0": {
+            "value": "[variables('mysqlsshNatRuleFrontEndPort0')]"
+          },
+          "sshNatRuleFrontEndPort1": {
+            "value": "[variables('mysqlsshNatRuleFrontEndPort1')]"
+          },
+          "mysqlProbePort0": {
+            "value": "[variables('mysqlProbePort0')]"
+          },
+          "mysqlProbePort1": {
+            "value": "[variables('mysqlProbePort1')]"
+          },
+          "artifactsPath": {
+            "value": "[variables('mysqlTemplateLocation')]"
+          },
+          "publicIPName": {
+            "value": "[variables('mySqlpublicIPName')]"
+          },
+          "storageAccountNamePrefix": {
+            "value": "[variables('dbStorageAccountNamePrefix')]"
+          }
         }
       }
     },
     {
       "name": "gluster",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -443,21 +479,51 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "hostOs": { "value": "[variables('glusterOS')]" },
-          "storageAccountName": { "value": "[variables('glusterStorageAccountName')]" },
-          "scaleNumber": { "value": "[parameters('glusterInstanceCount')]" },
-          "virtualNetworkName": { "value": "[variables('glusterVnetName')]" },
-          "adminUsername": { "value": "[parameters('adminUsername')]" },
-          "adminPassword": { "value": "[parameters('adminPassword')]" },
-          "vmSize": { "value": "[parameters('glusterVMSize')]" },
-          "vmNamePrefix": { "value": "[variables('glusterVMNamePrefix')]" },
-          "vmIPPrefix": { "value": "[variables('glusterVMIPPrefix')]" },
-          "vnetAddressPrefix": { "value": "[variables('glusterVnetAddressPrefix')]" },
-          "gfsSubnetName": { "value": "[variables('glusterSubnetName')]" },
-          "gfsSubnetPrefix": { "value": "[variables('glusterSubnetPrefix')]" },
-          "customScriptFilePath": { "value": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/gluster-file-system/azuregfs.sh" },
-          "customScriptCommandToExecute": { "value": "bash azuregfs.sh" },
-          "volumeName": { "value": "gfsvol" }
+          "hostOs": {
+            "value": "[variables('glusterOS')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('glusterStorageAccountName')]"
+          },
+          "scaleNumber": {
+            "value": "[parameters('glusterInstanceCount')]"
+          },
+          "virtualNetworkName": {
+            "value": "[variables('glusterVnetName')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "vmSize": {
+            "value": "[parameters('glusterVMSize')]"
+          },
+          "vmNamePrefix": {
+            "value": "[variables('glusterVMNamePrefix')]"
+          },
+          "vmIPPrefix": {
+            "value": "[variables('glusterVMIPPrefix')]"
+          },
+          "vnetAddressPrefix": {
+            "value": "[variables('glusterVnetAddressPrefix')]"
+          },
+          "gfsSubnetName": {
+            "value": "[variables('glusterSubnetName')]"
+          },
+          "gfsSubnetPrefix": {
+            "value": "[variables('glusterSubnetPrefix')]"
+          },
+          "customScriptFilePath": {
+            "value": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/gluster-file-system/azuregfs.sh"
+          },
+          "customScriptCommandToExecute": {
+            "value": "bash azuregfs.sh"
+          },
+          "volumeName": {
+            "value": "gfsvol"
+          }
         }
       }
     },
@@ -535,13 +601,10 @@
                   "typeHandlerVersion": "2.0",
                   "autoUpgradeMinorVersion": true,
                   "settings": {
-                    "fileUris": 
-                      [
-                        "[concat(parameters('templateLocation'),'/scripts/install_drupal.sh')]"
-                      ],
-                      "commandToExecute":
-                      
-                      "[concat('sudo bash install_drupal.sh -d ',parameters('drupalVersion') ,' -u ',parameters('drupalAdminUser'),' -p ',parameters('drupalAdminPassword') ,' -g ',variables('glusterVMNamePrefix'),'0 -v gfsvol -s ', parameters('existingMySqlFQDN'),' -n ', parameters('existingMysqlUser'),' -P ', parameters('mysqlUserPassword'),' -k ',parameters('drupalInstallationDatabaseName'),' -z ',parameters('createNewMySQLServer'),' -S ',parameters('newMySqlDnsLabelPrefix'), '.', variables('location'), '.cloudapp.azure.com')]"
+                    "fileUris": [
+                      "[concat(parameters('templateLocation'),'/scripts/install_drupal.sh')]"
+                    ],
+                    "commandToExecute": "[concat('sudo bash install_drupal.sh -d ',parameters('drupalVersion') ,' -u ',parameters('drupalAdminUser'),' -p ',parameters('drupalAdminPassword') ,' -g ',variables('glusterVMNamePrefix'),'0 -v gfsvol -s ', parameters('existingMySqlFQDN'),' -n ', parameters('existingMysqlUser'),' -P ', parameters('mysqlUserPassword'),' -k ',parameters('drupalInstallationDatabaseName'),' -z ',parameters('createNewMySQLServer'),' -S ',parameters('newMySqlDnsLabelPrefix'), '.', variables('location'), '.cloudapp.azure.com')]"
                   }
                 }
               },
@@ -570,7 +633,7 @@
     },
     {
       "type": "Microsoft.Insights/autoscaleSettings",
-      "apiVersion": "[variables('insightsApiVersion')]",
+      "apiVersion": "2015-04-01",
       "name": "autoscalesetting",
       "location": "[resourceGroup().location]",
       "dependsOn": [
@@ -600,7 +663,7 @@
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "GreaterThan",
-                  "threshold": 60.0
+                  "threshold": 60
                 },
                 "scaleAction": {
                   "direction": "Increase",
@@ -619,7 +682,7 @@
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "LessThan",
-                  "threshold": 50.0
+                  "threshold": 50
                 },
                 "scaleAction": {
                   "direction": "Decrease",
@@ -633,7 +696,5 @@
         ]
       }
     }
-
-
   ]
 }

--- a/301-drupal8-vmss-glusterfs-mysql/nested/mysql-resources_yes.json
+++ b/301-drupal8-vmss-glusterfs-mysql/nested/mysql-resources_yes.json
@@ -1,227 +1,227 @@
-{ 
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-       "dnsName": {
-            "type": "string",
-            "metadata": {
-                "description": "Connect to your cluster using dnsName.location.cloudapp.azure.com"
-            }
-        },
-        "location": {
-            "type": "string",
-            "metadata": {
-                "description": "Location where the MySQL cluster will be deployed to"
-            }
-        },
-        "vmUserName": {
-            "type": "string",
-            "metadata": {
-                "description": "user name to ssh to the VMs"
-            }
-        },
-        "vmPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "password to ssh to the VMs"
-            }
-        },
-        "mysqlRootPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "mysql root user password single quote not allowed"
-            }
-        },
-        "mysqlReplicationPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "mysql replication user password single quote not allowed"
-            }
-        },
-        "mysqlProbePassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "mysql probe password single quote not allowed"
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "defaultValue": "Standard_D2",
-            "metadata": {
-                "description": "size for the VMs"
-            }
-        },
-        "storageAccountType": {
-            "type": "string",
-            "defaultValue": "Standard_LRS",
-            "metadata": {
-                "description": "Storage account type for the cluster"
-            }
-        },
-        "virtualNetworkName": {
-            "type": "string",
-            "defaultValue": "mysqlvnet",
-            "metadata": {
-                "description": "Virtual network name for the cluster"
-            }
-        },
-        "vnetNewOrExisting": {
-            "type": "string",
-            "defaultValue": "new",
-            "allowedValues": [
-                "new",
-                "existing"
-            ],
-            "metadata": {
-                "description": "Identifies whether to use new or existing Virtual Network"
-            }
-        },
-        "virtualNetworkExistingRGName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "If using existing VNet, specifies the resource group for the existing VNet"
-            }
-        },
-        "dbSubnetName": {
-            "type": "string",
-            "defaultValue": "dbsubnet",
-            "metadata": {
-                "description": "subnet name for the MySQL nodes"
-            }
-        },
-        "vnetAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/16",
-            "metadata": {
-                "description": "IP address in CIDR for virtual network"
-            }
-        },
-        "dbSubnetAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.1.0/24",
-            "metadata": {
-                "description": "IP address in CIDR for db subnet"
-            }
-        },
-        "dbSubnetStartAddress": {
-            "type": "string",
-            "defaultValue": "10.0.1.4",
-            "metadata": {
-                "description": "Start IP address in the subnet for the VMs"
-            }
-        },
-        "imagePublisher": {
-            "type": "string",
-            "defaultValue": "OpenLogic",
-            "allowedValues": [
-                "OpenLogic"
-            ],
-            "metadata": {
-                "description": "publisher for the VM OS image"
-            }
-        },
-        "imageOffer": {
-            "type": "string",
-            "defaultValue": "CentOS",
-            "allowedValues": [
-                "CentOS"
-            ],
-            "metadata": {
-                "description": "VM OS name"
-            }
-        },
-        "imageSKU": {
-            "type": "string",
-            "defaultValue": "6.6",
-            "allowedValues": [
-                "6.5",
-                "6.6"
-            ],
-            "metadata": {
-                "description": "VM OS version"
-            }
-        },
-        "mysqlFrontEndPort0": {
-            "type": "int",
-            "defaultValue": 3306,
-            "metadata": {
-                "description": "MySQL public port master"
-            }
-        },
-        "mysqlFrontEndPort1": {
-            "type": "int",
-            "defaultValue": 3307,
-            "metadata": {
-                "description": "MySQL public port slave"
-            }
-        },
-        "sshNatRuleFrontEndPort0": {
-            "type": "int",
-            "defaultValue": 64001,
-            "metadata": {
-                "description": "public ssh port for VM1"
-            }
-        },
-        "sshNatRuleFrontEndPort1": {
-            "type": "int",
-            "defaultValue": 64002,
-            "metadata": {
-                "description": "public ssh port for VM2"
-            }
-        },
-        "mysqlProbePort0": {
-            "type": "int",
-            "defaultValue": 9200,
-            "metadata": {
-                "description": "MySQL public port master"
-            }
-        },
-        "mysqlProbePort1": {
-            "type": "int",
-            "defaultValue": 9201,
-            "metadata": {
-                "description": "MySQL public port slave"
-            }
-        },
-        "artifactsPath": {
-            "type": "string",
-            "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-replication",
-            "metadata": {
-                "description": "template and script file location",
-                "artifactsBaseUrl": "Base URL of the Publisher Template gallery package"
-            }
-        },
-        "customScriptCommandToExecute": {
-            "type": "string",
-            "defaultValue": "bash azuremysql.sh",
-            "metadata": {
-                "description": "bash script command line"
-            }
-        },
-        "publicIPName": {
-            "type": "string",
-            "defaultValue": "mysqlIP01",
-            "metadata": {
-                "description": "public IP name for MySQL loadbalancer"
-            }
-        },
-        "storageAccountNamePrefix": {
-          "type": "string",
-          "metadata": {
-              "description": "Storage account name prefix for the cluster"
-          }
-        }
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dnsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Connect to your cluster using dnsName.location.cloudapp.azure.com"
+      }
     },
-    "variables": {
-        "mysqlTemplateLocation" : "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-replication/",
-        "templateAPIVersion" : "2015-01-01"
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Location where the MySQL cluster will be deployed to"
+      }
     },
-    "resources": [
-        {
+    "vmUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "user name to ssh to the VMs"
+      }
+    },
+    "vmPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "password to ssh to the VMs"
+      }
+    },
+    "mysqlRootPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql root user password single quote not allowed"
+      }
+    },
+    "mysqlReplicationPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql replication user password single quote not allowed"
+      }
+    },
+    "mysqlProbePassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql probe password single quote not allowed"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2",
+      "metadata": {
+        "description": "size for the VMs"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "metadata": {
+        "description": "Storage account type for the cluster"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "mysqlvnet",
+      "metadata": {
+        "description": "Virtual network name for the cluster"
+      }
+    },
+    "vnetNewOrExisting": {
+      "type": "string",
+      "defaultValue": "new",
+      "allowedValues": [
+        "new",
+        "existing"
+      ],
+      "metadata": {
+        "description": "Identifies whether to use new or existing Virtual Network"
+      }
+    },
+    "virtualNetworkExistingRGName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "If using existing VNet, specifies the resource group for the existing VNet"
+      }
+    },
+    "dbSubnetName": {
+      "type": "string",
+      "defaultValue": "dbsubnet",
+      "metadata": {
+        "description": "subnet name for the MySQL nodes"
+      }
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "IP address in CIDR for virtual network"
+      }
+    },
+    "dbSubnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.1.0/24",
+      "metadata": {
+        "description": "IP address in CIDR for db subnet"
+      }
+    },
+    "dbSubnetStartAddress": {
+      "type": "string",
+      "defaultValue": "10.0.1.4",
+      "metadata": {
+        "description": "Start IP address in the subnet for the VMs"
+      }
+    },
+    "imagePublisher": {
+      "type": "string",
+      "defaultValue": "OpenLogic",
+      "allowedValues": [
+        "OpenLogic"
+      ],
+      "metadata": {
+        "description": "publisher for the VM OS image"
+      }
+    },
+    "imageOffer": {
+      "type": "string",
+      "defaultValue": "CentOS",
+      "allowedValues": [
+        "CentOS"
+      ],
+      "metadata": {
+        "description": "VM OS name"
+      }
+    },
+    "imageSKU": {
+      "type": "string",
+      "defaultValue": "6.6",
+      "allowedValues": [
+        "6.5",
+        "6.6"
+      ],
+      "metadata": {
+        "description": "VM OS version"
+      }
+    },
+    "mysqlFrontEndPort0": {
+      "type": "int",
+      "defaultValue": 3306,
+      "metadata": {
+        "description": "MySQL public port master"
+      }
+    },
+    "mysqlFrontEndPort1": {
+      "type": "int",
+      "defaultValue": 3307,
+      "metadata": {
+        "description": "MySQL public port slave"
+      }
+    },
+    "sshNatRuleFrontEndPort0": {
+      "type": "int",
+      "defaultValue": 64001,
+      "metadata": {
+        "description": "public ssh port for VM1"
+      }
+    },
+    "sshNatRuleFrontEndPort1": {
+      "type": "int",
+      "defaultValue": 64002,
+      "metadata": {
+        "description": "public ssh port for VM2"
+      }
+    },
+    "mysqlProbePort0": {
+      "type": "int",
+      "defaultValue": 9200,
+      "metadata": {
+        "description": "MySQL public port master"
+      }
+    },
+    "mysqlProbePort1": {
+      "type": "int",
+      "defaultValue": 9201,
+      "metadata": {
+        "description": "MySQL public port slave"
+      }
+    },
+    "artifactsPath": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-replication",
+      "metadata": {
+        "description": "template and script file location",
+        "artifactsBaseUrl": "Base URL of the Publisher Template gallery package"
+      }
+    },
+    "customScriptCommandToExecute": {
+      "type": "string",
+      "defaultValue": "bash azuremysql.sh",
+      "metadata": {
+        "description": "bash script command line"
+      }
+    },
+    "publicIPName": {
+      "type": "string",
+      "defaultValue": "mysqlIP01",
+      "metadata": {
+        "description": "public IP name for MySQL loadbalancer"
+      }
+    },
+    "storageAccountNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Storage account name prefix for the cluster"
+      }
+    }
+  },
+  "variables": {
+    "mysqlTemplateLocation": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-replication/",
+    "templateAPIVersion": "2015-01-01"
+  },
+  "resources": [
+    {
       "name": "mysqlnested",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -229,37 +229,87 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "dnsName": { "value": "[parameters('dnsName')]" },
-          "vmUserName": { "value": "[parameters('vmUserName')]" },
-          "vmPassword": { "value": "[parameters('vmPassword')]" },
-          "mysqlRootPassword": { "value": "[parameters('mysqlRootPassword')]" },
-          "mysqlReplicationPassword": { "value": "[parameters('mysqlReplicationPassword')]" },
-          "mysqlProbePassword": { "value": "[parameters('mysqlProbePassword')]" },
-          "vmSize": { "value": "[parameters('vmSize')]" },
-          "storageAccountType": { "value": "[parameters('storageAccountType')]" },
-          "virtualNetworkName": { "value": "[parameters('virtualNetworkName')]" },
-          "vnetNewOrExisting": { "value": "new" },
-          "virtualNetworkExistingRGName": { "value": "" },
-          "dbSubnetName": { "value": "[parameters('dbSubnetName')]" },
-          "vnetAddressPrefix": { "value": "[parameters('vnetAddressPrefix')]" },
-          "dbSubnetAddressPrefix": { "value": "[parameters('dbSubnetAddressPrefix')]" },
-          "dbSubnetStartAddress": { "value": "[parameters('dbSubnetStartAddress')]" },
-          "imagePublisher": { "value": "[parameters('imagePublisher')]" },
-          "imageOffer": { "value": "[parameters('imageOffer')]" },
-          "imageSKU": { "value": "[parameters('imageSKU')]" },
-          "mysqlFrontEndPort0": { "value": "[parameters('mysqlFrontEndPort0')]" },
-          "mysqlFrontEndPort1": { "value": "[parameters('mysqlFrontEndPort1')]" },
-          "sshNatRuleFrontEndPort0": { "value": "[parameters('sshNatRuleFrontEndPort0')]" },
-          "sshNatRuleFrontEndPort1": { "value": "[parameters('sshNatRuleFrontEndPort1')]" },
-          "mysqlProbePort0": { "value": "[parameters('mysqlProbePort0')]" },
-          "mysqlProbePort1": { "value": "[parameters('mysqlProbePort1')]" },
-          "artifactsPath": { "value": "[parameters('artifactsPath')]" },
-          "publicIPName": { "value": "[parameters('publicIPName')]" }
-          
+          "dnsName": {
+            "value": "[parameters('dnsName')]"
+          },
+          "vmUserName": {
+            "value": "[parameters('vmUserName')]"
+          },
+          "vmPassword": {
+            "value": "[parameters('vmPassword')]"
+          },
+          "mysqlRootPassword": {
+            "value": "[parameters('mysqlRootPassword')]"
+          },
+          "mysqlReplicationPassword": {
+            "value": "[parameters('mysqlReplicationPassword')]"
+          },
+          "mysqlProbePassword": {
+            "value": "[parameters('mysqlProbePassword')]"
+          },
+          "vmSize": {
+            "value": "[parameters('vmSize')]"
+          },
+          "storageAccountType": {
+            "value": "[parameters('storageAccountType')]"
+          },
+          "virtualNetworkName": {
+            "value": "[parameters('virtualNetworkName')]"
+          },
+          "vnetNewOrExisting": {
+            "value": "new"
+          },
+          "virtualNetworkExistingRGName": {
+            "value": ""
+          },
+          "dbSubnetName": {
+            "value": "[parameters('dbSubnetName')]"
+          },
+          "vnetAddressPrefix": {
+            "value": "[parameters('vnetAddressPrefix')]"
+          },
+          "dbSubnetAddressPrefix": {
+            "value": "[parameters('dbSubnetAddressPrefix')]"
+          },
+          "dbSubnetStartAddress": {
+            "value": "[parameters('dbSubnetStartAddress')]"
+          },
+          "imagePublisher": {
+            "value": "[parameters('imagePublisher')]"
+          },
+          "imageOffer": {
+            "value": "[parameters('imageOffer')]"
+          },
+          "imageSKU": {
+            "value": "[parameters('imageSKU')]"
+          },
+          "mysqlFrontEndPort0": {
+            "value": "[parameters('mysqlFrontEndPort0')]"
+          },
+          "mysqlFrontEndPort1": {
+            "value": "[parameters('mysqlFrontEndPort1')]"
+          },
+          "sshNatRuleFrontEndPort0": {
+            "value": "[parameters('sshNatRuleFrontEndPort0')]"
+          },
+          "sshNatRuleFrontEndPort1": {
+            "value": "[parameters('sshNatRuleFrontEndPort1')]"
+          },
+          "mysqlProbePort0": {
+            "value": "[parameters('mysqlProbePort0')]"
+          },
+          "mysqlProbePort1": {
+            "value": "[parameters('mysqlProbePort1')]"
+          },
+          "artifactsPath": {
+            "value": "[parameters('artifactsPath')]"
+          },
+          "publicIPName": {
+            "value": "[parameters('publicIPName')]"
+          }
         }
       }
     }
-    ],
-    "outputs": {
-    }
+  ],
+  "outputs": {}
 }

--- a/301-expressroute-circuit-vnet-connection/azuredeploy.json
+++ b/301-expressroute-circuit-vnet-connection/azuredeploy.json
@@ -1,181 +1,180 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "gatewayType": {
-            "type": "string",
-            "defaultValue": "ExpressRoute",
-            "allowedValues": [
-                "ExpressRoute"
-            ],
-            "metadata": {
-                "description": "The type of gateway to deploy. For connecting to ExpressRoute circuits, the gateway must be of type ExpressRoute. Other types are Vpn."
-            }
-        },
-        "connectionType": {
-            "type": "string",
-            "defaultValue": "ExpressRoute",
-            "allowedValues": [
-                "ExpressRoute"
-            ],
-            "metadata": {
-                "description": "The type of connection. For connecting to ExpressRoute circuits, the connectionType must be of type ExpressRoute. Other types are IPsec and Vnet2Vnet."
-            }
-        },
-        "virtualNetworkName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the virtual network to create."
-            }
-        },
-        "addressPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "The address space in CIDR notation for the new virtual network."
-            }
-        },
-        "subnetName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the first subnet in the new virtual network."
-            }
-        },
-        "gatewaySubnet": {
-            "type": "string",
-            "defaultValue": "GatewaySubnet",
-            "allowedValues": [
-                "GatewaySubnet"
-            ],
-            "metadata": {
-                "description": "The name of the subnet where Gateway is to be deployed. This must always be named GatewaySubnet."
-            }
-        },
-        "subnetPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "The address range in CIDR notation for the first subnet."
-            }
-        },
-        "gatewaySubnetPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "The address range in CIDR notation for the Gateway subnet. For ExpressRoute enabled Gateways, this must be minimum of /28."
-            }
-        },
-        "gatewayPublicIPName": {
-            "type": "string",
-            "metadata": {
-                "description": "The resource name given to the public IP attached to the gateway."
-            }
-        },
-        "gatewayName": {
-            "type": "string",
-            "metadata": {
-                "description": "The resource name given to the ExpressRoute gateway."
-            }
-        },
-        "connectionName": {
-            "type": "string",
-            "metadata": {
-                "description": "The resource name given to the Connection which links VNet Gateway to ExpressRoute circuit."
-            }
-        },
-        "circuitName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the ExpressRoute circuit with which the VNet Gateway needs to connect. The Circuit must be already created successfully and must have its circuitProvisioningState property set to 'Enabled', and serviceProviderProvisioningState property set to 'Provisioned'. The Circuit must also have a BGP Peering of type AzurePrivatePeering."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "gatewayType": {
+      "type": "string",
+      "defaultValue": "ExpressRoute",
+      "allowedValues": [
+        "ExpressRoute"
+      ],
+      "metadata": {
+        "description": "The type of gateway to deploy. For connecting to ExpressRoute circuits, the gateway must be of type ExpressRoute. Other types are Vpn."
+      }
     },
-    "variables": {
-    	"apiVersion": "2015-06-15",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
-        "gatewaySubnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('gatewaySubnet'))]",
-        "routingWeight": 3
+    "connectionType": {
+      "type": "string",
+      "defaultValue": "ExpressRoute",
+      "allowedValues": [
+        "ExpressRoute"
+      ],
+      "metadata": {
+        "description": "The type of connection. For connecting to ExpressRoute circuits, the connectionType must be of type ExpressRoute. Other types are IPsec and Vnet2Vnet."
+      }
     },
-    "resources": [
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[parameters('virtualNetworkName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[parameters('addressPrefix')]"
-            ]
+    "virtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the virtual network to create."
+      }
+    },
+    "addressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The address space in CIDR notation for the new virtual network."
+      }
+    },
+    "subnetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the first subnet in the new virtual network."
+      }
+    },
+    "gatewaySubnet": {
+      "type": "string",
+      "defaultValue": "GatewaySubnet",
+      "allowedValues": [
+        "GatewaySubnet"
+      ],
+      "metadata": {
+        "description": "The name of the subnet where Gateway is to be deployed. This must always be named GatewaySubnet."
+      }
+    },
+    "subnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The address range in CIDR notation for the first subnet."
+      }
+    },
+    "gatewaySubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The address range in CIDR notation for the Gateway subnet. For ExpressRoute enabled Gateways, this must be minimum of /28."
+      }
+    },
+    "gatewayPublicIPName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource name given to the public IP attached to the gateway."
+      }
+    },
+    "gatewayName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource name given to the ExpressRoute gateway."
+      }
+    },
+    "connectionName": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource name given to the Connection which links VNet Gateway to ExpressRoute circuit."
+      }
+    },
+    "circuitName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the ExpressRoute circuit with which the VNet Gateway needs to connect. The Circuit must be already created successfully and must have its circuitProvisioningState property set to 'Enabled', and serviceProviderProvisioningState property set to 'Provisioned'. The Circuit must also have a BGP Peering of type AzurePrivatePeering."
+      }
+    }
+  },
+  "variables": {
+    "apiVersion": "2015-06-15",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+    "gatewaySubnetRef": "[concat(variables('vnetID'),'/subnets/',parameters('gatewaySubnet'))]",
+    "routingWeight": 3
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetPrefix')]"
+            }
           },
-          "subnets": [
-            {
-              "name": "[parameters('subnetName')]",
-              "properties": {
-                "addressPrefix": "[parameters('subnetPrefix')]"
+          {
+            "name": "[parameters('gatewaySubnet')]",
+            "properties": {
+              "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('gatewayPublicIPName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworkGateways",
+      "name": "[parameters('gatewayName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('gatewaySubnetRef')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
               }
             },
-            {
-              "name": "[parameters('gatewaySubnet')]",
-              "properties": {
-                "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[parameters('gatewayPublicIPName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "Dynamic"
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/virtualNetworkGateways",
-        "name": "[parameters('gatewayName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
+            "name": "vnetGatewayConfig"
+          }
         ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "[variables('gatewaySubnetRef')]"
-                },
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
-                }
-              },
-              "name": "vnetGatewayConfig"
-            }
-          ],
-          "gatewayType": "[parameters('gatewayType')]"
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/connections",
-        "name": "[parameters('connectionName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]"
-        ],
-        "properties": {
-          "virtualNetworkGateway1": {
-            "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName'))]"
-          },
-          "peer": {
-            "id": "[resourceId('Microsoft.Network/expressRouteCircuits',parameters('circuitName'))]"
-          },
-          "connectionType": "[parameters('connectionType')]",
-          "routingWeight": "[variables('routingWeight')]"
-        }
+        "gatewayType": "[parameters('gatewayType')]"
       }
-    ]
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/connections",
+      "name": "[parameters('connectionName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]"
+      ],
+      "properties": {
+        "virtualNetworkGateway1": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName'))]"
+        },
+        "peer": {
+          "id": "[resourceId('Microsoft.Network/expressRouteCircuits',parameters('circuitName'))]"
+        },
+        "connectionType": "[parameters('connectionType')]",
+        "routingWeight": "[variables('routingWeight')]"
+      }
+    }
+  ]
 }
-

--- a/301-multi-tier-service-networking/azuredeploy.json
+++ b/301-multi-tier-service-networking/azuredeploy.json
@@ -1,763 +1,763 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-	"newDBStorageAccountName": {
-	    "type": "string",
-	    "metadata": {
-		"description": "Unique DNS Name for the Storage Account where the DB Virtual Machine disks will be placed."
-	    }
-	},
-	"adminUsername": {
-	    "type": "string",
-	    "metadata": {
-		"description": "Username for the Virtual Machine."
-	    }
-	},
-	"adminPassword": {
-	    "type": "securestring",
-	    "metadata": {
-		"description": "Password for the Virtual Machine."
-	    }
-	},
-	"appVmNamePrefix": {
-	    "type": "string",
-	    "defaultValue": "MultiTierApp",
-	    "metadata": {
-		"description": "Prefix for the name of Application servers"
-	    }
-	},
-	"dbVmNamePrefix": {
-	    "type": "string",
-	    "defaultValue": "MultiTierDB",
-	    "metadata": {
-		"description": "Prefix for the name of Database servers"
-	    }
-	},
-	"vmSize": {
-	    "type": "string",
-	    "defaultValue": "Standard_D2",
-	    "metadata": {
-		"description": "Size of the VM"
-	    }
-	},
-	"publicIPAddressType": {
-	    "type": "string",
-	    "defaultValue": "Dynamic",
-	    "allowedValues": [
-		"Dynamic",
-		"Static"
-	    ],
-	    "metadata": {
-		"description": "Type of public IP address"
-	    }
-	},
-	"appServersPublicIPPrefix": {
-	    "type": "string",
-	    "defaultValue": "appserverpubIP",
-	    "metadata": {
-		"description": "Prefix for the name of Database servers"
-	    }
-	},
-	"skuName": {
-	    "type": "string",
-	    "allowedValues": [
-		"Standard_Small",
-		"Standard_Medium",
-		"Standard_Large"
-	    ],
-	    "defaultValue": "Standard_Medium",
-	    "metadata": {
-		"description": "Sku Name"
-	    }
-	},
-	"appGatewayCapacity": {
-	    "type": "int",
-	    "defaultValue": 2,
-	    "metadata": {
-		"description": "Number of instances of the Appication Gateway"
-	    }
-	},
-	"multitierILB": {
-	    "type": "string",
-	    "defaultValue": "ILBforSql",
-	    "metadata": {
-		"description": "Internal Load Balancer name"
-	    }
-	},
-	"windowsOSVersion": {
-	    "type": "string",
-	    "defaultValue": "2012-R2-Datacenter",
-	    "allowedValues": [
-		"2008-R2-SP1",
-		"2012-Datacenter",
-		"2012-R2-Datacenter"
-	    ],
-	    "metadata": {
-		"description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
-	    }
-	}
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newDBStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Storage Account where the DB Virtual Machine disks will be placed."
+      }
     },
-    "variables": {
-	"imagePublisher": "MicrosoftWindowsServer",
-	"imageOffer": "WindowsServer",
-	"storageAccountType": "Standard_LRS",
-	"vmSize": "Standard_A2",
-	"VNetName": "multiTierVNet",
-	"FESubnetName": "FrontendSubnet",
-	"AppSubnetName": "AppSubnet",
-	"BESubnetName": "BackendSubnet",
-	"vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('VNetName'))]",
-	"FESubnetRef": "[concat(variables('vnetID'),'/subnets/', variables('FESubnetName'))]",
-	"AppSubnetRef": "[concat(variables('vnetID'),'/subnets/', variables('AppSubnetName'))]",
-	"BESubnetRef": "[concat(variables('vnetID'),'/subnets/', variables('BESubnetName'))]",
-	"VNetAddressPrefix": "10.1.0.0/16",
-	"FrontendPrefix": "10.1.0.0/24",
-	"AppPrefix": "10.1.1.0/24",
-	"BackendPrefix": "10.1.2.0/24",
-	"feAvailabilitySetName": "feAvSet",
-	"appAvailabilitySetName": "appAvSet",
-	"beAvailabilitySetName": "beAvSet",
-	"AppServerIP1": "10.1.1.4",
-	"AppServerIP2": "10.1.1.5",
-	"FeNsgname": "FrontendNSG",
-	"AppNsgname": "AppNSG",
-	"BeNsgname": "BackendNSG",
-	"appGatewayName": "multitierAppGateway",
-	"appGatewayPubIPName": "multitierAppGatewayIP",
-	"appGatewayPubPRef": "[resourceId('Microsoft.Network/publicIPAddresses', variables('appGatewayPubIPName'))]",
-	"applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('appGatewayName'))]" ,
-	"ILBIP": "10.1.2.100",
-	"SqlIP1": "10.1.2.4",
-	"SqlIP2": "10.1.2.5",
-	"SqlIP3": "10.1.2.6",
-	"IlbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('multitierILB'))]",
-	"privateIPConfigID": "[concat(variables('IlbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
-	"IlbPoolID": "[concat(variables('IlbID'),'/backendAddressPools/BackendPool1')]",
-	"IlbProbeID": "[concat(variables('IlbID'),'/probes/tcpProbe')]",
-	"appNicName": "appNic",
-	"dbNicName": "dbNic",
-	"appScaleCount" : 2,
-	"dbSclaeCount" : 3,
-	"dbAvailabilitySetName": "DbAvlSet",
-	"apiVer": "2015-06-15"
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
     },
-    "resources": [
-      {
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[parameters('newDBStorageAccountName')]",
-        "apiVersion": "2015-05-01-preview",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "accountType": "[variables('storageAccountType')]"
-        }
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
+    },
+    "appVmNamePrefix": {
+      "type": "string",
+      "defaultValue": "MultiTierApp",
+      "metadata": {
+        "description": "Prefix for the name of Application servers"
+      }
+    },
+    "dbVmNamePrefix": {
+      "type": "string",
+      "defaultValue": "MultiTierDB",
+      "metadata": {
+        "description": "Prefix for the name of Database servers"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2",
+      "metadata": {
+        "description": "Size of the VM"
+      }
+    },
+    "publicIPAddressType": {
+      "type": "string",
+      "defaultValue": "Dynamic",
+      "allowedValues": [
+        "Dynamic",
+        "Static"
+      ],
+      "metadata": {
+        "description": "Type of public IP address"
+      }
+    },
+    "appServersPublicIPPrefix": {
+      "type": "string",
+      "defaultValue": "appserverpubIP",
+      "metadata": {
+        "description": "Prefix for the name of Database servers"
+      }
+    },
+    "skuName": {
+      "type": "string",
+      "allowedValues": [
+        "Standard_Small",
+        "Standard_Medium",
+        "Standard_Large"
+      ],
+      "defaultValue": "Standard_Medium",
+      "metadata": {
+        "description": "Sku Name"
+      }
+    },
+    "appGatewayCapacity": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "Number of instances of the Appication Gateway"
+      }
+    },
+    "multitierILB": {
+      "type": "string",
+      "defaultValue": "ILBforSql",
+      "metadata": {
+        "description": "Internal Load Balancer name"
+      }
+    },
+    "windowsOSVersion": {
+      "type": "string",
+      "defaultValue": "2012-R2-Datacenter",
+      "allowedValues": [
+        "2008-R2-SP1",
+        "2012-Datacenter",
+        "2012-R2-Datacenter"
+      ],
+      "metadata": {
+        "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
+      }
+    }
+  },
+  "variables": {
+    "imagePublisher": "MicrosoftWindowsServer",
+    "imageOffer": "WindowsServer",
+    "storageAccountType": "Standard_LRS",
+    "vmSize": "Standard_A2",
+    "VNetName": "multiTierVNet",
+    "FESubnetName": "FrontendSubnet",
+    "AppSubnetName": "AppSubnet",
+    "BESubnetName": "BackendSubnet",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks', variables('VNetName'))]",
+    "FESubnetRef": "[concat(variables('vnetID'),'/subnets/', variables('FESubnetName'))]",
+    "AppSubnetRef": "[concat(variables('vnetID'),'/subnets/', variables('AppSubnetName'))]",
+    "BESubnetRef": "[concat(variables('vnetID'),'/subnets/', variables('BESubnetName'))]",
+    "VNetAddressPrefix": "10.1.0.0/16",
+    "FrontendPrefix": "10.1.0.0/24",
+    "AppPrefix": "10.1.1.0/24",
+    "BackendPrefix": "10.1.2.0/24",
+    "feAvailabilitySetName": "feAvSet",
+    "appAvailabilitySetName": "appAvSet",
+    "beAvailabilitySetName": "beAvSet",
+    "AppServerIP1": "10.1.1.4",
+    "AppServerIP2": "10.1.1.5",
+    "FeNsgname": "FrontendNSG",
+    "AppNsgname": "AppNSG",
+    "BeNsgname": "BackendNSG",
+    "appGatewayName": "multitierAppGateway",
+    "appGatewayPubIPName": "multitierAppGatewayIP",
+    "appGatewayPubPRef": "[resourceId('Microsoft.Network/publicIPAddresses', variables('appGatewayPubIPName'))]",
+    "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('appGatewayName'))]",
+    "ILBIP": "10.1.2.100",
+    "SqlIP1": "10.1.2.4",
+    "SqlIP2": "10.1.2.5",
+    "SqlIP3": "10.1.2.6",
+    "IlbID": "[resourceId('Microsoft.Network/loadBalancers',parameters('multitierILB'))]",
+    "privateIPConfigID": "[concat(variables('IlbID'),'/frontendIPConfigurations/LoadBalancerFrontEnd')]",
+    "IlbPoolID": "[concat(variables('IlbID'),'/backendAddressPools/BackendPool1')]",
+    "IlbProbeID": "[concat(variables('IlbID'),'/probes/tcpProbe')]",
+    "appNicName": "appNic",
+    "dbNicName": "dbNic",
+    "appScaleCount": 2,
+    "dbSclaeCount": 3,
+    "dbAvailabilitySetName": "DbAvlSet",
+    "apiVer": "2015-06-15"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('newDBStorageAccountName')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('appGatewayPubIPName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[parameters('publicIPAddressType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(parameters('appServersPublicIPPrefix'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "foo",
+        "count": "[variables('appScaleCount')]"
       },
-      {
-        "apiVersion": "[variables('apiVer')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[variables('appGatewayPubIPName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "[parameters('publicIPAddressType')]"
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVer')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[concat(parameters('appServersPublicIPPrefix'), copyIndex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "foo",
-          "count": "[variables('appScaleCount')]"
+      "properties": {
+        "publicIPAllocationMethod": "[parameters('publicIPAddressType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('VNetName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('FeNsgname'))]",
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('AppNsgname'))]",
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('BeNsgname'))]"
+      ],
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('VNetAddressPrefix')]"
+          ]
         },
-        "properties": {
-          "publicIPAllocationMethod": "[parameters('publicIPAddressType')]"
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVer')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[variables('VNetName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/networkSecurityGroups/', variables('FeNsgname'))]",
-          "[concat('Microsoft.Network/networkSecurityGroups/', variables('AppNsgname'))]",
-          "[concat('Microsoft.Network/networkSecurityGroups/', variables('BeNsgname'))]"
-        ],
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[variables('VNetAddressPrefix')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[variables('FESubnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('FrontendPrefix')]",
-                "networkSecurityGroup": {
-                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('FeNsgname'))]"
-                }
+        "subnets": [
+          {
+            "name": "[variables('FESubnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('FrontendPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('FeNsgname'))]"
               }
-            },
-            {
-              "name": "[variables('AppSubnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('AppPrefix')]",
-                "networkSecurityGroup": {
-                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('AppNsgname'))]"
-                }
-              }
-            },
-            {
-              "name": "[variables('BESubnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('BackendPrefix')]",
-                "networkSecurityGroup": {
-                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('BeNsgname'))]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVer')]",
-        "type": "Microsoft.Network/networkSecurityGroups",
-        "name": "[variables('FeNsgname')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "securityRules": [
-            {
-              "name": "rdp_rule",
-              "properties": {
-                "description": "Allow RDP",
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "3389",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 100,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "web_rule",
-              "properties": {
-                "description": "Allow Website",
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "80",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 200,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "App_subnet_rule",
-              "properties": {
-                "description": "Outbound to App",
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "*",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "[variables('AppPrefix')]",
-                "access": "Allow",
-                "priority": 1000,
-                "direction": "Outbound"
-              }
-            },
-            {
-              "name": "Block_Internal_Network",
-              "properties": {
-                "description": "Outbound to Internal Network",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "*",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "VirtualNetwork",
-                "access": "Deny",
-                "priority": 2000,
-                "direction": "Outbound"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVer')]",
-        "type": "Microsoft.Network/networkSecurityGroups",
-        "name": "[variables('AppNsgname')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "securityRules": [
-            {
-              "name": "fe_rule",
-              "properties": {
-                "description": "Allow Frontend",
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "*",
-                "sourceAddressPrefix": "[variables('FrontendPrefix')]",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 100,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "rdp_rule",
-              "properties": {
-                "description": "Allow RDP",
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "3389",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 200,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "vnet_rule",
-              "properties": {
-                "description": "Block Internal Network",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "*",
-                "sourceAddressPrefix": "VirtualNetwork",
-                "destinationAddressPrefix": "*",
-                "access": "Deny",
-                "priority": 300,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "DB_outbound_rule",
-              "properties": {
-                "description": "Allow Outbound DB",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "*",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "[variables('BackendPrefix')]",
-                "access": "Allow",
-                "priority": 1000,
-                "direction": "Outbound"
-              }
-            },
-            {
-              "name": "Deny_Internet",
-              "properties": {
-                "description": "Deny_Internet",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "*",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "Internet",
-                "access": "Deny",
-                "priority": 2000,
-                "direction": "Outbound"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVer')]",
-        "type": "Microsoft.Network/networkSecurityGroups",
-        "name": "[variables('BeNsgname')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "securityRules": [
-            {
-              "name": "app_rule",
-              "properties": {
-                "description": "Allow App servers",
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "*",
-                "sourceAddressPrefix": "[variables('AppPrefix')]",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 100,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "vnet_rule",
-              "properties": {
-                "description": "Block Internal Network",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "*",
-                "sourceAddressPrefix": "VirtualNetwork",
-                "destinationAddressPrefix": "*",
-                "access": "Deny",
-                "priority": 200,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "Deny_Internet",
-              "properties": {
-                "description": "Deny_Internet",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "*",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "Internet",
-                "access": "Deny",
-                "priority": 1000,
-                "direction": "Outbound"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVer')]",
-        "name": "[variables('appGatewayName')]",
-        "type": "Microsoft.Network/applicationGateways",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/virtualNetworks/', variables('VNetName'))]",
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('appGatewayPubIPName'))]"
-        ],
-        "properties": {
-          "sku": {
-            "name": "[parameters('skuName')]",
-            "tier": "Standard",
-            "capacity": "[parameters('appGatewayCapacity')]"
-          },
-          "gatewayIPConfigurations": [
-            {
-              "name": "appGatewayIpConfig",
-              "properties": {
-                "subnet": {
-                  "id": "[variables('FESubnetRef')]"
-                }
-              }
-            }
-          ],
-          "frontendIPConfigurations": [
-            {
-              "name": "appGatewayFrontendIP",
-              "properties": {
-                "PublicIPAddress": {
-                  "id": "[variables('appGatewayPubPRef')]"
-                }
-              }
-            }
-          ],
-          "frontendPorts": [
-            {
-              "name": "appGatewayFrontendPort",
-              "properties": {
-                "Port": 80
-              }
-            }
-          ],
-          "backendAddressPools": [
-            {
-              "name": "appGatewayBackendPool",
-              "properties": {
-                "BackendAddresses": [
-                  {
-                    "IpAddress": "[variables('AppServerIP1')]"
-                  },
-                  {
-                    "IpAddress": "[variables('AppServerIP2')]"
-                  }
-                ]
-              }
-            }
-          ],
-          "backendHttpSettingsCollection": [
-            {
-              "name": "appGatewayBackendHttpSettings",
-              "properties": {
-                "Port": 80,
-                "Protocol": "Http",
-                "CookieBasedAffinity": "Enabled"
-              }
-            }
-          ],
-          "httpListeners": [
-            {
-              "name": "appGatewayHttpListener",
-              "properties": {
-                "FrontendIPConfiguration": {
-                  "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-                },
-                "FrontendPort": {
-                  "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
-                },
-                "Protocol": "Http",
-                "SslCertificate": null
-              }
-            }
-          ],
-          "requestRoutingRules": [
-            {
-              "Name": "rule1",
-              "properties": {
-                "RuleType": "Basic",
-                "httpListener": {
-                  "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener')]"
-                },
-                "backendAddressPool": {
-                  "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
-                },
-                "backendHttpSettings": {
-                  "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "2015-05-01-preview",
-        "name": "[parameters('multitierILB')]",
-        "type": "Microsoft.Network/loadBalancers",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/virtualNetworks/', variables('VNetName'))]"
-        ],
-        "properties": {
-          "frontendIPConfigurations": [
-            {
-              "name": "LoadBalancerFrontEnd",
-              "properties": {
-                "subnet": {
-                  "id": "[variables('BESubnetRef')]"
-                },
-                "privateIPAddress": "[variables('ILBIP')]",
-                "privateIPAllocationMethod": "Static"
-              }
-            }
-          ],
-          "backendAddressPools": [
-            {
-              "name": "BackendPool1"
-            }
-          ],
-          "loadBalancingRules": [
-            {
-              "name": "LBRule",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('privateIPConfigID')]"
-                },
-                "backendAddressPool": {
-                  "id": "[variables('IlbPoolID')]"
-                },
-                "protocol": "tcp",
-                "frontendPort": 1433,
-                "backendPort": 1433,
-                "enableFloatingIP": true,
-                "idleTimeoutInMinutes": 5,
-                "probe": {
-                  "id": "[variables('IlbProbeID')]"
-                }
-              }
-            }
-          ],
-          "probes": [
-            {
-              "name": "tcpProbe",
-              "properties": {
-                "protocol": "tcp",
-                "port": 1433,
-                "intervalInSeconds": "5",
-                "numberOfProbes": "2"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVer')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[concat(variables('appNicName'), copyIndex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "foo",
-          "count": "[variables('appScaleCount')]"
-        },
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', parameters('appServersPublicIPPrefix'), copyIndex())]",
-          "[concat('Microsoft.Network/virtualNetworks/', variables('VNetName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfig1",
-              "properties": {
-                "privateIPAllocationMethod": "Static",
-                "privateIPAddress": "[concat('10.1.1.', copyIndex(4))]",
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(parameters('appServersPublicIPPrefix'), copyIndex()))]"
-                },
-                "subnet": {
-                  "id": "[variables('AppSubnetRef')]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVer')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[concat(variables('dbNicName'), copyIndex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "foo",
-          "count": "[variables('dbSclaeCount')]"
-        },
-        "dependsOn": [
-          "[concat('Microsoft.Network/virtualNetworks/', variables('VNetName'))]",
-          "[concat('Microsoft.Network/loadBalancers/', parameters('multitierILB'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfig1",
-              "properties": {
-                "privateIPAllocationMethod": "Static",
-                "privateIPAddress": "[concat('10.1.2.', copyIndex(4))]",
-                "subnet": {
-                  "id": "[variables('BESubnetRef')]"
-                },
-                "loadBalancerBackendAddressPools": [
-                  {
-                    "id": "[concat(variables('IlbID'), '/backendAddressPools/BackendPool1')]"
-                  }
-                ]
-              }
-            }
-          ]
-        }
-      },
-      {
-        "type": "Microsoft.Compute/availabilitySets",
-        "name": "[variables('appAvailabilitySetName')]",
-        "apiVersion": "2016-04-30-preview",
-        "location": "[resourceGroup().location]",
-          "properties": {
-	      "platformFaultDomainCount": "2",
-	      "platformUpdateDomainCount": "2",
-	      "managed" : "true"
-	  }
-      },
-      {
-        "apiVersion": "2016-04-30-preview",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[concat(parameters('appVmNamePrefix'), copyIndex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "foo",
-          "count": "[variables('appScaleCount')]"
-        },
-        "dependsOn": [
-          "[concat('Microsoft.Network/networkInterfaces/', variables('appNicName'), copyIndex())]",
-          "[concat('Microsoft.Compute/availabilitySets/', variables('appAvailabilitySetName'))]"
-        ],
-        "properties": {
-          "availabilitySet": {
-            "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('appAvailabilitySetName'))]"
-          },
-          "hardwareProfile": {
-            "vmSize": "[parameters('vmSize')]"
-          },
-          "osProfile": {
-            "computerName": "[concat(parameters('appVmNamePrefix'), copyIndex())]",
-            "adminUsername": "[parameters('adminUserName')]",
-            "adminPassword": "[parameters('adminPassword')]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "[variables('imagePublisher')]",
-              "offer": "[variables('imageOffer')]",
-              "sku": "[parameters('windowsOSVersion')]",
-              "version": "latest"
-            },
-            "osDisk": {
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
             }
           },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('appNicName'), copyIndex()))]"
+          {
+            "name": "[variables('AppSubnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('AppPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('AppNsgname'))]"
               }
-            ]
+            }
+          },
+          {
+            "name": "[variables('BESubnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('BackendPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('BeNsgname'))]"
+              }
+            }
           }
-        }
-      },
-      {
-        "type": "Microsoft.Compute/availabilitySets",
-        "name": "[variables('dbAvailabilitySetName')]",
-        "apiVersion": "2016-04-30-preview",
-        "location": "[resourceGroup().location]",
-          "properties": {
-	      "platformFaultDomainCount": "2",
-	      "platformUpdateDomainCount": "2",
-	      "managed" : "true"
-	  }
-      },
-      {
-        "apiVersion": "2016-04-30-preview",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[concat(parameters('dbVmNamePrefix'), copyIndex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "foo",
-          "count": "[variables('dbSclaeCount')]"
-        },
-        "dependsOn": [
-          "[concat('Microsoft.Network/networkInterfaces/', variables('dbNicName'), copyIndex())]",
-          "[concat('Microsoft.Compute/availabilitySets/', variables('dbAvailabilitySetName'))]"
-        ],
-        "properties": {
-          "availabilitySet": {
-            "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('dbAvailabilitySetName'))]"
-          },
-          "hardwareProfile": {
-            "vmSize": "[parameters('vmSize')]"
-          },
-          "osProfile": {
-            "computerName": "[concat(parameters('dbVmNamePrefix'), copyIndex())]",
-            "adminUsername": "[parameters('adminUserName')]",
-            "adminPassword": "[parameters('adminPassword')]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "[variables('imagePublisher')]",
-              "offer": "[variables('imageOffer')]",
-              "sku": "[parameters('windowsOSVersion')]",
-              "version": "latest"
-            },
-            "osDisk": {
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('FeNsgname')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "rdp_rule",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "3389",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
             }
           },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('dbNicName'), copyIndex()))]"
-              }
-            ]
+          {
+            "name": "web_rule",
+            "properties": {
+              "description": "Allow Website",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 200,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "App_subnet_rule",
+            "properties": {
+              "description": "Outbound to App",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "[variables('AppPrefix')]",
+              "access": "Allow",
+              "priority": 1000,
+              "direction": "Outbound"
+            }
+          },
+          {
+            "name": "Block_Internal_Network",
+            "properties": {
+              "description": "Outbound to Internal Network",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "VirtualNetwork",
+              "access": "Deny",
+              "priority": 2000,
+              "direction": "Outbound"
+            }
           }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('AppNsgname')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "fe_rule",
+            "properties": {
+              "description": "Allow Frontend",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "[variables('FrontendPrefix')]",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "rdp_rule",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "3389",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 200,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "vnet_rule",
+            "properties": {
+              "description": "Block Internal Network",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "*",
+              "access": "Deny",
+              "priority": 300,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "DB_outbound_rule",
+            "properties": {
+              "description": "Allow Outbound DB",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "[variables('BackendPrefix')]",
+              "access": "Allow",
+              "priority": 1000,
+              "direction": "Outbound"
+            }
+          },
+          {
+            "name": "Deny_Internet",
+            "properties": {
+              "description": "Deny_Internet",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "Internet",
+              "access": "Deny",
+              "priority": 2000,
+              "direction": "Outbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('BeNsgname')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "app_rule",
+            "properties": {
+              "description": "Allow App servers",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "[variables('AppPrefix')]",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "vnet_rule",
+            "properties": {
+              "description": "Block Internal Network",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "*",
+              "access": "Deny",
+              "priority": 200,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Deny_Internet",
+            "properties": {
+              "description": "Deny_Internet",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "Internet",
+              "access": "Deny",
+              "priority": 1000,
+              "direction": "Outbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "name": "[variables('appGatewayName')]",
+      "type": "Microsoft.Network/applicationGateways",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('VNetName'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('appGatewayPubIPName'))]"
+      ],
+      "properties": {
+        "sku": {
+          "name": "[parameters('skuName')]",
+          "tier": "Standard",
+          "capacity": "[parameters('appGatewayCapacity')]"
+        },
+        "gatewayIPConfigurations": [
+          {
+            "name": "appGatewayIpConfig",
+            "properties": {
+              "subnet": {
+                "id": "[variables('FESubnetRef')]"
+              }
+            }
+          }
+        ],
+        "frontendIPConfigurations": [
+          {
+            "name": "appGatewayFrontendIP",
+            "properties": {
+              "PublicIPAddress": {
+                "id": "[variables('appGatewayPubPRef')]"
+              }
+            }
+          }
+        ],
+        "frontendPorts": [
+          {
+            "name": "appGatewayFrontendPort",
+            "properties": {
+              "Port": 80
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "appGatewayBackendPool",
+            "properties": {
+              "BackendAddresses": [
+                {
+                  "IpAddress": "[variables('AppServerIP1')]"
+                },
+                {
+                  "IpAddress": "[variables('AppServerIP2')]"
+                }
+              ]
+            }
+          }
+        ],
+        "backendHttpSettingsCollection": [
+          {
+            "name": "appGatewayBackendHttpSettings",
+            "properties": {
+              "Port": 80,
+              "Protocol": "Http",
+              "CookieBasedAffinity": "Enabled"
+            }
+          }
+        ],
+        "httpListeners": [
+          {
+            "name": "appGatewayHttpListener",
+            "properties": {
+              "FrontendIPConfiguration": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+              },
+              "FrontendPort": {
+                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort')]"
+              },
+              "Protocol": "Http",
+              "SslCertificate": null
+            }
+          }
+        ],
+        "requestRoutingRules": [
+          {
+            "Name": "rule1",
+            "properties": {
+              "RuleType": "Basic",
+              "httpListener": {
+                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener')]"
+              },
+              "backendAddressPool": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
+              },
+              "backendHttpSettings": {
+                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "name": "[parameters('multitierILB')]",
+      "type": "Microsoft.Network/loadBalancers",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('VNetName'))]"
+      ],
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "LoadBalancerFrontEnd",
+            "properties": {
+              "subnet": {
+                "id": "[variables('BESubnetRef')]"
+              },
+              "privateIPAddress": "[variables('ILBIP')]",
+              "privateIPAllocationMethod": "Static"
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "BackendPool1"
+          }
+        ],
+        "loadBalancingRules": [
+          {
+            "name": "LBRule",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('privateIPConfigID')]"
+              },
+              "backendAddressPool": {
+                "id": "[variables('IlbPoolID')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": 1433,
+              "backendPort": 1433,
+              "enableFloatingIP": true,
+              "idleTimeoutInMinutes": 5,
+              "probe": {
+                "id": "[variables('IlbProbeID')]"
+              }
+            }
+          }
+        ],
+        "probes": [
+          {
+            "name": "tcpProbe",
+            "properties": {
+              "protocol": "tcp",
+              "port": 1433,
+              "intervalInSeconds": "5",
+              "numberOfProbes": "2"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('appNicName'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "foo",
+        "count": "[variables('appScaleCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('appServersPublicIPPrefix'), copyIndex())]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('VNetName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[concat('10.1.1.', copyIndex(4))]",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(parameters('appServersPublicIPPrefix'), copyIndex()))]"
+              },
+              "subnet": {
+                "id": "[variables('AppSubnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('dbNicName'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "foo",
+        "count": "[variables('dbSclaeCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('VNetName'))]",
+        "[concat('Microsoft.Network/loadBalancers/', parameters('multitierILB'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[concat('10.1.2.', copyIndex(4))]",
+              "subnet": {
+                "id": "[variables('BESubnetRef')]"
+              },
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "[concat(variables('IlbID'), '/backendAddressPools/BackendPool1')]"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[variables('appAvailabilitySetName')]",
+      "apiVersion": "2016-04-30-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "platformFaultDomainCount": "2",
+        "platformUpdateDomainCount": "2",
+        "managed": "true"
+      }
+    },
+    {
+      "apiVersion": "2016-04-30-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('appVmNamePrefix'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "foo",
+        "count": "[variables('appScaleCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('appNicName'), copyIndex())]",
+        "[concat('Microsoft.Compute/availabilitySets/', variables('appAvailabilitySetName'))]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('appAvailabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('appVmNamePrefix'), copyIndex())]",
+          "adminUsername": "[parameters('adminUserName')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('windowsOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('appNicName'), copyIndex()))]"
+            }
+          ]
         }
       }
-    ]
+    },
+    {
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[variables('dbAvailabilitySetName')]",
+      "apiVersion": "2016-04-30-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "platformFaultDomainCount": "2",
+        "platformUpdateDomainCount": "2",
+        "managed": "true"
+      }
+    },
+    {
+      "apiVersion": "2016-04-30-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('dbVmNamePrefix'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "foo",
+        "count": "[variables('dbSclaeCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('dbNicName'), copyIndex())]",
+        "[concat('Microsoft.Compute/availabilitySets/', variables('dbAvailabilitySetName'))]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('dbAvailabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('dbVmNamePrefix'), copyIndex())]",
+          "adminUsername": "[parameters('adminUserName')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('windowsOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('dbNicName'), copyIndex()))]"
+            }
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/301-subnet-driven-deployment/LabSubnet.json
+++ b/301-subnet-driven-deployment/LabSubnet.json
@@ -46,7 +46,6 @@
         "description": "CIDR prefix of the subnet to add"
       }
     }
-
   },
   "variables": {
     "apiVersion": "2015-06-15",
@@ -56,7 +55,9 @@
     "sbn": [
       {
         "name": "[parameters('addedSubnetName')]",
-        "properties": { "addressPrefix": "[parameters('addedSubnetPrefix')]" }
+        "properties": {
+          "addressPrefix": "[parameters('addedSubnetPrefix')]"
+        }
       }
     ]
   },
@@ -88,7 +89,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIPAddressName')]",
       "location": "[variables('location')]",
@@ -103,8 +104,10 @@
       "name": "[parameters('vnetName')]",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]" ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressName'))]"
+      ],
       "tags": {
         "displayName": "[parameters('vnetName')]"
       },
@@ -135,6 +138,5 @@
       "type": "string",
       "value": "[variables('lbName')]"
     }
-
   }
 }

--- a/301-subnet-driven-deployment/WinServ.json
+++ b/301-subnet-driven-deployment/WinServ.json
@@ -4,7 +4,7 @@
   "parameters": {
     "dDisks": {
       "type": "array",
-      "defaultValue": [ ],
+      "defaultValue": [],
       "metadata": {
         "description": "Array of disks objects that can be added (see azuredeploy.json for the disk object content)"
       }
@@ -69,7 +69,6 @@
       "metadata": {
         "description": "Image version, 'latest' by default (recommended)"
       }
-
     },
     "indx": {
       "type": "int",
@@ -214,7 +213,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
       "name": "[variables('inboundNatName')]",
       "location": "[resourceGroup().location]",
@@ -228,9 +227,8 @@
         "enableFloatingIP": false
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -262,7 +260,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -326,7 +324,7 @@
             "type": "BGInfo",
             "typeHandlerVersion": "2.1",
             "settings": {
-              "properties": [ ]
+              "properties": []
             }
           }
         },

--- a/301-subnet-driven-deployment/confDomainMember.json
+++ b/301-subnet-driven-deployment/confDomainMember.json
@@ -43,7 +43,6 @@
         "description": "The user to join the domain"
       }
     }
-
   },
   "variables": {
     "vmName": "[concat(parameters('vmNamePrefix'), parameters('computerName'), parameters('indx'))]",
@@ -51,10 +50,10 @@
   },
   "resources": [
     {
-      "name": "[concat(variables('vmName'),'/extensions')]", 
+      "name": "[concat(variables('vmName'),'/extensions')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "properties": {
         "publisher": "Microsoft.Compute",
         "type": "JsonADDomainExtension",
@@ -65,7 +64,6 @@
           "User": "[concat(parameters('domainJoinUsername'), '@',parameters('domainName'))]",
           "Restart": "true",
           "Options": 3
-
         },
         "protectedSettings": {
           "Password": "[parameters('domainJoinPassword')]"
@@ -73,6 +71,5 @@
       }
     }
   ],
-  "outputs": {
-  }
+  "outputs": {}
 }

--- a/ansible-advancedlinux/azuredeploy.json
+++ b/ansible-advancedlinux/azuredeploy.json
@@ -1,5 +1,4 @@
 {
-
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
@@ -39,7 +38,6 @@
         "description": "VM Size, for Premium Storage specify DS VMs."
       }
     },
-
     "vmSizeDataDisks": {
       "type": "int",
       "defaultValue": 120,
@@ -108,13 +106,12 @@
       "metadata": {
         "description": "Private storage account key in which you are storing your ssh certificates"
       }
-    },    
+    },
     "dnsLabelPrefix": {
       "type": "string",
       "metadata": {
         "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
       }
-
     },
     "publicIPType": {
       "type": "string",
@@ -190,10 +187,9 @@
     "newStorageAccountName": "[concat(uniquestring(resourceGroup().id), 'stg')]",
     "storageRef": "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]"
   },
-
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -220,13 +216,12 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPName')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[variables('vnetRef')]"
-
       ],
       "properties": {
         "publicIPAllocationMethod": "[parameters('publicIPType')]",
@@ -236,7 +231,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[resourceGroup().location]",
@@ -244,7 +239,6 @@
         "[variables('publicIPRef')]"
       ],
       "properties": {
-
         "frontendIPConfigurations": [
           {
             "name": "[variables('lbFEConfig')]",
@@ -253,49 +247,50 @@
                 "id": "[variables('publicIPRef')]"
               }
             }
-
           }
         ],
         "backendAddressPools": [
-          { "name": "[variables('lbBEConfig')]" }
+          {
+            "name": "[variables('lbBEConfig')]"
+          }
         ],
         "inboundNatRules": [
           {
             "name": "sshToAnsibleControllerNAT",
             "properties": {
-              "frontendIPConfiguration": { "id": "[variables('lbFEConfigRef')]" },
+              "frontendIPConfiguration": {
+                "id": "[variables('lbFEConfigRef')]"
+              },
               "protocol": "tcp",
               "frontendPort": "[concat(variables('sshNatRuleFrontEndPort'),'0')]",
               "backendPort": "[variables('sshNatRuleBackEndPort')]",
               "enableFloatingIP": false
             }
           }
-
         ]
       }
     },
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "PlatformFaultDomainCount": "[variables('faultDomainCount')]",
         "PlatformUpdateDomainCount": "[variables('updateDomainCount')]"
-
       }
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[parameters('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('vmNICNamePattern'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -318,16 +313,17 @@
                 "id": "[variables('subnetBackEndRef')]"
               },
               "loadBalancerBackendAddressPools": [
-                { "id": "[variables('lbBEConfigRef')]" }
+                {
+                  "id": "[variables('lbBEConfigRef')]"
+                }
               ]
             }
-
           }
         ]
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmNamePattern'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -414,7 +410,6 @@
             }
           ]
         },
-
         "networkProfile": {
           "networkInterfaces": [
             {
@@ -427,7 +422,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmNamePattern'),copyIndex(),'/configuressh')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "VMExtensionsLoop",
@@ -438,22 +433,21 @@
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-		"type": "CustomScript",
-		"typeHandlerVersion": "2.0",
-		"autoUpgradeMinorVersion": true,
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
             "[variables('customScriptSSHRootUrl')]",
             "[variables('pythonAzureScriptUrl')]"
           ],
           "commandToExecute": "[variables('customScriptSSHRootCommand')]",
-          "protectedSettings": { }
-
+          "protectedSettings": {}
         }
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "AnsibleController",
       "location": "[resourceGroup().location]",
@@ -468,18 +462,21 @@
             "properties": {
               "privateIPAllocationMethod": "Static",
               "privateIPAddress": "[concat(variables('VMIPAddressStart'),parameters('numberOfVms'))]",
-              "subnet": { "id": "[variables('subnetBackEndRef')]" },
+              "subnet": {
+                "id": "[variables('subnetBackEndRef')]"
+              },
               "loadBalancerInboundNatRules": [
-                { "id": "[concat(variables('loadBalancerRef'),'/inboundNatRules/sshToAnsibleControllerNAT')]" }
+                {
+                  "id": "[concat(variables('loadBalancerRef'),'/inboundNatRules/sshToAnsibleControllerNAT')]"
+                }
               ]
             }
-
           }
         ]
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "AnsibleController",
       "location": "[resourceGroup().location]",
@@ -531,8 +528,7 @@
             "caching": "ReadWrite",
             "createOption": "FromImage"
           },
-          "dataDisks": [
-          ]
+          "dataDisks": []
         },
         "networkProfile": {
           "networkInterfaces": [
@@ -546,7 +542,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "AnsibleController/installAnsible",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "VMExtensionsLoop"
@@ -563,12 +559,11 @@
             "[variables('pythonAzureScriptUrl')]"
           ],
           "commandToExecute": "[concat(variables('customScriptAnsibleCommand'),variables('customScriptAnsibleParameters'),' -a ', parameters('sshStorageAccountName'),' -k ', parameters('sshStorageAccountKey'))]",
-          "protectedSettings": { }
+          "protectedSettings": {}
         }
       }
     }
   ],
-
   "outputs": {
     "sshResourceURL": {
       "value": "[concat('SSH Url to Ansible Controller:',parameters('adminUsername'),'@', reference(variables('publicIPRef'),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn,' -p ',variables('sshNatRuleFrontEndPort'))]",

--- a/asr-oms-monitoring/azuredeploy.json
+++ b/asr-oms-monitoring/azuredeploy.json
@@ -259,7 +259,7 @@
       ]
     },
     {
-      "apiversion": "2015-10-31",
+      "apiVersion": "2015-10-31",
       "location": "[parameters('omsAutomationRegion')]",
       "name": "[parameters('omsAutomationAccountName')]",
       "type": "Microsoft.Automation/automationAccounts",

--- a/azmgmt-demo/azuredeploy.parameters.json
+++ b/azmgmt-demo/azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/azmgmt-demo/nestedtemplates/drEnablement.json
+++ b/azmgmt-demo/nestedtemplates/drEnablement.json
@@ -34,7 +34,7 @@
     },
     "resources": [
         {
-            "apiversion": "2017-06-01",
+            "apiVersion": "2017-06-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
             "location": "[resourceGroup().location]",

--- a/azmgmt-demo/nestedtemplates/managedVms.json
+++ b/azmgmt-demo/nestedtemplates/managedVms.json
@@ -100,7 +100,7 @@
     },
     "resources": [
         {
-            "apiversion": "2017-06-01",
+            "apiVersion": "2017-06-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
             "location": "[resourceGroup().location]",

--- a/azmgmt-demo/nestedtemplates/omsAutomation.json
+++ b/azmgmt-demo/nestedtemplates/omsAutomation.json
@@ -63,7 +63,7 @@
     },
     "resources": [
         {
-            "apiversion": "2015-10-31",
+            "apiVersion": "2015-10-31",
             "location": "[parameters('omsAutomationRegion')]",
             "name": "[parameters('omsAutomationAccountName')]",
             "type": "Microsoft.Automation/automationAccounts",

--- a/azure-governance-operations-automation/nested/AutomationRunbooksOMSDashboard/OMSAutomationRunbooksDashboard.json
+++ b/azure-governance-operations-automation/nested/AutomationRunbooksOMSDashboard/OMSAutomationRunbooksDashboard.json
@@ -76,7 +76,6 @@
     "scheduleRunbookTemplateFileName": "[concat(parameters('_artifactsLocation'),'/deployRunbookOnSchedule.json')]",
     "runonceJobSchedulerName": "runoncescheduleingestion",
     "sku": "Basic",
-
     "psModules": {
       "AzureRmProfile": {
         "Name": "AzureRm.Profile",
@@ -108,10 +107,10 @@
     {
       "name": "[parameters('automationAccountName')]",
       "type": "Microsoft.Automation/automationAccounts",
-      "apiVersion": "[variables('aaApiVersion')]",
+      "apiVersion": "2015-10-31",
       "location": "[parameters('automationRegion')]",
       "tags": {
-          "quickstartName": "[parameters('quickstartTags').name]"
+        "quickstartName": "[parameters('quickstartTags').name]"
       },
       "properties": {
         "sku": {
@@ -342,7 +341,6 @@
             }
           }
         }
-                
       ]
     }
   ]

--- a/azure-resource-optimization-toolkit/azuredeploy.parameters.json
+++ b/azure-resource-optimization-toolkit/azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/bitcore-centos-vm/azuredeploy.json
+++ b/bitcore-centos-vm/azuredeploy.json
@@ -69,14 +69,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -88,7 +88,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -135,7 +135,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -191,7 +191,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/blockchain/azuredeploy.json
+++ b/blockchain/azuredeploy.json
@@ -118,14 +118,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -137,7 +137,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -158,7 +158,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -184,7 +184,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -229,7 +229,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/bootstorm-vm-boot-time/azuredeploy.json
+++ b/bootstorm-vm-boot-time/azuredeploy.json
@@ -1,322 +1,324 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.16.05.27",
-    "parameters": {
-        "azureAccountUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Azure account SPN user name to authenticate inside controller VM."
-            }
-        },
-        "azureAccountPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Azure account SPN password to authenticate inside controller VM."
-            }
-        },
-        "tenantId": {
-            "type": "string",
-            "metadata": {
-                "description": "Azure Subscription Tenant Id."
-            }
-        },
-        "vmCount": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "Number of VMs to create."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.16.05.27",
+  "parameters": {
+    "azureAccountUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure account SPN user name to authenticate inside controller VM."
+      }
     },
-    "variables": {
-        "apiVersion": "2015-06-15",
-        "apiVersionCRP": "2015-06-15",
-        "apiVersionSRP": "2015-06-15",
-        "apiVersionNRP": "2015-05-01-preview",
-        "imagePublisher": "MicrosoftWindowsServer",
-        "imageOffer": "WindowsServer",
-        "addressPrefix": "10.0.0.0/16",
-        "location": "[resourceGroup().location]",
-        "subnetName": "[concat('vsn', resourceGroup().name)]",
-        "subnetPrefix": "10.0.0.0/24",
-        "storageAccountType": "Standard_LRS",
-        "publicIPAddressType": "Dynamic",
-        "publicIPAddressName": "[concat('ip', resourceGroup().name)]",
-        "uniqueDnsNameForPublicIP": "[concat('dns', resourceGroup().name)]",
-        "uniqueStorageAccountName": "[concat('sa', resourceGroup().name)]",
-        "uniqueStorageAccountContainerName": "[concat('sc', resourceGroup().name)]",
-        "adResourceID": "null",
-        "vmOsSku": "2012-R2-Datacenter",
-        "vmAdminUsername": "vmadministrator",
-        "vmAdminPassword": "pwd0a!8b7",
-        "vmName": "[concat('vm', resourceGroup().name)]",
-        "vmOsDiskName": "[concat('od', resourceGroup().name)]",
-        "vmSize": "Standard_A2",
-        "vmNicName": "[concat('nc', resourceGroup().name)]",
-        "virtualNetworkName": "[concat('vn', resourceGroup().name)]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-        "nsgName": "[concat('ng', resourceGroup().name)]",
-        "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
-        "modulesPath": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/bootstorm-vm-boot-time/",
-        "moduleVMBootAll": "VMBootAll.zip",
-        "modulesUrlVMBootAll": "[concat(variables('modulesPath'),variables('moduleVMBootAll'))]",
-        "configurationFunctionVMBootAll": "VMBootAll.ps1\\ConfigureVMBootAll"
+    "azureAccountPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Azure account SPN password to authenticate inside controller VM."
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "[variables('apiVersionSRP')]",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[tolower(variables('uniqueStorageAccountName'))]",
-            "location": "[variables('location')]",
-            "properties": {
-                "accountType": "[variables('storageAccountType')]"
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionNRP')]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[variables('publicIPAddressName')]",
-            "location": "[variables('location')]",
-            "properties": {
-                "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-                "dnsSettings": {
-                    "domainNameLabel": "[variables('uniqueDnsNameForPublicIP')]"
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionNRP')]",
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "name": "[variables('nsgName')]",
-            "location": "[variables('location')]",
-            "properties": {
-                "securityRules": [
-                    {
-                        "name": "nsgsrule",
-                        "properties": {
-                            "protocol": "*",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "*",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 101,
-                            "direction": "Inbound"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionNRP')]",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[variables('virtualNetworkName')]",
-            "location": "[variables('location')]",
-            "dependsOn": [ "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]" ],
-            "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('addressPrefix')]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('subnetName')]",
-                        "properties": {
-                            "addressPrefix": "[variables('subnetPrefix')]",
-                            "networkSecurityGroup": {
-                                "id": "[variables('nsgID')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionNRP')]",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[variables('vmNicName')]",
-            "location": "[variables('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/',variables('publicIPAddressName'))]",
-                "[concat('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "ipconfigpublic",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-                            },
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionNRP')]",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[concat(variables('vmNicName'),copyIndex())]",
-            "location": "[variables('location')]",
-            "copy": {
-                "name": "nicLoop",
-                "count": "[parameters('vmCount')]"
-            },
-            "dependsOn": [
-                "[concat('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "ipconfigprivate",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "subnet": {
-                                "id": "[variables('subnetRef')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionCRP')]",
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[variables('vmName')]",
-            "location": "[variables('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/',variables('uniqueStorageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/',variables('vmNicName'))]"
-            ],
-            "properties": {
-                "hardwareProfile": {
-                    "vmSize": "[variables('vmSize')]"
-                },
-                "osProfile": {
-                    "computerName": "[variables('vmName')]",
-                    "adminUsername": "[variables('vmAdminUsername')]",
-                    "adminPassword": "[variables('vmAdminPassword')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "[variables('imagePublisher')]",
-                        "offer": "[variables('imageOffer')]",
-                        "sku": "[variables('vmOsSku')]",
-                        "version": "latest"
-                    },
-                    "osDisk": {
-                        "name": "osdisk",
-                        "vhd": {
-                            "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob,variables('uniqueStorageAccountContainerName'),'/',variables('vmOsDiskName'),'.vhd')]"
-                        },
-                        "caching": "ReadWrite",
-                        "createOption": "FromImage"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmNicName')))]"
-                        }
-                    ]
-                },
-                "diagnosticsProfile": {
-                    "bootDiagnostics": {
-                        "enabled": "true",
-                        "storageUri": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionCRP')]",
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[concat(variables('vmName'),copyIndex())]",
-            "location": "[variables('location')]",
-            "copy": {
-                "name": "vmLoop",
-                "count": "[parameters('vmCount')]"
-            },
-            "dependsOn": [
-                "[concat('Microsoft.Storage/storageAccounts/',variables('uniqueStorageAccountName'))]",
-                "[concat('Microsoft.Network/networkInterfaces/',variables('vmNicName'),copyIndex())]"
-            ],
-            "properties": {
-                "hardwareProfile": {
-                    "vmSize": "[variables('vmSize')]"
-                },
-                "osProfile": {
-                    "computerName": "[variables('vmName')]",
-                    "adminUsername": "[variables('vmAdminUsername')]",
-                    "adminPassword": "[variables('vmAdminPassword')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "[variables('imagePublisher')]",
-                        "offer": "[variables('imageOffer')]",
-                        "sku": "[variables('vmOsSku')]",
-                        "version": "latest"
-                    },
-                    "osDisk": {
-                        "name": "osdisk",
-                        "vhd": {
-                            "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob,variables('uniqueStorageAccountContainerName'),'/',concat(variables('vmOsDiskName'),copyIndex()),'.vhd')]"
-                        },
-                        "caching": "ReadWrite",
-                        "createOption": "FromImage"
-                    }
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmNicName'),copyIndex()))]"
-                        }
-                    ]
-                },
-                "diagnosticsProfile": {
-                    "bootDiagnostics": {
-                        "enabled": "true",
-                        "storageUri": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionCRP')]",
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(variables('vmName'),'/dscExtension')]",
-            "location": "[variables('location')]",
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/',variables('vmName'))]"
-            ],
-            "properties": {
-                "publisher": "Microsoft.Powershell",
-                "type": "DSC",
-                "typeHandlerVersion": "2.15",
-                "autoUpgradeMinorVersion": true,
-                "settings": {
-                    "modulesUrl": "[variables('modulesUrlVMBootAll')]",
-                    "configurationFunction": "[variables('configurationFunctionVMBootAll')]",
-                    "properties": {
-                        "azureAccountUsername": "[parameters('azureAccountUsername')]",
-                        "azureAccountPassword": "[parameters('azureAccountPassword')]",
-                        "AdResourceID": "[variables('adResourceID')]",
-                        "TenantId": "[parameters('tenantId')]",
-                        "VMName": "[variables('vmName')]",
-                        "VMCount": "[parameters('vmCount')]",
-                        "VMAdminUserName": "[variables('vmAdminUsername')]",
-                        "VMAdminPassword": "[variables('vmAdminPassword')]",
-                        "AzureStorageAccount": "[variables('uniqueStorageAccountName')]",
-                        "AzureStorageAccessKey": "[listKeys(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')), variables('apiVersionSRP')).key1]"
-                    }
-                }
-            }
+    "tenantId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure Subscription Tenant Id."
+      }
+    },
+    "vmCount": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "Number of VMs to create."
+      }
+    }
+  },
+  "variables": {
+    "apiVersion": "2015-06-15",
+    "apiVersionCRP": "2015-06-15",
+    "apiVersionSRP": "2015-06-15",
+    "apiVersionNRP": "2015-05-01-preview",
+    "imagePublisher": "MicrosoftWindowsServer",
+    "imageOffer": "WindowsServer",
+    "addressPrefix": "10.0.0.0/16",
+    "location": "[resourceGroup().location]",
+    "subnetName": "[concat('vsn', resourceGroup().name)]",
+    "subnetPrefix": "10.0.0.0/24",
+    "storageAccountType": "Standard_LRS",
+    "publicIPAddressType": "Dynamic",
+    "publicIPAddressName": "[concat('ip', resourceGroup().name)]",
+    "uniqueDnsNameForPublicIP": "[concat('dns', resourceGroup().name)]",
+    "uniqueStorageAccountName": "[concat('sa', resourceGroup().name)]",
+    "uniqueStorageAccountContainerName": "[concat('sc', resourceGroup().name)]",
+    "adResourceID": "null",
+    "vmOsSku": "2012-R2-Datacenter",
+    "vmAdminUsername": "vmadministrator",
+    "vmAdminPassword": "pwd0a!8b7",
+    "vmName": "[concat('vm', resourceGroup().name)]",
+    "vmOsDiskName": "[concat('od', resourceGroup().name)]",
+    "vmSize": "Standard_A2",
+    "vmNicName": "[concat('nc', resourceGroup().name)]",
+    "virtualNetworkName": "[concat('vn', resourceGroup().name)]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "nsgName": "[concat('ng', resourceGroup().name)]",
+    "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
+    "modulesPath": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/bootstorm-vm-boot-time/",
+    "moduleVMBootAll": "VMBootAll.zip",
+    "modulesUrlVMBootAll": "[concat(variables('modulesPath'),variables('moduleVMBootAll'))]",
+    "configurationFunctionVMBootAll": "VMBootAll.ps1\\ConfigureVMBootAll"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[tolower(variables('uniqueStorageAccountName'))]",
+      "location": "[variables('location')]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[variables('uniqueDnsNameForPublicIP')]"
         }
-    ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('nsgName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "nsgsrule",
+            "properties": {
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 101,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgName'))]"
+      ],
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[variables('nsgID')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('vmNicName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/',variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfigpublic",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('vmNicName'),copyIndex())]",
+      "location": "[variables('location')]",
+      "copy": {
+        "name": "nicLoop",
+        "count": "[parameters('vmCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfigprivate",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/',variables('uniqueStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/',variables('vmNicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[variables('vmName')]",
+          "adminUsername": "[variables('vmAdminUsername')]",
+          "adminPassword": "[variables('vmAdminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('vmOsSku')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob,variables('uniqueStorageAccountContainerName'),'/',variables('vmOsDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmNicName')))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(variables('vmName'),copyIndex())]",
+      "location": "[variables('location')]",
+      "copy": {
+        "name": "vmLoop",
+        "count": "[parameters('vmCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/',variables('uniqueStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/',variables('vmNicName'),copyIndex())]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[variables('vmName')]",
+          "adminUsername": "[variables('vmAdminUsername')]",
+          "adminPassword": "[variables('vmAdminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('vmOsSku')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob,variables('uniqueStorageAccountContainerName'),'/',concat(variables('vmOsDiskName'),copyIndex()),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmNicName'),copyIndex()))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')),providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmName'),'/dscExtension')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/',variables('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Powershell",
+        "type": "DSC",
+        "typeHandlerVersion": "2.15",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "modulesUrl": "[variables('modulesUrlVMBootAll')]",
+          "configurationFunction": "[variables('configurationFunctionVMBootAll')]",
+          "properties": {
+            "azureAccountUsername": "[parameters('azureAccountUsername')]",
+            "azureAccountPassword": "[parameters('azureAccountPassword')]",
+            "AdResourceID": "[variables('adResourceID')]",
+            "TenantId": "[parameters('tenantId')]",
+            "VMName": "[variables('vmName')]",
+            "VMCount": "[parameters('vmCount')]",
+            "VMAdminUserName": "[variables('vmAdminUsername')]",
+            "VMAdminPassword": "[variables('vmAdminPassword')]",
+            "AzureStorageAccount": "[variables('uniqueStorageAccountName')]",
+            "AzureStorageAccessKey": "[listKeys(concat('Microsoft.Storage/storageAccounts/', variables('uniqueStorageAccountName')), variables('apiVersionSRP')).key1]"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/bosh-cf-crossregion/azuredeploy.json
+++ b/bosh-cf-crossregion/azuredeploy.json
@@ -65,10 +65,10 @@
     "primaryLocation": {
       "type": "string",
       "allowedValues": [
-          "North Europe",
-          "West Europe",
-          "East US",
-          "West US"
+        "North Europe",
+        "West Europe",
+        "East US",
+        "West US"
       ],
       "metadata": {
         "description": "The primary location to provision resources for Bosh and CF"
@@ -77,10 +77,10 @@
     "secondaryLocation": {
       "type": "string",
       "allowedValues": [
-          "North Europe",
-          "West Europe",
-          "East US",
-          "West US"
+        "North Europe",
+        "West Europe",
+        "East US",
+        "West US"
       ],
       "metadata": {
         "description": "The secondary location to provision resources for Bosh and CF"
@@ -190,7 +190,6 @@
       "[uri(variables('baseUriAzureChinaCloud'), 'cf-cli/cf.deb')]"
     ],
     "filesToDownload": "[variables(concat('filesToDownload', parameters('environment')))]",
-
     "environmentAzureCloud": {
       "serviceHostBase": "core.windows.net",
       "boshReleaseUrl": "https://bosh.io/d/github.com/cloudfoundry/bosh?v=256.2",
@@ -214,12 +213,11 @@
       "cfReleaseUrl": "[uri(variables('baseUriAzureChinaCloud'), 'releases/cf-release-231.tgz')]"
     },
     "environment": "[variables(concat('environment', parameters('environment')))]",
-
     "keepUnreachableVMs": "false"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('boshNetworkSecurityGroup')]",
       "location": "[parameters('primaryLocation')]",
@@ -285,7 +283,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('devboxNetworkSecurityGroup')]",
       "location": "[parameters('primaryLocation')]",
@@ -309,7 +307,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('primaryCfNetworkSecurityGroup')]",
       "location": "[parameters('primaryLocation')]",
@@ -347,7 +345,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('secondaryCfNetworkSecurityGroup')]",
       "location": "[parameters('secondaryLocation')]",
@@ -387,7 +385,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('primaryStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('primaryLocation')]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
@@ -396,7 +394,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('defaultprimaryStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('primaryLocation')]",
       "properties": {
         "accountType": "[variables('defaultstorageAccountType')]"
@@ -405,7 +403,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('secondaryStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('secondaryLocation')]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
@@ -414,14 +412,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('defaultsecondaryStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('secondaryLocation')]",
       "properties": {
         "accountType": "[variables('defaultstorageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('vmName'),'-devbox')]",
       "location": "[parameters('primaryLocation')]",
@@ -433,7 +431,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('vmName'),'-bosh')]",
       "location": "[parameters('primaryLocation')]",
@@ -442,7 +440,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('vmName'), '-cf-primary')]",
       "location": "[parameters('primaryLocation')]",
@@ -451,7 +449,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('vmName'), '-cf-secondary')]",
       "location": "[parameters('secondaryLocation')]",
@@ -460,7 +458,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('primaryVpnGatewayPublicIPName')]",
       "location": "[parameters('primaryLocation')]",
@@ -469,7 +467,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('secondaryVpnGatewayPublicIPName')]",
       "location": "[parameters('secondaryLocation')]",
@@ -478,7 +476,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('primaryVirtualNetworkName')]",
       "location": "[parameters('primaryLocation')]",
@@ -517,7 +515,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('secondaryVirtualNetworkName')]",
       "location": "[parameters('secondaryLocation')]",
@@ -550,7 +548,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('primaryNicName')]",
       "location": "[parameters('primaryLocation')]",
@@ -581,115 +579,115 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworkGateways",
       "name": "[variables('primaryVpnGatewayName')]",
       "location": "[parameters('primaryLocation')]",
       "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('primaryVpnGatewayPublicIPName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', variables('primaryVirtualNetworkName'))]"
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('primaryVpnGatewayPublicIPName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('primaryVirtualNetworkName'))]"
       ],
       "properties": {
-          "ipConfigurations": [
-              {
-                  "properties": {
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                          "id": "[variables('primarySubnetGatewayRef')]"
-                      },
-                      "publicIPAddress": {
-                          "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('primaryVpnGatewayPublicIPName'))]"
-                      }
-                  },
-                  "name": "vnetGatewayConfigMain"
+        "ipConfigurations": [
+          {
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('primarySubnetGatewayRef')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('primaryVpnGatewayPublicIPName'))]"
               }
-          ],
-           "sku": {
-            "name": "[variables('vpnGwSku')]",
-            "tier": "[variables('vpnGwSku')]"
+            },
+            "name": "vnetGatewayConfigMain"
+          }
+        ],
+        "sku": {
+          "name": "[variables('vpnGwSku')]",
+          "tier": "[variables('vpnGwSku')]"
         },
-          "gatewayType": "Vpn",
-          "vpnType": "[variables('vpnType')]",
-          "enableBgp": "false"
+        "gatewayType": "Vpn",
+        "vpnType": "[variables('vpnType')]",
+        "enableBgp": "false"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworkGateways",
       "name": "[variables('secondaryVpnGatewayName')]",
       "location": "[parameters('secondaryLocation')]",
       "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('secondaryVpnGatewayPublicIPName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', variables('secondaryVirtualNetworkName'))]"
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('secondaryVpnGatewayPublicIPName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('secondaryVirtualNetworkName'))]"
       ],
       "properties": {
-          "ipConfigurations": [
-              {
-                  "properties": {
-                      "privateIPAllocationMethod": "Dynamic",
-                      "subnet": {
-                          "id": "[variables('secondarySubnetGatewayRef')]"
-                      },
-                      "publicIPAddress": {
-                          "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('secondaryVpnGatewayPublicIPName'))]"
-                      }
-                  },
-                  "name": "vnetGatewayConfigMain"
+        "ipConfigurations": [
+          {
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('secondarySubnetGatewayRef')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('secondaryVpnGatewayPublicIPName'))]"
               }
-          ],
-           "sku": {
-            "name": "[variables('vpnGwSku')]",
-            "tier": "[variables('vpnGwSku')]"
+            },
+            "name": "vnetGatewayConfigMain"
+          }
+        ],
+        "sku": {
+          "name": "[variables('vpnGwSku')]",
+          "tier": "[variables('vpnGwSku')]"
         },
-          "gatewayType": "Vpn",
-          "vpnType": "[variables('vpnType')]",
-          "enableBgp": "false"
+        "gatewayType": "Vpn",
+        "vpnType": "[variables('vpnType')]",
+        "enableBgp": "false"
       }
     },
     {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/connections",
-        "name": "[variables('primaryVpnGwConnectionName')]",
-        "location": "[parameters('primaryLocation')]",
-        "dependsOn": [
-            "[concat('Microsoft.Network/virtualNetworkGateways/', variables('primaryVpnGatewayName'))]",
-            "[concat('Microsoft.Network/virtualNetworkGateways/', variables('secondaryVpnGatewayName'))]"
-        ],
-        "properties": {
-            "virtualNetworkGateway1": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('primaryVpnGatewayName'))]"
-            },
-            "virtualNetworkGateway2": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('secondaryVpnGatewayName'))]"
-            },
-            "connectionType": "Vnet2Vnet",
-            "routingWeight": 3,
-            "sharedKey": "[parameters('vpnGwSharedKey')]"
-        }
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/connections",
+      "name": "[variables('primaryVpnGwConnectionName')]",
+      "location": "[parameters('primaryLocation')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworkGateways/', variables('primaryVpnGatewayName'))]",
+        "[concat('Microsoft.Network/virtualNetworkGateways/', variables('secondaryVpnGatewayName'))]"
+      ],
+      "properties": {
+        "virtualNetworkGateway1": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('primaryVpnGatewayName'))]"
+        },
+        "virtualNetworkGateway2": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('secondaryVpnGatewayName'))]"
+        },
+        "connectionType": "Vnet2Vnet",
+        "routingWeight": 3,
+        "sharedKey": "[parameters('vpnGwSharedKey')]"
+      }
     },
     {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/connections",
-        "name": "[variables('secondaryVpnGwConnectionName')]",
-        "location": "[parameters('secondaryLocation')]",
-        "dependsOn": [
-            "[concat('Microsoft.Network/virtualNetworkGateways/', variables('primaryVpnGatewayName'))]",
-            "[concat('Microsoft.Network/virtualNetworkGateways/', variables('secondaryVpnGatewayName'))]"
-        ],
-        "properties": {
-            "virtualNetworkGateway1": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('secondaryVpnGatewayName'))]"
-            },
-            "virtualNetworkGateway2": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('primaryVpnGatewayName'))]"
-            },
-            "connectionType": "Vnet2Vnet",
-            "routingWeight": 3,
-            "sharedKey": "[parameters('vpnGwSharedKey')]"
-        }
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/connections",
+      "name": "[variables('secondaryVpnGwConnectionName')]",
+      "location": "[parameters('secondaryLocation')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworkGateways/', variables('primaryVpnGatewayName'))]",
+        "[concat('Microsoft.Network/virtualNetworkGateways/', variables('secondaryVpnGatewayName'))]"
+      ],
+      "properties": {
+        "virtualNetworkGateway1": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('secondaryVpnGatewayName'))]"
+        },
+        "virtualNetworkGateway2": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',variables('primaryVpnGatewayName'))]"
+        },
+        "connectionType": "Vnet2Vnet",
+        "routingWeight": 3,
+        "sharedKey": "[parameters('vpnGwSharedKey')]"
+      }
     },
     {
-      "apiversion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[parameters('primaryLocation')]",
@@ -744,7 +742,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmName'),'/initdevbox')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('primaryLocation')]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"

--- a/bosh-setup/azuredeploy.json
+++ b/bosh-setup/azuredeploy.json
@@ -607,7 +607,7 @@
       }
     },
     {
-      "apiversion": "2015-06-15",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/chef-automate-ha/azuredeploy.json
+++ b/chef-automate-ha/azuredeploy.json
@@ -1,548 +1,548 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "objectId": {
-            "type": "securestring",
-            "defaultValue": "44b29aa9-ccd0-4314-aaa0-fd4df282b906",
-            "metadata": {
-                "description": "Object Id of the AAD user or service principal that will have access to the vault. Available from the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets"
-            }
-        },
-        "vaultSku": {
-            "type": "string",
-            "defaultValue": "Standard",
-            "allowedValues": [
-                "Standard",
-                "Premium"
-            ],
-            "metadata": {
-                "description": "SKU for the vault"
-            }
-        },
-        "adminUsername": {
-            "defaultValue": "chefuser",
-            "type": "string",
-            "metadata": {
-                "description": "User name for the Virtual Machine."
-            }
-        },
-        "sshKeyData": {
-            "defaultValue": "",
-            "type": "securestring",
-            "metadata": {
-                "description": "SSH rsa public key file as a string."
-            }
-        },
-        "vmSize": {
-            "defaultValue": "Standard_DS3",
-            "allowedValues": [
-                "Standard_DS3",
-                "Standard_DS4",
-                "Standard_DS11",
-                "Standard_DS12",
-                "Standard_DS13",
-                "Standard_DS14",
-                "Standard_DS3_v2",
-                "Standard_DS4_v2",
-                "Standard_DS5_v2",
-                "Standard_DS11_v2",
-                "Standard_DS12_v2",
-                "Standard_DS13_v2",
-                "Standard_DS14_v2",
-                "Standard_DS15_v2",
-                "Standard_F4s",
-                "Standard_F8s",
-                "Standard_F16s"
-            ],
-            "type": "string",
-            "metadata": {
-                "description": "size of the Virtual Machine."
-            }
-        },
-        "chefServerDnsPrefix": {
-            "type": "string",
-            "defaultValue": "chefserver",
-            "metadata": {
-                "description": "dens name for chef server"
-            }
-        },
-        "chefAutomateDnsPrefix": {
-            "type": "string",
-            "defaultValue": "chefautomate",
-            "metadata": {
-                "description": "chef automate dns name"
-            }
-        },
-        "firstName": {
-            "defaultValue": "",
-            "type": "string",
-            "metadata": {
-                "description": "administrator user for chef automate"
-            }
-        },
-        "lastName": {
-            "defaultValue": "",
-            "type": "string",
-            "metadata": {
-                "description": "administrator user for chef automate"
-            }
-        },
-        "emailId": {
-            "defaultValue": "user@password.com",
-            "type": "string",
-            "metadata": {
-                "description": "emaild for chef automate"
-            }
-        },
-        "organizationName": {
-            "defaultValue": "chef",
-            "type": "string",
-            "metadata": {
-                "description": "Organization name for chef automate"
-            }
-        },
-        "appID": {
-            "defaultValue": "",
-            "minLength": 1,
-            "type": "securestring",
-            "metadata": {
-                "description": "servicePrinciple"
-            }
-        },
-        "password": {
-            "defaultValue": "",
-            "minLength": 1,
-            "type": "securestring",
-            "metadata": {
-                "description": "password"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "objectId": {
+      "type": "securestring",
+      "defaultValue": "44b29aa9-ccd0-4314-aaa0-fd4df282b906",
+      "metadata": {
+        "description": "Object Id of the AAD user or service principal that will have access to the vault. Available from the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets"
+      }
     },
-    "variables": {
-        "keyvaultSettings": {
-            "keyVaultApiVersion": "2015-06-01",
-            "keyVaultName": "[concat('chef-key',substring(variables('prefix') ,0 ,5))]",
-            "tenantId": "[subscription().tenantId]",
-            "dbPasswordValue": "[concat('chv-',substring(variables('prefix'),0,10),'-dbp')]",
-            "replicationPasswordValue": "[concat('chv-',substring(variables('prefix'),0,11),'-rpp')]",
-            "clusterTokenValue": "[concat('chv-',substring(variables('prefix'),0,12),'-ctt')]",
-            "clusterNameValue": "[concat('chef-',substring(variables('prefix'),0,8))]",
-            "location": "[resourceGroup().location]",
-            "objectId": "[parameters('objectId')]",
-            "vaultSku": "[parameters('vaultSku')]",
-            "dbPassword": "dbPassword",
-            "replicationPassword": "replicationPassword",
-            "clusterToken": "clusterToken",
-            "clusterName": "clusterName",
-            "appID": "[parameters('appID')]",
-            "password": "[parameters('password')]"
-        },
-        "computeSettings": {
-            "count": 7,
-            "location": "[resourceGroup().location]",
-            "computeApiVersion": "2016-04-30-preview",
-            "adminUsername": "[parameters('adminUsername')]",
-            "sshKeyData": "[parameters('sshKeyData')]",
-            "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
-            "chefServerUserName": "delivery",
-            "managedDiskName": "dataDisk",
-            "storageAccountType": "Premium_LRS",
-            "diagStorageAccountType": "Standard_LRS",
-            "diskCreateOption": "empty",
-            "diskSizeGB": 50,
-            "vmSize": "[parameters('vmSize')]",
-            "imagePublisher": "Canonical",
-            "imageOffer": "UbuntuServer",
-            "ubuntuOSVersion": "16.04-LTS",
-            "imageVersion": "latest",
-            "chefBEAvailName": "be-avail",
-            "leadercomputerName": "be0",
-            "followercomputerName1": "be1",
-            "followercomputerName2": "be2",
-            "leaderExtensionName": "be0-ex0",
-            "followerExtensionName1": "be-ex1",
-            "followerExtensionName2": "be-ex2",
-            "leadercustomData": "[variables('customData').leaderCustomData]",
-            "followercustomData": "[variables('customData').followerCustomData]",
-            "feComputerName0": "fe0",
-            "feComputerName1": "fe1",
-            "feComputerName2": "fe2",
-            "feVmExtensionName0": "fe0-ex0",
-            "feVmExtensionName1": "fe1-ex1",
-            "feVmExtensionName2": "fe1-ex2",
-            "fe0CustomData": "[variables('customData').fe0Customdata]",
-            "feCustomData": "[variables('customData').feCustomData]",
-            "chefFEAvailName": "fe-avail",
-            "autoComputerName": "chefautomate",
-            "chefAutoExtenName": "chef-auto-ex",
-            "automateCustomData": "[variables('customData').automateCustomData]",
-            "firstName": "[parameters('firstName')]",
-            "lastName": "[parameters('lastName')]",
-            "emailId": "[parameters('emailId')]",
-            "organizationName": "[parameters('organizationName')]",
-            "keyvaultId": "[concat(subscription().id,'/resourceGroups/',resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', variables('keyvaultSettings').keyVaultName)]"
-        },
-        "storageSettings": {
-            "location": "[resourceGroup().location]",
-            "diagStorageAccName": "[concat('diagstr',substring(variables('prefix') ,0 ,5))]",
-            "diagStorageAccountType": "Standard_LRS",
-            "storageApiVersion": "2015-06-15"
-        },
-        "networkSettings": {
-            "location": "[resourceGroup().location]",
-            "networkApiVersion": "2015-06-15",
-            "leaderNicName": "be-nic0",
-            "followerNicName1": "be-nic1",
-            "followerNicName2": "be-nic2",
-            "feNicName0": "fe-nic0",
-            "feNicName1": "fe-nic1",
-            "feNicName2": "fe-nic2",
-            "chefAutoNicName": "chefauto-nic",
-            "feNsg": "fe-nsg",
-            "beNsg": "be-nsg",
-            "bePoolName1": "chef-ha-pool-fe",
-            "bePoolName2": "chef-ha-pool-ssh-admin",
-            "felbPublicIPAddressName": "fe-pip",
-            "chefAutoPublicIPAddressName": "chefauto-pip",
-            "virtualNetworkName": "chef-vnet",
-            "addressPrefix": "10.0.0.0/16",
-            "feSubnetName": "fe-subnet",
-            "feSubnetPrefix": "10.0.0.0/24",
-            "feLoadBalancerName": "fe-lb",
-            "beSubnetName": "be-subnet",
-            "beSubnetPrefix": "10.0.1.0/24",
-            "publicIPAddressType": "Dynamic",
-            "dnsLabelPrefixFE": "[concat(parameters('chefServerDnsPrefix'),substring(variables('prefix') ,0 ,3))]",
-            "dnsLabelPrefixChefAuto": "[concat(parameters('chefAutomateDnsPrefix'),substring(variables('prefix') ,0 ,3))]",
-            "diagStorageAccName": "[concat('diagstr',substring(variables('prefix') ,0 ,5))]"
-        },
-        "chef_backend_install_script_base": "[concat('dbPassword=$1\n','replicationPassword=$2\n','clusterToken=$3\n','clusterName=$4\n','apt-get install -y apt-transport-https\n','wget -qO - https://downloads.chef.io/packages-chef-io-public.key | sudo apt-key add -\n','echo \"deb https://packages.chef.io/stable-apt trusty main\" > /etc/apt/sources.list.d/chef-stable.list\n','apt-get update\n','apt-get install -y chef-backend\n','apt-get install -y lvm2 xfsprogs sysstat atop\n','umount -f /mnt\n','pvcreate -f /dev/sdc\n','vgcreate chef-vg /dev/sdc\n','lvcreate -n chef-lv -l 80%VG chef-vg\n','mkfs.xfs /dev/chef-vg/chef-lv\n','mkdir -p /var/opt/chef-backend\n','mount /dev/chef-vg/chef-lv /var/opt/chef-backend\n','cat > /etc/chef-backend/chef-backend-secrets.json <<EOF\n','{\n','\"postgresql\": {\n','\"db_superuser_password\": \"######\",\n','\"replication_password\": \"#######\"\n','},\n','\"etcd\": {\n','\"initial_cluster_token\": \"########\"\n',' },\n','\"elasticsearch\": {\n','\"cluster_name\": \"#########\"\n','}\n','}\n','EOF\n','sed -i ''0,/######/s//''$dbPassword''/'' /etc/chef-backend/chef-backend-secrets.json\n','sed -i ''0,/#######/s//''$replicationPassword''/'' /etc/chef-backend/chef-backend-secrets.json\n','sed -i ''0,/########/s//''$clusterToken''/'' /etc/chef-backend/chef-backend-secrets.json\n','sed -i ''0,/#########/s//''$clusterName''/'' /etc/chef-backend/chef-backend-secrets.json\n','IP=`ifconfig eth0 | awk ''/inet addr/{print substr($2,6)}''`\n','cat > /etc/chef-backend/chef-backend.rb <<EOF\n','publish_address ''${IP}''\n','postgresql.log_min_duration_statement = 500\n','elasticsearch.heap_size = 3500\n','postgresql.md5_auth_cidr_addresses = [\"samehost\", \"samenet\", \"10.0.0.0/24\"]\n','EOF\n')]",
-        "chef_frontend_install_script_base": "[concat('dbPassword=$1\n','firstName=$2\n','lastName=$3\n','emailId=$4\n','organizationName=$5\n','appID=$6\n','tenantID=$7\n','password=$8\n','objectId=$9\n','keyVaultName=${10}\n','fqdn=`hostname -f`\n','apt-get install -y apt-transport-https\n','apt-get install -y sshpass\n','wget -qO - https://downloads.chef.io/packages-chef-io-public.key | sudo apt-key add -\n','echo \"deb https://packages.chef.io/stable-apt trusty main\" > /etc/apt/sources.list.d/chef-stable.list\n','apt-get update\n','apt-get install -y lvm2 xfsprogs sysstat atop\n','umount -f /mnt\n','pvcreate -f /dev/sdc\n','vgcreate chef-vg /dev/sdc\n','lvcreate -n chef-data -l 20%VG chef-vg\n','lvcreate -n chef-logs -l 80%VG chef-vg\n','mkfs.xfs /dev/chef-vg/chef-data\n','mkfs.xfs /dev/chef-vg/chef-logs\n','mkdir -p /var/opt/opscode\n','mkdir -p /var/log/opscode\n','mount /dev/chef-vg/chef-data /var/opt/opscode\n','mount /dev/chef-vg/chef-logs /var/log/opscode\n','apt-get install -y chef-server-core chef-manage\n','apt-get install -y libssl-dev libffi-dev python-dev build-essential\n','echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main\" > /etc/apt/sources.list.d/azure-cli.list\n','apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893\n','apt-get update\n','apt-get install azure-cli\n','cat > /etc/opscode/chef-server.rb <<EOF\n','\n','fqdn \"####\"\n','\n','use_chef_backend true\n','chef_backend_members [\"10.0.1.6\", \"10.0.1.5\", \"10.0.1.4\"]\n','\n','haproxy[''remote_postgresql_port''] = 5432\n','haproxy[''remote_elasticsearch_port''] = 9200\n','\n','postgresql[''external''] = true\n','postgresql[''vip''] = ''127.0.0.1''\n','postgresql[''db_superuser''] = ''chef_pgsql''\n','postgresql[''db_superuser_password''] = ''######''\n','\n','opscode_solr4[''external''] = true\n','opscode_solr4[''external_url''] = ''http://127.0.0.1:9200''\n','opscode_erchef[''search_provider''] = ''elasticsearch''\n','opscode_erchef[''search_queue_mode''] = ''batch''\n','\n','bookshelf[''storage_type''] = :sql\n','\n','rabbitmq[''enable''] = false\n','rabbitmq[''management_enabled''] = false\n','rabbitmq[''queue_length_monitor_enabled''] = false\n','\n','opscode_expander[''enable''] = false\n','\n','dark_launch[''actions''] = false\n','\n','opscode_erchef[''nginx_bookshelf_caching''] = :on\n','opscode_erchef[''s3_url_expiry_window_size''] = ''50%''\n','opscode_erchef[''s3_url_expiry_window_size''] = ''100%''\n','license[''nodes''] = 999999\n','oc_chef_authz[''http_init_count''] = 100\n','oc_chef_authz[''http_max_count''] = 100\n','oc_chef_authz[''http_queue_max''] = 200\n','oc_bifrost[''db_pool_size''] = 20\n','oc_bifrost[''db_pool_queue_max''] = 40\n','oc_bifrost[''db_pooler_timeout''] = 2000\n','opscode_erchef[''depsolver_worker_count''] = 4\n','opscode_erchef[''depsolver_timeout''] = 20000\n','opscode_erchef[''db_pool_size''] = 20\n','opscode_erchef[''db_pool_queue_max''] = 40\n','opscode_erchef[''db_pooler_timeout''] = 2000\n','opscode_erchef[''authz_pooler_timeout''] = 2000\n','EOF\n','sed -i ''0,/######/s//''$dbPassword''/'' /etc/opscode/chef-server.rb\n','sed -i ''0,/####/s//''$fqdn''/'' /etc/opscode/chef-server.rb\n')]",
-        "chef_automate_install_script_base": "[concat('appID=$1\n','tenantID=$2\n','password=$3\n','objectId=$4\n','keyVaultName=$5\n','apt-get install -y libssl-dev libffi-dev python-dev build-essential\n','echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main\" > /etc/apt/sources.list.d/azure-cli.list\n','apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893\n','apt-get update\n','apt-get install azure-cli\n','apt-get install -y apt-transport-https\n','apt-get update\n','apt-get install -y sshpass\n','apt-get install -y wget\n','apt-get install -y lvm2 xfsprogs sysstat atop\n','umount -f /mnt\n','pvcreate -f /dev/sdc\n','vgcreate delivery-vg /dev/sdc\n','lvcreate -n delivery-lv -l 80%VG delivery-vg\n','mkfs.xfs /dev/delivery-vg/delivery-lv\n','mkdir -p /var/opt/delivery\n','mount /dev/delivery-vg/delivery-lv /var/opt/delivery\n','wget  https://packages.chef.io/files/stable/automate/0.8.5/ubuntu/16.04/automate_0.8.5-1_amd64.deb\n','dpkg -i automate_0.8.5-1_amd64.deb\n','az login --service-principal -u $appID --password $password --tenant $tenantID\n','az keyvault secret download --file /etc/delivery/chefautomatedeliveryuser.pem --name chefdeliveryuserkey --vault-name $keyVaultName\n','cat > /etc/delivery/command_to_execute <<EOF\n','automate-ctl setup --license AUTOMATE_LICENSE --key < AUTOMATE_CHEF_USER_KEY > --server-url https:// < CHEF_SERVER_FQDN/organizations >/chef-automate-org --fqdn < AUTOMATE_SERVER_FQDN >  --enterprise < ENTERPRISE_NAME >\n','EOF\n')]",
-        "scripts": {
-            "chef_backend_install_script_leader": "[concat(variables('chef_backend_install_script_base'),'chef-backend-ctl create-cluster --accept-license --yes --quiet --verbose\n')]",
-            "chef_backend_install_script_follower": "[concat(variables('chef_backend_install_script_base'),'chef-backend-ctl join-cluster 10.0.1.4 -s /etc/chef-backend/chef-backend-secrets.json --accept-license --yes --quiet --verbose\n')]",
-            "chef_frontend_install_script_fe0": "[concat(variables('chef_frontend_install_script_base'),'chef-server-ctl reconfigure --accept-license\n','sudo chef-manage-ctl reconfigure --accept-license\n','echo ''ENABLED=\"true\"'' > /etc/default/sysstat\n','service sysstat start\n','sleep 5\n','chef-server-ctl user-create delivery $firstName $lastName $emailId $password --filename /etc/opscode/chefautomatedeliveryuser.pem\n','sleep 5\n','sudo chef-server-ctl org-create $organizationName ''Chef Automate Org'' --file /etc/opscode/chef_automate_org-validator.pem -a delivery\n','sleep 5\n','az login --service-principal -u $appID --password $password --tenant $tenantID\n','if [ `echo $?` -eq 0 ]\n','then\n','echo \"uploading the secret files to keyvault\"\n','az keyvault secret set --name chefsecrets --vault-name $keyVaultName --file /etc/opscode/private-chef-secrets.json\n','az keyvault secret set --name chefdeliveryuserkey --vault-name $keyVaultName --file /etc/opscode/chefautomatedeliveryuser.pem\n','az keyvault secret set --name chefdeliveryuserpassword --vault-name $keyVaultName --value $password\n','else\n','echo \"Authentication to Azure keyvault failed\"\n','fi\n')]",
-            "chef_frontend_install_script_fe": "[concat(variables('chef_frontend_install_script_base'),'az login --service-principal -u $appID --password $password --tenant $tenantID\n','az keyvault secret download --file /etc/opscode/private-chef-secrets.json --name chefsecrets --vault-name $keyVaultName\n','mkdir -p /var/opt/opscode/upgrades/\n','touch /var/opt/opscode/bootstrapped\n','chef-server-ctl reconfigure --accept-license\n','sudo chef-manage-ctl reconfigure --accept-license\n','echo ''ENABLED=\"true\"'' > /etc/default/sysstat\n','service sysstat start\n')]"
-        },
-        "customData": {
-            "fe0Customdata": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_frontend_install_script_fe0) , '\n', '    path: /etc/opscode/chef-frontend-install.sh\n', '    permissions: 0700\n'))]",
-            "feCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_frontend_install_script_fe) , '\n', '    path: /etc/opscode/chef-frontend-install.sh\n', '    permissions: 0700\n'))]",
-            "leaderCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_backend_install_script_leader) , '\n', '    path: /etc/chef-backend/chef-backend-install.sh\n', '    permissions: 0700\n'))]",
-            "followerCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_backend_install_script_follower) , '\n', '    path: /etc/chef-backend/chef-backend-install.sh\n', '    permissions: 0700\n'))]",
-            "automateCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('chef_automate_install_script_base')) , '\n', '    path: /etc/delivery/chef-automate-install.sh\n', '    permissions: 0700\n'))]"
-        },
-        "baseUrl": "https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/chef-automate-ha/",
-        "keyvaultResourcesURL": "[concat(variables('baseUrl'),'nested/keyvaultResource.json')]",
-        "managedDisksResourcesURL": "[concat(variables('baseUrl'),'nested/managedDisksResource.json')]",
-        "diagnosticStorageAccountResourcesURL": "[concat(variables('baseUrl'),'nested/diagnosticStorageAccountResource.json')]",
-        "availabilitySetSResourcesURL": "[concat(variables('baseUrl'),'nested/availabilitySetsResource.json')]",
-        "publicIPAddressesResourcesURL": "[concat(variables('baseUrl'),'nested/publicIPAddressResource.json')]",
-        "networkSecurityGroupsResourcesURL": "[concat(variables('baseUrl'),'nested/networkSecurityGroupsResource.json')]",
-        "virtualNetworksResourcesURL": "[concat(variables('baseUrl'),'nested/virtualNetworksResource.json')]",
-        "fe-loadBalancersResourcesURL": "[concat(variables('baseUrl'),'nested/loadBalancersResource.json')]",
-        "fe-networkInterfacesResourcesURL": "[concat(variables('baseUrl'),'nested/fe-networkInterfacesResource.json')]",
-        "be-networkInterfacesResourcesURL": "[concat(variables('baseUrl'),'nested/be-networkInterfacesResource.json')]",
-        "chefAuto-networkInterfacesResourcesURL": "[concat(variables('baseUrl'),'nested/chefAuto-networkInterfacesResource.json')]",
-        "fe-be-VmsWithExtensionsURL": "[concat(variables('baseUrl'),'nested/fe-be-virtualmachines-with-extensions.json')]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('networkSettings').virtualNetworkName)]",
-        "beSubnetRef": "[concat(variables('vnetID'),'/subnets/',variables('networkSettings').beSubnetName)]",
-        "feSubnetRef": "[concat(variables('vnetID'),'/subnets/',variables('networkSettings').feSubnetName)]",
-        "felbPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('networkSettings').felbPublicIPAddressName)]",
-        "chefAutoPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('networkSettings').chefAutoPublicIPAddressName)]",
-        "deploymentApiVersion": "2015-01-01",
-        "prefix": "[uniqueString(resourceGroup().id)]",
-        "provider": "[toUpper('33194f91-eb5f-4110-827a-e95f640a9e46')]"
+    "vaultSku": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "allowedValues": [
+        "Standard",
+        "Premium"
+      ],
+      "metadata": {
+        "description": "SKU for the vault"
+      }
     },
-    "resources": [
-        {
-            "name": "keyvaultResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('keyvaultResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "keyvaultSettings": {
-                        "value": "[variables('keyvaultSettings')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "managedDisksResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('managedDisksResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "computeSettings": {
-                        "value": "[variables('computeSettings')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "diagnosticStorageAccountsResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('diagnosticStorageAccountResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "storageSettings": {
-                        "value": "[variables('storageSettings')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "availabilitySetsResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('availabilitySetSResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "computeSettings": {
-                        "value": "[variables('computeSettings')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "publicIPAddressesResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('publicIPAddressesResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "networkSecurityGroupsResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('networkSecurityGroupsResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "virtualNetworksResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "dependsOn": [
-                "networkSecurityGroupsResource"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('virtualNetworksResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "fe-loadBalancersResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "dependsOn": [
-                "publicIPAddressesResource"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('fe-loadBalancersResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    },
-                    "felbPublicIPAddressID": {
-                        "value": "[variables('felbPublicIPAddressID')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "fe-networkInterfacesResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "dependsOn": [
-                "fe-loadBalancersResource",
-                "virtualNetworksResource",
-                "networkSecurityGroupsResource"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('fe-networkInterfacesResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    },
-                    "feSubnetRef": {
-                        "value": "[variables('feSubnetRef')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "be-networkInterfacesResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "dependsOn": [
-                "virtualNetworksResource",
-                "networkSecurityGroupsResource"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('be-networkInterfacesResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    },
-                    "beSubnetRef": {
-                        "value": "[variables('beSubnetRef')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "chefAuto-networkInterfacesResource",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "dependsOn": [
-                "publicIPAddressesResource",
-                "virtualNetworksResource",
-                "networkSecurityGroupsResource"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('chefAuto-networkInterfacesResourcesURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    },
-                    "feSubnetRef": {
-                        "value": "[variables('feSubnetRef')]"
-                    },
-                    "chefAutoPublicIPAddressID": {
-                        "value": "[variables('chefAutoPublicIPAddressID')]"
-                    }
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Resources/deployments",
-            "name": "fe-be-virtualMachinesWithExtensions",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('fe-be-VmsWithExtensionsURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "computeSettings": {
-                        "value": "[variables('computeSettings')]"
-                    },
-                    "networkSettings": {
-                        "value": "[variables('networksettings')]"
-                    },
-                    "keyvaultSettings": {
-                        "value": "[variables('keyvaultSettings')]"
-                    }
-                }
-            },
-            "dependsOn": [
-                "managedDisksResource",
-                "diagnosticStorageAccountsResource",
-                "availabilitySetsResource",
-                "fe-networkInterfacesResource",
-                "be-networkInterfacesResource",
-                "chefAuto-networkInterfacesResource",
-                "keyvaultResource"
-            ]
-        }
-    ],
-    "outputs": {
-        "adminusername": {
-            "type": "string",
-            "value": "[variables('computeSettings').adminUsername]"
-        },
-        "chef-server-url": {
-            "type": "string",
-            "value": "[concat('https://',reference('publicIPAddressesResource').outputs.chefServerfqdn.value)]"
-        },
-        "chef-server-fqdn": {
-            "type": "string",
-            "value": "[reference('publicIPAddressesResource').outputs.chefServerfqdn.value]"
-        },
-        "keyvaultName":{
-            "type": "string",
-            "value": "[variables('keyvaultSettings').keyVaultName]"
-        },
-        "chef-server-webLogin-userName": {
-            "type": "string",
-            "value": "[variables('computeSettings').chefServerUserName]"
-        },
-         "chef-server-webLogin-password": {
-            "type": "string",
-            "value": "The chef-server-weblogin-password stored in the keyvault,you can retrieve it using azure CLI 2.0 [az keyvault secret show --name chefdeliveryuserpassword --vault-name < keyvaultname >]"
-        },
-        "chef-automate-url": {
-            "type": "string",
-            "value": "[concat('https://',reference('publicIPAddressesResource').outputs.chefAutomatefqdn.value)]"
-        },
-        "chef-automate-fqdn": {
-            "type": "string",
-            "value": "[reference('publicIPAddressesResource').outputs.chefAutomatefqdn.value]"
-        }
+    "adminUsername": {
+      "defaultValue": "chefuser",
+      "type": "string",
+      "metadata": {
+        "description": "User name for the Virtual Machine."
+      }
+    },
+    "sshKeyData": {
+      "defaultValue": "",
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH rsa public key file as a string."
+      }
+    },
+    "vmSize": {
+      "defaultValue": "Standard_DS3",
+      "allowedValues": [
+        "Standard_DS3",
+        "Standard_DS4",
+        "Standard_DS11",
+        "Standard_DS12",
+        "Standard_DS13",
+        "Standard_DS14",
+        "Standard_DS3_v2",
+        "Standard_DS4_v2",
+        "Standard_DS5_v2",
+        "Standard_DS11_v2",
+        "Standard_DS12_v2",
+        "Standard_DS13_v2",
+        "Standard_DS14_v2",
+        "Standard_DS15_v2",
+        "Standard_F4s",
+        "Standard_F8s",
+        "Standard_F16s"
+      ],
+      "type": "string",
+      "metadata": {
+        "description": "size of the Virtual Machine."
+      }
+    },
+    "chefServerDnsPrefix": {
+      "type": "string",
+      "defaultValue": "chefserver",
+      "metadata": {
+        "description": "dens name for chef server"
+      }
+    },
+    "chefAutomateDnsPrefix": {
+      "type": "string",
+      "defaultValue": "chefautomate",
+      "metadata": {
+        "description": "chef automate dns name"
+      }
+    },
+    "firstName": {
+      "defaultValue": "",
+      "type": "string",
+      "metadata": {
+        "description": "administrator user for chef automate"
+      }
+    },
+    "lastName": {
+      "defaultValue": "",
+      "type": "string",
+      "metadata": {
+        "description": "administrator user for chef automate"
+      }
+    },
+    "emailId": {
+      "defaultValue": "user@password.com",
+      "type": "string",
+      "metadata": {
+        "description": "emaild for chef automate"
+      }
+    },
+    "organizationName": {
+      "defaultValue": "chef",
+      "type": "string",
+      "metadata": {
+        "description": "Organization name for chef automate"
+      }
+    },
+    "appID": {
+      "defaultValue": "",
+      "minLength": 1,
+      "type": "securestring",
+      "metadata": {
+        "description": "servicePrinciple"
+      }
+    },
+    "password": {
+      "defaultValue": "",
+      "minLength": 1,
+      "type": "securestring",
+      "metadata": {
+        "description": "password"
+      }
     }
+  },
+  "variables": {
+    "keyvaultSettings": {
+      "keyVaultApiVersion": "2015-06-01",
+      "keyVaultName": "[concat('chef-key',substring(variables('prefix') ,0 ,5))]",
+      "tenantId": "[subscription().tenantId]",
+      "dbPasswordValue": "[concat('chv-',substring(variables('prefix'),0,10),'-dbp')]",
+      "replicationPasswordValue": "[concat('chv-',substring(variables('prefix'),0,11),'-rpp')]",
+      "clusterTokenValue": "[concat('chv-',substring(variables('prefix'),0,12),'-ctt')]",
+      "clusterNameValue": "[concat('chef-',substring(variables('prefix'),0,8))]",
+      "location": "[resourceGroup().location]",
+      "objectId": "[parameters('objectId')]",
+      "vaultSku": "[parameters('vaultSku')]",
+      "dbPassword": "dbPassword",
+      "replicationPassword": "replicationPassword",
+      "clusterToken": "clusterToken",
+      "clusterName": "clusterName",
+      "appID": "[parameters('appID')]",
+      "password": "[parameters('password')]"
+    },
+    "computeSettings": {
+      "count": 7,
+      "location": "[resourceGroup().location]",
+      "computeApiVersion": "2016-04-30-preview",
+      "adminUsername": "[parameters('adminUsername')]",
+      "sshKeyData": "[parameters('sshKeyData')]",
+      "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+      "chefServerUserName": "delivery",
+      "managedDiskName": "dataDisk",
+      "storageAccountType": "Premium_LRS",
+      "diagStorageAccountType": "Standard_LRS",
+      "diskCreateOption": "empty",
+      "diskSizeGB": 50,
+      "vmSize": "[parameters('vmSize')]",
+      "imagePublisher": "Canonical",
+      "imageOffer": "UbuntuServer",
+      "ubuntuOSVersion": "16.04-LTS",
+      "imageVersion": "latest",
+      "chefBEAvailName": "be-avail",
+      "leadercomputerName": "be0",
+      "followercomputerName1": "be1",
+      "followercomputerName2": "be2",
+      "leaderExtensionName": "be0-ex0",
+      "followerExtensionName1": "be-ex1",
+      "followerExtensionName2": "be-ex2",
+      "leadercustomData": "[variables('customData').leaderCustomData]",
+      "followercustomData": "[variables('customData').followerCustomData]",
+      "feComputerName0": "fe0",
+      "feComputerName1": "fe1",
+      "feComputerName2": "fe2",
+      "feVmExtensionName0": "fe0-ex0",
+      "feVmExtensionName1": "fe1-ex1",
+      "feVmExtensionName2": "fe1-ex2",
+      "fe0CustomData": "[variables('customData').fe0Customdata]",
+      "feCustomData": "[variables('customData').feCustomData]",
+      "chefFEAvailName": "fe-avail",
+      "autoComputerName": "chefautomate",
+      "chefAutoExtenName": "chef-auto-ex",
+      "automateCustomData": "[variables('customData').automateCustomData]",
+      "firstName": "[parameters('firstName')]",
+      "lastName": "[parameters('lastName')]",
+      "emailId": "[parameters('emailId')]",
+      "organizationName": "[parameters('organizationName')]",
+      "keyvaultId": "[concat(subscription().id,'/resourceGroups/',resourceGroup().name, '/providers/Microsoft.KeyVault/vaults/', variables('keyvaultSettings').keyVaultName)]"
+    },
+    "storageSettings": {
+      "location": "[resourceGroup().location]",
+      "diagStorageAccName": "[concat('diagstr',substring(variables('prefix') ,0 ,5))]",
+      "diagStorageAccountType": "Standard_LRS",
+      "storageApiVersion": "2015-06-15"
+    },
+    "networkSettings": {
+      "location": "[resourceGroup().location]",
+      "networkApiVersion": "2015-06-15",
+      "leaderNicName": "be-nic0",
+      "followerNicName1": "be-nic1",
+      "followerNicName2": "be-nic2",
+      "feNicName0": "fe-nic0",
+      "feNicName1": "fe-nic1",
+      "feNicName2": "fe-nic2",
+      "chefAutoNicName": "chefauto-nic",
+      "feNsg": "fe-nsg",
+      "beNsg": "be-nsg",
+      "bePoolName1": "chef-ha-pool-fe",
+      "bePoolName2": "chef-ha-pool-ssh-admin",
+      "felbPublicIPAddressName": "fe-pip",
+      "chefAutoPublicIPAddressName": "chefauto-pip",
+      "virtualNetworkName": "chef-vnet",
+      "addressPrefix": "10.0.0.0/16",
+      "feSubnetName": "fe-subnet",
+      "feSubnetPrefix": "10.0.0.0/24",
+      "feLoadBalancerName": "fe-lb",
+      "beSubnetName": "be-subnet",
+      "beSubnetPrefix": "10.0.1.0/24",
+      "publicIPAddressType": "Dynamic",
+      "dnsLabelPrefixFE": "[concat(parameters('chefServerDnsPrefix'),substring(variables('prefix') ,0 ,3))]",
+      "dnsLabelPrefixChefAuto": "[concat(parameters('chefAutomateDnsPrefix'),substring(variables('prefix') ,0 ,3))]",
+      "diagStorageAccName": "[concat('diagstr',substring(variables('prefix') ,0 ,5))]"
+    },
+    "chef_backend_install_script_base": "[concat('dbPassword=$1\n','replicationPassword=$2\n','clusterToken=$3\n','clusterName=$4\n','apt-get install -y apt-transport-https\n','wget -qO - https://downloads.chef.io/packages-chef-io-public.key | sudo apt-key add -\n','echo \"deb https://packages.chef.io/stable-apt trusty main\" > /etc/apt/sources.list.d/chef-stable.list\n','apt-get update\n','apt-get install -y chef-backend\n','apt-get install -y lvm2 xfsprogs sysstat atop\n','umount -f /mnt\n','pvcreate -f /dev/sdc\n','vgcreate chef-vg /dev/sdc\n','lvcreate -n chef-lv -l 80%VG chef-vg\n','mkfs.xfs /dev/chef-vg/chef-lv\n','mkdir -p /var/opt/chef-backend\n','mount /dev/chef-vg/chef-lv /var/opt/chef-backend\n','cat > /etc/chef-backend/chef-backend-secrets.json <<EOF\n','{\n','\"postgresql\": {\n','\"db_superuser_password\": \"######\",\n','\"replication_password\": \"#######\"\n','},\n','\"etcd\": {\n','\"initial_cluster_token\": \"########\"\n',' },\n','\"elasticsearch\": {\n','\"cluster_name\": \"#########\"\n','}\n','}\n','EOF\n','sed -i ''0,/######/s//''$dbPassword''/'' /etc/chef-backend/chef-backend-secrets.json\n','sed -i ''0,/#######/s//''$replicationPassword''/'' /etc/chef-backend/chef-backend-secrets.json\n','sed -i ''0,/########/s//''$clusterToken''/'' /etc/chef-backend/chef-backend-secrets.json\n','sed -i ''0,/#########/s//''$clusterName''/'' /etc/chef-backend/chef-backend-secrets.json\n','IP=`ifconfig eth0 | awk ''/inet addr/{print substr($2,6)}''`\n','cat > /etc/chef-backend/chef-backend.rb <<EOF\n','publish_address ''${IP}''\n','postgresql.log_min_duration_statement = 500\n','elasticsearch.heap_size = 3500\n','postgresql.md5_auth_cidr_addresses = [\"samehost\", \"samenet\", \"10.0.0.0/24\"]\n','EOF\n')]",
+    "chef_frontend_install_script_base": "[concat('dbPassword=$1\n','firstName=$2\n','lastName=$3\n','emailId=$4\n','organizationName=$5\n','appID=$6\n','tenantID=$7\n','password=$8\n','objectId=$9\n','keyVaultName=${10}\n','fqdn=`hostname -f`\n','apt-get install -y apt-transport-https\n','apt-get install -y sshpass\n','wget -qO - https://downloads.chef.io/packages-chef-io-public.key | sudo apt-key add -\n','echo \"deb https://packages.chef.io/stable-apt trusty main\" > /etc/apt/sources.list.d/chef-stable.list\n','apt-get update\n','apt-get install -y lvm2 xfsprogs sysstat atop\n','umount -f /mnt\n','pvcreate -f /dev/sdc\n','vgcreate chef-vg /dev/sdc\n','lvcreate -n chef-data -l 20%VG chef-vg\n','lvcreate -n chef-logs -l 80%VG chef-vg\n','mkfs.xfs /dev/chef-vg/chef-data\n','mkfs.xfs /dev/chef-vg/chef-logs\n','mkdir -p /var/opt/opscode\n','mkdir -p /var/log/opscode\n','mount /dev/chef-vg/chef-data /var/opt/opscode\n','mount /dev/chef-vg/chef-logs /var/log/opscode\n','apt-get install -y chef-server-core chef-manage\n','apt-get install -y libssl-dev libffi-dev python-dev build-essential\n','echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main\" > /etc/apt/sources.list.d/azure-cli.list\n','apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893\n','apt-get update\n','apt-get install azure-cli\n','cat > /etc/opscode/chef-server.rb <<EOF\n','\n','fqdn \"####\"\n','\n','use_chef_backend true\n','chef_backend_members [\"10.0.1.6\", \"10.0.1.5\", \"10.0.1.4\"]\n','\n','haproxy[''remote_postgresql_port''] = 5432\n','haproxy[''remote_elasticsearch_port''] = 9200\n','\n','postgresql[''external''] = true\n','postgresql[''vip''] = ''127.0.0.1''\n','postgresql[''db_superuser''] = ''chef_pgsql''\n','postgresql[''db_superuser_password''] = ''######''\n','\n','opscode_solr4[''external''] = true\n','opscode_solr4[''external_url''] = ''http://127.0.0.1:9200''\n','opscode_erchef[''search_provider''] = ''elasticsearch''\n','opscode_erchef[''search_queue_mode''] = ''batch''\n','\n','bookshelf[''storage_type''] = :sql\n','\n','rabbitmq[''enable''] = false\n','rabbitmq[''management_enabled''] = false\n','rabbitmq[''queue_length_monitor_enabled''] = false\n','\n','opscode_expander[''enable''] = false\n','\n','dark_launch[''actions''] = false\n','\n','opscode_erchef[''nginx_bookshelf_caching''] = :on\n','opscode_erchef[''s3_url_expiry_window_size''] = ''50%''\n','opscode_erchef[''s3_url_expiry_window_size''] = ''100%''\n','license[''nodes''] = 999999\n','oc_chef_authz[''http_init_count''] = 100\n','oc_chef_authz[''http_max_count''] = 100\n','oc_chef_authz[''http_queue_max''] = 200\n','oc_bifrost[''db_pool_size''] = 20\n','oc_bifrost[''db_pool_queue_max''] = 40\n','oc_bifrost[''db_pooler_timeout''] = 2000\n','opscode_erchef[''depsolver_worker_count''] = 4\n','opscode_erchef[''depsolver_timeout''] = 20000\n','opscode_erchef[''db_pool_size''] = 20\n','opscode_erchef[''db_pool_queue_max''] = 40\n','opscode_erchef[''db_pooler_timeout''] = 2000\n','opscode_erchef[''authz_pooler_timeout''] = 2000\n','EOF\n','sed -i ''0,/######/s//''$dbPassword''/'' /etc/opscode/chef-server.rb\n','sed -i ''0,/####/s//''$fqdn''/'' /etc/opscode/chef-server.rb\n')]",
+    "chef_automate_install_script_base": "[concat('appID=$1\n','tenantID=$2\n','password=$3\n','objectId=$4\n','keyVaultName=$5\n','apt-get install -y libssl-dev libffi-dev python-dev build-essential\n','echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main\" > /etc/apt/sources.list.d/azure-cli.list\n','apt-key adv --keyserver packages.microsoft.com --recv-keys 417A0893\n','apt-get update\n','apt-get install azure-cli\n','apt-get install -y apt-transport-https\n','apt-get update\n','apt-get install -y sshpass\n','apt-get install -y wget\n','apt-get install -y lvm2 xfsprogs sysstat atop\n','umount -f /mnt\n','pvcreate -f /dev/sdc\n','vgcreate delivery-vg /dev/sdc\n','lvcreate -n delivery-lv -l 80%VG delivery-vg\n','mkfs.xfs /dev/delivery-vg/delivery-lv\n','mkdir -p /var/opt/delivery\n','mount /dev/delivery-vg/delivery-lv /var/opt/delivery\n','wget  https://packages.chef.io/files/stable/automate/0.8.5/ubuntu/16.04/automate_0.8.5-1_amd64.deb\n','dpkg -i automate_0.8.5-1_amd64.deb\n','az login --service-principal -u $appID --password $password --tenant $tenantID\n','az keyvault secret download --file /etc/delivery/chefautomatedeliveryuser.pem --name chefdeliveryuserkey --vault-name $keyVaultName\n','cat > /etc/delivery/command_to_execute <<EOF\n','automate-ctl setup --license AUTOMATE_LICENSE --key < AUTOMATE_CHEF_USER_KEY > --server-url https:// < CHEF_SERVER_FQDN/organizations >/chef-automate-org --fqdn < AUTOMATE_SERVER_FQDN >  --enterprise < ENTERPRISE_NAME >\n','EOF\n')]",
+    "scripts": {
+      "chef_backend_install_script_leader": "[concat(variables('chef_backend_install_script_base'),'chef-backend-ctl create-cluster --accept-license --yes --quiet --verbose\n')]",
+      "chef_backend_install_script_follower": "[concat(variables('chef_backend_install_script_base'),'chef-backend-ctl join-cluster 10.0.1.4 -s /etc/chef-backend/chef-backend-secrets.json --accept-license --yes --quiet --verbose\n')]",
+      "chef_frontend_install_script_fe0": "[concat(variables('chef_frontend_install_script_base'),'chef-server-ctl reconfigure --accept-license\n','sudo chef-manage-ctl reconfigure --accept-license\n','echo ''ENABLED=\"true\"'' > /etc/default/sysstat\n','service sysstat start\n','sleep 5\n','chef-server-ctl user-create delivery $firstName $lastName $emailId $password --filename /etc/opscode/chefautomatedeliveryuser.pem\n','sleep 5\n','sudo chef-server-ctl org-create $organizationName ''Chef Automate Org'' --file /etc/opscode/chef_automate_org-validator.pem -a delivery\n','sleep 5\n','az login --service-principal -u $appID --password $password --tenant $tenantID\n','if [ `echo $?` -eq 0 ]\n','then\n','echo \"uploading the secret files to keyvault\"\n','az keyvault secret set --name chefsecrets --vault-name $keyVaultName --file /etc/opscode/private-chef-secrets.json\n','az keyvault secret set --name chefdeliveryuserkey --vault-name $keyVaultName --file /etc/opscode/chefautomatedeliveryuser.pem\n','az keyvault secret set --name chefdeliveryuserpassword --vault-name $keyVaultName --value $password\n','else\n','echo \"Authentication to Azure keyvault failed\"\n','fi\n')]",
+      "chef_frontend_install_script_fe": "[concat(variables('chef_frontend_install_script_base'),'az login --service-principal -u $appID --password $password --tenant $tenantID\n','az keyvault secret download --file /etc/opscode/private-chef-secrets.json --name chefsecrets --vault-name $keyVaultName\n','mkdir -p /var/opt/opscode/upgrades/\n','touch /var/opt/opscode/bootstrapped\n','chef-server-ctl reconfigure --accept-license\n','sudo chef-manage-ctl reconfigure --accept-license\n','echo ''ENABLED=\"true\"'' > /etc/default/sysstat\n','service sysstat start\n')]"
+    },
+    "customData": {
+      "fe0Customdata": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_frontend_install_script_fe0) , '\n', '    path: /etc/opscode/chef-frontend-install.sh\n', '    permissions: 0700\n'))]",
+      "feCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_frontend_install_script_fe) , '\n', '    path: /etc/opscode/chef-frontend-install.sh\n', '    permissions: 0700\n'))]",
+      "leaderCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_backend_install_script_leader) , '\n', '    path: /etc/chef-backend/chef-backend-install.sh\n', '    permissions: 0700\n'))]",
+      "followerCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('scripts').chef_backend_install_script_follower) , '\n', '    path: /etc/chef-backend/chef-backend-install.sh\n', '    permissions: 0700\n'))]",
+      "automateCustomData": "[base64(concat('#cloud-config\n', '\n', 'write_files:\n', '-   encoding: b64\n', '    content: ', base64(variables('chef_automate_install_script_base')) , '\n', '    path: /etc/delivery/chef-automate-install.sh\n', '    permissions: 0700\n'))]"
+    },
+    "baseUrl": "https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/chef-automate-ha/",
+    "keyvaultResourcesURL": "[concat(variables('baseUrl'),'nested/keyvaultResource.json')]",
+    "managedDisksResourcesURL": "[concat(variables('baseUrl'),'nested/managedDisksResource.json')]",
+    "diagnosticStorageAccountResourcesURL": "[concat(variables('baseUrl'),'nested/diagnosticStorageAccountResource.json')]",
+    "availabilitySetSResourcesURL": "[concat(variables('baseUrl'),'nested/availabilitySetsResource.json')]",
+    "publicIPAddressesResourcesURL": "[concat(variables('baseUrl'),'nested/publicIPAddressResource.json')]",
+    "networkSecurityGroupsResourcesURL": "[concat(variables('baseUrl'),'nested/networkSecurityGroupsResource.json')]",
+    "virtualNetworksResourcesURL": "[concat(variables('baseUrl'),'nested/virtualNetworksResource.json')]",
+    "fe-loadBalancersResourcesURL": "[concat(variables('baseUrl'),'nested/loadBalancersResource.json')]",
+    "fe-networkInterfacesResourcesURL": "[concat(variables('baseUrl'),'nested/fe-networkInterfacesResource.json')]",
+    "be-networkInterfacesResourcesURL": "[concat(variables('baseUrl'),'nested/be-networkInterfacesResource.json')]",
+    "chefAuto-networkInterfacesResourcesURL": "[concat(variables('baseUrl'),'nested/chefAuto-networkInterfacesResource.json')]",
+    "fe-be-VmsWithExtensionsURL": "[concat(variables('baseUrl'),'nested/fe-be-virtualmachines-with-extensions.json')]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('networkSettings').virtualNetworkName)]",
+    "beSubnetRef": "[concat(variables('vnetID'),'/subnets/',variables('networkSettings').beSubnetName)]",
+    "feSubnetRef": "[concat(variables('vnetID'),'/subnets/',variables('networkSettings').feSubnetName)]",
+    "felbPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('networkSettings').felbPublicIPAddressName)]",
+    "chefAutoPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('networkSettings').chefAutoPublicIPAddressName)]",
+    "deploymentApiVersion": "2015-01-01",
+    "prefix": "[uniqueString(resourceGroup().id)]",
+    "provider": "[toUpper('33194f91-eb5f-4110-827a-e95f640a9e46')]"
+  },
+  "resources": [
+    {
+      "name": "keyvaultResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('keyvaultResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "keyvaultSettings": {
+            "value": "[variables('keyvaultSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "managedDisksResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('managedDisksResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "computeSettings": {
+            "value": "[variables('computeSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "diagnosticStorageAccountsResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('diagnosticStorageAccountResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "storageSettings": {
+            "value": "[variables('storageSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "availabilitySetsResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('availabilitySetSResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "computeSettings": {
+            "value": "[variables('computeSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "publicIPAddressesResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('publicIPAddressesResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "networkSecurityGroupsResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('networkSecurityGroupsResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "virtualNetworksResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "networkSecurityGroupsResource"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('virtualNetworksResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "fe-loadBalancersResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "publicIPAddressesResource"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('fe-loadBalancersResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          },
+          "felbPublicIPAddressID": {
+            "value": "[variables('felbPublicIPAddressID')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "fe-networkInterfacesResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "fe-loadBalancersResource",
+        "virtualNetworksResource",
+        "networkSecurityGroupsResource"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('fe-networkInterfacesResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          },
+          "feSubnetRef": {
+            "value": "[variables('feSubnetRef')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "be-networkInterfacesResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "virtualNetworksResource",
+        "networkSecurityGroupsResource"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('be-networkInterfacesResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          },
+          "beSubnetRef": {
+            "value": "[variables('beSubnetRef')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "chefAuto-networkInterfacesResource",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "publicIPAddressesResource",
+        "virtualNetworksResource",
+        "networkSecurityGroupsResource"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('chefAuto-networkInterfacesResourcesURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          },
+          "feSubnetRef": {
+            "value": "[variables('feSubnetRef')]"
+          },
+          "chefAutoPublicIPAddressID": {
+            "value": "[variables('chefAutoPublicIPAddressID')]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "name": "fe-be-virtualMachinesWithExtensions",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('fe-be-VmsWithExtensionsURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "computeSettings": {
+            "value": "[variables('computeSettings')]"
+          },
+          "networkSettings": {
+            "value": "[variables('networksettings')]"
+          },
+          "keyvaultSettings": {
+            "value": "[variables('keyvaultSettings')]"
+          }
+        }
+      },
+      "dependsOn": [
+        "managedDisksResource",
+        "diagnosticStorageAccountsResource",
+        "availabilitySetsResource",
+        "fe-networkInterfacesResource",
+        "be-networkInterfacesResource",
+        "chefAuto-networkInterfacesResource",
+        "keyvaultResource"
+      ]
+    }
+  ],
+  "outputs": {
+    "adminusername": {
+      "type": "string",
+      "value": "[variables('computeSettings').adminUsername]"
+    },
+    "chef-server-url": {
+      "type": "string",
+      "value": "[concat('https://',reference('publicIPAddressesResource').outputs.chefServerfqdn.value)]"
+    },
+    "chef-server-fqdn": {
+      "type": "string",
+      "value": "[reference('publicIPAddressesResource').outputs.chefServerfqdn.value]"
+    },
+    "keyvaultName": {
+      "type": "string",
+      "value": "[variables('keyvaultSettings').keyVaultName]"
+    },
+    "chef-server-webLogin-userName": {
+      "type": "string",
+      "value": "[variables('computeSettings').chefServerUserName]"
+    },
+    "chef-server-webLogin-password": {
+      "type": "string",
+      "value": "The chef-server-weblogin-password stored in the keyvault,you can retrieve it using azure CLI 2.0 [az keyvault secret show --name chefdeliveryuserpassword --vault-name < keyvaultname >]"
+    },
+    "chef-automate-url": {
+      "type": "string",
+      "value": "[concat('https://',reference('publicIPAddressesResource').outputs.chefAutomatefqdn.value)]"
+    },
+    "chef-automate-fqdn": {
+      "type": "string",
+      "value": "[reference('publicIPAddressesResource').outputs.chefAutomatefqdn.value]"
+    }
+  }
 }

--- a/chef-automate-ha/nested/availabilitySetsResource.json
+++ b/chef-automate-ha/nested/availabilitySetsResource.json
@@ -16,7 +16,7 @@
                 "name": "Aligned"
             },
             "name": "[parameters('computeSettings').chefFEAvailName]",
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "location": "[parameters('computeSettings').location]",
             "properties": {
                 "platformUpdateDomainCount": 3,
@@ -32,7 +32,7 @@
                 "name": "Aligned"
             },
             "name": "[parameters('computeSettings').chefBEAvailName]",
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "location": "[parameters('computeSettings').location]",
             "properties": {
                 "platformUpdateDomainCount": 3,

--- a/chef-automate-ha/nested/be-networkInterfacesResource.json
+++ b/chef-automate-ha/nested/be-networkInterfacesResource.json
@@ -16,7 +16,7 @@
         {
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[parameters('networkSettings').leaderNicName]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "ipConfigurations": [
@@ -46,7 +46,7 @@
         {
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[parameters('networkSettings').followerNicName1]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "ipConfigurations": [
@@ -76,7 +76,7 @@
         {
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[parameters('networkSettings').followerNicName2]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "ipConfigurations": [

--- a/chef-automate-ha/nested/chefAuto-networkInterfacesResource.json
+++ b/chef-automate-ha/nested/chefAuto-networkInterfacesResource.json
@@ -19,7 +19,7 @@
     {
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[parameters('networkSettings').chefAutoNicName]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "ipConfigurations": [

--- a/chef-automate-ha/nested/diagnosticStorageAccountResource.json
+++ b/chef-automate-ha/nested/diagnosticStorageAccountResource.json
@@ -13,7 +13,7 @@
         {
             "name": "[parameters('storageSettings').diagStorageAccName]",
             "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "[parameters('storageSettings').storageApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('storageSettings').location]",
             "properties": {
                 "accountType": "[parameters('storageSettings').diagStorageAccountType]"

--- a/chef-automate-ha/nested/fe-be-virtualmachines-with-extensions.json
+++ b/chef-automate-ha/nested/fe-be-virtualmachines-with-extensions.json
@@ -17,7 +17,7 @@
     },
     "resources": [
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').leaderComputerName]",
             "location": "[resourceGroup().location]",
@@ -85,7 +85,7 @@
                     "name": "[parameters('computeSettings').leaderExtensionName]",
                     "type": "extensions",
                     "location": "[resourceGroup().location]",
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').leaderComputerName)]"
                     ],
@@ -105,7 +105,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').followerComputerName1]",
             "location": "[resourceGroup().location]",
@@ -173,7 +173,7 @@
                     "name": "[parameters('computeSettings').followerExtensionName1]",
                     "type": "extensions",
                     "location": "[resourceGroup().location]",
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').followerComputerName1)]",
                         "[concat('Microsoft.Compute/virtualMachines/',parameters('computeSettings').leaderComputerName,'/extensions/', parameters('computeSettings').leaderExtensionName)]"
@@ -194,7 +194,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').followerComputerName2]",
             "location": "[resourceGroup().location]",
@@ -262,7 +262,7 @@
                     "name": "[parameters('computeSettings').followerExtensionName2]",
                     "type": "extensions",
                     "location": "[resourceGroup().location]",
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').followerComputerName2)]",
                         "[concat('Microsoft.Compute/virtualMachines/',parameters('computeSettings').followerComputerName1,'/extensions/', parameters('computeSettings').followerExtensionName1)]"
@@ -283,7 +283,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').feComputerName0]",
             "location": "[resourceGroup().location]",
@@ -351,7 +351,7 @@
                     "name": "[parameters('computeSettings').feVmExtensionName0]",
                     "type": "extensions",
                     "location": "[resourceGroup().location]",
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').feComputerName0)]",
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').leaderComputerName, parameters('computeSettings').leaderExtensionName)]",
@@ -374,7 +374,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').feComputerName1]",
             "location": "[resourceGroup().location]",
@@ -446,7 +446,7 @@
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').feComputerName1)]",
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').feComputerName0, parameters('computeSettings').feVmExtensionName0)]"
                     ],
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "properties": {
                         "publisher": "Microsoft.Azure.Extensions",
                         "type": "CustomScript",
@@ -463,7 +463,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').feComputerName2]",
             "location": "[resourceGroup().location]",
@@ -535,7 +535,7 @@
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').feComputerName2)]",
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').feComputerName0,parameters('computeSettings').feVmExtensionName0)]"
                     ],
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "properties": {
                         "publisher": "Microsoft.Azure.Extensions",
                         "type": "CustomScript",
@@ -552,7 +552,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').autoComputerName]",
             "location": "[resourceGroup().location]",
@@ -623,7 +623,7 @@
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').feComputerName1,parameters('computeSettings').feVmExtensionName1)]",
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').feComputerName2,parameters('computeSettings').feVmExtensionName2)]"
                     ],
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "properties": {
                         "publisher": "Microsoft.Azure.Extensions",
                         "type": "CustomScript",

--- a/chef-automate-ha/nested/fe-be-virtualmachines-with-extensions1.json
+++ b/chef-automate-ha/nested/fe-be-virtualmachines-with-extensions1.json
@@ -17,7 +17,7 @@
     },
     "resources": [
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').leaderComputerName]",
             "location": "[resourceGroup().location]",
@@ -75,7 +75,7 @@
                     "name": "[parameters('computeSettings').leaderExtensionName]",
                     "type": "extensions",
                     "location": "[resourceGroup().location]",
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').leaderComputerName)]"
                     ],
@@ -95,7 +95,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').followerComputerName1]",
             "location": "[resourceGroup().location]",
@@ -153,7 +153,7 @@
                     "name": "[parameters('computeSettings').followerExtensionName1]",
                     "type": "extensions",
                     "location": "[resourceGroup().location]",
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').followerComputerName1)]",
                         "[concat('Microsoft.Compute/virtualMachines/',parameters('computeSettings').leaderComputerName,'/extensions/', parameters('computeSettings').leaderExtensionName)]"
@@ -174,7 +174,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').followerComputerName2]",
             "location": "[resourceGroup().location]",
@@ -232,7 +232,7 @@
                     "name": "[parameters('computeSettings').followerExtensionName2]",
                     "type": "extensions",
                     "location": "[resourceGroup().location]",
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').followerComputerName2)]",
                         "[concat('Microsoft.Compute/virtualMachines/',parameters('computeSettings').followerComputerName1,'/extensions/', parameters('computeSettings').followerExtensionName1)]"
@@ -253,7 +253,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').feComputerName0]",
             "location": "[resourceGroup().location]",
@@ -311,7 +311,7 @@
                     "name": "[parameters('computeSettings').feVmExtensionName0]",
                     "type": "extensions",
                     "location": "[resourceGroup().location]",
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "dependsOn": [
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').feComputerName0)]",
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').leaderComputerName, parameters('computeSettings').leaderExtensionName)]",
@@ -331,7 +331,7 @@
             ]
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').feComputerName1]",
             "location": "[resourceGroup().location]",
@@ -393,7 +393,7 @@
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').feComputerName1)]",
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').feComputerName0, parameters('computeSettings').feVmExtensionName0)]"
                     ],
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "properties": {
                         "publisher": "Microsoft.Azure.Extensions",
                         "type": "CustomScript",
@@ -410,7 +410,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').feComputerName2]",
             "location": "[resourceGroup().location]",
@@ -472,7 +472,7 @@
                         "[concat('Microsoft.Compute/virtualMachines/', parameters('computeSettings').feComputerName2)]",
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').feComputerName0,parameters('computeSettings').feVmExtensionName0)]"
                     ],
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "properties": {
                         "publisher": "Microsoft.Azure.Extensions",
                         "type": "CustomScript",
@@ -489,7 +489,7 @@
             }
         },
         {
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').autoComputerName]",
             "location": "[resourceGroup().location]",
@@ -550,7 +550,7 @@
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').feComputerName1,parameters('computeSettings').feVmExtensionName1)]",
                         "[resourceId('Microsoft.Compute/virtualMachines/extensions',parameters('computeSettings').feComputerName2,parameters('computeSettings').feVmExtensionName2)]"
                     ],
-                    "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+                    "apiVersion": "2016-04-30-preview",
                     "properties": {
                         "publisher": "Microsoft.Azure.Extensions",
                         "type": "CustomScript",

--- a/chef-automate-ha/nested/fe-networkInterfacesResource.json
+++ b/chef-automate-ha/nested/fe-networkInterfacesResource.json
@@ -16,7 +16,7 @@
         {
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[parameters('networkSettings').feNicName0]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "ipConfigurations": [
@@ -54,7 +54,7 @@
         {
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[parameters('networkSettings').feNicName1]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "ipConfigurations": [
@@ -89,7 +89,7 @@
         {
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[parameters('networkSettings').feNicName2]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "ipConfigurations": [

--- a/chef-automate-ha/nested/keyvaultResource.json
+++ b/chef-automate-ha/nested/keyvaultResource.json
@@ -13,7 +13,7 @@
         {
             "type": "Microsoft.KeyVault/vaults",
             "name": "[parameters('keyvaultSettings').keyVaultName]",
-            "apiVersion": "[parameters('keyvaultSettings').keyVaultApiVersion]",
+            "apiVersion": "2015-06-01",
             "location": "[parameters('keyvaultSettings').location]",
             "properties": {
                 "enabledForDeployment": true,

--- a/chef-automate-ha/nested/loadBalancersResource.json
+++ b/chef-automate-ha/nested/loadBalancersResource.json
@@ -16,7 +16,7 @@
         {
             "type": "Microsoft.Network/loadBalancers",
             "name": "[parameters('networkSettings').feLoadBalancerName]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "frontendIPConfigurations": [

--- a/chef-automate-ha/nested/managedDisksResource.json
+++ b/chef-automate-ha/nested/managedDisksResource.json
@@ -13,7 +13,7 @@
         {
             "type": "Microsoft.Compute/disks",
             "name": "[concat(parameters('computeSettings').managedDiskName,copyIndex())]",
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "location": "[parameters('computeSettings').location]",
             "copy": {
                 "name": "dataDiskCopy",

--- a/chef-automate-ha/nested/networkSecurityGroupsResource.json
+++ b/chef-automate-ha/nested/networkSecurityGroupsResource.json
@@ -13,7 +13,7 @@
         {
             "type": "Microsoft.Network/networkSecurityGroups",
             "name": "[parameters('networkSettings').feNsg]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "securityRules": [
@@ -91,7 +91,7 @@
         {
             "type": "Microsoft.Network/networkSecurityGroups",
             "name": "[parameters('networkSettings').beNsg]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "securityRules": [

--- a/chef-automate-ha/nested/publicIPAddressResource.json
+++ b/chef-automate-ha/nested/publicIPAddressResource.json
@@ -13,7 +13,7 @@
         {
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[parameters('networkSettings').felbPublicIPAddressName]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "publicIPAllocationMethod": "[parameters('networkSettings').publicIPAddressType]",
@@ -28,7 +28,7 @@
         {
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "[parameters('networkSettings').chefAutoPublicIPAddressName]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "publicIPAllocationMethod": "[parameters('networkSettings').publicIPAddressType]",

--- a/chef-automate-ha/nested/virtualNetworksResource.json
+++ b/chef-automate-ha/nested/virtualNetworksResource.json
@@ -13,7 +13,7 @@
         {
             "type": "Microsoft.Network/virtualNetworks",
             "name": "[parameters('networkSettings').virtualNetworkName]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "addressSpace": {

--- a/cloudbeesjenkins-dockerdatacenter/azuredeploy.json
+++ b/cloudbeesjenkins-dockerdatacenter/azuredeploy.json
@@ -168,21 +168,21 @@
     "jenkinsAuthenticationType": "password",
     "jenkinssshPublicKey": "",
     "dockerTags": {
-      "type":"object",
-      "provider": "8CF0E79C-DF97-4992-9B59-602DB544D354"  
+      "type": "object",
+      "provider": "8CF0E79C-DF97-4992-9B59-602DB544D354"
     },
     "cloudbeesTags": {
-      "type":"object",
-      "provider": "9F392E29-83D7-4569-AE61-608E2708A010"  
+      "type": "object",
+      "provider": "9F392E29-83D7-4569-AE61-608E2708A010"
     },
     "quickstartTags": {
-      "type":"object",
-      "name": "cloudbeesjenkins-dockerdatacenter"  
+      "type": "object",
+      "name": "cloudbeesjenkins-dockerdatacenter"
     }
   },
   "resources": [
     {
-      "apiVersion": "[variables('deploymentApiVersion')]",
+      "apiVersion": "2015-01-01",
       "name": "virtualNetworkDeployment",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -235,7 +235,7 @@
       }
     },
     {
-      "apiVersion": "[variables('deploymentApiVersion')]",
+      "apiVersion": "2015-01-01",
       "name": "cloudbeesDeployment",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -306,7 +306,7 @@
       }
     },
     {
-      "apiVersion": "[variables('deploymentApiVersion')]",
+      "apiVersion": "2015-01-01",
       "name": "dockerDatacenterDeployment",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [

--- a/cloudbeesjenkins-dockerdatacenter/nested/docker-data-center-deployment.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/docker-data-center-deployment.json
@@ -165,14 +165,14 @@
         "description": "Password for UCP Admin Account"
       }
     },
-     "dockerTags": {
+    "dockerTags": {
       "type": "object"
     },
-     "cloudbeesTags": {
+    "cloudbeesTags": {
       "type": "object"
     },
-     "quickstartTags": {
-       "type": "object"
+    "quickstartTags": {
+      "type": "object"
     }
   },
   "variables": {
@@ -371,41 +371,41 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetNameUcpControllers')]",
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       }
     },
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetNameUcpNodes')]",
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       }
     },
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetNameUcpNodesDtr')]",
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       }
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('ucpControllerStorageAccountName')]",
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "accountType": "[variables('vmSizesMap')[parameters('ucpControllerSize')].storageAccountType]"
@@ -414,11 +414,11 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('ucpNodeStorageAccountName')]",
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "accountType": "[variables('vmSizesMap')[parameters('ucpNodeSize')].storageAccountType]"
@@ -427,24 +427,24 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('ucpNodeDtrStorageAccountName')]",
-      "apiVersion": "[variables('apiVersionStorage')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "accountType": "[variables('vmSizesMap')[parameters('ucpDtrNodeSize')].storageAccountType]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('controllerLbPublicIpAddress')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
@@ -454,13 +454,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('nodeLbPublicIpAddress')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
@@ -470,13 +470,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('nodeDtrLbPublicIpAddress')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
@@ -486,13 +486,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('controllerLbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', parameters('controllerLbPublicIpAddress'))]"
@@ -548,13 +548,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
       "name": "[concat(variables('controllerLbName'), '/', 'SSH-', parameters('clusterPrefix'), '0')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "dependsOn": [
         "[variables('controllerLbId')]"
@@ -570,13 +570,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
       "name": "[concat(variables('controllerLbName'), '/', 'SSH-', parameters('clusterPrefix'), copyIndex(1))]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "copy": {
         "name": "controllerLbLoopNode",
@@ -597,13 +597,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('nodeLbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', parameters('nodeLbPublicIpAddress'))]"
@@ -687,13 +687,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
       "name": "[concat(variables('nodeLbName'), '/', 'SSH-', parameters('clusterPrefix'), '0')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "dependsOn": [
         "[variables('nodeLbId')]"
@@ -709,13 +709,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
       "name": "[concat(variables('nodeLbName'), '/', 'SSH-', parameters('clusterPrefix'), copyIndex(1))]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "copy": {
         "name": "nodeLbLoopNode",
@@ -736,13 +736,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('nodeDtrLbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', parameters('nodeDtrLbPublicIpAddress'))]"
@@ -798,13 +798,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
       "name": "[concat(variables('nodeDtrLbName'), '/', 'SSH-', parameters('clusterPrefix'), '0')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "dependsOn": [
         "[variables('nodeDtrLbId')]"
@@ -820,13 +820,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetwork')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
       "name": "[concat(variables('nodeDtrLbName'), '/', 'SSH-', parameters('clusterPrefix'), copyIndex(1))]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "copy": {
         "name": "nodeDtrLbLoopNode",
@@ -847,7 +847,7 @@
       }
     },
     {
-      "apiVersion": "[variables('linkTemplateApiVersion')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat('ucpController', copyindex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -931,7 +931,7 @@
       }
     },
     {
-      "apiVersion": "[variables('linkTemplateApiVersion')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat('ucpNode', copyindex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1015,7 +1015,7 @@
       }
     },
     {
-      "apiVersion": "[variables('linkTemplateApiVersion')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat('ucpDtrNode', copyindex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1099,13 +1099,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterPrefix'), '0-ucpctrl/ucpControllerConfig')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "dependsOn": [
         "ucpController0"
@@ -1126,13 +1126,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterPrefix'), '0', '-ucpctrl/ebscript')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "dependsOn": [
         "ucpController0",
@@ -1142,7 +1142,6 @@
         "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(parameters('clusterPrefix'), '0-ucpdtrnode'), 'ucpDtrNodeConfig')]",
         "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(parameters('clusterPrefix'), '1-ucpdtrnode'), 'ucpDtrNodeConfig')]",
         "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(parameters('clusterPrefix'), '2-ucpdtrnode'), 'ucpDtrNodeConfig')]"
-
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
@@ -1160,13 +1159,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterPrefix'), copyIndex(1), '-ucpctrl/ucpControllerConfig')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "copy": {
         "name": "ucpReplicaScriptSet",
@@ -1192,13 +1191,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterPrefix'), copyIndex(1), '-ucpctrl/ucpControllerConnect')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "copy": {
         "name": "ucpReplicaScriptSet",
@@ -1228,13 +1227,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterPrefix'), copyindex(), '-ucpnode/ucpNodeConfig')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "copy": {
         "name": "ucpNodeScriptSet",
@@ -1260,19 +1259,18 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterPrefix'), '0-ucpdtrnode/ucpDtrNodeConfig')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "dependsOn": [
         "ucpDtrNode0",
         "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(parameters('clusterPrefix'), variables('ucpNodeReplicaCount'), '-ucpnode'), 'ucpNodeConfig')]",
         "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(parameters('clusterPrefix'), '0-ucpctrl'), 'ucpControllerConfig')]"
-
       ],
       "properties": {
         "publisher": "Microsoft.OSTCExtensions",
@@ -1290,13 +1288,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionCompute')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterPrefix'), copyindex(1), '-ucpdtrnode/ucpDtrNodeConfig')]",
       "location": "[parameters('location')]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-         "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "copy": {
         "name": "ucpDtrNodeScriptSet",
@@ -1304,7 +1302,7 @@
       },
       "dependsOn": [
         "[concat('ucpDtrNode', copyindex(1))]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(parameters('clusterPrefix'), '0-ucpctrl'), 'ucpControllerConfig')]"     
+        "[resourceId('Microsoft.Compute/virtualMachines/extensions', concat(parameters('clusterPrefix'), '0-ucpctrl'), 'ucpControllerConfig')]"
       ],
       "properties": {
         "publisher": "Microsoft.OSTCExtensions",

--- a/cloudbeesjenkins-dockerdatacenter/nested/jenkins-nsg.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/jenkins-nsg.json
@@ -16,12 +16,12 @@
         "description": "Network Security Group Name"
       }
     },
-  "networkApiVersion":{
-    "type":"string",
-    "defaultValue":"2016-03-30",
-  "metaData":{
-  "description":"API Version for the Network Resources"
-}
+    "networkApiVersion": {
+      "type": "string",
+      "defaultValue": "2016-03-30",
+      "metaData": {
+        "description": "API Version for the Network Resources"
+      }
     },
     "tag": {
       "type": "object",
@@ -45,15 +45,15 @@
   },
   "variables": {},
   "resources": [
-{
-      "apiVersion":"[parameters('networkApiVersion')]",
+    {
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('networkSecurityGroupName')]",
       "location": "[parameters('location')]",
       "tags": {
         "[parameters('tag').key1]": "[parameters('tag').value1]",
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('cloudbeesTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('cloudbeesTags').provider]"
       },
       "properties": {
         "securityRules": [

--- a/cloudbeesjenkins-dockerdatacenter/nested/network-interface.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/network-interface.json
@@ -59,28 +59,28 @@
         "description": "subnet reference where the Network Interface is being Deployed"
       }
     },
-     "dockerTags": {
-       "type": "object"
-     },
-     "cloudbeesTags": {
-       "type": "object"
-     },
-     "quickstartTags": {
-        "type": "object"
-     }
+    "dockerTags": {
+      "type": "object"
+    },
+    "cloudbeesTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
+    }
   },
   "variables": {},
   "resources": [
     {
       "comments": "Network Interface Resource",
-      "apiVersion": "[parameters('networkApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceName')]",
       "location": "[parameters('location')]",
       "tags": {
         "[parameters('tag').key1]": "[parameters('tag').value1]",
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "networkSecurityGroup": {

--- a/cloudbeesjenkins-dockerdatacenter/nested/newvnet.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/newvnet.json
@@ -1,131 +1,128 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"location": {
-			"type": "string",
-			"metadata": {
-				"description": "Location where to create the resources"
-			}
-		},
-		"virtualNetworkName": {
-			"type": "string",
-			"metadata": {
-				"description": "Name of the Virtual Network"
-			}
-		},
-		"virtualNetworkAddressPrefix": {
-			"type": "string",
-			"metadata": {
-				"description": "Address Prefix for Virtual Network"
-			}		
-		},
-		"jenkinsSubnetName": {
-			"type": "string",
-			"metadata": {
-				"description": "Name of Jenkins Subnet"
-			}		
-		},
-		"jenkinsSubnetPrefix": {
-			"type": "string",
-			"metadata": {
-				"description": "Address Prefix for Jenkins Subnet"
-			}		
-		},
-		"controllerSubnetName": {
-			"type": "string",
-			"metadata": {
-				"description": "Name of controller Subnet"
-			}		
-		},
-		"controllerSubnetPrefix": {
-			"type": "string",
-			"metadata": {
-				"description": "Address Prefix for controller Subnet"
-			}		
-		},
-		"nodeSubnetName": {
-			"type": "string",
-			"metadata": {
-				"description": "The node Subnet name"
-			}
-		},
-		"nodeSubnetPrefix": {
-			"type": "string",
-			"metadata": {
-				"description": "The node Subnet prefix"
-			}
-		},
-		"apiVersion": {
-			"type": "string",
-			"metadata": {
-				"description": "Api version"
-			}					
-		},
-		"dockerTags": {
-		    "type": "object"
-		},
-		"cloudbeesTags": {
-		    "type": "object"
-		},
-		"quickstartTags": {
-		    "type": "object"
-		}	
-	},
-	
-	"variables": {
-		"vnetID" : "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
-		"controllerSubnet" : "[concat(variables('vnetID'),'/subnets/',parameters('controllerSubnetName'))]",
-		"nodeSubnet" : "[concat(variables('vnetID'),'/subnets/',parameters('nodeSubnetName'))]"
-	},
-	
-	"resources": [
-		{
-			"apiVersion": "[parameters('apiVersion')]",
-			"type": "Microsoft.Network/virtualNetworks",
-			"name": "[parameters('virtualNetworkName')]",
-			"location": "[parameters('location')]",
-                        "tags": {
-                           "quickstartName":"[parameters('quickstartTags').name]",
-                           "provider":"[parameters('dockerTags').provider]"
-                        },
-			"properties": {
-				"addressSpace": {
-					"addressPrefixes": [
-						"[parameters('virtualNetworkAddressPrefix')]"
-					]
-				},
-				"subnets": [
-				{
-					"name": "[parameters('jenkinsSubnetName')]",
-					"properties": {
-						"addressPrefix": "[parameters('jenkinsSubnetPrefix')]"
-					}
-				},
-				{
-					"name": "[parameters('controllerSubnetName')]",
-					"properties": {
-						"addressPrefix": "[parameters('controllerSubnetPrefix')]"
-					}
-				},
-				{
-					"name": "[parameters('nodeSubnetName')]",
-					"properties": {
-						"addressPrefix": "[parameters('nodeSubnetPrefix')]"
-					}
-				}]
-			}
-		}
-	],
-	"outputs": {
-		
-        "controllerSubnetId": {
-            "value": "[variables('controllerSubnet')]",
-            "type": "string"
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Location where to create the resources"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Virtual Network"
+      }
+    },
+    "virtualNetworkAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address Prefix for Virtual Network"
+      }
+    },
+    "jenkinsSubnetName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of Jenkins Subnet"
+      }
+    },
+    "jenkinsSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address Prefix for Jenkins Subnet"
+      }
+    },
+    "controllerSubnetName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of controller Subnet"
+      }
+    },
+    "controllerSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address Prefix for controller Subnet"
+      }
+    },
+    "nodeSubnetName": {
+      "type": "string",
+      "metadata": {
+        "description": "The node Subnet name"
+      }
+    },
+    "nodeSubnetPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The node Subnet prefix"
+      }
+    },
+    "apiVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "Api version"
+      }
+    },
+    "dockerTags": {
+      "type": "object"
+    },
+    "cloudbeesTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
+    }
+  },
+  "variables": {
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+    "controllerSubnet": "[concat(variables('vnetID'),'/subnets/',parameters('controllerSubnetName'))]",
+    "nodeSubnet": "[concat(variables('vnetID'),'/subnets/',parameters('nodeSubnetName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
+      },
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('virtualNetworkAddressPrefix')]"
+          ]
         },
-		"nodeSubnetId": {
-            "value": "[variables('nodeSubnet')]",
-            "type": "string"
-        }
-	}	
+        "subnets": [
+          {
+            "name": "[parameters('jenkinsSubnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('jenkinsSubnetPrefix')]"
+            }
+          },
+          {
+            "name": "[parameters('controllerSubnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('controllerSubnetPrefix')]"
+            }
+          },
+          {
+            "name": "[parameters('nodeSubnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('nodeSubnetPrefix')]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "controllerSubnetId": {
+      "value": "[variables('controllerSubnet')]",
+      "type": "string"
+    },
+    "nodeSubnetId": {
+      "value": "[variables('nodeSubnet')]",
+      "type": "string"
+    }
+  }
 }

--- a/cloudbeesjenkins-dockerdatacenter/nested/newvnet.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/newvnet.json
@@ -79,6 +79,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",

--- a/cloudbeesjenkins-dockerdatacenter/nested/nic-static-private-ip.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/nic-static-private-ip.json
@@ -53,9 +53,9 @@
       }
     },
     "privateIPAddress": {
-       "type": "string",
-       "allowedValues": [ ],
-       "metadata": {
+      "type": "string",
+      "allowedValues": [],
+      "metadata": {
         "description": "Static Private IP will be assigned to the machine"
       }
     },
@@ -66,30 +66,28 @@
         "description": "subnet reference where the Network Interface is being Deployed"
       }
     },
-     "dockerTags": {
-        "type": "object"
-     },
-     "cloudbeesTags": {
-        "type": "object"
-     },
-     "quickstartTags": {
-        "type": "object"
-     }
+    "dockerTags": {
+      "type": "object"
+    },
+    "cloudbeesTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
+    }
   },
-  "variables": {
-    
-  },
+  "variables": {},
   "resources": [
     {
       "comments": "Network Interface Resource",
-      "apiVersion": "[parameters('networkApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceName')]",
       "location": "[parameters('location')]",
       "tags": {
         "[parameters('tag').key1]": "[parameters('tag').value1]",
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "networkSecurityGroup": {

--- a/cloudbeesjenkins-dockerdatacenter/nested/public-ip.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/public-ip.json
@@ -59,14 +59,14 @@
   "resources": [
     {
       "comments": "Public IP Address Resource",
-      "apiVersion": "[parameters('networkApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIPAddressName')]",
       "location": "[parameters('location')]",
       "tags": {
         "[parameters('tag').key1]": "[parameters('tag').value1]",
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "publicIPAllocationMethod": "Dynamic",

--- a/cloudbeesjenkins-dockerdatacenter/nested/storage.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/storage.json
@@ -67,12 +67,12 @@
       "comments": "Storage Account Resource",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "[parameters('storageApiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[parameters('location')]",
       "tags": {
         "[parameters('tag').key1]": "[parameters('tag').value1]",
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('dockerTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
       },
       "properties": {
         "accountType": "[parameters('storageAccountType')]"

--- a/cloudbeesjenkins-dockerdatacenter/nested/ucpcontroller.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/ucpcontroller.json
@@ -142,6 +142,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",
@@ -175,6 +176,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNamePrefix'), '-ucpctrl')]",
       "location": "[parameters('location')]",

--- a/cloudbeesjenkins-dockerdatacenter/nested/ucpcontroller.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/ucpcontroller.json
@@ -1,232 +1,233 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"imagePublisher": {
-			"type": "string",
-			"metadata": {
-				"description": "Image Publisher Name"
-			}
-		},
-		"imageOffer": {
-			"type": "string",
-			"metadata": {
-				"description": "Image Offer Name"
-			}
-		},
-		"imageSKU": {
-			"type": "string",
-			"metadata": {
-				"description": "Image SKU Name"
-			}
-		},
-		"apiVersionCompute": {
-			"type": "string",
-			"metadata": {
-				"description": "compute API Version"
-			}
-		},
-		"apiVersionNetwork": {
-			"type": "string",
-			"metadata": {
-				"description": "Network API Version"
-			}
-		},
-		"location": {
-			"type": "string",
-			"metadata": {
-				"description": "Location where to create the resources"
-			}
-		},
-		"vmNamePrefix": {
-			"type": "string",
-			"metadata": {
-				"description": "Cluster Name (Prefix)"
-			}
-		},
-		"adminUsername": {
-			"type": "string",
-			"metadata": {
-				"description": "Admin user name"
-			}
-		},
-		"adminPassword": {
-			"type": "securestring",
-			"metadata": {
-				"description": "Admin password"
-			}
-		},
-		"authenticationType": {
-			"type": "string",
-			"metadata": {
-				"description": "Authentication type"
-			}
-		},
-		"sshPublicKey": {
-			"type": "string",
-			"metadata": {
-				"description": "SSH public key"
-			}
-		},
-		"vmSize": {
-			"type": "string",
-			"metadata": {
-				"description": "Master VM Size"
-			}
-		},
-		"availabilitySetName": {
-			"type": "string",
-			"metadata": {
-				"description": "Availability Set Name"
-			}
-		},
-		"controllerSubnetRef": {
-			"type": "string",
-			"metadata": {
-				"description": "Subnet reference"
-			}
-		},
-		"controllerLbBackendPoolName": {
-			"type": "string",
-			"metadata": {
-				"description": "Load balancer name"
-			}
-		},
-		"controllerLbId": {
-			"type": "string",
-			"metadata": {
-				"description": "Load balancer name"
-			}
-		},
-		"storageAccountName": {
-			"type": "string",
-			"metadata": {
-				"description": "Storage account name"
-			}
-		},
-		"dockerTags": {
-		    "type": "object"
-		},
-		"cloudbeesTags": {
-		    "type": "object"
-		},
-		"quickstartTags": {
-		    "type": "object"
-		}
-	},
-
-	"variables": {
-		"sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
-		"osProfileChosen": "[concat('osProfile', parameters('authenticationType'))]",
-		"osProfilesshPublicKey": {
-			"computerName": "[concat(parameters('vmNamePrefix'), '-ucpctrl')]",
-			"adminUsername": "[parameters('adminUsername')]",
-			"linuxConfiguration": {
-				"disablePasswordAuthentication": "true",
-				"ssh": {
-					"publicKeys": [{
-						"keyData": "[parameters('sshPublicKey')]",
-						"path": "[variables('sshKeyPath')]"
-					}]
-				}
-			}
-		},
-		"osProfilepassword": {
-			"computerName": "[concat(parameters('vmNamePrefix'), '-ucpctrl')]",
-			"adminUsername": "[parameters('adminUsername')]",
-			"adminPassword": "[parameters('adminPassword')]"
-		},
-		"nicName": "[concat(parameters('vmNamePrefix'),'-ucpctrl-nic')]",
-		"storageUriProd": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net/vhds/')]"
-	},
-
-	"resources": [
-		{
-			"apiVersion": "[parameters('apiVersionNetwork')]",
-			"type": "Microsoft.Network/networkInterfaces",
-			"name": "[variables('nicName')]",
-			"location": "[parameters('location')]",
-		        "tags": {
-			    "quickstartName":"[parameters('quickstartTags').name]",
-			    "provider":"[parameters('dockerTags').provider]"
-		        },
-			"dependsOn": [],
-			"properties": {
-				"ipConfigurations": [{
-					"name": "ipconfig1",
-					"properties": {
-						"privateIPAllocationMethod": "Dynamic",
-						"subnet": {
-							"id": "[parameters('controllerSubnetRef')]"
-						},
-						"loadBalancerBackendAddressPools": [
-							{
-								"id": "[concat(parameters('controllerLbId'), '/backendAddressPools/', parameters('controllerLbBackendPoolName'))]"
-							}
-						],
-						"loadBalancerInboundNatRules": [
-							{
-								"id": "[concat(parameters('controllerLbId'),'/inboundNatRules/SSH-',parameters('VMNamePrefix'))]"
-							}
-						]
-					}
-				}]
-			}
-		},
-
-		{
-			"apiVersion": "[parameters('apiVersionCompute')]",
-			"type": "Microsoft.Compute/virtualMachines",
-			"name": "[concat(parameters('vmNamePrefix'), '-ucpctrl')]",
-			"location": "[parameters('location')]",
-		        "tags": {
-			      "quickstartName":"[parameters('quickstartTags').name]",
-			      "provider":"[parameters('dockerTags').provider]"
-		         },
-			"plan": {
-                "name": "[parameters('imageSKU')]",
-                "publisher": "[parameters('imagePublisher')]",
-                "product": "[parameters('imageOffer')]"
-            },
-			"dependsOn": [
-				"[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-			],
-			"properties": {
-				"availabilitySet": {
-					"id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
-				},
-				"hardwareProfile": {
-					"vmSize": "[parameters('vmSize')]"
-				},
-				"osProfile": "[variables(variables('osProfileChosen'))]",
-				"storageProfile": {
-					"imageReference": {
-                        "publisher": "[parameters('imagePublisher')]",
-                        "offer": "[parameters('imageOffer')]",
-                        "sku": "[parameters('imageSKU')]",
-                        "version": "latest"
-                    },
-					"osDisk": {
-						"name": "[concat(parameters('vmNamePrefix'),'-ucpctrl-osDisk')]",
-						"caching": "ReadWrite",
-						"createOption": "FromImage",
-						"vhd": {
-							"uri": "[concat(variables('storageUriProd'), parameters('vmNamePrefix'),'-ucpctrl-osDisk.vhd')]"
-						}
-					}
-				},
-				"networkProfile": {
-					"networkInterfaces": [{
-						"id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-					}]
-				}
-			}
-		}
-	],
-	"outputs": {
-		"privateIp": {
-			"value": "[reference(variables('nicName')).ipConfigurations[0].properties.privateIpAddress]",
-			"type": "string"
-		}
-	}
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "imagePublisher": {
+      "type": "string",
+      "metadata": {
+        "description": "Image Publisher Name"
+      }
+    },
+    "imageOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "Image Offer Name"
+      }
+    },
+    "imageSKU": {
+      "type": "string",
+      "metadata": {
+        "description": "Image SKU Name"
+      }
+    },
+    "apiVersionCompute": {
+      "type": "string",
+      "metadata": {
+        "description": "compute API Version"
+      }
+    },
+    "apiVersionNetwork": {
+      "type": "string",
+      "metadata": {
+        "description": "Network API Version"
+      }
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Location where to create the resources"
+      }
+    },
+    "vmNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Cluster Name (Prefix)"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Admin user name"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin password"
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "metadata": {
+        "description": "Authentication type"
+      }
+    },
+    "sshPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "SSH public key"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "Master VM Size"
+      }
+    },
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "Availability Set Name"
+      }
+    },
+    "controllerSubnetRef": {
+      "type": "string",
+      "metadata": {
+        "description": "Subnet reference"
+      }
+    },
+    "controllerLbBackendPoolName": {
+      "type": "string",
+      "metadata": {
+        "description": "Load balancer name"
+      }
+    },
+    "controllerLbId": {
+      "type": "string",
+      "metadata": {
+        "description": "Load balancer name"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Storage account name"
+      }
+    },
+    "dockerTags": {
+      "type": "object"
+    },
+    "cloudbeesTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
+    }
+  },
+  "variables": {
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+    "osProfileChosen": "[concat('osProfile', parameters('authenticationType'))]",
+    "osProfilesshPublicKey": {
+      "computerName": "[concat(parameters('vmNamePrefix'), '-ucpctrl')]",
+      "adminUsername": "[parameters('adminUsername')]",
+      "linuxConfiguration": {
+        "disablePasswordAuthentication": "true",
+        "ssh": {
+          "publicKeys": [
+            {
+              "keyData": "[parameters('sshPublicKey')]",
+              "path": "[variables('sshKeyPath')]"
+            }
+          ]
+        }
+      }
+    },
+    "osProfilepassword": {
+      "computerName": "[concat(parameters('vmNamePrefix'), '-ucpctrl')]",
+      "adminUsername": "[parameters('adminUsername')]",
+      "adminPassword": "[parameters('adminPassword')]"
+    },
+    "nicName": "[concat(parameters('vmNamePrefix'),'-ucpctrl-nic')]",
+    "storageUriProd": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net/vhds/')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
+      },
+      "dependsOn": [],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[parameters('controllerSubnetRef')]"
+              },
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "[concat(parameters('controllerLbId'), '/backendAddressPools/', parameters('controllerLbBackendPoolName'))]"
+                }
+              ],
+              "loadBalancerInboundNatRules": [
+                {
+                  "id": "[concat(parameters('controllerLbId'),'/inboundNatRules/SSH-',parameters('VMNamePrefix'))]"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('vmNamePrefix'), '-ucpctrl')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
+      },
+      "plan": {
+        "name": "[parameters('imageSKU')]",
+        "publisher": "[parameters('imagePublisher')]",
+        "product": "[parameters('imageOffer')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": "[variables(variables('osProfileChosen'))]",
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imagePublisher')]",
+            "offer": "[parameters('imageOffer')]",
+            "sku": "[parameters('imageSKU')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('vmNamePrefix'),'-ucpctrl-osDisk')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "vhd": {
+              "uri": "[concat(variables('storageUriProd'), parameters('vmNamePrefix'),'-ucpctrl-osDisk.vhd')]"
+            }
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "privateIp": {
+      "value": "[reference(variables('nicName')).ipConfigurations[0].properties.privateIpAddress]",
+      "type": "string"
+    }
+  }
 }

--- a/cloudbeesjenkins-dockerdatacenter/nested/ucpdtrnode.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/ucpdtrnode.json
@@ -1,232 +1,234 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"imagePublisher": {
-			"type": "string",
-			"metadata": {
-				"description": "Image Publisher Name"
-			}
-		},
-		"imageOffer": {
-			"type": "string",
-			"metadata": {
-				"description": "Image Offer Name"
-			}
-		},
-		"imageSKU": {
-			"type": "string",
-			"metadata": {
-				"description": "Image SKU Name"
-			}
-		},
-		"apiVersionCompute": {
-			"type": "string",
-			"metadata": {
-				"description": "compute API Version"
-			}
-		},
-		"apiVersionNetwork": {
-			"type": "string",
-			"metadata": {
-				"description": "Network API Version"
-			}
-		},
-		"location": {
-			"type": "string",
-			"metadata": {
-				"description": "Location where to create the resources"
-			}
-		},
-		"vmNamePrefix": {
-			"type": "string",
-			"metadata": {
-				"description": "Cluster Name (Prefix)"
-			}
-		},
-		"adminUsername": {
-			"type": "string",
-			"metadata": {
-				"description": "Admin user name"
-			}
-		},
-		"adminPassword": {
-			"type": "securestring",
-			"metadata": {
-				"description": "Admin password"
-			}
-		},
-		"authenticationType": {
-			"type": "string",
-			"metadata": {
-				"description": "Authentication type"
-			}
-		},
-		"sshPublicKey": {
-			"type": "string",
-			"metadata": {
-				"description": "SSH public key"
-			}
-		},
-		"vmSize": {
-			"type": "string",
-			"metadata": {
-				"description": "Master VM Size"
-			}
-		},
-		"availabilitySetName": {
-			"type": "string",
-			"metadata": {
-				"description": "Availability Set Name"
-			}
-		},
-		"nodeSubnetRef": {
-			"type": "string",
-			"metadata": {
-				"description": "Node Subnet reference"
-			}
-		},
-		"nodeLbBackendPoolName": {
-			"type": "string",
-			"metadata": {
-				"description": "Node Load Balancer back end pool name"
-			}
-		},
-		"nodeLbId": {
-			"type": "string",
-			"metadata": {
-				"description": "Node Load Balancer ID"
-			}
-		},
-		"storageAccountName": {
-			"type": "string",
-			"metadata": {
-				"description": "Storage account name"
-			}
-		},
-		"dockerTags": {
-		    "type": "object"
-		},
-		"cloudbeesTags": {
-		    "type": "object"
-		},
-		"quickstartTags": {
-		    "type": "object"
-		}
-	},
-
-	"variables": {
-		"sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
-		"osProfileChosen": "[concat('osProfile', parameters('authenticationType'))]",
-		"osProfilesshPublicKey": {
-			"computerName": "[concat(parameters('vmNamePrefix'), '-ucpdtrnode')]",
-			"adminUsername": "[parameters('adminUsername')]",
-			"linuxConfiguration": {
-				"disablePasswordAuthentication": "true",
-				"ssh": {
-					"publicKeys": [{
-						"keyData": "[parameters('sshPublicKey')]",
-						"path": "[variables('sshKeyPath')]"
-					}]
-				}
-			}
-		},
-		"osProfilepassword": {
-			"computerName": "[concat(parameters('vmNamePrefix'), '-ucpdtrnode')]",
-			"adminUsername": "[parameters('adminUsername')]",
-			"adminPassword": "[parameters('adminPassword')]"
-		},
-		"nicName": "[concat(parameters('vmNamePrefix'),'-ucpdtrnode-nic')]",
-		"dataDiskSize": "128",
-		"storageUriProd": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net/vhds/')]"
-	},
-
-	"resources": [{
-			"apiVersion": "[parameters('apiVersionNetwork')]",
-			"type": "Microsoft.Network/networkInterfaces",
-			"name": "[variables('nicName')]",
-			"location": "[parameters('location')]",
-		        "tags": {
-			   "quickstartName":"[parameters('quickstartTags').name]",
-			   "provider":"[parameters('dockerTags').provider]"
-		        },
-			"dependsOn": [],
-			"properties": {
-				"ipConfigurations": [{
-					"name": "ipconfig1",
-					"properties": {
-						"privateIPAllocationMethod": "Dynamic",
-						"subnet": {
-							"id": "[parameters('nodeSubnetRef')]"
-						},
-						"loadBalancerBackendAddressPools": [
-							{
-								"id": "[concat(parameters('nodeLbId'), '/backendAddressPools/', parameters('nodeLbBackendPoolName'))]"
-							}
-						],
-						"loadBalancerInboundNatRules": [
-							{
-								"id": "[concat(parameters('nodeLbId'),'/inboundNatRules/SSH-',parameters('VMNamePrefix'))]"
-							}
-						]
-					}
-				}]
-			}
-		},
-
-		{
-			"apiVersion": "[parameters('apiVersionCompute')]",
-			"type": "Microsoft.Compute/virtualMachines",
-			"name": "[concat(parameters('vmNamePrefix'), '-ucpdtrnode')]",
-			"location": "[parameters('location')]",
-		        "tags": {
-			    "quickstartName":"[parameters('quickstartTags').name]",
-			    "provider":"[parameters('dockerTags').provider]"
-		        },
-			"plan": {
-                "name": "[parameters('imageSKU')]",
-                "publisher": "[parameters('imagePublisher')]",
-                "product": "[parameters('imageOffer')]"
-            },
-			"dependsOn": [
-				"[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-			],
-			"properties": {
-				"availabilitySet": {
-					"id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
-				},
-				"hardwareProfile": {
-					"vmSize": "[parameters('vmSize')]"
-				},
-				"osProfile": "[variables(variables('osProfileChosen'))]",
-				"storageProfile": {
-					"imageReference": {
-                        "publisher": "[parameters('imagePublisher')]",
-                        "offer": "[parameters('imageOffer')]",
-                        "sku": "[parameters('imageSKU')]",
-                        "version": "latest"
-                    },
-					"osDisk": {
-						"name": "[concat(parameters('vmNamePrefix'),'-ucpdtrnode-osDisk')]",
-						"caching": "ReadWrite",
-						"createOption": "FromImage",
-						"vhd": {
-							"uri": "[concat(variables('storageUriProd'), parameters('vmNamePrefix'),'-ucpdtrnode-osDisk.vhd')]"
-						}
-					}					
-				},
-				"networkProfile": {
-					"networkInterfaces": [{
-						"id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-					}]
-				}
-			}
-		}
-	],
-	"outputs": {
-		"privateIp": {
-			"value": "[reference(variables('nicName')).ipConfigurations[0].properties.privateIpAddress]",
-			"type": "string"
-		}
-	}
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "imagePublisher": {
+      "type": "string",
+      "metadata": {
+        "description": "Image Publisher Name"
+      }
+    },
+    "imageOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "Image Offer Name"
+      }
+    },
+    "imageSKU": {
+      "type": "string",
+      "metadata": {
+        "description": "Image SKU Name"
+      }
+    },
+    "apiVersionCompute": {
+      "type": "string",
+      "metadata": {
+        "description": "compute API Version"
+      }
+    },
+    "apiVersionNetwork": {
+      "type": "string",
+      "metadata": {
+        "description": "Network API Version"
+      }
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Location where to create the resources"
+      }
+    },
+    "vmNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Cluster Name (Prefix)"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Admin user name"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin password"
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "metadata": {
+        "description": "Authentication type"
+      }
+    },
+    "sshPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "SSH public key"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "Master VM Size"
+      }
+    },
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "Availability Set Name"
+      }
+    },
+    "nodeSubnetRef": {
+      "type": "string",
+      "metadata": {
+        "description": "Node Subnet reference"
+      }
+    },
+    "nodeLbBackendPoolName": {
+      "type": "string",
+      "metadata": {
+        "description": "Node Load Balancer back end pool name"
+      }
+    },
+    "nodeLbId": {
+      "type": "string",
+      "metadata": {
+        "description": "Node Load Balancer ID"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Storage account name"
+      }
+    },
+    "dockerTags": {
+      "type": "object"
+    },
+    "cloudbeesTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
+    }
+  },
+  "variables": {
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+    "osProfileChosen": "[concat('osProfile', parameters('authenticationType'))]",
+    "osProfilesshPublicKey": {
+      "computerName": "[concat(parameters('vmNamePrefix'), '-ucpdtrnode')]",
+      "adminUsername": "[parameters('adminUsername')]",
+      "linuxConfiguration": {
+        "disablePasswordAuthentication": "true",
+        "ssh": {
+          "publicKeys": [
+            {
+              "keyData": "[parameters('sshPublicKey')]",
+              "path": "[variables('sshKeyPath')]"
+            }
+          ]
+        }
+      }
+    },
+    "osProfilepassword": {
+      "computerName": "[concat(parameters('vmNamePrefix'), '-ucpdtrnode')]",
+      "adminUsername": "[parameters('adminUsername')]",
+      "adminPassword": "[parameters('adminPassword')]"
+    },
+    "nicName": "[concat(parameters('vmNamePrefix'),'-ucpdtrnode-nic')]",
+    "dataDiskSize": "128",
+    "storageUriProd": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net/vhds/')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
+      },
+      "dependsOn": [],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[parameters('nodeSubnetRef')]"
+              },
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "[concat(parameters('nodeLbId'), '/backendAddressPools/', parameters('nodeLbBackendPoolName'))]"
+                }
+              ],
+              "loadBalancerInboundNatRules": [
+                {
+                  "id": "[concat(parameters('nodeLbId'),'/inboundNatRules/SSH-',parameters('VMNamePrefix'))]"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('vmNamePrefix'), '-ucpdtrnode')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
+      },
+      "plan": {
+        "name": "[parameters('imageSKU')]",
+        "publisher": "[parameters('imagePublisher')]",
+        "product": "[parameters('imageOffer')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": "[variables(variables('osProfileChosen'))]",
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imagePublisher')]",
+            "offer": "[parameters('imageOffer')]",
+            "sku": "[parameters('imageSKU')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('vmNamePrefix'),'-ucpdtrnode-osDisk')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "vhd": {
+              "uri": "[concat(variables('storageUriProd'), parameters('vmNamePrefix'),'-ucpdtrnode-osDisk.vhd')]"
+            }
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "privateIp": {
+      "value": "[reference(variables('nicName')).ipConfigurations[0].properties.privateIpAddress]",
+      "type": "string"
+    }
+  }
 }

--- a/cloudbeesjenkins-dockerdatacenter/nested/ucpdtrnode.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/ucpdtrnode.json
@@ -143,6 +143,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",
@@ -176,6 +177,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNamePrefix'), '-ucpdtrnode')]",
       "location": "[parameters('location')]",

--- a/cloudbeesjenkins-dockerdatacenter/nested/ucpnode.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/ucpnode.json
@@ -143,6 +143,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",
@@ -176,6 +177,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNamePrefix'), '-ucpnode')]",
       "location": "[parameters('location')]",

--- a/cloudbeesjenkins-dockerdatacenter/nested/ucpnode.json
+++ b/cloudbeesjenkins-dockerdatacenter/nested/ucpnode.json
@@ -1,238 +1,240 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"imagePublisher": {
-			"type": "string",
-			"metadata": {
-				"description": "Image Publisher Name"
-			}
-		},
-		"imageOffer": {
-			"type": "string",
-			"metadata": {
-				"description": "Image Offer Name"
-			}
-		},
-		"imageSKU": {
-			"type": "string",
-			"metadata": {
-				"description": "Image SKU Name"
-			}
-		},
-		"apiVersionCompute": {
-			"type": "string",
-			"metadata": {
-				"description": "compute API Version"
-			}
-		},
-		"apiVersionNetwork": {
-			"type": "string",
-			"metadata": {
-				"description": "Network API Version"
-			}
-		},
-		"location": {
-			"type": "string",
-			"metadata": {
-				"description": "Location where to create the resources"
-			}
-		},
-		"vmNamePrefix": {
-			"type": "string",
-			"metadata": {
-				"description": "Cluster Name (Prefix)"
-			}
-		},
-		"adminUsername": {
-			"type": "string",
-			"metadata": {
-				"description": "Admin user name"
-			}
-		},
-		"adminPassword": {
-			"type": "securestring",
-			"metadata": {
-				"description": "Admin password"
-			}
-		},
-		"authenticationType": {
-			"type": "string",
-			"metadata": {
-				"description": "Authentication type"
-			}
-		},
-		"sshPublicKey": {
-			"type": "string",
-			"metadata": {
-				"description": "SSH public key"
-			}
-		},
-		"vmSize": {
-			"type": "string",
-			"metadata": {
-				"description": "Master VM Size"
-			}
-		},
-		"availabilitySetName": {
-			"type": "string",
-			"metadata": {
-				"description": "Availability Set Name"
-			}
-		},
-		"nodeSubnetRef": {
-			"type": "string",
-			"metadata": {
-				"description": "Node Subnet reference"
-			}
-		},
-		"nodeLbBackendPoolName": {
-			"type": "string",
-			"metadata": {
-				"description": "Node Load Balancer back end pool name"
-			}
-		},
-		"nodeLbId": {
-			"type": "string",
-			"metadata": {
-				"description": "Node Load Balancer ID"
-			}
-		},
-		"storageAccountName": {
-			"type": "string",
-			"metadata": {
-				"description": "Storage account name"
-			}
-		},
-		"dockerTags": {
-		    "type": "object"
-		},
-		"cloudbeesTags": {
-		    "type": "object"
-		},
-		"quickstartTags": {
-		    "type": "object"
-		}
-	},
-
-	"variables": {
-		"sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
-		"osProfileChosen": "[concat('osProfile', parameters('authenticationType'))]",
-		"osProfilesshPublicKey": {
-			"computerName": "[concat(parameters('vmNamePrefix'), '-ucpnode')]",
-			"adminUsername": "[parameters('adminUsername')]",
-			"linuxConfiguration": {
-				"disablePasswordAuthentication": "true",
-				"ssh": {
-					"publicKeys": [{
-						"keyData": "[parameters('sshPublicKey')]",
-						"path": "[variables('sshKeyPath')]"
-					}]
-				}
-			}
-		},
-		"osProfilepassword": {
-			"computerName": "[concat(parameters('vmNamePrefix'), '-ucpnode')]",
-			"adminUsername": "[parameters('adminUsername')]",
-			"adminPassword": "[parameters('adminPassword')]"
-		},
-		"nicName": "[concat(parameters('vmNamePrefix'),'-ucpnode-nic')]",
-		"dataDiskSize": "128",
-		"storageUriProd": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net/vhds/')]"
-	},
-
-	"resources": [{
-			"apiVersion": "[parameters('apiVersionNetwork')]",
-			"type": "Microsoft.Network/networkInterfaces",
-			"name": "[variables('nicName')]",
-			"location": "[parameters('location')]",
-			"dependsOn": [],
-		        "tags": {
-			    "quickstartName":"[parameters('quickstartTags').name]",
-			    "provider":"[parameters('dockerTags').provider]"
-		        },
-			"properties": {
-				"ipConfigurations": [{
-					"name": "ipconfig1",
-					"properties": {
-						"privateIPAllocationMethod": "Dynamic",
-						"subnet": {
-							"id": "[parameters('nodeSubnetRef')]"
-						},
-						"loadBalancerBackendAddressPools": [
-							{
-								"id": "[concat(parameters('nodeLbId'), '/backendAddressPools/', parameters('nodeLbBackendPoolName'))]"
-							}
-						],
-						"loadBalancerInboundNatRules": [
-							{
-								"id": "[concat(parameters('nodeLbId'),'/inboundNatRules/SSH-',parameters('VMNamePrefix'))]"
-							}
-						]
-					}
-				}]
-			}
-		},
-
-		{
-			"apiVersion": "[parameters('apiVersionCompute')]",
-			"type": "Microsoft.Compute/virtualMachines",
-			"name": "[concat(parameters('vmNamePrefix'), '-ucpnode')]",
-			"location": "[parameters('location')]",
-		        "tags": {
-			    "quickstartName":"[parameters('quickstartTags').name]",
-			    "provider":"[parameters('dockerTags').provider]"
-		        },
-			"plan": {
-                "name": "[parameters('imageSKU')]",
-                "publisher": "[parameters('imagePublisher')]",
-                "product": "[parameters('imageOffer')]"
-            },
-			"dependsOn": [
-				"[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-			],
-			"properties": {
-				"availabilitySet": {
-					"id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
-				},
-				"hardwareProfile": {
-					"vmSize": "[parameters('vmSize')]"
-				},
-				"osProfile": "[variables(variables('osProfileChosen'))]",
-				"storageProfile": {
-					"imageReference": {
-                        "publisher": "[parameters('imagePublisher')]",
-                        "offer": "[parameters('imageOffer')]",
-                        "sku": "[parameters('imageSKU')]",
-                        "version": "latest"
-                    },
-					"osDisk": {
-						"name": "[concat(parameters('vmNamePrefix'),'-ucpnode-osDisk')]",
-						"caching": "ReadWrite",
-						"createOption": "FromImage",
-						"vhd": {
-							"uri": "[concat(variables('storageUriProd'), parameters('vmNamePrefix'),'-ucpnode-osDisk.vhd')]"
-						}
-					},
-					"dataDisks": [ 
-                    {
-						"name": "[concat(parameters('vmNamePrefix'),'-ucpnode-data-disk')]",
-						"diskSizeGB": "[variables('dataDiskSize')]",
-						"lun": 0,
-						"vhd": {
-							"Uri": "[concat(variables('storageUriProd') ,parameters('vmNamePrefix'),'-ucpnode-data-disk.vhd')]"
-						},
-						"createOption": "Empty"
-					}
-					]
-				},
-				"networkProfile": {
-					"networkInterfaces": [{
-						"id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-					}]
-				}
-			}
-		}
-	],
-	"outputs": {}
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "imagePublisher": {
+      "type": "string",
+      "metadata": {
+        "description": "Image Publisher Name"
+      }
+    },
+    "imageOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "Image Offer Name"
+      }
+    },
+    "imageSKU": {
+      "type": "string",
+      "metadata": {
+        "description": "Image SKU Name"
+      }
+    },
+    "apiVersionCompute": {
+      "type": "string",
+      "metadata": {
+        "description": "compute API Version"
+      }
+    },
+    "apiVersionNetwork": {
+      "type": "string",
+      "metadata": {
+        "description": "Network API Version"
+      }
+    },
+    "location": {
+      "type": "string",
+      "metadata": {
+        "description": "Location where to create the resources"
+      }
+    },
+    "vmNamePrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Cluster Name (Prefix)"
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Admin user name"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin password"
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "metadata": {
+        "description": "Authentication type"
+      }
+    },
+    "sshPublicKey": {
+      "type": "string",
+      "metadata": {
+        "description": "SSH public key"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "Master VM Size"
+      }
+    },
+    "availabilitySetName": {
+      "type": "string",
+      "metadata": {
+        "description": "Availability Set Name"
+      }
+    },
+    "nodeSubnetRef": {
+      "type": "string",
+      "metadata": {
+        "description": "Node Subnet reference"
+      }
+    },
+    "nodeLbBackendPoolName": {
+      "type": "string",
+      "metadata": {
+        "description": "Node Load Balancer back end pool name"
+      }
+    },
+    "nodeLbId": {
+      "type": "string",
+      "metadata": {
+        "description": "Node Load Balancer ID"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Storage account name"
+      }
+    },
+    "dockerTags": {
+      "type": "object"
+    },
+    "cloudbeesTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
+    }
+  },
+  "variables": {
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+    "osProfileChosen": "[concat('osProfile', parameters('authenticationType'))]",
+    "osProfilesshPublicKey": {
+      "computerName": "[concat(parameters('vmNamePrefix'), '-ucpnode')]",
+      "adminUsername": "[parameters('adminUsername')]",
+      "linuxConfiguration": {
+        "disablePasswordAuthentication": "true",
+        "ssh": {
+          "publicKeys": [
+            {
+              "keyData": "[parameters('sshPublicKey')]",
+              "path": "[variables('sshKeyPath')]"
+            }
+          ]
+        }
+      }
+    },
+    "osProfilepassword": {
+      "computerName": "[concat(parameters('vmNamePrefix'), '-ucpnode')]",
+      "adminUsername": "[parameters('adminUsername')]",
+      "adminPassword": "[parameters('adminPassword')]"
+    },
+    "nicName": "[concat(parameters('vmNamePrefix'),'-ucpnode-nic')]",
+    "dataDiskSize": "128",
+    "storageUriProd": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net/vhds/')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [],
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[parameters('nodeSubnetRef')]"
+              },
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "[concat(parameters('nodeLbId'), '/backendAddressPools/', parameters('nodeLbBackendPoolName'))]"
+                }
+              ],
+              "loadBalancerInboundNatRules": [
+                {
+                  "id": "[concat(parameters('nodeLbId'),'/inboundNatRules/SSH-',parameters('VMNamePrefix'))]"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(parameters('vmNamePrefix'), '-ucpnode')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('dockerTags').provider]"
+      },
+      "plan": {
+        "name": "[parameters('imageSKU')]",
+        "publisher": "[parameters('imagePublisher')]",
+        "product": "[parameters('imageOffer')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('availabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": "[variables(variables('osProfileChosen'))]",
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imagePublisher')]",
+            "offer": "[parameters('imageOffer')]",
+            "sku": "[parameters('imageSKU')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('vmNamePrefix'),'-ucpnode-osDisk')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "vhd": {
+              "uri": "[concat(variables('storageUriProd'), parameters('vmNamePrefix'),'-ucpnode-osDisk.vhd')]"
+            }
+          },
+          "dataDisks": [
+            {
+              "name": "[concat(parameters('vmNamePrefix'),'-ucpnode-data-disk')]",
+              "diskSizeGB": "[variables('dataDiskSize')]",
+              "lun": 0,
+              "vhd": {
+                "Uri": "[concat(variables('storageUriProd') ,parameters('vmNamePrefix'),'-ucpnode-data-disk.vhd')]"
+              },
+              "createOption": "Empty"
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": {}
 }

--- a/cloudera-director-on-centos/azuredeploy.json
+++ b/cloudera-director-on-centos/azuredeploy.json
@@ -322,7 +322,7 @@
     {
       "name": "shared-vnet",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('version').templateAPIVersion]",
+      "apiVersion": "2017-05-10",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -342,7 +342,7 @@
     {
       "name": "director-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('version').templateAPIVersion]",
+      "apiVersion": "2017-05-10",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-vnet"
       ],
@@ -389,7 +389,7 @@
     {
       "name": "update-vnet-dns",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('version').templateAPIVersion]",
+      "apiVersion": "2017-05-10",
       "dependsOn": [
         "Microsoft.Resources/deployments/director-node"
       ],
@@ -412,7 +412,7 @@
     {
       "name": "network-restart-dns",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('version').templateAPIVersion]",
+      "apiVersion": "2017-05-10",
       "dependsOn": [
         "Microsoft.Resources/deployments/update-vnet-dns"
       ],
@@ -441,7 +441,7 @@
     {
       "name": "prepare-conf-launch-cluster",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('version').templateAPIVersion]",
+      "apiVersion": "2017-05-10",
       "dependsOn": [
         "Microsoft.Resources/deployments/network-restart-dns",
         "Microsoft.Resources/deployments/director-node"

--- a/cloudera-director-on-centos/director-node-and-shared-resources.json
+++ b/cloudera-director-on-centos/director-node-and-shared-resources.json
@@ -46,28 +46,28 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('masterAsName')]",
       "location": "[resourceGroup().location]",
       "properties": { }
     },
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('workerAsName')]",
       "location": "[resourceGroup().location]",
       "properties": { }
     },
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('edgeAsName')]",
       "location": "[resourceGroup().location]",
       "properties": { }
     },
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(parameters('networkSpec').virtualNetworkName,'-nsg')]",
       "location": "[resourceGroup().location]",
@@ -91,7 +91,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('dirSecurityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -117,14 +117,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[parameters('storageAccount').type]"
       }
     },
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -136,7 +136,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'))]",
       "location": "[resourceGroup().location]",
@@ -166,7 +166,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'))]",
       "plan": {
@@ -231,7 +231,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), '/bootstrapServer')]",
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/cloudera-director-on-centos/network-restart-new-vnet.json
+++ b/cloudera-director-on-centos/network-restart-new-vnet.json
@@ -19,7 +19,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmName'), '/bootstrapServer')]",
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",

--- a/cloudera-director-on-centos/prepare-conf-launch-cluster.json
+++ b/cloudera-director-on-centos/prepare-conf-launch-cluster.json
@@ -22,7 +22,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmName'), '/bootstrapServer')]",
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",

--- a/cloudera-director-on-centos/shared-resources-new-vnet.json
+++ b/cloudera-director-on-centos/shared-resources-new-vnet.json
@@ -11,7 +11,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSpec').virtualNetworkName]",
       "location": "[resourceGroup().location]",

--- a/cloudera-director-on-centos/update-new-vnet-dns.json
+++ b/cloudera-director-on-centos/update-new-vnet-dns.json
@@ -12,7 +12,7 @@
   "variables": {},
   "resources": [
     {
-      "apiVersion": "[parameters('version').resourceAPIVersion]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSpec').virtualNetworkName]",
       "location": "[resourceGroup().location]",

--- a/cloudera-on-centos/azuredeploy.json
+++ b/cloudera-on-centos/azuredeploy.json
@@ -61,8 +61,8 @@
         "description": "The name of the virtual network provisioned for the deployment"
       }
     },
-    "vnetNewOrExisting" : {
-      "type" : "string",
+    "vnetNewOrExisting": {
+      "type": "string",
       "defaultValue": "new",
       "allowedValues": [
         "new",
@@ -138,7 +138,12 @@
       "metadata": {
         "description": "The size of the VMs deployed in the cluster (defaults to Standard_DS14)"
       },
-      "allowedValues": ["Standard_DS14", "Standard_DS13", "Standard_DS14_V2", "Standard_DS13_V2"]
+      "allowedValues": [
+        "Standard_DS14",
+        "Standard_DS13",
+        "Standard_DS14_V2",
+        "Standard_DS13_V2"
+      ]
     },
     "vmImage": {
       "type": "string",
@@ -146,7 +151,10 @@
       "metadata": {
         "description": "The OS VM Image (defaults to ClouderaCentOS6_7)"
       },
-      "allowedValues": ["ClouderaCentOS6_7", "ClouderaCentOS6_8"]
+      "allowedValues": [
+        "ClouderaCentOS6_7",
+        "ClouderaCentOS6_8"
+      ]
     },
     "company": {
       "type": "string",
@@ -230,20 +238,20 @@
     }
   },
   "variables": {
-    "templateAPIVersion":"2015-11-01",
-    "resourceAPIVersion":"2015-06-15",
-    "installCDH":"True",
-    "addressPrefix":"[parameters('addressPrefix')]",
-    "subnetPrefix":"[parameters('subnetPrefix')]",
+    "templateAPIVersion": "2015-11-01",
+    "resourceAPIVersion": "2015-06-15",
+    "installCDH": "True",
+    "addressPrefix": "[parameters('addressPrefix')]",
+    "subnetPrefix": "[parameters('subnetPrefix')]",
     "scriptsUriDescription": "For Command Line Deployment, scriptsUri must point to an Azure-accessible location like: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/cloudera-on-centos",
     "scriptsUri": "[uri(deployment().properties.templateLink.uri, '.')]",
     "share-resourcesUri": "[concat(variables('scriptsUri'), '/shared-resources-', parameters('vnetNewOrExisting'), '-vnet.json')]",
-    "data-nodeUri":"[concat(variables('scriptsUri'), '/data-node-', toLower(subString(parameters('vmSize'), 0, 13)), '.json')]",
+    "data-nodeUri": "[concat(variables('scriptsUri'), '/data-node-', toLower(subString(parameters('vmSize'), 0, 13)), '.json')]",
     "sa": "[parameters('masterNodeIPAddress')]",
     "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
     "ipOctet2": "[int(split(variables('sa'), '.')[2])]",
     "ipOctet3": "[int(split(variables('sa'), '.')[3])]",
-    "datanodeIpOctet3":"[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
+    "datanodeIpOctet3": "[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
     "masterStorageAccount": {
       "prefix": "[parameters('storageAccountSuffix')]",
       "type": "[parameters('masterStorageAccountType')]"
@@ -275,7 +283,7 @@
           "offer": "cloudera-centos-6",
           "sku": "cloudera-centos-6",
           "version": "latest"
-          }
+        }
       },
       "ClouderaCentOS6_8": {
         "plan": {
@@ -314,23 +322,23 @@
       "ipOctet01": "[variables('ipOctet01')]",
       "ipOctet2": "[variables('ipOctet2')]",
       "ipOctet3": "[variables('ipOctet3')]",
-      "datanodeIpOctet3":"[variables('datanodeIpOctet3')]",
-      "masterIP":"[variables('sa')]",
-      "workerIP":"[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
+      "datanodeIpOctet3": "[variables('datanodeIpOctet3')]",
+      "masterIP": "[variables('sa')]",
+      "workerIP": "[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
-      "virtualNetworkRGName":"[parameters('virtualNetworkRGName')]",
+      "virtualNetworkRGName": "[parameters('virtualNetworkRGName')]",
       "vnetNewOrExisting": "[parameters('vnetNewOrExisting')]",
       "virtualNetworkSubnetName": "[parameters('subnetName')]"
     },
-    "newVNetId":"[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
-    "existingVNetId":"[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "newVNetId": "[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "existingVNetId": "[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
     "VNetId": "[variables(concat(parameters('vnetNewOrExisting'),'VNetId'))]"
   },
   "resources": [
     {
       "name": "shared-resources",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -338,8 +346,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "networkSpec": {
             "value": "[variables('networkSpec')]"
@@ -356,7 +364,7 @@
     {
       "name": "master-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -367,11 +375,11 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -400,7 +408,7 @@
     {
       "name": "data-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -411,14 +419,14 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "templateAPIVersion":{
-            "value":"[variables('templateAPIVersion')]"
+          "templateAPIVersion": {
+            "value": "[variables('templateAPIVersion')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -447,7 +455,7 @@
     {
       "name": "setup-cloudera",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/data-node",
         "Microsoft.Resources/deployments/master-node"
@@ -459,8 +467,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"

--- a/cloudera-on-centos/azuredeploy.json
+++ b/cloudera-on-centos/azuredeploy.json
@@ -338,7 +338,7 @@
     {
       "name": "shared-resources",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2015-11-01",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -364,7 +364,7 @@
     {
       "name": "master-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2015-11-01",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -408,7 +408,7 @@
     {
       "name": "data-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2015-11-01",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -455,7 +455,7 @@
     {
       "name": "setup-cloudera",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2015-11-01",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/data-node",
         "Microsoft.Resources/deployments/master-node"

--- a/cloudera-on-centos/azuredeployGermany.json
+++ b/cloudera-on-centos/azuredeployGermany.json
@@ -61,8 +61,8 @@
         "description": "The name of the virtual network provisioned for the deployment"
       }
     },
-    "vnetNewOrExisting" : {
-      "type" : "string",
+    "vnetNewOrExisting": {
+      "type": "string",
       "defaultValue": "new",
       "allowedValues": [
         "new",
@@ -138,7 +138,10 @@
       "metadata": {
         "description": "The size of the VMs deployed in the cluster (defaults to Standard_DS14_V2)"
       },
-      "allowedValues": ["Standard_DS14_V2", "Standard_DS13_V2"]
+      "allowedValues": [
+        "Standard_DS14_V2",
+        "Standard_DS13_V2"
+      ]
     },
     "vmImage": {
       "type": "string",
@@ -146,7 +149,9 @@
       "metadata": {
         "description": "The OS VM Image (defaults to ClouderaCentOS6_7Germany)"
       },
-      "allowedValues": ["ClouderaCentOS6_7Germany"]
+      "allowedValues": [
+        "ClouderaCentOS6_7Germany"
+      ]
     },
     "company": {
       "type": "string",
@@ -230,20 +235,20 @@
     }
   },
   "variables": {
-    "templateAPIVersion":"2015-11-01",
-    "resourceAPIVersion":"2015-06-15",
-    "installCDH":"True",
-    "addressPrefix":"[parameters('addressPrefix')]",
-    "subnetPrefix":"[parameters('subnetPrefix')]",
+    "templateAPIVersion": "2015-11-01",
+    "resourceAPIVersion": "2015-06-15",
+    "installCDH": "True",
+    "addressPrefix": "[parameters('addressPrefix')]",
+    "subnetPrefix": "[parameters('subnetPrefix')]",
     "scriptsUriDescription": "For Command Line Deployment, scriptsUri must point to an Azure-accessible location like: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/cloudera-on-centos",
     "scriptsUri": "[uri(deployment().properties.templateLink.uri, '.')]",
     "share-resourcesUri": "[concat(variables('scriptsUri'), '/shared-resources-', parameters('vnetNewOrExisting'), '-vnet.json')]",
-    "data-nodeUri":"[concat(variables('scriptsUri'), '/data-node-', toLower(subString(parameters('vmSize'), 0, 13)), '.json')]",
+    "data-nodeUri": "[concat(variables('scriptsUri'), '/data-node-', toLower(subString(parameters('vmSize'), 0, 13)), '.json')]",
     "sa": "[parameters('masterNodeIPAddress')]",
     "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
     "ipOctet2": "[int(split(variables('sa'), '.')[2])]",
     "ipOctet3": "[int(split(variables('sa'), '.')[3])]",
-    "datanodeIpOctet3":"[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
+    "datanodeIpOctet3": "[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
     "masterStorageAccount": {
       "prefix": "[parameters('storageAccountSuffix')]",
       "type": "[parameters('masterStorageAccountType')]"
@@ -275,7 +280,7 @@
           "offer": "cloudera-centos-6",
           "sku": "cloudera-centos-6",
           "version": "latest"
-          }
+        }
       },
       "ClouderaCentOS6_8": {
         "plan": {
@@ -314,23 +319,23 @@
       "ipOctet01": "[variables('ipOctet01')]",
       "ipOctet2": "[variables('ipOctet2')]",
       "ipOctet3": "[variables('ipOctet3')]",
-      "datanodeIpOctet3":"[variables('datanodeIpOctet3')]",
-      "masterIP":"[variables('sa')]",
-      "workerIP":"[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
+      "datanodeIpOctet3": "[variables('datanodeIpOctet3')]",
+      "masterIP": "[variables('sa')]",
+      "workerIP": "[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
-      "virtualNetworkRGName":"[parameters('virtualNetworkRGName')]",
+      "virtualNetworkRGName": "[parameters('virtualNetworkRGName')]",
       "vnetNewOrExisting": "[parameters('vnetNewOrExisting')]",
       "virtualNetworkSubnetName": "[parameters('subnetName')]"
     },
-    "newVNetId":"[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
-    "existingVNetId":"[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "newVNetId": "[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "existingVNetId": "[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
     "VNetId": "[variables(concat(parameters('vnetNewOrExisting'),'VNetId'))]"
   },
   "resources": [
     {
       "name": "shared-resources",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -338,8 +343,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "networkSpec": {
             "value": "[variables('networkSpec')]"
@@ -356,7 +361,7 @@
     {
       "name": "master-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -367,11 +372,11 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -400,7 +405,7 @@
     {
       "name": "data-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -411,14 +416,14 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "templateAPIVersion":{
-            "value":"[variables('templateAPIVersion')]"
+          "templateAPIVersion": {
+            "value": "[variables('templateAPIVersion')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -447,7 +452,7 @@
     {
       "name": "setup-cloudera",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/data-node",
         "Microsoft.Resources/deployments/master-node"
@@ -459,8 +464,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"

--- a/cloudera-on-centos/azuredeployds13.json
+++ b/cloudera-on-centos/azuredeployds13.json
@@ -61,8 +61,8 @@
         "description": "The name of the virtual network provisioned for the deployment"
       }
     },
-    "vnetNewOrExisting" : {
-      "type" : "string",
+    "vnetNewOrExisting": {
+      "type": "string",
       "defaultValue": "new",
       "allowedValues": [
         "new",
@@ -138,7 +138,12 @@
       "metadata": {
         "description": "The size of the VMs deployed in the cluster (defaults to Standard_DS13)"
       },
-      "allowedValues": ["Standard_DS14", "Standard_DS13", "Standard_DS14_V2", "Standard_DS13_V2"]
+      "allowedValues": [
+        "Standard_DS14",
+        "Standard_DS13",
+        "Standard_DS14_V2",
+        "Standard_DS13_V2"
+      ]
     },
     "vmImage": {
       "type": "string",
@@ -146,7 +151,10 @@
       "metadata": {
         "description": "The OS VM Image (defaults to ClouderaCentOS6_7)"
       },
-      "allowedValues": ["ClouderaCentOS6_7", "ClouderaCentOS6_8"]
+      "allowedValues": [
+        "ClouderaCentOS6_7",
+        "ClouderaCentOS6_8"
+      ]
     },
     "company": {
       "type": "string",
@@ -230,20 +238,20 @@
     }
   },
   "variables": {
-    "templateAPIVersion":"2015-11-01",
-    "resourceAPIVersion":"2015-06-15",
-    "installCDH":"True",
-    "addressPrefix":"[parameters('addressPrefix')]",
-    "subnetPrefix":"[parameters('subnetPrefix')]",
+    "templateAPIVersion": "2015-11-01",
+    "resourceAPIVersion": "2015-06-15",
+    "installCDH": "True",
+    "addressPrefix": "[parameters('addressPrefix')]",
+    "subnetPrefix": "[parameters('subnetPrefix')]",
     "scriptsUriDescription": "For Command Line Deployment, scriptsUri must point to an Azure-accessible location like: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/cloudera-on-centos",
     "scriptsUri": "[uri(deployment().properties.templateLink.uri, '.')]",
     "share-resourcesUri": "[concat(variables('scriptsUri'), '/shared-resources-', parameters('vnetNewOrExisting'), '-vnet.json')]",
-    "data-nodeUri":"[concat(variables('scriptsUri'), '/data-node-', toLower(subString(parameters('vmSize'), 0, 13)), '.json')]",
+    "data-nodeUri": "[concat(variables('scriptsUri'), '/data-node-', toLower(subString(parameters('vmSize'), 0, 13)), '.json')]",
     "sa": "[parameters('masterNodeIPAddress')]",
     "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
     "ipOctet2": "[int(split(variables('sa'), '.')[2])]",
     "ipOctet3": "[int(split(variables('sa'), '.')[3])]",
-    "datanodeIpOctet3":"[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
+    "datanodeIpOctet3": "[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
     "masterStorageAccount": {
       "prefix": "[parameters('storageAccountSuffix')]",
       "type": "[parameters('masterStorageAccountType')]"
@@ -275,7 +283,7 @@
           "offer": "cloudera-centos-6",
           "sku": "cloudera-centos-6",
           "version": "latest"
-          }
+        }
       },
       "ClouderaCentOS6_8": {
         "plan": {
@@ -314,23 +322,23 @@
       "ipOctet01": "[variables('ipOctet01')]",
       "ipOctet2": "[variables('ipOctet2')]",
       "ipOctet3": "[variables('ipOctet3')]",
-      "datanodeIpOctet3":"[variables('datanodeIpOctet3')]",
-      "masterIP":"[variables('sa')]",
-      "workerIP":"[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
+      "datanodeIpOctet3": "[variables('datanodeIpOctet3')]",
+      "masterIP": "[variables('sa')]",
+      "workerIP": "[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
-      "virtualNetworkRGName":"[parameters('virtualNetworkRGName')]",
+      "virtualNetworkRGName": "[parameters('virtualNetworkRGName')]",
       "vnetNewOrExisting": "[parameters('vnetNewOrExisting')]",
       "virtualNetworkSubnetName": "[parameters('subnetName')]"
     },
-    "newVNetId":"[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
-    "existingVNetId":"[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "newVNetId": "[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "existingVNetId": "[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
     "VNetId": "[variables(concat(parameters('vnetNewOrExisting'),'VNetId'))]"
   },
   "resources": [
     {
       "name": "shared-resources",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -338,8 +346,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "networkSpec": {
             "value": "[variables('networkSpec')]"
@@ -356,7 +364,7 @@
     {
       "name": "master-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -367,11 +375,11 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -400,7 +408,7 @@
     {
       "name": "data-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -411,14 +419,14 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "templateAPIVersion":{
-            "value":"[variables('templateAPIVersion')]"
+          "templateAPIVersion": {
+            "value": "[variables('templateAPIVersion')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -447,7 +455,7 @@
     {
       "name": "setup-cloudera",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/data-node",
         "Microsoft.Resources/deployments/master-node"
@@ -459,8 +467,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"

--- a/cloudera-on-centos/data-node-ds13.json
+++ b/cloudera-on-centos/data-node-ds13.json
@@ -3,10 +3,10 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -32,8 +32,8 @@
   },
   "variables": {
     "singleQuote": "'",
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]",
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]",
     "vmName": "[concat(parameters('dnsNamePrefix'), '-dn')]",
     "nicName": "[concat(variables('vmName'), '-nic')]",
     "storageAccountName": "[parameters('storageAccount').prefix]",
@@ -42,7 +42,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -68,7 +67,6 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'dn', resourceGroup().id)), variables('storageAccountName'))]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "storageAccountLoop",
@@ -79,7 +77,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -95,7 +92,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -129,7 +125,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": {
@@ -245,7 +240,6 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "dataNodeNicLoop",

--- a/cloudera-on-centos/data-node-ds13.json
+++ b/cloudera-on-centos/data-node-ds13.json
@@ -42,6 +42,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -65,6 +66,7 @@
       }
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'dn', resourceGroup().id)), variables('storageAccountName'))]",
       "location": "[resourceGroup().location]",
@@ -77,6 +79,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -92,6 +95,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -125,6 +129,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": {
@@ -238,6 +243,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-on-centos/data-node-ds14.json
+++ b/cloudera-on-centos/data-node-ds14.json
@@ -3,10 +3,10 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -32,8 +32,8 @@
   },
   "variables": {
     "singleQuote": "'",
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]",
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]",
     "vmName": "[concat(parameters('dnsNamePrefix'), '-dn')]",
     "nicName": "[concat(variables('vmName'), '-nic')]",
     "storageAccountName": "[parameters('storageAccount').prefix]",
@@ -42,7 +42,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -68,7 +67,6 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'dn', resourceGroup().id)), variables('storageAccountName'))]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "storageAccountLoop",
@@ -79,7 +77,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -95,7 +92,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -129,7 +125,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": {
@@ -290,7 +285,6 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "dataNodeNicLoop",

--- a/cloudera-on-centos/data-node-ds14.json
+++ b/cloudera-on-centos/data-node-ds14.json
@@ -42,6 +42,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -65,6 +66,7 @@
       }
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'dn', resourceGroup().id)), variables('storageAccountName'))]",
       "location": "[resourceGroup().location]",
@@ -77,6 +79,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -92,6 +95,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -125,6 +129,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": {
@@ -283,6 +288,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-on-centos/data-node-standard_ds13.json
+++ b/cloudera-on-centos/data-node-standard_ds13.json
@@ -3,13 +3,13 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
     "templateAPIVersion": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -34,13 +34,12 @@
     }
   },
   "variables": {
-    "vmUri":"[concat(parameters('scriptsUri'),'/vm-5-datadisks.json')]"
+    "vmUri": "[concat(parameters('scriptsUri'),'/vm-5-datadisks.json')]"
   },
   "resources": [
     {
       "name": "vm-with-datadisks",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[parameters('templateAPIVersion')]",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -49,31 +48,31 @@
         },
         "parameters": {
           "vnetID": {
-            "value":"[parameters('vnetID')]"
+            "value": "[parameters('vnetID')]"
           },
-          "resourceAPIVersion":{
-            "value":"[parameters('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[parameters('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
-            "value":"[parameters('dnsNamePrefix')]"
+            "value": "[parameters('dnsNamePrefix')]"
           },
           "scriptsUri": {
-            "value":"[parameters('scriptsUri')]"
+            "value": "[parameters('scriptsUri')]"
           },
           "storageAccount": {
-            "value":"[parameters('storageAccount')]"
+            "value": "[parameters('storageAccount')]"
           },
           "vmCount": {
-            "value":"[parameters('vmCount')]"
+            "value": "[parameters('vmCount')]"
           },
           "vmSpec": {
-            "value":"[parameters('vmSpec')]"
+            "value": "[parameters('vmSpec')]"
           },
           "networkSpec": {
-            "value":"[parameters('networkSpec')]"
+            "value": "[parameters('networkSpec')]"
           },
           "clusterSpec": {
-            "value":"[parameters('clusterSpec')]"
+            "value": "[parameters('clusterSpec')]"
           }
         }
       }

--- a/cloudera-on-centos/data-node-standard_ds13.json
+++ b/cloudera-on-centos/data-node-standard_ds13.json
@@ -24,7 +24,7 @@
       "type": "int"
     },
     "vmSpec": {
-      "type": "secureobject"
+      "type": "secureObject"
     },
     "networkSpec": {
       "type": "object"
@@ -38,6 +38,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2015-01-01",
       "name": "vm-with-datadisks",
       "type": "Microsoft.Resources/deployments",
       "properties": {

--- a/cloudera-on-centos/data-node-standard_ds14.json
+++ b/cloudera-on-centos/data-node-standard_ds14.json
@@ -3,13 +3,13 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
     "templateAPIVersion": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -34,13 +34,12 @@
     }
   },
   "variables": {
-    "vmUri":"[concat(parameters('scriptsUri'),'/vm-10-datadisks.json')]"
+    "vmUri": "[concat(parameters('scriptsUri'),'/vm-10-datadisks.json')]"
   },
   "resources": [
     {
       "name": "vm-with-datadisks",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[parameters('templateAPIVersion')]",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -49,31 +48,31 @@
         },
         "parameters": {
           "vnetID": {
-            "value":"[parameters('vnetID')]"
+            "value": "[parameters('vnetID')]"
           },
-          "resourceAPIVersion":{
-            "value":"[parameters('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[parameters('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
-            "value":"[parameters('dnsNamePrefix')]"
+            "value": "[parameters('dnsNamePrefix')]"
           },
           "scriptsUri": {
-            "value":"[parameters('scriptsUri')]"
+            "value": "[parameters('scriptsUri')]"
           },
           "storageAccount": {
-            "value":"[parameters('storageAccount')]"
+            "value": "[parameters('storageAccount')]"
           },
           "vmCount": {
-            "value":"[parameters('vmCount')]"
+            "value": "[parameters('vmCount')]"
           },
           "vmSpec": {
-            "value":"[parameters('vmSpec')]"
+            "value": "[parameters('vmSpec')]"
           },
           "networkSpec": {
-            "value":"[parameters('networkSpec')]"
+            "value": "[parameters('networkSpec')]"
           },
           "clusterSpec": {
-            "value":"[parameters('clusterSpec')]"
+            "value": "[parameters('clusterSpec')]"
           }
         }
       }

--- a/cloudera-on-centos/data-node-standard_ds14.json
+++ b/cloudera-on-centos/data-node-standard_ds14.json
@@ -24,7 +24,7 @@
       "type": "int"
     },
     "vmSpec": {
-      "type": "secureobject"
+      "type": "secureObject"
     },
     "networkSpec": {
       "type": "object"
@@ -38,6 +38,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2015-01-01",
       "name": "vm-with-datadisks",
       "type": "Microsoft.Resources/deployments",
       "properties": {

--- a/cloudera-on-centos/ds13.json
+++ b/cloudera-on-centos/ds13.json
@@ -61,8 +61,8 @@
         "description": "The name of the virtual network provisioned for the deployment"
       }
     },
-    "vnetNewOrExisting" : {
-      "type" : "string",
+    "vnetNewOrExisting": {
+      "type": "string",
       "defaultValue": "new",
       "allowedValues": [
         "new",
@@ -221,19 +221,19 @@
     }
   },
   "variables": {
-    "templateAPIVersion":"2015-11-01",
-    "resourceAPIVersion":"2015-06-15",
-    "installCDH":"True",
-    "addressPrefix":"[parameters('addressPrefix')]",
-    "subnetPrefix":"[parameters('subnetPrefix')]",
+    "templateAPIVersion": "2015-11-01",
+    "resourceAPIVersion": "2015-06-15",
+    "installCDH": "True",
+    "addressPrefix": "[parameters('addressPrefix')]",
+    "subnetPrefix": "[parameters('subnetPrefix')]",
     "scriptsUri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/cloudera-on-centos",
     "share-resourcesUri": "[concat(variables('scriptsUri'), '/shared-resources-', parameters('vnetNewOrExisting'), '-vnet.json')]",
-    "data-nodeUri":"[concat(variables('scriptsUri'), '/data-node-', toLower(subString(parameters('vmSize'), 9, 4)), '.json')]",
+    "data-nodeUri": "[concat(variables('scriptsUri'), '/data-node-', toLower(subString(parameters('vmSize'), 9, 4)), '.json')]",
     "sa": "[parameters('masterNodeIPAddress')]",
     "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
     "ipOctet2": "[int(split(variables('sa'), '.')[2])]",
     "ipOctet3": "[int(split(variables('sa'), '.')[3])]",
-    "datanodeIpOctet3":"[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
+    "datanodeIpOctet3": "[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
     "masterStorageAccount": {
       "prefix": "[parameters('storageAccountSuffix')]",
       "type": "[parameters('masterStorageAccountType')]"
@@ -266,23 +266,23 @@
       "ipOctet01": "[variables('ipOctet01')]",
       "ipOctet2": "[variables('ipOctet2')]",
       "ipOctet3": "[variables('ipOctet3')]",
-      "datanodeIpOctet3":"[variables('datanodeIpOctet3')]",
-      "masterIP":"[variables('sa')]",
-      "workerIP":"[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
+      "datanodeIpOctet3": "[variables('datanodeIpOctet3')]",
+      "masterIP": "[variables('sa')]",
+      "workerIP": "[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
-      "virtualNetworkRGName":"[parameters('virtualNetworkRGName')]",
+      "virtualNetworkRGName": "[parameters('virtualNetworkRGName')]",
       "vnetNewOrExisting": "[parameters('vnetNewOrExisting')]",
       "virtualNetworkSubnetName": "[parameters('subnetName')]"
     },
-    "newVNetId":"[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
-    "existingVNetId":"[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "newVNetId": "[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "existingVNetId": "[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
     "VNetId": "[variables(concat(parameters('vnetNewOrExisting'),'VNetId'))]"
   },
   "resources": [
     {
       "name": "shared-resources",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -290,8 +290,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "networkSpec": {
             "value": "[variables('networkSpec')]"
@@ -308,7 +308,7 @@
     {
       "name": "master-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -319,11 +319,11 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -352,7 +352,7 @@
     {
       "name": "data-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
       ],
@@ -363,11 +363,11 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -396,7 +396,7 @@
     {
       "name": "setup-cloudera",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "dependsOn": [
         "Microsoft.Resources/deployments/data-node",
         "Microsoft.Resources/deployments/master-node"
@@ -408,8 +408,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"

--- a/cloudera-on-centos/master-node.json
+++ b/cloudera-on-centos/master-node.json
@@ -42,6 +42,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -65,6 +66,7 @@
       }
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'mn', resourceGroup().id)), variables('storageAccountName'))]",
       "location": "[resourceGroup().location]",
@@ -77,6 +79,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -92,6 +95,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -125,6 +129,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": "[parameters('vmSpec').imageInfo.plan]",
@@ -211,6 +216,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-on-centos/master-node.json
+++ b/cloudera-on-centos/master-node.json
@@ -3,10 +3,10 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -32,8 +32,8 @@
   },
   "variables": {
     "singleQuote": "'",
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]",
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]",
     "vmName": "[concat(parameters('dnsNamePrefix'), '-mn')]",
     "nicName": "[concat(variables('vmName'), '-nic')]",
     "publicIPAddressName": "[concat(variables('vmName'), '-publicIP')]",
@@ -42,7 +42,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -68,7 +67,6 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'mn', resourceGroup().id)), variables('storageAccountName'))]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "storageAccountLoop",
@@ -79,7 +77,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -95,7 +92,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -129,7 +125,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": "[parameters('vmSpec').imageInfo.plan]",
@@ -200,7 +195,7 @@
               "diskSizeGB": "512",
               "lun": 3,
               "vhd": {
-               "uri": "[ concat(reference(concat('Microsoft.Storage/storageAccounts/', uniquestring(concat(copyIndex(), 'mn', resourceGroup().id)), variables('storageAccountName')), '2015-06-15').primaryEndpoints.blob, uniquestring(concat(copyIndex(), 'mn', resourceGroup().id)), '/', variables('vmName'), '-datadisk3.vhd')]"
+                "uri": "[ concat(reference(concat('Microsoft.Storage/storageAccounts/', uniquestring(concat(copyIndex(), 'mn', resourceGroup().id)), variables('storageAccountName')), '2015-06-15').primaryEndpoints.blob, uniquestring(concat(copyIndex(), 'mn', resourceGroup().id)), '/', variables('vmName'), '-datadisk3.vhd')]"
               },
               "createOption": "Empty"
             }
@@ -218,7 +213,6 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "nameNodeNicLoop",
@@ -238,7 +232,6 @@
             "[concat(parameters('scriptsUri'), '/scripts/initialize-node.sh')]"
           ],
           "commandToExecute": "[concat('sh initialize-node.sh ', variables('singleQuote'), variables('masterIP'), variables('singleQuote'), ' ', variables('singleQuote'), variables('workerIP'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('dnsNamePrefix'), variables('singleQuote'), ' ', variables('singleQuote'), reference(concat(variables('publicIPAddressName'), copyIndex())).dnsSettings.fqdn, variables('singleQuote'), ' ', variables('singleQuote'), parameters('clusterSpec').masterNodeCount, variables('singleQuote'), ' ', variables('singleQuote'), parameters('clusterSpec').dataNodeCount, variables('singleQuote'), ' ', variables('singleQuote'), parameters('vmSpec').adminUserName, variables('singleQuote'), ' ', 'masternode', ' >> /var/log/cloudera-azure-initialize.log 2>&1')]"
-
         }
       }
     }

--- a/cloudera-on-centos/setup-cloudera.json
+++ b/cloudera-on-centos/setup-cloudera.json
@@ -2,8 +2,8 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.1",
   "parameters": {
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -56,14 +56,13 @@
   },
   "variables": {
     "singleQuote": "'",
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]"
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]"
   },
   "resources": [
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('dnsNamePrefix'), '-mn0', '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",

--- a/cloudera-on-centos/setup-cloudera.json
+++ b/cloudera-on-centos/setup-cloudera.json
@@ -61,6 +61,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('dnsNamePrefix'), '-mn0', '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-on-centos/shared-resources-existing-vnet.json
+++ b/cloudera-on-centos/shared-resources-existing-vnet.json
@@ -2,8 +2,8 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.1",
   "parameters": {
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "networkSpec": {
       "type": "object"
@@ -18,21 +18,18 @@
   "variables": {},
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('masterNodeASName')]",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('dataNodeASName')]",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(parameters('networkSpec').virtualNetworkName, '-sg')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-on-centos/shared-resources-existing-vnet.json
+++ b/cloudera-on-centos/shared-resources-existing-vnet.json
@@ -18,18 +18,21 @@
   "variables": {},
   "resources": [
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('masterNodeASName')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('dataNodeASName')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(parameters('networkSpec').virtualNetworkName, '-sg')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-on-centos/shared-resources-new-vnet.json
+++ b/cloudera-on-centos/shared-resources-new-vnet.json
@@ -2,8 +2,8 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.1",
   "parameters": {
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "networkSpec": {
       "type": "object"
@@ -18,21 +18,18 @@
   "variables": {},
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('masterNodeASName')]",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('dataNodeASName')]",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(parameters('networkSpec').virtualNetworkName, '-sg')]",
       "location": "[resourceGroup().location]",
@@ -56,7 +53,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSpec').virtualNetworkName]",
       "dependsOn": [

--- a/cloudera-on-centos/shared-resources-new-vnet.json
+++ b/cloudera-on-centos/shared-resources-new-vnet.json
@@ -18,18 +18,21 @@
   "variables": {},
   "resources": [
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('masterNodeASName')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('dataNodeASName')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(parameters('networkSpec').virtualNetworkName, '-sg')]",
       "location": "[resourceGroup().location]",
@@ -53,6 +56,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSpec').virtualNetworkName]",
       "dependsOn": [

--- a/cloudera-on-centos/vm-10-datadisks.json
+++ b/cloudera-on-centos/vm-10-datadisks.json
@@ -3,10 +3,10 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -32,8 +32,8 @@
   },
   "variables": {
     "singleQuote": "'",
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]",
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]",
     "vmName": "[concat(parameters('dnsNamePrefix'), '-dn')]",
     "nicName": "[concat(variables('vmName'), '-nic')]",
     "storageAccountName": "[parameters('storageAccount').prefix]",
@@ -42,7 +42,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -68,7 +67,6 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'dn', resourceGroup().id)), variables('storageAccountName'))]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "storageAccountLoop",
@@ -79,7 +77,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -95,7 +92,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -129,7 +125,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": "[parameters('vmSpec').imageInfo.plan]",
@@ -281,7 +276,6 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "dataNodeNicLoop",

--- a/cloudera-on-centos/vm-10-datadisks.json
+++ b/cloudera-on-centos/vm-10-datadisks.json
@@ -21,7 +21,7 @@
       "type": "int"
     },
     "vmSpec": {
-      "type": "secureobject"
+      "type": "secureObject"
     },
     "networkSpec": {
       "type": "object"
@@ -42,6 +42,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -65,6 +66,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'dn', resourceGroup().id)), variables('storageAccountName'))]",
       "location": "[resourceGroup().location]",
@@ -77,6 +79,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -92,6 +95,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -125,6 +129,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": "[parameters('vmSpec').imageInfo.plan]",
@@ -274,6 +279,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-on-centos/vm-5-datadisks.json
+++ b/cloudera-on-centos/vm-5-datadisks.json
@@ -3,10 +3,10 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -32,8 +32,8 @@
   },
   "variables": {
     "singleQuote": "'",
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]",
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]",
     "vmName": "[concat(parameters('dnsNamePrefix'), '-dn')]",
     "nicName": "[concat(variables('vmName'), '-nic')]",
     "storageAccountName": "[parameters('storageAccount').prefix]",
@@ -42,7 +42,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -68,7 +67,6 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'dn', resourceGroup().id)), variables('storageAccountName'))]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "storageAccountLoop",
@@ -79,7 +77,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -95,7 +92,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -129,7 +125,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": "[parameters('vmSpec').imageInfo.plan]",
@@ -236,7 +231,6 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "dataNodeNicLoop",

--- a/cloudera-on-centos/vm-5-datadisks.json
+++ b/cloudera-on-centos/vm-5-datadisks.json
@@ -42,6 +42,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -65,6 +66,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(uniquestring(concat(copyIndex(), 'dn', resourceGroup().id)), variables('storageAccountName'))]",
       "location": "[resourceGroup().location]",
@@ -77,6 +79,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -92,6 +95,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -125,6 +129,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": "[parameters('vmSpec').imageInfo.plan]",
@@ -229,6 +234,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-tableau/azuredeploy.json
+++ b/cloudera-tableau/azuredeploy.json
@@ -322,13 +322,13 @@
     "quickstartTags": {
       "type": "object",
       "name": "cloudera-tableau"
-    } 
+    }
   },
   "resources": [
     {
       "name": "shared-resources",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "comments": "Resources that are shared within the infrastructure environment",
       "properties": {
         "mode": "Incremental",
@@ -350,12 +350,12 @@
             "value": "[variables('vmSpec').masterNodeASName]"
           },
           "dataNodeASName": {
-            "value": "[variables('vmSpec').dataNodeASName]"  
+            "value": "[variables('vmSpec').dataNodeASName]"
           },
           "clouderaTags": {
             "value": "[variables('clouderaTags')]"
           },
-          "tableauTags":{
+          "tableauTags": {
             "value": "[variables('tableauTags')]"
           },
           "quickstartTags": {
@@ -367,7 +367,7 @@
     {
       "name": "master-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "comments": "Cloudera master node that manages the cluster nodes",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
@@ -409,10 +409,10 @@
           "clouderaTags": {
             "value": "[variables('clouderaTags')]"
           },
-          "tableauTags":{
+          "tableauTags": {
             "value": "[variables('tableauTags')]"
           },
-          "quickstartTags":{
+          "quickstartTags": {
             "value": "[variables('quickstartTags')]"
           }
         }
@@ -421,7 +421,7 @@
     {
       "name": "data-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "comments": "Cloudera data nodes or cluster members",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
@@ -463,7 +463,7 @@
           "clouderaTags": {
             "value": "[variables('clouderaTags')]"
           },
-          "tableauTags":{
+          "tableauTags": {
             "value": "[variables('tableauTags')]"
           },
           "quickstartTags": {
@@ -475,7 +475,7 @@
     {
       "name": "tableau-server",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "comments": "Tableau Server offering from the Azure market place",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
@@ -517,7 +517,7 @@
           "clouderaTags": {
             "value": "[variables('clouderaTags')]"
           },
-          "tableauTags":{
+          "tableauTags": {
             "value": "[variables('tableauTags')]"
           },
           "quickstartTags": {
@@ -529,7 +529,7 @@
     {
       "name": "setup-cloudera",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "comments": "Scripts and configuration settings that intialize the Cloudera cluster environment",
       "dependsOn": [
         "Microsoft.Resources/deployments/data-node",
@@ -596,7 +596,7 @@
           "clouderaTags": {
             "value": "[variables('clouderaTags')]"
           },
-          "tableauTags":{
+          "tableauTags": {
             "value": "[variables('tableauTags')]"
           },
           "quickstartTags": {

--- a/cloudera-tableau/nested/data-node-ds13.json
+++ b/cloudera-tableau/nested/data-node-ds13.json
@@ -21,7 +21,7 @@
       "type": "int"
     },
     "vmSpec": {
-      "type": "secureobject"
+      "type": "secureObject"
     },
     "networkSpec": {
       "type": "object"
@@ -50,6 +50,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -274,10 +275,15 @@
       }
     },
     {
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(copyIndex(), variables('storageAccountName'))]",
       "location": "[resourceGroup().location]",
       "comments": "Data Node storage account configurations",
+      "kind": "Storage",
+      "sku":{
+        "name":"Standard_LRS"
+      },
       "tags": {
         "quickstartName": "[parameters('quickstartTags').name]",
         "provider": "[parameters('clouderaTags').provider]"
@@ -291,6 +297,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -311,6 +318,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -349,6 +357,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": {
@@ -483,6 +492,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-tableau/nested/data-node-ds13.json
+++ b/cloudera-tableau/nested/data-node-ds13.json
@@ -3,10 +3,10 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -29,19 +29,19 @@
     "clusterSpec": {
       "type": "object"
     },
-    "clouderaTags":{
-      "type":"object"
+    "clouderaTags": {
+      "type": "object"
     },
-    "tableauTags":{
-      "type":"object"
+    "tableauTags": {
+      "type": "object"
     },
-    "quickstartTags":{
-      "type":"object"
+    "quickstartTags": {
+      "type": "object"
     }
   },
   "variables": {
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]",
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]",
     "vmName": "[concat(parameters('dnsNamePrefix'), '-dn')]",
     "nicName": "[concat(variables('vmName'), '-nic')]",
     "storageAccountName": "[concat('dn', parameters('storageAccount').prefix)]",
@@ -50,15 +50,14 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
       "comments": "Shared Resources Network Security Group Rules",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {
         "securityRules": [
           {
@@ -277,13 +276,12 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(copyIndex(), variables('storageAccountName'))]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "comments": "Data Node storage account configurations",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "storageAccountLoop",
         "count": "[parameters('vmCount')]"
@@ -293,15 +291,14 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
       "comments": "Data Node Public IP Address configuration",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "publicIPLoop",
         "count": "[parameters('vmCount')]"
@@ -314,15 +311,14 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
       "comments": "Data Node network interface configuration",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'), copyIndex())]",
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('securityGroupName'))]"
@@ -353,7 +349,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "plan": {
@@ -364,9 +359,9 @@
       "location": "[resourceGroup().location]",
       "comments": "Data Node virtual machines configurations",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "dataNodeNicLoop",
         "count": "[parameters('vmCount')]"
@@ -490,13 +485,12 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "comments": "Data Node VM Extensions and scripts to configure the Cloudera cluster",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "dataNodeNicLoop",
         "count": "[parameters('vmCount')]"

--- a/cloudera-tableau/nested/data-node-ds14.json
+++ b/cloudera-tableau/nested/data-node-ds14.json
@@ -3,10 +3,10 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -29,19 +29,19 @@
     "clusterSpec": {
       "type": "object"
     },
-    "clouderaTags":{
-      "type":"object"
+    "clouderaTags": {
+      "type": "object"
     },
-    "tableauTags":{
-      "type":"object"
+    "tableauTags": {
+      "type": "object"
     },
-    "quickstartTags":{
-      "type":"object"
+    "quickstartTags": {
+      "type": "object"
     }
   },
   "variables": {
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]",
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]",
     "vmName": "[concat(parameters('dnsNamePrefix'), '-dn')]",
     "nicName": "[concat(variables('vmName'), '-nic')]",
     "storageAccountName": "[concat('dn', parameters('storageAccount').prefix)]",
@@ -50,15 +50,14 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
       "comments": "Shared Resources Network Security Group Rules",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {
         "securityRules": [
           {
@@ -277,13 +276,12 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(copyIndex(), variables('storageAccountName'))]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node storage account configurations",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "storageAccountLoop",
         "count": "[parameters('vmCount')]"
@@ -293,15 +291,14 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node Public IP Address configuration",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "publicIPLoop",
         "count": "[parameters('vmCount')]"
@@ -314,15 +311,14 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node network interface configuration",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'), copyIndex())]",
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('securityGroupName'))]"
@@ -353,13 +349,12 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "plan": {
         "name": "cloudera-centos-6",
         "publisher": "cloudera",
@@ -535,13 +530,12 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node VM Extensions and scripts to configure the Cloudera cluster",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "dataNodeNicLoop",
         "count": "[parameters('vmCount')]"

--- a/cloudera-tableau/nested/data-node-ds14.json
+++ b/cloudera-tableau/nested/data-node-ds14.json
@@ -21,7 +21,7 @@
       "type": "int"
     },
     "vmSpec": {
-      "type": "secureobject"
+      "type": "secureObject"
     },
     "networkSpec": {
       "type": "object"
@@ -50,6 +50,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -274,6 +275,7 @@
       }
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(copyIndex(), variables('storageAccountName'))]",
       "location": "[resourceGroup().location]",
@@ -291,6 +293,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -311,6 +314,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -349,6 +353,7 @@
       }
     },
     {
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "tags": {
@@ -528,6 +533,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-tableau/nested/ds13.json
+++ b/cloudera-tableau/nested/ds13.json
@@ -61,8 +61,8 @@
         "description": "The name of the virtual network provisioned for the deployment"
       }
     },
-    "vnetNewOrExisting" : {
-      "type" : "string",
+    "vnetNewOrExisting": {
+      "type": "string",
       "defaultValue": "new",
       "allowedValues": [
         "new",
@@ -219,30 +219,30 @@
         "Storage"
       ]
     },
-    "clouderaTags":{
-      "type":"object"
+    "clouderaTags": {
+      "type": "object"
     },
-    "tableauTags":{
-      "type":"object"
+    "tableauTags": {
+      "type": "object"
     },
-    "quickstartTags":{
-      "type":"object"
+    "quickstartTags": {
+      "type": "object"
     }
   },
   "variables": {
-    "templateAPIVersion":"2015-11-01",
-    "resourceAPIVersion":"2015-06-15",
-    "installCDH":"True",
-    "addressPrefix":"[parameters('addressPrefix')]",
-    "subnetPrefix":"[parameters('subnetPrefix')]",
+    "templateAPIVersion": "2015-11-01",
+    "resourceAPIVersion": "2015-06-15",
+    "installCDH": "True",
+    "addressPrefix": "[parameters('addressPrefix')]",
+    "subnetPrefix": "[parameters('subnetPrefix')]",
     "scriptsUri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/cloudera-on-centos",
     "share-resourcesUri": "[concat(variables('scriptsUri'), '/nested/shared-resources-', parameters('vnetNewOrExisting'), '-vnet.json')]",
-    "data-nodeUri":"[concat(variables('scriptsUri'), '/nested/data-node-', toLower(subString(parameters('vmSize'), 9, 4)), '.json')]",
+    "data-nodeUri": "[concat(variables('scriptsUri'), '/nested/data-node-', toLower(subString(parameters('vmSize'), 9, 4)), '.json')]",
     "sa": "[parameters('masterNodeIPAddress')]",
     "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
     "ipOctet2": "[int(split(variables('sa'), '.')[2])]",
     "ipOctet3": "[int(split(variables('sa'), '.')[3])]",
-    "datanodeIpOctet3":"[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
+    "datanodeIpOctet3": "[add(int(split(variables('sa'), '.')[3]), parameters('dataNodeIPOffSetFromMaster'))]",
     "masterStorageAccount": {
       "prefix": "[parameters('storageAccountPrefix')]",
       "type": "[parameters('masterStorageAccountType')]"
@@ -275,23 +275,23 @@
       "ipOctet01": "[variables('ipOctet01')]",
       "ipOctet2": "[variables('ipOctet2')]",
       "ipOctet3": "[variables('ipOctet3')]",
-      "datanodeIpOctet3":"[variables('datanodeIpOctet3')]",
-      "masterIP":"[variables('sa')]",
-      "workerIP":"[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
+      "datanodeIpOctet3": "[variables('datanodeIpOctet3')]",
+      "masterIP": "[variables('sa')]",
+      "workerIP": "[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(variables('datanodeIpOctet3'), 255)), '.', mod(variables('datanodeIpOctet3'), 255))]",
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
-      "virtualNetworkRGName":"[parameters('virtualNetworkRGName')]",
+      "virtualNetworkRGName": "[parameters('virtualNetworkRGName')]",
       "vnetNewOrExisting": "[parameters('vnetNewOrExisting')]",
       "virtualNetworkSubnetName": "[parameters('subnetName')]"
     },
-    "newVNetId":"[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
-    "existingVNetId":"[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "newVNetId": "[resourceId(concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
+    "existingVNetId": "[resourceId(parameters('virtualNetworkRGName'),concat('Microsoft.Network','/','virtualNetworks'),parameters('virtualNetworkName'))]",
     "VNetId": "[variables(concat(parameters('vnetNewOrExisting'),'VNetId'))]"
   },
   "resources": [
     {
       "name": "shared-resources",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "comments": "Utilizes the shared resources configurations.  Uses the DS13 servers sizes for the deployment",
       "properties": {
         "mode": "Incremental",
@@ -300,8 +300,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "networkSpec": {
             "value": "[variables('networkSpec')]"
@@ -315,7 +315,7 @@
           "clouderaTags": {
             "value": "[parameters('clouderaTags')]"
           },
-          "tableauTags":{
+          "tableauTags": {
             "value": "[parameters('tableauTags')]"
           },
           "quickstartTags": {
@@ -327,7 +327,7 @@
     {
       "name": "master-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "comments": "Cloudera Master Node resource",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
@@ -339,11 +339,11 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -369,7 +369,7 @@
           "clouderaTags": {
             "value": "[parameters('clouderaTags')]"
           },
-          "tableauTags":{
+          "tableauTags": {
             "value": "[parameters('tableauTags')]"
           },
           "quickstartTags": {
@@ -381,7 +381,7 @@
     {
       "name": "data-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "comments": "Cloudera Data Node resource",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
@@ -393,11 +393,11 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "vnetID":{
-            "value":"[variables('VNetId')]"
+          "vnetID": {
+            "value": "[variables('VNetId')]"
           },
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -423,7 +423,7 @@
           "clouderaTags": {
             "value": "[parameters('clouderaTags')]"
           },
-          "tableauTags":{
+          "tableauTags": {
             "value": "[parameters('tableauTags')]"
           },
           "quickstartTags": {
@@ -435,7 +435,7 @@
     {
       "name": "setup-cloudera",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-11-01",
       "comments": "Resources that setup the Cloudera cluster",
       "dependsOn": [
         "Microsoft.Resources/deployments/data-node",
@@ -448,8 +448,8 @@
           "contentVersion": "1.0.0.1"
         },
         "parameters": {
-          "resourceAPIVersion":{
-            "value":"[variables('resourceAPIVersion')]"
+          "resourceAPIVersion": {
+            "value": "[variables('resourceAPIVersion')]"
           },
           "dnsNamePrefix": {
             "value": "[parameters('dnsNamePrefix')]"
@@ -502,7 +502,7 @@
           "clouderaTags": {
             "value": "[parameters('clouderaTags')]"
           },
-          "tableauTags":{
+          "tableauTags": {
             "value": "[parameters('tableauTags')]"
           },
           "quickstartTags": {

--- a/cloudera-tableau/nested/ds13.json
+++ b/cloudera-tableau/nested/ds13.json
@@ -291,7 +291,7 @@
     {
       "name": "shared-resources",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2015-11-01",
+      "apiVersion": "2017-05-10",
       "comments": "Utilizes the shared resources configurations.  Uses the DS13 servers sizes for the deployment",
       "properties": {
         "mode": "Incremental",
@@ -327,7 +327,7 @@
     {
       "name": "master-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2015-11-01",
+      "apiVersion": "2015-01-01",
       "comments": "Cloudera Master Node resource",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
@@ -381,7 +381,7 @@
     {
       "name": "data-node",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2015-11-01",
+      "apiVersion": "2015-01-01",
       "comments": "Cloudera Data Node resource",
       "dependsOn": [
         "Microsoft.Resources/deployments/shared-resources"
@@ -435,7 +435,7 @@
     {
       "name": "setup-cloudera",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2015-11-01",
+      "apiVersion": "2015-01-01",
       "comments": "Resources that setup the Cloudera cluster",
       "dependsOn": [
         "Microsoft.Resources/deployments/data-node",

--- a/cloudera-tableau/nested/master-node.json
+++ b/cloudera-tableau/nested/master-node.json
@@ -3,10 +3,10 @@
   "contentVersion": "1.0.0.1",
   "parameters": {
     "vnetID": {
-      "type":"string"
+      "type": "string"
     },
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -29,19 +29,19 @@
     "clusterSpec": {
       "type": "object"
     },
-    "clouderaTags":{
-      "type":"object"
+    "clouderaTags": {
+      "type": "object"
     },
-    "tableauTags":{
-      "type":"object"
+    "tableauTags": {
+      "type": "object"
     },
-    "quickstartTags":{
-      "type":"object"
+    "quickstartTags": {
+      "type": "object"
     }
   },
   "variables": {
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]",
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]",
     "vmName": "[concat(parameters('dnsNamePrefix'), '-mn')]",
     "nicName": "[concat(variables('vmName'), '-nic')]",
     "publicIPAddressName": "[concat(variables('vmName'), '-publicIP')]",
@@ -50,15 +50,14 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
       "comments": "Shared Resources Network Security Group Rules",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {
         "securityRules": [
           {
@@ -277,13 +276,12 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(copyIndex(), variables('storageAccountName'))]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node storage account configurations",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "storageAccountLoop",
         "count": "[parameters('vmCount')]"
@@ -293,15 +291,14 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node Public IP Address configuration",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "publicIPLoop",
         "count": "[parameters('vmCount')]"
@@ -314,15 +311,14 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node network interface configuration",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'), copyIndex())]",
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('securityGroupName'))]"
@@ -353,15 +349,14 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node virtual machines configurations",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "masterNodeNicLoop",
         "count": "[parameters('vmCount')]"
@@ -451,13 +446,12 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node VM Extensions and scripts to configure the Cloudera cluster",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "copy": {
         "name": "nameNodeNicLoop",
         "count": "[parameters('vmCount')]"

--- a/cloudera-tableau/nested/master-node.json
+++ b/cloudera-tableau/nested/master-node.json
@@ -50,6 +50,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -274,6 +275,7 @@
       }
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(copyIndex(), variables('storageAccountName'))]",
       "location": "[resourceGroup().location]",
@@ -291,6 +293,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -311,6 +314,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -349,6 +353,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -444,6 +449,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyIndex(), '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-tableau/nested/setup-cloudera.json
+++ b/cloudera-tableau/nested/setup-cloudera.json
@@ -2,8 +2,8 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.1",
   "parameters": {
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "dnsNamePrefix": {
       "type": "string"
@@ -53,31 +53,30 @@
     "installCDH": {
       "type": "string"
     },
-    "clouderaTags":{
-      "type":"object"
+    "clouderaTags": {
+      "type": "object"
     },
-    "tableauTags":{
-      "type":"object"
+    "tableauTags": {
+      "type": "object"
     },
-    "quickstartTags":{
-      "type":"object"
+    "quickstartTags": {
+      "type": "object"
     }
   },
   "variables": {
-    "masterIP":"[parameters('networkSpec').masterIP]",
-    "workerIP":"[parameters('networkSpec').workerIP]"
+    "masterIP": "[parameters('networkSpec').masterIP]",
+    "workerIP": "[parameters('networkSpec').workerIP]"
   },
   "resources": [
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('dnsNamePrefix'), '-mn0', '/prepareDisks')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "comments": "Cloudera Setup extensions that run to configure the Cloudera cluster environment",
-       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
         "type": "CustomScript",

--- a/cloudera-tableau/nested/setup-cloudera.json
+++ b/cloudera-tableau/nested/setup-cloudera.json
@@ -69,6 +69,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('dnsNamePrefix'), '-mn0', '/prepareDisks')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-tableau/nested/shared-resources-existing-vnet.json
+++ b/cloudera-tableau/nested/shared-resources-existing-vnet.json
@@ -2,8 +2,8 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.1",
   "parameters": {
-    "resourceAPIVersion":{
-      "type":"string"
+    "resourceAPIVersion": {
+      "type": "string"
     },
     "networkSpec": {
       "type": "object"
@@ -17,64 +17,60 @@
     "tableauASName": {
       "type": "string"
     },
-    "clouderaTags":{
-      "type":"object"
+    "clouderaTags": {
+      "type": "object"
     },
-    "tableauTags":{
-      "type":"object"
+    "tableauTags": {
+      "type": "object"
     },
-    "quickstartTags":{
-      "type":"object"
+    "quickstartTags": {
+      "type": "object"
     }
   },
   "variables": {},
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('masterNodeASName')]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node Name",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('dataNodeASName')]",
       "location": "[resourceGroup().location]",
       "comments": "Data Node Name",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('tableauASName')]",
       "location": "[resourceGroup().location]",
       "comments": "Tableau Server Name",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('tableauTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('tableauTags').provider]"
+      },
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(parameters('networkSpec').virtualNetworkName, '-sg')]",
       "location": "[resourceGroup().location]",
       "comments": "Shared Resources Network Security Group Rules",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {
         "securityRules": [
           {

--- a/cloudera-tableau/nested/shared-resources-existing-vnet.json
+++ b/cloudera-tableau/nested/shared-resources-existing-vnet.json
@@ -30,6 +30,7 @@
   "variables": {},
   "resources": [
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('masterNodeASName')]",
       "location": "[resourceGroup().location]",
@@ -41,6 +42,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('dataNodeASName')]",
       "location": "[resourceGroup().location]",
@@ -52,6 +54,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('tableauASName')]",
       "location": "[resourceGroup().location]",
@@ -63,6 +66,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(parameters('networkSpec').virtualNetworkName, '-sg')]",
       "location": "[resourceGroup().location]",

--- a/cloudera-tableau/nested/shared-resources-new-vnet.json
+++ b/cloudera-tableau/nested/shared-resources-new-vnet.json
@@ -17,63 +17,59 @@
     "tableauASName": {
       "type": "string"
     },
-    "clouderaTags":{
-      "type":"object"
+    "clouderaTags": {
+      "type": "object"
     },
-    "tableauTags":{
-      "type":"object"
+    "tableauTags": {
+      "type": "object"
     },
-    "quickstartTags":{
-      "type":"object"
+    "quickstartTags": {
+      "type": "object"
     }
   },
   "variables": {},
   "resources": [
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('masterNodeASName')]",
       "location": "[resourceGroup().location]",
       "comments": "Master Node Name",
-       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('dataNodeASName')]",
       "location": "[resourceGroup().location]",
       "comments": "Data Node Name",
-       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('tableauASName')]",
       "location": "[resourceGroup().location]",
       "comments": "Tableau Server Name",
-       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('tableauTags').provider]"
-       },
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('tableauTags').provider]"
+      },
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(parameters('networkSpec').virtualNetworkName, '-sg')]",
       "location": "[resourceGroup().location]",
       "comments": "Provides Network Security Group rules",
       "tags": {
-       "quickstartName":"[parameters('quickstartTags').name]",
-       "provider":"[parameters('clouderaTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
       },
       "properties": {
         "securityRules": [
@@ -305,7 +301,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSpec').virtualNetworkName]",
       "dependsOn": [
@@ -314,8 +309,8 @@
       "location": "[resourceGroup().location]",
       "comments": "Shared Resources Virtual Network configuration",
       "tags": {
-       "quickstartName":"[parameters('quickstartTags').name]",
-       "provider":"[parameters('clouderaTags').provider]"
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
       },
       "properties": {
         "addressSpace": {

--- a/cloudera-tableau/nested/shared-resources-new-vnet.json
+++ b/cloudera-tableau/nested/shared-resources-new-vnet.json
@@ -30,6 +30,7 @@
   "variables": {},
   "resources": [
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('masterNodeASName')]",
       "location": "[resourceGroup().location]",
@@ -41,6 +42,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('dataNodeASName')]",
       "location": "[resourceGroup().location]",
@@ -52,6 +54,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[parameters('tableauASName')]",
       "location": "[resourceGroup().location]",
@@ -63,6 +66,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(parameters('networkSpec').virtualNetworkName, '-sg')]",
       "location": "[resourceGroup().location]",
@@ -301,6 +305,7 @@
       }
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSpec').virtualNetworkName]",
       "dependsOn": [

--- a/cloudera-tableau/nested/tableau-server.json
+++ b/cloudera-tableau/nested/tableau-server.json
@@ -47,14 +47,14 @@
         "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
       }
     },
-    "clouderaTags":{
-      "type":"object"
+    "clouderaTags": {
+      "type": "object"
     },
-    "tableauTags":{
-      "type":"object"
+    "tableauTags": {
+      "type": "object"
     },
-    "quickstartTags":{
-      "type":"object"
+    "quickstartTags": {
+      "type": "object"
     }
   },
   "variables": {
@@ -76,44 +76,43 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[parameters('resourceAPIVersion')]",
       "location": "[resourceGroup().location]",
       "comments": "Utilizes the Cloudera master storage account",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('clouderaTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('clouderaTags').provider]"
+      },
       "properties": {
         "accountType": "[parameters('storageAccount').type]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
       "comments": "Tableau Server Public IP Address",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('tableauTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('tableauTags').provider]"
+      },
       "properties": {
         "publicIPAllocationMethod": "[variables('publicIPAddressType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
       "comments": "Tableau Server nic name",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('tableauTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('tableauTags').provider]"
+      },
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
-        ],
+      ],
       "properties": {
         "ipConfigurations": [
           {
@@ -132,15 +131,15 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
       "comments": "Tableau Server VM",
       "tags": {
-        "quickstartName":"[parameters('quickstartTags').name]",
-        "provider":"[parameters('tableauTags').provider]"
-       },
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('tableauTags').provider]"
+      },
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"

--- a/cloudera-tableau/nested/tableau-server.json
+++ b/cloudera-tableau/nested/tableau-server.json
@@ -74,6 +74,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",

--- a/concourse-ci/azuredeploy.json
+++ b/concourse-ci/azuredeploy.json
@@ -501,7 +501,7 @@
       }
     },
     {
-      "apiversion": "2015-06-15",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/consul-on-ubuntu/azuredeploy.json
+++ b/consul-on-ubuntu/azuredeploy.json
@@ -74,12 +74,12 @@
       },
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('storageAccountName')]"
     },
     {
       "name": "[concat('publicIP', copyindex())]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "copy": {
         "count": "[variables('numberOfInstances')]",
@@ -94,7 +94,7 @@
       "properties": {},
       "type": "Microsoft.Compute/availabilitySets",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[concat(parameters('appPrefix'),'_AS')]"
     },
     {
@@ -118,12 +118,12 @@
       },
       "type": "Microsoft.Network/networkSecurityGroups",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[concat(parameters('appPrefix'),'_SG')]"
     },
     {
       "name": "[concat(parameters('appPrefix'),'_VNET')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkSecurityGroups/', parameters('appPrefix'),'_SG')]"
@@ -147,7 +147,7 @@
     },
     {
       "name": "[concat(parameters('appPrefix'),'_LB')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', parameters('appPrefix'),'_VNET')]"
@@ -204,7 +204,7 @@
     },
     {
       "name": "[concat(parameters('appPrefix'),'_nic1', copyindex())]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', 'publicIP', copyindex())]",
@@ -243,7 +243,7 @@
     },
     {
       "name": "[concat(parameters('appPrefix'), '_vm', copyIndex())]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/networkInterfaces/', parameters('appPrefix'),'_nic1', copyIndex())]",
@@ -297,7 +297,7 @@
     },
     {
       "name": "[concat(parameters('appPrefix'), '_vm', copyIndex(), '/extension')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('appPrefix'), '_vm', copyIndex())]"
@@ -309,16 +309,16 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-		"type": "CustomScript",
-		"typeHandlerVersion": "2.0",
-		"autoUpgradeMinorVersion": true,
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
             "[variables('customScriptFilePath')]"
           ]
         },
         "protectedSettings": {
-            "commandToExecute": "[concat(variables('customScriptCommandToExecute'),' ', parameters('existingAtlasInfraName'), ' ', parameters('existingAtlasToken'))]"
+          "commandToExecute": "[concat(variables('customScriptCommandToExecute'),' ', parameters('existingAtlasInfraName'), ' ', parameters('existingAtlasToken'))]"
         }
       }
     }

--- a/create-hpc-cluster-custom-image/azuredeploy.json
+++ b/create-hpc-cluster-custom-image/azuredeploy.json
@@ -81,7 +81,7 @@
       "type": "string",
       "defaultValue": "IaaSCN-",
       "minLength": 1,
-      "maxLength": 12,      
+      "maxLength": 12,
       "metadata": {
         "description": "The name prefix of the compute nodes. It must be no more than 12 characters, begin with a letter, and contain only letters, numbers and hyphens. For example, if 'IaaSCN-' is specified, the compute node names will be 'IaaSCN-000', 'IaaSCN-001', ..."
       }
@@ -90,7 +90,7 @@
       "type": "int",
       "defaultValue": 2,
       "minValue": 1,
-      "maxValue": 50,      
+      "maxValue": 50,
       "metadata": {
         "description": "The number of the compute nodes. All the compute nodes will be created in the storage account where the custom HPC Pack compute node image locates. It is recommended to create no more than 40 VMs in one storage account to avoid possible throttling."
       }
@@ -240,14 +240,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('hnStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -297,7 +297,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicNameHN')]",
       "location": "[resourceGroup().location]",
@@ -436,7 +436,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterName'),'/configureHeadNode')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "Microsoft.Resources/deployments/updateVNetDNS"

--- a/create-hpc-cluster-custom-image/customnode-rdma-disabled.json
+++ b/create-hpc-cluster-custom-image/customnode-rdma-disabled.json
@@ -84,15 +84,14 @@
       "type": "string",
       "metadata": {
         "description": "Optional URL of a public available PowerShell script you want to run on the compute nodes after they are configured. You can also specify arguments for the script, for example 'http://www.consto.com/mypostscript.ps1 -Arg1 arg1 -Arg2 arg2'."
-      }    
+      }
     }
   },
-  "variables":{
+  "variables": {
     "osDiskUri": "[uri(parameters('sourceImageVhdUri'), concat(toLower(parameters('vmName')), '-', uniqueString(parameters('subnetId'), toLower(parameters('vmName'))), '.vhd'))]"
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -111,7 +110,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster-custom-image/customnode-rdma-disabled.json
+++ b/create-hpc-cluster-custom-image/customnode-rdma-disabled.json
@@ -92,6 +92,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -110,6 +111,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster-custom-image/customnode-rdma-enabled.json
+++ b/create-hpc-cluster-custom-image/customnode-rdma-enabled.json
@@ -84,15 +84,14 @@
       "type": "string",
       "metadata": {
         "description": "Optional URL of a public available PowerShell script you want to run on the compute nodes after they are configured. You can also specify arguments for the script, for example 'http://www.consto.com/mypostscript.ps1 -Arg1 arg1 -Arg2 arg2'."
-      }    
+      }
     }
   },
-  "variables":{
+  "variables": {
     "osDiskUri": "[uri(parameters('sourceImageVhdUri'), concat(toLower(parameters('vmName')), '-', uniqueString(parameters('subnetId'), toLower(parameters('vmName'))), '.vhd'))]"
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -111,7 +110,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster-custom-image/customnode-rdma-enabled.json
+++ b/create-hpc-cluster-custom-image/customnode-rdma-enabled.json
@@ -92,6 +92,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -110,6 +111,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/availabilitySets.json
+++ b/create-hpc-cluster/availabilitySets.json
@@ -21,12 +21,11 @@
       }
     }
   },
-  "variables": { },
+  "variables": {},
   "resources": [
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('availabilitySetNamePrefix'), padLeft(string(copyIndex()), 3, '0'))]",
-      "apiVersion": "[parameters('apiVersion')]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "hpcAvsets",

--- a/create-hpc-cluster/availabilitySets.json
+++ b/create-hpc-cluster/availabilitySets.json
@@ -24,12 +24,16 @@
   "variables": {},
   "resources": [
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('availabilitySetNamePrefix'), padLeft(string(copyIndex()), 3, '0'))]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "hpcAvsets",
         "count": "[parameters('availabilitySetNumber')]"
+      },
+      "properties": {
+        
       }
     }
   ]

--- a/create-hpc-cluster/headnode-rdma-disabled.json
+++ b/create-hpc-cluster/headnode-rdma-disabled.json
@@ -65,7 +65,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/headnode-rdma-disabled.json
+++ b/create-hpc-cluster/headnode-rdma-disabled.json
@@ -65,6 +65,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/headnode-rdma-enabled.json
+++ b/create-hpc-cluster/headnode-rdma-enabled.json
@@ -65,7 +65,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/headnode-rdma-enabled.json
+++ b/create-hpc-cluster/headnode-rdma-enabled.json
@@ -65,6 +65,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/linuxnode.json
+++ b/create-hpc-cluster/linuxnode.json
@@ -109,15 +109,14 @@
       "defaultValue": "",
       "metadata": {
         "description": "Not used currently."
-      }    
+      }
     }
   },
-  "variables":{
+  "variables": {
     "osDiskUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-os', uniqueString(parameters('subnetId')), '.vhd')]"
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -136,7 +135,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/linuxnode.json
+++ b/create-hpc-cluster/linuxnode.json
@@ -117,6 +117,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -135,6 +136,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/mainTemplate.json
+++ b/create-hpc-cluster/mainTemplate.json
@@ -230,14 +230,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('hnStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[parameters('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -287,7 +287,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicNameHN')]",
       "location": "[resourceGroup().location]",
@@ -426,7 +426,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('clusterName'),'/configureHeadNode')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "Microsoft.Resources/deployments/updateVNetDNS"
@@ -450,7 +450,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(parameters('storageAccountNamePrefix'), padLeft(string(copyIndex(variables('cnStorageAccountStartIndex'))), variables('storageAccountIndexWidth'), '0'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "Microsoft.Resources/deployments/createHeadNode"
@@ -535,7 +535,7 @@
             "value": "[parameters('privateDomainName')]"
           },
           "computeNodePostConfigScript": {
-            "value": "[trim(parameters('computeNodePostConfigScript'))]"          
+            "value": "[trim(parameters('computeNodePostConfigScript'))]"
           }
         }
       }

--- a/create-hpc-cluster/publicip-new.json
+++ b/create-hpc-cluster/publicip-new.json
@@ -26,7 +26,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIPAddressName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/publicip-new.json
+++ b/create-hpc-cluster/publicip-new.json
@@ -26,6 +26,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIPAddressName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/vnet-with-dns-server.json
+++ b/create-hpc-cluster/vnet-with-dns-server.json
@@ -43,7 +43,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "name": "[parameters('virtualNetworkName')]",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/vnet-with-dns-server.json
+++ b/create-hpc-cluster/vnet-with-dns-server.json
@@ -43,6 +43,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "name": "[parameters('virtualNetworkName')]",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/windowsnode-rdma-disabled.json
+++ b/create-hpc-cluster/windowsnode-rdma-disabled.json
@@ -109,15 +109,14 @@
       "defaultValue": "",
       "metadata": {
         "description": "Optional URL of a public available PowerShell script you want to run on the compute nodes after they are configured. You can also specify arguments for the script, for example 'http://www.consto.com/mypostscript.ps1 -Arg1 arg1 -Arg2 arg2'."
-      }    
+      }
     }
   },
-  "variables":{
+  "variables": {
     "osDiskUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-os', uniqueString(parameters('subnetId')), '.vhd')]"
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -136,7 +135,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/windowsnode-rdma-disabled.json
+++ b/create-hpc-cluster/windowsnode-rdma-disabled.json
@@ -117,6 +117,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -135,6 +136,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/windowsnode-rdma-enabled.json
+++ b/create-hpc-cluster/windowsnode-rdma-enabled.json
@@ -109,15 +109,14 @@
       "defaultValue": "",
       "metadata": {
         "description": "Optional URL of a public available PowerShell script you want to run on the compute nodes after they are configured. You can also specify arguments for the script, for example 'http://www.consto.com/mypostscript.ps1 -Arg1 arg1 -Arg2 arg2'."
-      }    
+      }
     }
   },
-  "variables":{
+  "variables": {
     "osDiskUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net/vhds/', toLower(parameters('vmName')), '-os', uniqueString(parameters('subnetId')), '.vhd')]"
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -136,7 +135,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('apiVersion')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/create-hpc-cluster/windowsnode-rdma-enabled.json
+++ b/create-hpc-cluster/windowsnode-rdma-enabled.json
@@ -117,6 +117,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicName')]",
       "location": "[resourceGroup().location]",
@@ -135,6 +136,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",

--- a/datameer-trend-chef-riskanalysis/azuredeploy.json
+++ b/datameer-trend-chef-riskanalysis/azuredeploy.json
@@ -361,7 +361,6 @@
     "vmNameOrchServer": "orchestratorServer",
     "nicNameTrendDSM": "[concat(variables('vmNameTrendDSM'),'-nic')]",
     "networkInterfaceNameChefServer": "[concat(variables('vmNameChefServer'),'-nic')]",
-
     "networkInterfaceNameOrchServer": "[concat(variables('vmNameOrchServer'),'-nic')]",
     "securityGroupNameTrendDSM": "[concat(variables('nicNameTrendDSM'),'-nsg')]",
     "networkSecurityGroupNameChefServer": "[concat(variables('networkInterfaceNameChefServer'),'-nsg')]",
@@ -512,21 +511,21 @@
       "type": "object",
       "provider": "F0253A01-8156-4D41-BD91-E182158D4972"
     },
-    "chefSoftwareTags":{
-      "type":"object",
-      "provider":"33194f91-eb5f-4110-827a-e95f640a9e46"
+    "chefSoftwareTags": {
+      "type": "object",
+      "provider": "33194f91-eb5f-4110-827a-e95f640a9e46"
     },
     "quickstartTags": {
       "type": "object",
       "name": "datameer-trend-chef-riskanalysis"
-      }
+    }
   },
   "resources": [
     {
       "comments": "Common",
       "name": "vnetstorage",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('deployment-api-version2')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -603,7 +602,7 @@
     {
       "name": "trendmicrodsm",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('deployment-api-version2')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "['Microsoft.Resources/deployments/vnetstorage']"
       ],
@@ -725,7 +724,7 @@
     {
       "name": "orchestrator",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('deployment-api-version2')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "['Microsoft.Resources/deployments/vnetstorage']"
       ],
@@ -811,7 +810,7 @@
     {
       "name": "chefserver",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('deployment-api-version2')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "['Microsoft.Resources/deployments/vnetstorage']",
         "['Microsoft.Resources/deployments/trendmicrodsm']",
@@ -918,7 +917,7 @@
       }
     },
     {
-      "apiVersion": "[variables('deployment-api-version2')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "dsagents",
       "dependsOn": [
@@ -1036,7 +1035,7 @@
       }
     },
     {
-      "apiVersion": "[variables('deployment-api-version2')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "chefnodes",
       "dependsOn": [
@@ -1188,7 +1187,6 @@
           },
           "baseUrl": {
             "value": "[parameters('_artifactsLocation')]"
-
           },
           "datameerTags": {
             "value": "[variables('datameerTags')]"
@@ -1203,10 +1201,10 @@
             "value": "[variables('quickstartTags')]"
           }
         }
-        }
+      }
     },
     {
-      "apiVersion": "[variables('deployment-api-version2')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "datameerhdinsight",
       "dependsOn": [
@@ -1227,23 +1225,23 @@
           },
           "clusterType": {
             "value": "[variables('datameerHDInsightCluster').clusterType]"
-          }, 
+          },
           "clusterLoginUserName": {
             "value": "[variables('datameerHDInsightCluster').clusterLoginUserName]"
-          }, 
+          },
           "clusterLoginPassword": {
             "value": "[variables('datameerHDInsightCluster').clusterLoginPassword]"
-          }, 
+          },
           "sshUserName": {
             "value": "[variables('datameerHDInsightCluster').sshUserName]"
-          }, 
+          },
           "sshPassword": {
             "value": "[variables('datameerHDInsightCluster').sshPassword]"
-          }, 
+          },
           "storageAccount": {
             "value": "[variables('datameerHDInsightCluster').storageAccount]"
           },
-          "clusterVNetName" :{
+          "clusterVNetName": {
             "value": "[variables('virtualNetworkName')]"
           },
           "clusterVnetAddressSpace": {
@@ -1269,7 +1267,7 @@
           }
         }
       }
-    }    
+    }
   ],
   "outputs": {
     "TrendMicro DSM URI": {

--- a/datameer-trend-chef-riskanalysis/nested/database-new.json
+++ b/datameer-trend-chef-riskanalysis/nested/database-new.json
@@ -2,23 +2,35 @@
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "location": { "type": "string" },
-    "newsqlServerName": { "type": "string" },
-    "existingSQLServerName": { "type": "string" },
-    "dbAdminName": { "type": "string" },
-    "dbAdminPassword": { "type": "string" },
-    "sqlDBName": { "type": "string" },
+    "location": {
+      "type": "string"
+    },
+    "newsqlServerName": {
+      "type": "string"
+    },
+    "existingSQLServerName": {
+      "type": "string"
+    },
+    "dbAdminName": {
+      "type": "string"
+    },
+    "dbAdminPassword": {
+      "type": "string"
+    },
+    "sqlDBName": {
+      "type": "string"
+    },
     "datameerTags": {
-        "type": "object"
+      "type": "object"
     },
     "trendmicroTags": {
-        "type": "object"
+      "type": "object"
     },
     "chefSoftwareTags": {
-        "type": "object"
+      "type": "object"
     },
     "quickstartTags": {
-        "type": "object"
+      "type": "object"
     }
   },
   "variables": {
@@ -27,51 +39,51 @@
     "sqlfirewallrules-api-version": "2014-04-01"
   },
   "resources": [
-      {
-          "name": "[parameters('newsqlServerName')]",
-          "type": "Microsoft.Sql/servers",
+    {
+      "name": "[parameters('newsqlServerName')]",
+      "type": "Microsoft.Sql/servers",
+      "location": "[parameters('location')]",
+      "apiVersion": "2014-04-01",
+      "properties": {
+        "administratorLogin": "[parameters('dbAdminName')]",
+        "administratorLoginPassword": "[parameters('dbAdminPassword')]",
+        "version": "12.0"
+      },
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
+      },
+      "resources": [
+        {
+          "name": "[parameters('sqlDBName')]",
+          "type": "databases",
           "location": "[parameters('location')]",
-          "apiVersion": "[variables('sql-api-version')]",
+          "apiVersion": "[variables('sqldb-api-version')]",
+          "dependsOn": [
+            "[concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))]"
+          ],
           "properties": {
-            "administratorLogin": "[parameters('dbAdminName')]",
-            "administratorLoginPassword": "[parameters('dbAdminPassword')]",
-            "version": "12.0"
+            "edition": "Standard",
+            "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "maxSizeBytes": "21474836480",
+            "requestedServiceObjectiveName": "S3"
+          }
+        },
+        {
+          "apiVersion": "[variables('sqlfirewallrules-api-version')]",
+          "dependsOn": [
+            "[concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))]"
+          ],
+          "location": "[parameters('location')]",
+          "name": "AllowAllAzureIps",
+          "properties": {
+            "endIpAddress": "0.0.0.0",
+            "startIpAddress": "0.0.0.0"
           },
-          "tags": {
-            "quickstartName": "[parameters('quickstartTags').name]",
-            "provider": "[parameters('trendmicroTags').provider]"
-          },
-          "resources": [
-              {
-                  "name": "[parameters('sqlDBName')]",
-                  "type": "databases",
-                  "location": "[parameters('location')]",
-                  "apiVersion": "[variables('sqldb-api-version')]",
-                  "dependsOn": [
-                      "[concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))]"
-                      ],
-                  "properties": {
-                      "edition": "Standard",
-                      "collation": "SQL_Latin1_General_CP1_CI_AS",
-                      "maxSizeBytes": "21474836480",
-                      "requestedServiceObjectiveName": "S3"
-                  }
-              },
-              {
-                  "apiVersion": "[variables('sqlfirewallrules-api-version')]",
-                  "dependsOn": [
-                      "[concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))]"
-                  ],
-                  "location": "[parameters('location')]",
-                  "name": "AllowAllAzureIps",
-                  "properties": {
-                      "endIpAddress": "0.0.0.0",
-                      "startIpAddress": "0.0.0.0"
-                  },
-                  "type": "firewallrules"
-              }
-          ]
-      }
+          "type": "firewallrules"
+        }
+      ]
+    }
   ],
   "outputs": {
     "sqlServerFQDN": {

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-chefnodes.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-chefnodes.json
@@ -189,16 +189,16 @@
       }
     },
     "datameerTags": {
-        "type": "object"
+      "type": "object"
     },
     "trendmicroTags": {
-        "type": "object"
+      "type": "object"
     },
     "chefSoftwareTags": {
-        "type": "object"
+      "type": "object"
     },
     "quickstartTags": {
-        "type": "object"
+      "type": "object"
     }
   },
   "variables": {
@@ -216,7 +216,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('chefprefix'),variables('publicIPAddressNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -234,7 +234,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('chefprefix'),variables('networkInterfaceNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -265,7 +265,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -311,12 +311,10 @@
           ]
         }
       },
-      "resources": [
-        
-      ]
+      "resources": []
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('chefprefix'),variables('publicIPAddressNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -338,7 +336,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('chefprefix'),variables('networkInterfaceNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -373,7 +371,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -427,7 +425,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyIndex(),'/', variables('vmExtensionName'))]",
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -465,7 +463,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyIndex(),'/', variables('vmExtensionName2'))]",
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-chefnodes.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-chefnodes.json
@@ -216,7 +216,7 @@
   },
   "resources": [
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('chefprefix'),variables('publicIPAddressNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -234,7 +234,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('chefprefix'),variables('networkInterfaceNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -265,7 +265,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -314,7 +314,7 @@
       "resources": []
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('chefprefix'),variables('publicIPAddressNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -336,7 +336,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('chefprefix'),variables('networkInterfaceNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -371,7 +371,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -425,7 +425,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyIndex(),'/', variables('vmExtensionName'))]",
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -463,7 +463,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyIndex(),'/', variables('vmExtensionName2'))]",
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-chefserver.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-chefserver.json
@@ -130,7 +130,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmNameChefServer')]",
-      "apiVersion": "",
+      "apiVersion": "2016-04-30-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -188,7 +188,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameChefServer'),'/', 'chefServerSetup')]",
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -215,7 +215,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceNameChefServer')]",
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -252,7 +252,7 @@
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('networkSecurityGroupNameChefServer')]",
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-chefserver.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-chefserver.json
@@ -1,338 +1,348 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-
-        "publicIPAddressNameChefServer": {
-            "defaultValue": "",
-            "type": "String"
-        },
-        "publicIPDomainNameLabelChefServer": {
-            "defaultValue": "",
-            "type": "String"
-        },
-        "networkSecurityGroupNameChefServer": {
-            "defaultValue": "",
-            "type": "String"
-        },
-        "networkInterfaceNameChefServer": {
-            "defaultValue": "",
-            "type": "String"
-        },
-        "vmNameChefServer": {
-            "defaultValue": "",
-            "type": "String"
-        },
-        "vmAdminUsernameChefServer": {
-            "defaultValue": "",
-            "type": "String"
-        },
-        "vmAdminPasswordChefServer": {
-            "defaultValue": "",
-            "type": "SecureString"
-        },
-        "storageAccountName": {
-            "defaultValue": "",
-            "type": "String"
-        },
-        "vmStorageAccountContainerName": {
-            "defaultValue": "",
-            "type": "String"
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "network-api-version": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "compute-api-version": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "tagvalues": {
-            "type": "object",
-            "defaultValue": {
-                "program": "PushToPilot",
-                "project": "DatameerTrendHDInsightChef"
-            }
-        },
-        "publisherChefServer": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "offerChoosedChefServer": {
-            "type": "object",
-            "defaultValue": ""
-        },
-        "subnet2Ref": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "publicIPAddressType": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "chefUserName": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "chefUserFirstName": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "chefUserLastName": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "chefUserEmail": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "chefUserPassword": {
-            "type": "securestring",
-            "defaultValue": ""
-        },
-        "chefOrgShortName": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "chefOrgFullName": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "chefServerScriptUrl": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "publicIPDomainNameLabelOrchServer": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "datameerTags": {
-            "type": "object"
-        },
-        "trendmicroTags": {
-            "type": "object"
-        },
-        "chefSoftwareTags": {
-            "type": "object"
-        },
-        "quickstartTags": {
-            "type": "object"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "publicIPAddressNameChefServer": {
+      "defaultValue": "",
+      "type": "String"
     },
-    "variables": {
-        "singleQuote": "'",
-        "publicIPDomainNameLabelOrchServer": "[concat('http://',parameters('publicIPDomainNameLabelOrchServer'),'.',parameters('location'),'.cloudapp.azure.com:33001/key')]"
+    "publicIPDomainNameLabelChefServer": {
+      "defaultValue": "",
+      "type": "String"
     },
-    "resources": [{
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[parameters('vmNameChefServer')]",
-            "apiVersion": "[parameters('compute-api-version')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "program": "[parameters('tagvalues').program]",
-                "project": "[parameters('tagvalues').project]",
-                "quickstartName": "[parameters('quickstartTags').name]",
-                "provider": "[parameters('chefSoftwareTags').provider]"
+    "networkSecurityGroupNameChefServer": {
+      "defaultValue": "",
+      "type": "String"
+    },
+    "networkInterfaceNameChefServer": {
+      "defaultValue": "",
+      "type": "String"
+    },
+    "vmNameChefServer": {
+      "defaultValue": "",
+      "type": "String"
+    },
+    "vmAdminUsernameChefServer": {
+      "defaultValue": "",
+      "type": "String"
+    },
+    "vmAdminPasswordChefServer": {
+      "defaultValue": "",
+      "type": "SecureString"
+    },
+    "storageAccountName": {
+      "defaultValue": "",
+      "type": "String"
+    },
+    "vmStorageAccountContainerName": {
+      "defaultValue": "",
+      "type": "String"
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "network-api-version": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "compute-api-version": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "tagvalues": {
+      "type": "object",
+      "defaultValue": {
+        "program": "PushToPilot",
+        "project": "DatameerTrendHDInsightChef"
+      }
+    },
+    "publisherChefServer": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "offerChoosedChefServer": {
+      "type": "object",
+      "defaultValue": ""
+    },
+    "subnet2Ref": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "publicIPAddressType": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "chefUserName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "chefUserFirstName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "chefUserLastName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "chefUserEmail": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "chefUserPassword": {
+      "type": "securestring",
+      "defaultValue": ""
+    },
+    "chefOrgShortName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "chefOrgFullName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "chefServerScriptUrl": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "publicIPDomainNameLabelOrchServer": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "datameerTags": {
+      "type": "object"
+    },
+    "trendmicroTags": {
+      "type": "object"
+    },
+    "chefSoftwareTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
+    }
+  },
+  "variables": {
+    "singleQuote": "'",
+    "publicIPDomainNameLabelOrchServer": "[concat('http://',parameters('publicIPDomainNameLabelOrchServer'),'.',parameters('location'),'.cloudapp.azure.com:33001/key')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmNameChefServer')]",
+      "apiVersion": "",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('chefSoftwareTags').provider]"
+      },
+      "plan": {
+        "name": "[parameters('offerChoosedChefServer').vmSku]",
+        "product": "[parameters('offerChoosedChefServer').product]",
+        "publisher": "[parameters('publisherChefServer')]"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('offerChoosedChefServer').vmSize]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('publisherChefServer')]",
+            "offer": "[parameters('offerChoosedChefServer').product]",
+            "sku": "[parameters('offerChoosedChefServer').vmSku]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('vmNameChefServer'),'-osDisk')]",
+            "createOption": "FromImage",
+            "vhd": {
+              "uri": "[concat('https', '://', parameters('storageAccountName'), '.blob.core.windows.net','/', parameters('vmStorageAccountContainerName'),'/', parameters('vmNameChefServer'),'-osdisk.vhd')]"
             },
-            "plan": {
-                "name": "[parameters('offerChoosedChefServer').vmSku]",
-                "product": "[parameters('offerChoosedChefServer').product]",
-                "publisher": "[parameters('publisherChefServer')]"
-            },
-            "properties": {
-                "hardwareProfile": {
-                    "vmSize": "[parameters('offerChoosedChefServer').vmSize]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "[parameters('publisherChefServer')]",
-                        "offer": "[parameters('offerChoosedChefServer').product]",
-                        "sku": "[parameters('offerChoosedChefServer').vmSku]",
-                        "version": "latest"
-                    },
-                    "osDisk": {
-                        "name": "[concat(parameters('vmNameChefServer'),'-osDisk')]",
-                        "createOption": "FromImage",
-                        "vhd": {
-                            "uri": "[concat('https', '://', parameters('storageAccountName'), '.blob.core.windows.net','/', parameters('vmStorageAccountContainerName'),'/', parameters('vmNameChefServer'),'-osdisk.vhd')]"
-                        },
-                        "caching": "ReadWrite"
-                    },
-                    "dataDisks": []
-                },
-                "osProfile": {
-                    "computerName": "[parameters('vmNameChefServer')]",
-                    "adminUsername": "[parameters('vmAdminUsernameChefServer')]",
-                    "linuxConfiguration": {
-                        "disablePasswordAuthentication": false
-                    },
-                    "secrets": [],
-                    "adminPassword": "[parameters('vmAdminPasswordChefServer')]"
-                },
-                "networkProfile": {
-                    "networkInterfaces": [{
-                        "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceNameChefServer'))]"
-                    }]
-                }
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceNameChefServer'))]"
-            ]
-        }, {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(parameters('vmNameChefServer'),'/', 'chefServerSetup')]",
-            "apiVersion": "[parameters('compute-api-version')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "program": "[parameters('tagvalues').program]",
-                "project": "[parameters('tagvalues').project]",
-                "quickstartName": "[parameters('quickstartTags').name]",
-                "provider": "[parameters('chefSoftwareTags').provider]"
-            },
-            "dependsOn": [
-                "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameChefServer'))]"
-
-            ],
-            "properties": {
-                "publisher": "Microsoft.Azure.Extensions",
-                "type": "CustomScript",
-                "typeHandlerVersion": "2.0",
-                "autoUpgradeMinorVersion": true,
-                "settings": {
-                    "fileUris": [
-                        "[parameters('chefServerScriptUrl')]"
-                    ],
-                    "commandToExecute": "[concat('bash chefserver.sh ', parameters('chefUserName'), ' ',parameters('chefUserFirstName'), ' ', parameters('chefUserLastName'), ' ',  parameters('chefUserEmail'), ' ',variables('singleQuote'), parameters('chefUserPassword'),variables('singleQuote'),' ',parameters('chefOrgShortName'),' ',variables('singleQuote'),parameters('chefOrgFullName'),variables('singleQuote'),' ',variables('publicIPDomainNameLabelOrchServer'))]"
-                }
+            "caching": "ReadWrite"
+          },
+          "dataDisks": []
+        },
+        "osProfile": {
+          "computerName": "[parameters('vmNameChefServer')]",
+          "adminUsername": "[parameters('vmAdminUsernameChefServer')]",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": false
+          },
+          "secrets": [],
+          "adminPassword": "[parameters('vmAdminPasswordChefServer')]"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceNameChefServer'))]"
             }
-        }, {
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[parameters('networkInterfaceNameChefServer')]",
-            "apiVersion": "[parameters('network-api-version')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "program": "[parameters('tagvalues').program]",
-                "project": "[parameters('tagvalues').project]"
-            },
-            "properties": {
-                "ipConfigurations": [{
-                    "name": "ipconfig1",
-                    "properties": {
-                        "privateIPAllocationMethod": "Dynamic",
-                        "publicIPAddress": {
-                            "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressNameChefServer'))]"
-                        },
-                        "subnet": {
-                            "id": "[parameters('subnet2Ref')]"
-                        }
-                    }
-                }],
-                "dnsSettings": {
-                    "dnsServers": []
-                },
-                "enableIPForwarding": false,
-                "networkSecurityGroup": {
-                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupNameChefServer'))]"
-                }
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressNameChefServer'))]",
-
-                "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupNameChefServer'))]"
-            ]
-        }, {
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "name": "[parameters('networkSecurityGroupNameChefServer')]",
-            "apiVersion": "[parameters('network-api-version')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "program": "[parameters('tagvalues').program]",
-                "project": "[parameters('tagvalues').project]",
-                "quickstartName": "[parameters('quickstartTags').name]",
-                "provider": "[parameters('chefSoftwareTags').provider]"
-            },
-            "properties": {
-                "securityRules": [{
-                    "name": "ssh",
-                    "properties": {
-                        "protocol": "Tcp",
-                        "sourcePortRange": "*",
-                        "destinationPortRange": "22",
-                        "sourceAddressPrefix": "*",
-                        "destinationAddressPrefix": "*",
-                        "access": "Allow",
-                        "priority": 1010,
-                        "direction": "Inbound"
-                    }
-                }, {
-                    "name": "http",
-                    "properties": {
-                        "protocol": "Tcp",
-                        "sourcePortRange": "*",
-                        "destinationPortRange": "80",
-                        "sourceAddressPrefix": "*",
-                        "destinationAddressPrefix": "*",
-                        "access": "Allow",
-                        "priority": 1020,
-                        "direction": "Inbound"
-                    }
-                }, {
-                    "name": "https",
-                    "properties": {
-                        "protocol": "Tcp",
-                        "sourcePortRange": "*",
-                        "destinationPortRange": "443",
-                        "sourceAddressPrefix": "*",
-                        "destinationAddressPrefix": "*",
-                        "access": "Allow",
-                        "priority": 1030,
-                        "direction": "Inbound"
-                    }
-                }, {
-                    "name": "https8443",
-                    "properties": {
-                        "protocol": "Tcp",
-                        "sourcePortRange": "*",
-                        "destinationPortRange": "8443",
-                        "sourceAddressPrefix": "*",
-                        "destinationAddressPrefix": "*",
-                        "access": "Allow",
-                        "priority": 1040,
-                        "direction": "Inbound"
-                    }
-                }]
-            },
-            "dependsOn": []
-        }, {
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[parameters('publicIPAddressNameChefServer')]",
-            "apiVersion": "2015-06-15",
-            "location": "[parameters('location')]",
-            "tags": {
-                "program": "[parameters('tagvalues').program]",
-                "project": "[parameters('tagvalues').project]",
-                "quickstartName": "[parameters('quickstartTags').name]",
-                "provider": "[parameters('chefSoftwareTags').provider]"
-            },
-            "properties": {
-                "publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
-                "dnsSettings": {
-                    "domainNameLabel": "[parameters('publicIPDomainNameLabelChefServer')]"
-                },
-                "idleTimeoutInMinutes": 4
-            },
-            "dependsOn": []
+          ]
         }
-
-    ],
-"outputs": {
-  "chefserverUri": {
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceNameChefServer'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmNameChefServer'),'/', 'chefServerSetup')]",
+      "apiVersion": "",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('chefSoftwareTags').provider]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameChefServer'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": [
+            "[parameters('chefServerScriptUrl')]"
+          ],
+          "commandToExecute": "[concat('bash chefserver.sh ', parameters('chefUserName'), ' ',parameters('chefUserFirstName'), ' ', parameters('chefUserLastName'), ' ',  parameters('chefUserEmail'), ' ',variables('singleQuote'), parameters('chefUserPassword'),variables('singleQuote'),' ',parameters('chefOrgShortName'),' ',variables('singleQuote'),parameters('chefOrgFullName'),variables('singleQuote'),' ',variables('publicIPDomainNameLabelOrchServer'))]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[parameters('networkInterfaceNameChefServer')]",
+      "apiVersion": "",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]"
+      },
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressNameChefServer'))]"
+              },
+              "subnet": {
+                "id": "[parameters('subnet2Ref')]"
+              }
+            }
+          }
+        ],
+        "dnsSettings": {
+          "dnsServers": []
+        },
+        "enableIPForwarding": false,
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupNameChefServer'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('publicIPAddressNameChefServer'))]",
+        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupNameChefServer'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('networkSecurityGroupNameChefServer')]",
+      "apiVersion": "",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('chefSoftwareTags').provider]"
+      },
+      "properties": {
+        "securityRules": [
+          {
+            "name": "ssh",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1010,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "http",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1020,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "https",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1030,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "https8443",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1040,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      },
+      "dependsOn": []
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('publicIPAddressNameChefServer')]",
+      "apiVersion": "2015-06-15",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('chefSoftwareTags').provider]"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('publicIPDomainNameLabelChefServer')]"
+        },
+        "idleTimeoutInMinutes": 4
+      },
+      "dependsOn": []
+    }
+  ],
+  "outputs": {
+    "chefserverUri": {
       "type": "string",
       "value": "[concat('https://',reference(resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameChefServer'))).dnsSettings.fqdn)]"
     }
-}
+  }
 }

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-dsagents.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-dsagents.json
@@ -119,16 +119,16 @@
       "defaultValue": ""
     },
     "datameerTags": {
-        "type": "object"
+      "type": "object"
     },
     "trendmicroTags": {
-        "type": "object"
+      "type": "object"
     },
     "chefSoftwareTags": {
-        "type": "object"
+      "type": "object"
     },
     "quickstartTags": {
-        "type": "object"
+      "type": "object"
     }
   },
   "variables": {
@@ -139,7 +139,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -161,7 +161,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('networkInterfaceNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -196,7 +196,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -248,7 +248,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameDSAWindows'), copyindex(),'/Installation')]",
       "location": "[parameters('location')]",
@@ -282,7 +282,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -304,7 +304,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('networkInterfaceNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -339,7 +339,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -391,7 +391,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameDSAgent'), copyindex(),'/Installation')]",
       "location": "[parameters('location')]",

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-dsagents.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-dsagents.json
@@ -139,7 +139,7 @@
   },
   "resources": [
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -161,7 +161,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('networkInterfaceNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -196,7 +196,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -248,7 +248,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameDSAWindows'), copyindex(),'/Installation')]",
       "location": "[parameters('location')]",
@@ -282,7 +282,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -304,7 +304,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('networkInterfaceNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -339,7 +339,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -391,7 +391,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameDSAgent'), copyindex(),'/Installation')]",
       "location": "[parameters('location')]",

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-orchestrator.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-orchestrator.json
@@ -79,16 +79,16 @@
       "defaultValue": ""
     },
     "datameerTags": {
-        "type": "object"
+      "type": "object"
     },
     "trendmicroTags": {
-        "type": "object"
+      "type": "object"
     },
     "chefSoftwareTags": {
-        "type": "object"
+      "type": "object"
     },
     "quickstartTags": {
-        "type": "object"
+      "type": "object"
     }
   },
   "variables": {
@@ -98,7 +98,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmNameOrchServer')]",
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -151,7 +151,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameOrchServer'),'/','installdockerandcompose')]",
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -173,7 +173,7 @@
     {
       "name": "orchestratorapplication",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[parameters('deployment-api-version2')]",
+      "apiVersion": "",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameOrchServer'),'/extensions/installdockerandcompose')]"
       ],
@@ -184,23 +184,23 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "location":{
+          "location": {
             "value": "[parameters('location')]"
           },
           "vmName": {
             "value": "[parameters('vmNameOrchServer')]"
           },
           "datameerTags": {
-                "value": "[parameters('datameerTags')]"
+            "value": "[parameters('datameerTags')]"
           },
           "trendmicroTags": {
-                "value": "[parameters('trendmicroTags')]"
+            "value": "[parameters('trendmicroTags')]"
           },
           "chefSoftwareTags": {
-                "value": "[parameters('chefSoftwareTags')]"
+            "value": "[parameters('chefSoftwareTags')]"
           },
           "quickstartTags": {
-                "value": "[parameters('quickstartTags')]"
+            "value": "[parameters('quickstartTags')]"
           }
         }
       }
@@ -208,7 +208,7 @@
     {
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressNameOrchServer')]",
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -228,7 +228,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceNameOrchServer')]",
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -267,7 +267,7 @@
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('networkSecurityGroupNameOrchServer')]",
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-orchestrator.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-orchestrator.json
@@ -98,7 +98,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmNameOrchServer')]",
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -151,7 +151,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameOrchServer'),'/','installdockerandcompose')]",
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -173,7 +173,7 @@
     {
       "name": "orchestratorapplication",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameOrchServer'),'/extensions/installdockerandcompose')]"
       ],
@@ -208,7 +208,7 @@
     {
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressNameOrchServer')]",
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -228,7 +228,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceNameOrchServer')]",
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -267,7 +267,7 @@
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('networkSecurityGroupNameOrchServer')]",
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-splunkenterprise.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-splunkenterprise.json
@@ -69,316 +69,339 @@
     }
   },
   "variables": {
-
     "publicIpName": "[parameters('machineSettings').publicIPName]",
     "splunkServerRole": "splunk_server",
     "singleQuote": "'",
     "clusterMasterIp": "[parameters('machineSettings').clusterMasterIp]"
-
   },
-  "resources": [{
-    "apiVersion": "[parameters('network-api-version')]",
-    "type": "Microsoft.Network/publicIPAddresses",
-    "name": "[concat(parameters('publicIPAddressSettingsSplunk').name, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]",
-    "copy": {
-      "name": "publicIPAddressLoop",
-      "count": "[parameters('publicIPAddressSettingsSplunk').count]"
-    },
-    "location": "[parameters('location')]",
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]"
-    },
-    "properties": {
-      "publicIPAllocationMethod": "Dynamic",
-      "dnsSettings": {
-        "domainNameLabel": "[concat(parameters('publicIPAddressSettingsSplunk').domainNamePrefix, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]"
-      }
-    }
-  }, {
-    "apiVersion": "[parameters('network-api-version')]",
-    "type": "Microsoft.Network/networkSecurityGroups",
-    "name": "[parameters('networkSecurityGroupNameSplunkEnterprise')]",
-    "location": "[parameters('location')]",
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]"
-    },
-    "properties": {
-      "securityRules": [{
-        "name": "Allow-SSH",
-        "properties": {
-          "description": "Allows SSH traffic",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "22",
-          "sourceAddressPrefix": "[parameters('machineSettings').sshFrom]",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 100,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-HTTP",
-        "properties": {
-          "description": "Allows HTTP traffic on port 8000",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "8000",
-          "sourceAddressPrefix": "*",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 110,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-HTTPS",
-        "properties": {
-          "description": "Allows HTTPS traffic on port 443",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "443",
-          "sourceAddressPrefix": "*",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 120,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-HTTP-Event-Collector",
-        "properties": {
-          "description": "Allows HTTP(S) Event Collector traffic on port 8088",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "8088",
-          "sourceAddressPrefix": "*",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 130,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-Receiver-TCP",
-        "properties": {
-          "description": "Allows receiver TCP traffic on port 9997",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "9997",
-          "sourceAddressPrefix": "[parameters('machineSettings').forwardedDataFrom]",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 140,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-Mgmt-From-VNET",
-        "properties": {
-          "description": "Allows mgmt on port 8089 from VNET only",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "8089",
-          "sourceAddressPrefix": "VirtualNetwork",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 150,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-Custom-UDP",
-        "properties": {
-          "description": "Allows UDP port entered by user",
-          "protocol": "Udp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "[parameters('udpPort')]",
-          "sourceAddressPrefix": "*",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 160,
-          "direction": "Inbound"
-        }
-      }]
-    }
-  }, {
-    "apiVersion": "[parameters('network-api-version')]",
-    "type": "Microsoft.Network/networkInterfaces",
-    "name": "[parameters('networkInterfaceNameSplunkEnterprise')]",
-    "location": "[parameters('location')]",
-    "dependsOn": [
-      "[concat('Microsoft.Network/networkSecurityGroups/', parameters('networkSecurityGroupNameSplunkEnterprise'))]",
-      "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIpName'))]"
-    ],
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]"
-    },
-    "properties": {
-      "networkSecurityGroup": {
-        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupNameSplunkEnterprise'))]"
+  "resources": [
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(parameters('publicIPAddressSettingsSplunk').name, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]",
+      "copy": {
+        "name": "publicIPAddressLoop",
+        "count": "[parameters('publicIPAddressSettingsSplunk').count]"
       },
-      "ipConfigurations": [{
-        "name": "ipconfig1",
-        "properties": {
-          "privateIPAllocationMethod": "Static",
-          "privateIPAddress": "[parameters('machineSettings').staticIp]",
-          "publicIPAddress": {
-            "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[concat(parameters('publicIPAddressSettingsSplunk').domainNamePrefix, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]"
+        }
+      }
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('networkSecurityGroupNameSplunkEnterprise')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]"
+      },
+      "properties": {
+        "securityRules": [
+          {
+            "name": "Allow-SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "[parameters('machineSettings').sshFrom]",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
           },
-          "subnet": {
-            "id": "[parameters('subnet3Ref')]"
+          {
+            "name": "Allow-HTTP",
+            "properties": {
+              "description": "Allows HTTP traffic on port 8000",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8000",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-HTTPS",
+            "properties": {
+              "description": "Allows HTTPS traffic on port 443",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-HTTP-Event-Collector",
+            "properties": {
+              "description": "Allows HTTP(S) Event Collector traffic on port 8088",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8088",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-Receiver-TCP",
+            "properties": {
+              "description": "Allows receiver TCP traffic on port 9997",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "9997",
+              "sourceAddressPrefix": "[parameters('machineSettings').forwardedDataFrom]",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 140,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-Mgmt-From-VNET",
+            "properties": {
+              "description": "Allows mgmt on port 8089 from VNET only",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8089",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 150,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-Custom-UDP",
+            "properties": {
+              "description": "Allows UDP port entered by user",
+              "protocol": "Udp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[parameters('udpPort')]",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 160,
+              "direction": "Inbound"
+            }
           }
-        }
-      }]
-    }
-  }, {
-    "apiVersion": "[parameters('compute-api-version')]",
-    "type": "Microsoft.Compute/virtualMachines",
-    "name": "[parameters('vmNameSplunkEnterprise')]",
-    "location": "[parameters('location')]",
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]"
+        ]
+      }
     },
-    "plan": {
-      "name": "[parameters('osSettingsSplunk').imageReference.sku]",
-      "publisher": "[parameters('osSettingsSplunk').imageReference.publisher]",
-      "product": "[parameters('osSettingsSplunk').imageReference.offer]"
-    },
-    "dependsOn": [
-      "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceNameSplunkEnterprise'))]"
-    ],
-    "properties": {
-      "availabilitySet": {
-        "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('machineSettings').availabilitySet)]"
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[parameters('networkInterfaceNameSplunkEnterprise')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkSecurityGroups/', parameters('networkSecurityGroupNameSplunkEnterprise'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIpName'))]"
+      ],
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]"
       },
-      "hardwareProfile": {
-        "vmSize": "[parameters('machineSettings').vmSize]"
-      },
-      "osProfile": {
-        "computername": "[parameters('vmNameSplunkEnterprise')]",
-        "adminUsername": "[parameters('vmAdminUsernameSplunkEnterprise')]",
-        "adminPassword": "[parameters('vmAdminPasswordSplunkEnterprise')]"
-      },
-      "storageProfile": {
-        "imageReference": "[parameters('osSettingsSplunk').imageReference]",
-        "osDisk": {
-          "name": "osdisk",
-          "vhd": {
-            "uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-osdisk.vhd')]"
-          },
-          "caching": "ReadWrite",
-          "createOption": "FromImage"
+      "properties": {
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupNameSplunkEnterprise'))]"
         },
-        "dataDisks": [{
-          "name": "datadisk1",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 0,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk1.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk2",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 1,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk2.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk3",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 2,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk3.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk4",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 3,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk4.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk5",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 4,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk5.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk6",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 5,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk6.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk7",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 6,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk7.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk8",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 7,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk8.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }]
-      },
-      "networkProfile": {
-        "networkInterfaces": [{
-          "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceNameSplunkEnterprise'))]"
-        }]
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[parameters('machineSettings').staticIp]",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+              },
+              "subnet": {
+                "id": "[parameters('subnet3Ref')]"
+              }
+            }
+          }
+        ]
       }
-    }
-  }, {
-    "apiVersion": "[parameters('compute-api-version')]",
-    "type": "Microsoft.Compute/virtualMachines/extensions",
-    "name": "[concat(parameters('vmNameSplunkEnterprise'), '/node-setup')]",
-    "location": "[parameters('location')]",
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]"
     },
-    "dependsOn": [
-      "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameSplunkEnterprise'))]",
-      "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceNameSplunkEnterprise'))]"
-    ],
-    "properties": {
-      "publisher": "Microsoft.OSTCExtensions",
-      "type": "CustomScriptForLinux",
-      "typeHandlerVersion": "1.5",
-      "settings": {
-        "fileUris": "[parameters('osSettingsSplunk').scripts]"
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmNameSplunkEnterprise')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]"
       },
-      "protectedSettings": {
-        "commandToExecute": "[concat('bash node-setup.sh', ' -r ', variables('splunkServerRole'), ' -c ', variables('clusterMasterIp'), ' -u ', parameters('udpPort'),  ' -p ', variables('singleQuote'), parameters('splunkAdminPassword'), variables('singleQuote'))]"
-
-
+      "plan": {
+        "name": "[parameters('osSettingsSplunk').imageReference.sku]",
+        "publisher": "[parameters('osSettingsSplunk').imageReference.publisher]",
+        "product": "[parameters('osSettingsSplunk').imageReference.offer]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceNameSplunkEnterprise'))]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('machineSettings').availabilitySet)]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('machineSettings').vmSize]"
+        },
+        "osProfile": {
+          "computername": "[parameters('vmNameSplunkEnterprise')]",
+          "adminUsername": "[parameters('vmAdminUsernameSplunkEnterprise')]",
+          "adminPassword": "[parameters('vmAdminPasswordSplunkEnterprise')]"
+        },
+        "storageProfile": {
+          "imageReference": "[parameters('osSettingsSplunk').imageReference]",
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          },
+          "dataDisks": [
+            {
+              "name": "datadisk1",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 0,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk1.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk2",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 1,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk2.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk3",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 2,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk3.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk4",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 3,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk4.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk5",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 4,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk5.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk6",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 5,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk6.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk7",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 6,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk7.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk8",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 7,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk8.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceNameSplunkEnterprise'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmNameSplunkEnterprise'), '/node-setup')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameSplunkEnterprise'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceNameSplunkEnterprise'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.OSTCExtensions",
+        "type": "CustomScriptForLinux",
+        "typeHandlerVersion": "1.5",
+        "settings": {
+          "fileUris": "[parameters('osSettingsSplunk').scripts]"
+        },
+        "protectedSettings": {
+          "commandToExecute": "[concat('bash node-setup.sh', ' -r ', variables('splunkServerRole'), ' -c ', variables('clusterMasterIp'), ' -u ', parameters('udpPort'),  ' -p ', variables('singleQuote'), parameters('splunkAdminPassword'), variables('singleQuote'))]"
+        }
       }
     }
-  }],
-"outputs": {
-  "splunkenterpriseUri": {
+  ],
+  "outputs": {
+    "splunkenterpriseUri": {
       "type": "string",
       "value": "[concat('https://',reference(resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressSettingsSplunk').name)).dnsSettings.fqdn)]"
     }
-}
+  }
 }

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-splunkenterprise.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-splunkenterprise.json
@@ -76,7 +76,7 @@
   },
   "resources": [
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('publicIPAddressSettingsSplunk').name, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]",
       "copy": {
@@ -96,7 +96,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('networkSecurityGroupNameSplunkEnterprise')]",
       "location": "[parameters('location')]",
@@ -208,7 +208,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceNameSplunkEnterprise')]",
       "location": "[parameters('location')]",
@@ -242,7 +242,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmNameSplunkEnterprise')]",
       "location": "[parameters('location')]",
@@ -373,7 +373,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameSplunkEnterprise'), '/node-setup')]",
       "location": "[parameters('location')]",

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-trenddsm.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-trenddsm.json
@@ -1,403 +1,414 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  	"contentVersion": "1.0.0.0",
-  	"parameters": {
-
-      "storageAccountName": {
-        "type": "string",
-        "defaultValue": ""
-      },
-      "vmStorageAccountContainerName": {
-        "type": "string",
-        "defaultValue": ""
-      },      
-      "location": {
-        "type": "string",
-        "defaultValue": ""
-      },
-      "network-api-version": {
-        "type": "string",
-        "defaultValue": ""
-      },
-      "compute-api-version": {
-        "type": "string",
-        "defaultValue": ""
-      },
-      "tagvalues": {
-	      "type": "object",
-	      "defaultValue": {
-          "program": "PushToPilot",
-          "project": "DatameerTrendHDInsightChef"
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "vmStorageAccountContainerName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "network-api-version": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "compute-api-version": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "tagvalues": {
+      "type": "object",
+      "defaultValue": {
+        "program": "PushToPilot",
+        "project": "DatameerTrendHDInsightChef"
       }
     },
     "publicIPAddressNameTrendDSM": {
-        "type": "string",
-        "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "publicIPDomainNameLabelTrendDSM": {
-        "type": "string",
-        "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "publicIPAddressType": {
-        "type": "string",
-        "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "nicNameTrendDSM": {
-        "type": "string",
-        "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "virtualNetworkName": {
-        "type": "string",
-          "defaultValue": "dsmvnet"
+      "type": "string",
+      "defaultValue": "dsmvnet"
     },
     "subnet1Ref": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "securityGroupNameTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "managerPortTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "heartbeatPortTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "vmNameTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "publisherTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "offerChoosedTrendDSM": {
-        "type": "object",
-          "defaultValue": ""
+      "type": "object",
+      "defaultValue": ""
     },
     "vmAdminNameTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "vmAdminPasswordTrendDSM": {
-        "type": "securestring",
-          "defaultValue": ""
+      "type": "securestring",
+      "defaultValue": ""
     },
     "linuxConfigurationChoosenTrendDSM": {
-        "type": "object",
-          "defaultValue": ""
+      "type": "object",
+      "defaultValue": ""
     },
     "deployment-api-version": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "baseUrl": {
-        "type": "string",
-        "metadata": {
-            "description": "The base URL for dependent assets",
-            "artifactsBaseUrl": ""
-        },
-        "defaultValue": "https://deepsecurityazure.blob.core.windows.net/dsmtemplate"
+      "type": "string",
+      "metadata": {
+        "description": "The base URL for dependent assets",
+        "artifactsBaseUrl": ""
+      },
+      "defaultValue": "https://deepsecurityazure.blob.core.windows.net/dsmtemplate"
     },
     "dsmAdminName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
-      "dsmAdminPassword": {
-        "type": "securestring",
-          "defaultValue": ""
+    "dsmAdminPassword": {
+      "type": "securestring",
+      "defaultValue": ""
     },
     "databaseOption": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "newsqlServerName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "existingSQLServerName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "dbAdminName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "dbAdminPassword": {
-        "type": "securestring",
-          "defaultValue": ""
+      "type": "securestring",
+      "defaultValue": ""
     },
     "dbName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "datameerTags": {
-        "type": "object"
+      "type": "object"
     },
     "trendmicroTags": {
-        "type": "object"
+      "type": "object"
     },
     "chefSoftwareTags": {
-        "type": "object"
+      "type": "object"
     },
     "quickstartTags": {
-        "type": "object"
+      "type": "object"
     }
-  	},
-  	"variables": {
-  		"licenseMode": "10"
-  		},
-  	"resources": [
-  	{
-        "apiVersion": "[parameters('network-api-version')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[parameters('publicIPAddressNameTrendDSM')]",
-        "location": "[parameters('location')]",
-        "tags": {
-          "program": "[parameters('tagvalues').program]",
-          "project": "[parameters('tagvalues').project]",
-          "quickstartName": "[parameters('quickstartTags').name]",
-          "provider": "[parameters('trendmicroTags').provider]"
-        },
-        "properties": {
-            "publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
-            "dnsSettings": {
-                "domainNameLabel": "[parameters('publicIPDomainNameLabelTrendDSM')]"
-            }
-        }
-     },
-  	{
-        "apiVersion": "[parameters('network-api-version')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[parameters('nicNameTrendDSM')]",
-        "location": "[parameters('location')]",
-        "tags": {
-          "program": "[parameters('tagvalues').program]",
-          "project": "[parameters('tagvalues').project]",
-          "quickstartName": "[parameters('quickstartTags').name]",
-          "provider": "[parameters('trendmicroTags').provider]"
-        },
-        "dependsOn": [
-            "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressNameTrendDSM'))]",
-           
-            "[concat('Microsoft.Network/networkSecurityGroups/', parameters('securityGroupNameTrendDSM'))]"
-        ],
-        "properties": {
-            "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('securityGroupNameTrendDSM'))]"
-            },
-            "ipConfigurations": [{
-                "name": "ipconfig1",
-                "properties": {
-                    "privateIPAllocationMethod": "Dynamic",
-                    "publicIPAddress": {
-                        "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM'))]"
-                    },
-                    "subnet": {
-                        "id": "[parameters('subnet1Ref')]"
-                    }
-                }
-            }]
-        }
+  },
+  "variables": {
+    "licenseMode": "10"
+  },
+  "resources": [
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('publicIPAddressNameTrendDSM')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
       },
-	 {
-        "apiVersion": "[parameters('network-api-version')]",
-        "type": "Microsoft.Network/networkSecurityGroups",
-        "name": "[parameters('securityGroupNameTrendDSM')]",
-        "location": "[parameters('location')]",
-        "tags": {
-          "program": "[parameters('tagvalues').program]",
-          "project": "[parameters('tagvalues').project]",
-          "quickstartName": "[parameters('quickstartTags').name]",
-          "provider": "[parameters('trendmicroTags').provider]"
-        },
-        "properties": {
-          "securityRules": [
-            {
-              "name": "allow-inbound-ssh",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "22",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1000,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmportal",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "[parameters('managerPortTrendDSM')]",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1100,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmagent",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "4118",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1200,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmheartbeat",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "[parameters('heartbeatPortTrendDSM')]",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1300,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmdownload",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "4122",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1400,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmwebinstaller",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "8443",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1500,
-                "direction": "Inbound"
-              }
-            }
-          ]
-        }
-      },
-	 {
-        "apiVersion": "[parameters('compute-api-version')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[parameters('vmNameTrendDSM')]",
-        "location": "[parameters('location')]",
-        "tags": {
-          "program": "[parameters('tagvalues').program]",
-          "project": "[parameters('tagvalues').project]",
-          "quickstartName": "[parameters('quickstartTags').name]",
-          "provider": "[parameters('trendmicroTags').provider]"
-        },
-        "dependsOn": [
-           
-            "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNameTrendDSM'))]",
-            "[concat('Microsoft.Resources/deployments/', 'buildSQLServer')]"
-        ],
-        "plan": {
-            "publisher": "[parameters('publisherTrendDSM')]",
-            "product": "[parameters('offerChoosedTrendDSM').product]",
-            "name": "[parameters('offerChoosedTrendDSM').vmSku]"            
-        },
-        "properties": {
-            "hardwareProfile": {
-                "vmSize": "[parameters('offerChoosedTrendDSM').vmSize]"
-            },
-            "osProfile": {
-                "computerName": "[parameters('vmNameTrendDSM')]",
-                "adminUsername": "[parameters('vmAdminNameTrendDSM')]",
-                "adminPassword": "[parameters('vmAdminPasswordTrendDSM')]",
-                "customData": "[base64(concat('vmName:',base64(parameters('vmNameTrendDSM')),',databaseServer:',reference('buildSQLServer').outputs.sqlServerFQDN.value,',databaseName:',base64(parameters('dbName')),',location:',parameters('location'),',managerPort:',parameters('managerPortTrendDSM'),',heartbeatPort:',parameters('heartbeatPortTrendDSM'),',vmFQDN:',reference(resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn,',publicIP:,adminUserName:',base64(parameters('dsmAdminName')),',adminPassword:',base64(parameters('dsmAdminPassword')),',databaseUserName:',base64(parameters('dbAdminName')),',databaseUserPassword:',base64(parameters('dbAdminPassword')),',subscriptionId:',subscription().subscriptionId,',databaseOption:',parameters('databaseOption'),',vmSize:',parameters('offerChoosedTrendDSM').vmSize,',licenseMode:',variables('licenseMode')))]",
-                "linuxConfiguration": "[parameters('linuxConfigurationChoosenTrendDSM')]"                
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "[parameters('publisherTrendDSM')]",
-                    "offer": "[parameters('offerChoosedTrendDSM').product]",
-                    "sku": "[parameters('offerChoosedTrendDSM').vmSku]",
-                    "version": "2.0.0"
-                },
-                "osDisk": {
-                    "name": "[concat(parameters('vmNameTrendDSM'),'-osDisk')]",
-                    "caching": "ReadWrite",
-                    "createOption": "FromImage",
-                    "vhd": {
-                        "uri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/',parameters('vmStorageAccountContainerName'),'/',parameters('vmNameTrendDSM'),'-osdisk.vhd')]"
-                    }
-                }
-            },
-            "networkProfile": {
-                "networkInterfaces": [{
-                    "id": "[resourceId('Microsoft.Network/networkInterfaces',parameters('nicNameTrendDSM'))]"
-                }]
-            },
-            "diagnosticsProfile": {
-                "bootDiagnostics": {
-                    "enabled": "true",
-                    "storageUri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/')]"
-                }
-            }
-        }
-      },
-      {
-        "name": "buildSQLServer",
-        "type": "Microsoft.Resources/deployments",
-        "apiVersion": "[parameters('deployment-api-version')]",
-        "dependsOn": [
-        ],
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-              "uri": "[concat(parameters('baseUrl'), '/nested/database-',parameters('databaseOption'),'.json')]",
-              "contentVersion": "1.0.0.0"
-            },
-            "parameters":{
-              "location": { "value": "[parameters('location')]" },
-              "newsqlServerName": { "value": "[parameters('newsqlServerName')]" },
-              "existingSQLServerName": { "value": "[parameters('existingSQLServerName')]"},
-              "dbAdminName": { "value": "[parameters('dbAdminName')]" },
-              "dbAdminPassword": { "value": "[parameters('dbAdminPassword')]" },
-              "sqlDBName": { "value": "[parameters('dbName')]" },
-              "datameerTags": {
-                "value": "[parameters('datameerTags')]"
-              },
-              "trendmicroTags": {
-                "value": "[parameters('trendmicroTags')]"
-              },
-              "chefSoftwareTags": {
-                "value": "[parameters('chefSoftwareTags')]"
-              },
-              "quickstartTags": {
-                "value": "[parameters('quickstartTags')]"
-              }           
-            }
+      "properties": {
+        "publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('publicIPDomainNameLabelTrendDSM')]"
         }
       }
-
-  	],
-"outputs": {
-  "trendmicrodsmUri": {
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[parameters('nicNameTrendDSM')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressNameTrendDSM'))]",
+        "[concat('Microsoft.Network/networkSecurityGroups/', parameters('securityGroupNameTrendDSM'))]"
+      ],
+      "properties": {
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('securityGroupNameTrendDSM'))]"
+        },
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM'))]"
+              },
+              "subnet": {
+                "id": "[parameters('subnet1Ref')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('securityGroupNameTrendDSM')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
+      },
+      "properties": {
+        "securityRules": [
+          {
+            "name": "allow-inbound-ssh",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1000,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmportal",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[parameters('managerPortTrendDSM')]",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmagent",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "4118",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1200,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmheartbeat",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[parameters('heartbeatPortTrendDSM')]",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1300,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmdownload",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "4122",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1400,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmwebinstaller",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1500,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmNameTrendDSM')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNameTrendDSM'))]",
+        "[concat('Microsoft.Resources/deployments/', 'buildSQLServer')]"
+      ],
+      "plan": {
+        "publisher": "[parameters('publisherTrendDSM')]",
+        "product": "[parameters('offerChoosedTrendDSM').product]",
+        "name": "[parameters('offerChoosedTrendDSM').vmSku]"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('offerChoosedTrendDSM').vmSize]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('vmNameTrendDSM')]",
+          "adminUsername": "[parameters('vmAdminNameTrendDSM')]",
+          "adminPassword": "[parameters('vmAdminPasswordTrendDSM')]",
+          "customData": "[base64(concat('vmName:',base64(parameters('vmNameTrendDSM')),',databaseServer:',reference('buildSQLServer').outputs.sqlServerFQDN.value,',databaseName:',base64(parameters('dbName')),',location:',parameters('location'),',managerPort:',parameters('managerPortTrendDSM'),',heartbeatPort:',parameters('heartbeatPortTrendDSM'),',vmFQDN:',reference(resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn,',publicIP:,adminUserName:',base64(parameters('dsmAdminName')),',adminPassword:',base64(parameters('dsmAdminPassword')),',databaseUserName:',base64(parameters('dbAdminName')),',databaseUserPassword:',base64(parameters('dbAdminPassword')),',subscriptionId:',subscription().subscriptionId,',databaseOption:',parameters('databaseOption'),',vmSize:',parameters('offerChoosedTrendDSM').vmSize,',licenseMode:',variables('licenseMode')))]",
+          "linuxConfiguration": "[parameters('linuxConfigurationChoosenTrendDSM')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('publisherTrendDSM')]",
+            "offer": "[parameters('offerChoosedTrendDSM').product]",
+            "sku": "[parameters('offerChoosedTrendDSM').vmSku]",
+            "version": "2.0.0"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('vmNameTrendDSM'),'-osDisk')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "vhd": {
+              "uri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/',parameters('vmStorageAccountContainerName'),'/',parameters('vmNameTrendDSM'),'-osdisk.vhd')]"
+            }
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',parameters('nicNameTrendDSM'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "buildSQLServer",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "",
+      "dependsOn": [],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('baseUrl'), '/nested/database-',parameters('databaseOption'),'.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "newsqlServerName": {
+            "value": "[parameters('newsqlServerName')]"
+          },
+          "existingSQLServerName": {
+            "value": "[parameters('existingSQLServerName')]"
+          },
+          "dbAdminName": {
+            "value": "[parameters('dbAdminName')]"
+          },
+          "dbAdminPassword": {
+            "value": "[parameters('dbAdminPassword')]"
+          },
+          "sqlDBName": {
+            "value": "[parameters('dbName')]"
+          },
+          "datameerTags": {
+            "value": "[parameters('datameerTags')]"
+          },
+          "trendmicroTags": {
+            "value": "[parameters('trendmicroTags')]"
+          },
+          "chefSoftwareTags": {
+            "value": "[parameters('chefSoftwareTags')]"
+          },
+          "quickstartTags": {
+            "value": "[parameters('quickstartTags')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "trendmicrodsmUri": {
       "type": "string",
       "value": "[concat('https://',reference(resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM'))).dnsSettings.fqdn)]"
     }
-}
+  }
 }

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-trenddsm.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-trenddsm.json
@@ -151,7 +151,7 @@
   },
   "resources": [
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIPAddressNameTrendDSM')]",
       "location": "[parameters('location')]",
@@ -169,7 +169,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicNameTrendDSM')]",
       "location": "[parameters('location')]",
@@ -204,7 +204,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('securityGroupNameTrendDSM')]",
       "location": "[parameters('location')]",
@@ -298,7 +298,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmNameTrendDSM')]",
       "location": "[parameters('location')]",
@@ -362,7 +362,7 @@
     {
       "name": "buildSQLServer",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "",
+      "apiVersion": "2015-01-01",
       "dependsOn": [],
       "properties": {
         "mode": "Incremental",

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-vnetstorage.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-vnetstorage.json
@@ -93,7 +93,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "",
+      "apiVersion": "2016-01-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -106,7 +106,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
@@ -151,7 +151,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('availabilitySetSettings').name, copyindex())]",
       "tags": {

--- a/datameer-trend-chef-riskanalysis/nested/trendp2p-vnetstorage.json
+++ b/datameer-trend-chef-riskanalysis/nested/trendp2p-vnetstorage.json
@@ -2,7 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-
     "storageAccountName": {
       "type": "string",
       "defaultValue": ""
@@ -88,13 +87,13 @@
     "quickstartTags": {
       "type": "object"
     }
-
   },
   "variables": {},
-  "resources": [{
+  "resources": [
+    {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "[parameters('storage-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -105,8 +104,9 @@
       "properties": {
         "accountType": "[parameters('storageAccountType')]"
       }
-    }, {
-      "apiVersion": "[parameters('network-api-version')]",
+    },
+    {
+      "apiVersion": "",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
@@ -150,9 +150,8 @@
         ]
       }
     },
-
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('availabilitySetSettings').name, copyindex())]",
       "tags": {

--- a/devtest-p2s-iis/azuredeploy.json
+++ b/devtest-p2s-iis/azuredeploy.json
@@ -1,254 +1,253 @@
-{  
-   "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-   "contentVersion":"1.0.0.0",
-   "parameters":{  
-      "environmentPrefix":{
-         "type":"string",
-         "metadata":{  
-            "description":"Prefix to use for most of the resources."
-         },
-         "defaultValue": "DevTest"
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Prefix to use for most of the resources."
       },
-      "adminUsername": {
-        "type": "string",
-        "metadata": {
-          "description": "Admin username"
-        }
-      },
-      "adminPassword": {
-        "type": "securestring",
-        "metadata": {
-          "description": "Admin password"
-        }
-      },
-      "vpnClientAddressPoolPrefix":{  
-         "type":"string",
-         "metadata":{  
-            "description":"The IP address range from which VPN clients will receive an IP address when connected. Range specified must not overlap with on-premise network."
-         },
-         "defaultValue": "10.10.8.0/24"
-      },
-      "clientRootCertName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"The name of the client root certificate used to authenticate VPN clients. This is a common name used to identify the root cert."
-         }
-      },
-      "clientRootCertData":{  
-         "type":"string",
-         "metadata":{  
-            "description":"Client root certificate data used to authenticate VPN clients."
-         }
+      "defaultValue": "DevTest"
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Admin username"
       }
-      
-   },
-   "variables":{  
-      "location":"[resourceGroup().location]",
-      "apiVersion":"2015-06-15",
-      "newStorageAccount": "[concat(uniqueString(resourceGroup().id),'store')]",
-      "storageAccountType": "Standard_LRS",
-      "vnetName": "[concat(parameters('environmentPrefix'),'Vnet')]",
-      "vnetID":"[resourceId('Microsoft.Network/virtualNetworks',variables('vnetName'))]",
-      "vnetAddressPrefix": "10.0.0.0/23",
-      "gatewaySubnetPrefix": "10.0.1.0/24",
-      "gatewayPublicIPName": "[concat(parameters('environmentPrefix'),'GatewayPIP')]",
-      "gatewayName": "[concat(parameters('environmentPrefix'),'Gateway')]",
-      "gatewaySku": "Basic",
-      "gatewaySubnetRef":"[concat(variables('vnetID'),'/subnets/','GatewaySubnet')]",
-      "appSubnetName": "appSubnet",
-      "appSubnetPrefix": "10.0.0.0/24",
-      "appSubnetRef": "[concat(variables('vnetID'),'/subnets/',variables('appSubnetName'))]",
-      "nicName": "[concat(parameters('environmentPrefix'),'NIC01')]",
-      "vmName": "[concat(parameters('environmentPrefix'),'VM01')]",
-      "vmSize": "Standard_D1",
-      "imagePublisher": "MicrosoftWindowsServer",
-      "imageOffer": "WindowsServer",
-      "imageSKU": "2012-R2-Datacenter",
-      "vmExtensionName": "dscExtension",
-      "modulesUrl":"https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/devtest-p2s-iis/DevTestWebsite.ps1.zip",
-      "configurationFunction":"DevTestWebsite.ps1\\DevTestWebsite"
-   },
-   "resources":[  
-      {
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[variables('newStorageAccount')]",
-        "apiVersion": "[variables('apiVersion')]",
-        "location": "[variables('location')]",
-        "properties": {
-          "accountType": "[variables('storageAccountType')]"
-        }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin password"
+      }
+    },
+    "vpnClientAddressPoolPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "The IP address range from which VPN clients will receive an IP address when connected. Range specified must not overlap with on-premise network."
       },
-      {  
-         "apiVersion":"[variables('apiVersion')]",
-         "type":"Microsoft.Network/publicIPAddresses",
-         "name":"[variables('gatewayPublicIPName')]",
-         "location":"[variables('location')]",
-         "properties":{  
-            "publicIPAllocationMethod":"Dynamic"
-         }
-      },
-      {  
-         "apiVersion":"[variables('apiVersion')]",
-         "type":"Microsoft.Network/virtualNetworks",
-         "name":"[variables('vnetName')]",
-         "location":"[variables('location')]",
-         "properties":{  
-            "addressSpace":{  
-               "addressPrefixes":[  
-                  "[variables('vnetAddressPrefix')]"
-               ]
+      "defaultValue": "10.10.8.0/24"
+    },
+    "clientRootCertName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the client root certificate used to authenticate VPN clients. This is a common name used to identify the root cert."
+      }
+    },
+    "clientRootCertData": {
+      "type": "string",
+      "metadata": {
+        "description": "Client root certificate data used to authenticate VPN clients."
+      }
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "apiVersion": "2015-06-15",
+    "newStorageAccount": "[concat(uniqueString(resourceGroup().id),'store')]",
+    "storageAccountType": "Standard_LRS",
+    "vnetName": "[concat(parameters('environmentPrefix'),'Vnet')]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('vnetName'))]",
+    "vnetAddressPrefix": "10.0.0.0/23",
+    "gatewaySubnetPrefix": "10.0.1.0/24",
+    "gatewayPublicIPName": "[concat(parameters('environmentPrefix'),'GatewayPIP')]",
+    "gatewayName": "[concat(parameters('environmentPrefix'),'Gateway')]",
+    "gatewaySku": "Basic",
+    "gatewaySubnetRef": "[concat(variables('vnetID'),'/subnets/','GatewaySubnet')]",
+    "appSubnetName": "appSubnet",
+    "appSubnetPrefix": "10.0.0.0/24",
+    "appSubnetRef": "[concat(variables('vnetID'),'/subnets/',variables('appSubnetName'))]",
+    "nicName": "[concat(parameters('environmentPrefix'),'NIC01')]",
+    "vmName": "[concat(parameters('environmentPrefix'),'VM01')]",
+    "vmSize": "Standard_D1",
+    "imagePublisher": "MicrosoftWindowsServer",
+    "imageOffer": "WindowsServer",
+    "imageSKU": "2012-R2-Datacenter",
+    "vmExtensionName": "dscExtension",
+    "modulesUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/devtest-p2s-iis/DevTestWebsite.ps1.zip",
+    "configurationFunction": "DevTestWebsite.ps1\\DevTestWebsite"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('newStorageAccount')]",
+      "apiVersion": "2015-06-15",
+      "location": "[variables('location')]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('gatewayPublicIPName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('vnetName')]",
+      "location": "[variables('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "GatewaySubnet",
+            "properties": {
+              "addressPrefix": "[variables('gatewaySubnetPrefix')]"
+            }
+          },
+          {
+            "name": "[variables('appSubnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('appSubnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('vnetName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('appSubnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccount'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[variables('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('imageSKU')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('newStorageAccount'),'.blob.core.windows.net/vhds/','osdisk.vhd')]"
             },
-            "subnets":[  
-               {  
-                  "name":"GatewaySubnet",
-                  "properties":{  
-                     "addressPrefix":"[variables('gatewaySubnetPrefix')]"
-                  }
-               },
-               {
-                 "name":"[variables('appSubnetName')]",
-                 "properties": {
-                   "addressPrefix": "[variables('appSubnetPrefix')]"
-                 }
-               }
-            ]
-         }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[variables('nicName')]",
-        "location": "[variables('location')]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/virtualNetworks/', variables('vnetName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
             {
-              "name": "ipconfig1",
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmName'),'/', variables('vmExtensionName'))]",
+      "apiVersion": "2015-06-15",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Powershell",
+        "type": "DSC",
+        "typeHandlerVersion": "2.19",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "ModulesUrl": "[variables('modulesUrl')]",
+          "ConfigurationFunction": "[variables('configurationFunction')]",
+          "Properties": {
+            "MachineName": "[variables('vmName')]"
+          }
+        },
+        "protectedSettings": null
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworkGateways",
+      "name": "[variables('gatewayName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('gatewayPublicIPName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('vnetName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('gatewaySubnetRef')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('gatewayPublicIPName'))]"
+              }
+            },
+            "name": "vnetGatewayConfig"
+          }
+        ],
+        "sku": {
+          "name": "[variables('gatewaySku')]",
+          "tier": "[variables('gatewaySku')]"
+        },
+        "gatewayType": "Vpn",
+        "vpnType": "RouteBased",
+        "enableBgp": "false",
+        "vpnClientConfiguration": {
+          "vpnClientAddressPool": {
+            "addressPrefixes": [
+              "[parameters('vpnClientAddressPoolPrefix')]"
+            ]
+          },
+          "vpnClientRootCertificates": [
+            {
+              "name": "[parameters('clientRootCertName')]",
               "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "[variables('appSubnetRef')]"
-                }
+                "PublicCertData": "[parameters('clientRootCertData')]"
               }
             }
           ]
         }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[variables('vmName')]",
-        "location": "[variables('location')]",
-        "dependsOn": [
-          "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccount'))]",
-          "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-        ],
-        "properties": {
-          "hardwareProfile": {
-            "vmSize": "[variables('vmSize')]"
-          },
-          "osProfile": {
-            "computerName": "[variables('vmName')]",
-            "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPassword')]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "[variables('imagePublisher')]",
-              "offer": "[variables('imageOffer')]",
-              "sku": "[variables('imageSKU')]",
-              "version": "latest"
-            },
-            "osDisk": {
-              "name": "osdisk",
-              "vhd": {
-                "uri": "[concat('http://',variables('newStorageAccount'),'.blob.core.windows.net/vhds/','osdisk.vhd')]"
-              },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
-            }
-          },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nicName'))]"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "type": "Microsoft.Compute/virtualMachines/extensions",
-        "name": "[concat(variables('vmName'),'/', variables('vmExtensionName'))]",
-        "apiVersion": "[variables('apiVersion')]",
-        "location": "[variables('location')]",
-        "dependsOn": [
-          "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
-        ],
-        "properties": {
-          "publisher": "Microsoft.Powershell",
-          "type": "DSC",
-          "typeHandlerVersion": "2.19",
-          "autoUpgradeMinorVersion": true,
-          "settings": {
-            "ModulesUrl": "[variables('modulesUrl')]",
-            "ConfigurationFunction": "[variables('configurationFunction')]",
-            "Properties": {
-              "MachineName": "[variables('vmName')]"
-            }
-          },
-          "protectedSettings": null
-        }
-      },
-      {  
-         "apiVersion":"[variables('apiVersion')]",
-         "type":"Microsoft.Network/virtualNetworkGateways",
-         "name":"[variables('gatewayName')]",
-         "location":"[variables('location')]",
-         "dependsOn":[  
-            "[concat('Microsoft.Network/publicIPAddresses/', variables('gatewayPublicIPName'))]",
-            "[concat('Microsoft.Network/virtualNetworks/', variables('vnetName'))]"
-         ],
-         "properties":{  
-            "ipConfigurations":[  
-               {  
-                  "properties":{  
-                     "privateIPAllocationMethod":"Dynamic",
-                     "subnet":{  
-                        "id":"[variables('gatewaySubnetRef')]"
-                     },
-                     "publicIPAddress":{  
-                        "id":"[resourceId('Microsoft.Network/publicIPAddresses',variables('gatewayPublicIPName'))]"
-                     }
-                  },
-                  "name":"vnetGatewayConfig"
-               }
-            ],
-	    "sku": {
-	      "name": "[variables('gatewaySku')]",
-	      "tier": "[variables('gatewaySku')]"
-	    },            
-            "gatewayType":"Vpn",
-            "vpnType":"RouteBased",
-            "enableBgp":"false",
-            "vpnClientConfiguration":{  
-               "vpnClientAddressPool":{  
-                  "addressPrefixes":[  
-                     "[parameters('vpnClientAddressPoolPrefix')]"
-                  ]
-               },
-               "vpnClientRootCertificates":[  
-                  {  
-                     "name": "[parameters('clientRootCertName')]",
-                     "properties":{
-                        "PublicCertData": "[parameters('clientRootCertData')]"
-                     }
-                  }
-               ]
-            }
-         }
       }
-   ]
+    }
+  ]
 }

--- a/docker-neo4j/azuredeploy.json
+++ b/docker-neo4j/azuredeploy.json
@@ -1,330 +1,334 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-        "contentVersion": "1.0.0.0",
-        "parameters": {
-            "newStorageAccountName": {
-                "type": "string",
-                "metadata": {
-                    "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
-                }
-            },
-            "adminUsername": {
-                "type": "string",
-                "metadata": {
-                    "description": "Username for the Virtual Machine."
-                }
-            },
-            "adminPassword": {
-                "type": "securestring",
-                "metadata": {
-                    "description": "Password for the Virtual Machine."
-                }
-            },
-            "dnsNameForPublicIP": {
-                "type": "string",
-                "metadata": {
-                    "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
-                }
-            },
-            "vmName": {
-                "type": "string",
-                "defaultValue": "neodockervm",
-                "metadata": {
-                    "description": "Name of the sample VM to create"
-                }
-            },
-            "vmSize": {
-                "type": "string",
-                "defaultValue": "Standard_A1",
-                "allowedValues": [
-                    "Standard_A1",
-                    "Standard_A2",
-                    "Standard_A3",
-                    "Standard_A6",
-                    "Standard_A7",
-                    "Standard_A8",
-                    "Standard_A9",
-                    "Standard_A10",
-                    "Standard_A11",
-                    "Standard_D2",
-                    "Standard_D3",
-                    "Standard_D4",
-                    "Standard_D11",
-                    "Standard_D12",
-                    "Standard_D13",
-                    "Standard_D14"
-                ],
-                "metadata": {
-                    "description": "Size of the Virtual Machine."
-                }
-            }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Storage Account where the Virtual Machine's disks will be placed."
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
+    },
+    "dnsNameForPublicIP": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+      }
+    },
+    "vmName": {
+      "type": "string",
+      "defaultValue": "neodockervm",
+      "metadata": {
+        "description": "Name of the sample VM to create"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_A1",
+      "allowedValues": [
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14"
+      ],
+      "metadata": {
+        "description": "Size of the Virtual Machine."
+      }
+    }
+  },
+  "variables": {
+    "apiVersion": "2015-05-01-preview",
+    "imagePublisher": "Canonical",
+    "imageOffer": "UbuntuServer",
+    "ubuntuOSVersion": "15.10",
+    "OSDiskName": "osDisk",
+    "nsgName": "[concat(parameters('vmName'),'NeoNSG')]",
+    "nicName": "[concat(parameters('vmName'),'NeoNIC')]",
+    "dockerExtensionName": "DockerExtension",
+    "azureVMUtilsName": "vmCustomizationExt",
+    "azureVMUtilsScriptUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/docker-neo4j/extras/setup_data_disk.sh",
+    "addressPrefix": "10.0.0.0/16",
+    "subnetName": "Subnet",
+    "subnetPrefix": "10.0.0.0/24",
+    "storageAccountType": "Standard_LRS",
+    "publicIPAddressName": "[concat(parameters('vmName'),'NeoPublicIP')]",
+    "publicIPAddressType": "Dynamic",
+    "vmStorageAccountContainerName": "vhds",
+    "vmName": "[parameters('vmName')]",
+    "vmSize": "[parameters('vmSize')]",
+    "virtualNetworkName": "[concat(parameters('vmName'),'NeoVNET')]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "dataDisk1VhdName": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk1.vhd')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('newStorageAccountName')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[variables('nsgID')]"
+      ],
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
         },
-        "variables": {
-            "apiVersion": "2015-05-01-preview",
-            "imagePublisher": "Canonical",
-            "imageOffer": "UbuntuServer",
-            "ubuntuOSVersion": "15.10",
-            "OSDiskName": "osDisk",
-            "nsgName": "[concat(parameters('vmName'),'NeoNSG')]",
-            "nicName": "[concat(parameters('vmName'),'NeoNIC')]",
-			"dockerExtensionName": "DockerExtension",
-            "azureVMUtilsName": "vmCustomizationExt",
-            "azureVMUtilsScriptUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/docker-neo4j/extras/setup_data_disk.sh",
-            "addressPrefix": "10.0.0.0/16",
-            "subnetName": "Subnet",
-            "subnetPrefix": "10.0.0.0/24",
-            "storageAccountType": "Standard_LRS",
-            "publicIPAddressName": "[concat(parameters('vmName'),'NeoPublicIP')]",
-            "publicIPAddressType": "Dynamic",
-            "vmStorageAccountContainerName": "vhds",
-            "vmName": "[parameters('vmName')]",
-            "vmSize": "[parameters('vmSize')]",
-            "virtualNetworkName": "[concat(parameters('vmName'),'NeoVNET')]",
-            "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-            "nsgID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName'))]",
-            "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-            "dataDisk1VhdName": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('vmName'),'dataDisk1.vhd')]"
-
-        },
-        "resources": [
+        "subnets": [
           {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[parameters('newStorageAccountName')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
+            "name": "[variables('subnetName')]",
             "properties": {
-              "accountType": "[variables('storageAccountType')]"
-            }
-          },
-          {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "name": "[variables('publicIPAddressName')]",
-            "location": "[resourceGroup().location]",
-            "properties": {
-              "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-              "dnsSettings": {
-                "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
-              }
-            }
-          },
-          {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[variables('virtualNetworkName')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-              "[variables('nsgID')]"
-            ],
-            "properties": {
-              "addressSpace": {
-                "addressPrefixes": [
-                  "[variables('addressPrefix')]"
-                ]
-              },
-              "subnets": [
-                {
-                  "name": "[variables('subnetName')]",
-                  "properties": {
-                    "addressPrefix": "[variables('subnetPrefix')]",
-                    "networkSecurityGroup": {
-                      "id": "[variables('nsgID')]"
-                    }
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[variables('nicName')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-              "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-              "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-            ],
-            "properties": {
-              "ipConfigurations": [
-                {
-                  "name": "ipconfig1",
-                  "properties": {
-                    "privateIPAllocationMethod": "Dynamic",
-                    "publicIPAddress": {
-                      "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-                    },
-                    "subnet": {
-                      "id": "[variables('subnetRef')]"
-                    }
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "name": "[variables('nsgName')]",
-            "location": "[resourceGroup().location]",
-            "properties": {
-              "securityRules": [
-                {
-                  "name": "neo4j",
-                  "properties": {
-                    "description": "Allow HTTP connections",
-                    "protocol": "Tcp",
-                    "sourcePortRange": "*",
-                    "destinationPortRange": "7474",
-                    "sourceAddressPrefix": "Internet",
-                    "destinationAddressPrefix": "*",
-                    "access": "Allow",
-                    "priority": 100,
-                    "direction": "Inbound"
-                  }
-                },
-                {
-                  "name": "neo4j-ssl",
-                  "properties": {
-                    "description": "Allow HTTPS connections",
-                    "protocol": "Tcp",
-                    "sourcePortRange": "*",
-                    "destinationPortRange": "7473",
-                    "sourceAddressPrefix": "Internet",
-                    "destinationAddressPrefix": "*",
-                    "access": "Allow",
-                    "priority": 101,
-                    "direction": "Inbound"
-                  }
-                },
-                {
-                  "name": "neo4j-remote-shell",
-                  "properties": {
-                    "description": "Remote shell connections",
-                    "protocol": "Tcp",
-                    "sourcePortRange": "*",
-                    "destinationPortRange": "1337",
-                    "sourceAddressPrefix": "Internet",
-                    "destinationAddressPrefix": "*",
-                    "access": "Allow",
-                    "priority": 102,
-                    "direction": "Inbound"
-                  }
-                },
-                {
-                  "name": "ssh",
-                  "properties": {
-                    "description": "Allow SSH",
-                    "protocol": "Tcp",
-                    "sourcePortRange": "*",
-                    "destinationPortRange": "22",
-                    "sourceAddressPrefix": "Internet",
-                    "destinationAddressPrefix": "*",
-                    "access": "Allow",
-                    "priority": 110,
-                    "direction": "Inbound"
-                  }
-                }
-              ]
-            }
-          },
-          {
-            "apiVersion": "[variables('apiVersion')]",
-            "type": "Microsoft.Compute/virtualMachines",
-            "name": "[variables('vmName')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-              "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
-              "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-            ],
-            "properties": {
-              "hardwareProfile": {
-                "vmSize": "[variables('vmSize')]"
-              },
-              "osProfile": {
-                "computerName": "[variables('vmName')]",
-                "adminUsername": "[parameters('adminUsername')]",
-                "adminPassword": "[parameters('adminPassword')]"
-              },
-              "storageProfile": {
-                "imageReference": {
-                  "publisher": "[variables('imagePublisher')]",
-                  "offer": "[variables('imageOffer')]",
-                  "sku": "[variables('ubuntuOSVersion')]",
-                  "version": "latest"
-                },
-                "osDisk": {
-                  "name": "osdisk1",
-                  "vhd": {
-                    "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-                  },
-                  "caching": "ReadWrite",
-                  "createOption": "FromImage"
-                },
-                "dataDisks": [
-                  {
-                    "name": "datadisk1",
-                    "diskSizeGB": "10",
-                    "lun": 0,
-                    "vhd": {
-                      "Uri": "[variables('dataDisk1VhdName')]"
-                    },
-                    "createOption": "Empty"
-                  }
-                ]
-              },
-              "networkProfile": {
-                "networkInterfaces": [
-                  {
-                    "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-                  }
-                ]
-              }
-            }
-          },
-          {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(variables('vmName'),'/', variables('azureVMUtilsName'))]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-              "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
-            ],
-            "properties": {
-              "publisher": "Microsoft.Azure.Extensions",
-              "type": "CustomScript",
-              "typeHandlerVersion": "2.0",
-              "autoUpgradeMinorVersion": true,
-              "settings": {
-                "fileUris": [
-                  "[variables('azureVMUtilsScriptUrl')]"
-                ],
-                "commandToExecute": "bash setup_data_disk.sh"
-              }
-            }
-          },
-          {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(variables('vmName'),'/', variables('dockerExtensionName'))]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-              "[concat('Microsoft.Compute/virtualMachines/',variables('vmName'),'/','extensions/',variables('azureVMUtilsName'))]"
-            ],
-            "properties": {
-              "publisher": "Microsoft.Azure.Extensions",
-              "type": "DockerExtension",
-              "typeHandlerVersion": "1.0",
-              "autoUpgradeMinorVersion": true,
-              "settings": {
-                "compose": {
-                  "neo4j": {
-                    "image": "tpires/neo4j",
-                    "ports": [ "7474:7474", "7473:7473" ],
-                    "volumes": [ "/datadisk:/var/lib/neo4j/data" ]
-                  }
-                }
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[variables('nsgID')]"
               }
             }
           }
-    ]
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('nsgName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "neo4j",
+            "properties": {
+              "description": "Allow HTTP connections",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "7474",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "neo4j-ssl",
+            "properties": {
+              "description": "Allow HTTPS connections",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "7473",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 101,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "neo4j-remote-shell",
+            "properties": {
+              "description": "Remote shell connections",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "1337",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 102,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "ssh",
+            "properties": {
+              "description": "Allow SSH",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[variables('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('ubuntuOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk1",
+            "vhd": {
+              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          },
+          "dataDisks": [
+            {
+              "name": "datadisk1",
+              "diskSizeGB": "10",
+              "lun": 0,
+              "vhd": {
+                "Uri": "[variables('dataDisk1VhdName')]"
+              },
+              "createOption": "Empty"
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmName'),'/', variables('azureVMUtilsName'))]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": [
+            "[variables('azureVMUtilsScriptUrl')]"
+          ],
+          "commandToExecute": "bash setup_data_disk.sh"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmName'),'/', variables('dockerExtensionName'))]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/',variables('vmName'),'/','extensions/',variables('azureVMUtilsName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "DockerExtension",
+        "typeHandlerVersion": "1.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "compose": {
+            "neo4j": {
+              "image": "tpires/neo4j",
+              "ports": [
+                "7474:7474",
+                "7473:7473"
+              ],
+              "volumes": [
+                "/datadisk:/var/lib/neo4j/data"
+              ]
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/docker-parse/azuredeploy.json
+++ b/docker-parse/azuredeploy.json
@@ -79,14 +79,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -98,7 +98,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -125,7 +125,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -151,7 +151,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('nsgName')]",
       "location": "[resourceGroup().location]",
@@ -189,7 +189,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -234,7 +234,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/', variables('extensionName'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/docker-rancher/azuredeploy.json
+++ b/docker-rancher/azuredeploy.json
@@ -14,74 +14,74 @@
         "description": "Password for the Virtual Machine."
       }
     },
-	"uniqueDeployPrefix": {
+    "uniqueDeployPrefix": {
       "type": "string",
       "metadata": {
         "description": "The unique prefix used for the nodes & dns. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
       }
     },
-	"vmSize": {
-	  "type": "string",
-	  "metadata": {
-	    "description": "The size of the virtual machine used for the deployment"
-	  },
-	  "allowedValues": [
-		"Standard_A0",
-		"Standard_A1",
-		"Standard_A2",
-		"Standard_A3",
-		"Standard_A4",
-		"Basic_A0",
-		"Basic_A1",
-		"Basic_A2",
-		"Basic_A3",
-		"Basic_A4",
-		"Standard_A5",
-		"Standard_A6",
-		"Standard_A7",
-		"Standard_D1",
-		"Standard_D2",
-		"Standard_D3",
-		"Standard_D4",
-		"Standard_D11",
-		"Standard_D12",
-		"Standard_D13",
-		"Standard_D14",
-		"Standard_D1_v2",
-		"Standard_D2_v2",
-		"Standard_D3_v2",
-		"Standard_D4_v2",
-		"Standard_D5_v2",
-		"Standard_D11_v2",
-		"Standard_D12_v2",
-		"Standard_D13_v2",
-		"Standard_D14_v2",
-		"Standard_DS1",
-		"Standard_DS2",
-		"Standard_DS3",
-		"Standard_DS4",
-		"Standard_DS11",
-		"Standard_DS12",
-		"Standard_DS13",
-		"Standard_DS14",
-		"Standard_G1",
-		"Standard_G2",
-		"Standard_G3",
-		"Standard_G4",
-		"Standard_G5",
-		"Standard_GS1",
-		"Standard_GS2",
-		"Standard_GS3",
-		"Standard_GS4",
-		"Standard_GS5",
-		"Standard_A8",
-		"Standard_A9",
-		"Standard_A10",
-		"Standard_A11"
-	  ],
-	  "defaultValue": "Standard_A2"
-	},
-	"deploymentType": {
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The size of the virtual machine used for the deployment"
+      },
+      "allowedValues": [
+        "Standard_A0",
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Basic_A0",
+        "Basic_A1",
+        "Basic_A2",
+        "Basic_A3",
+        "Basic_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_D1",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14",
+        "Standard_D1_v2",
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_D5_v2",
+        "Standard_D11_v2",
+        "Standard_D12_v2",
+        "Standard_D13_v2",
+        "Standard_D14_v2",
+        "Standard_DS1",
+        "Standard_DS2",
+        "Standard_DS3",
+        "Standard_DS4",
+        "Standard_DS11",
+        "Standard_DS12",
+        "Standard_DS13",
+        "Standard_DS14",
+        "Standard_G1",
+        "Standard_G2",
+        "Standard_G3",
+        "Standard_G4",
+        "Standard_G5",
+        "Standard_GS1",
+        "Standard_GS2",
+        "Standard_GS3",
+        "Standard_GS4",
+        "Standard_GS5",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11"
+      ],
+      "defaultValue": "Standard_A2"
+    },
+    "deploymentType": {
       "type": "string",
       "defaultValue": "Nodes",
       "allowedValues": [
@@ -93,44 +93,44 @@
       }
     },
     "nodesApi": {
-	  "type": "string",
-	  "defaultValue": "",
+      "type": "string",
+      "defaultValue": "",
       "metadata": {
         "description": "(Ignored for deploymentType server) The api link to your RancherHost."
       }
     },
-	"nodesCount": {
-	  "type": "int",
-	  "defaultValue": 1,
+    "nodesCount": {
+      "type": "int",
+      "defaultValue": 1,
       "metadata": {
         "description": "(Ignored for deploymentType server) The amount of nodes to be provisioned"
       },
-	  "minValue": 1,
-	  "maxValue": 5
+      "minValue": 1,
+      "maxValue": 5
     },
-	"templateBase": {
+    "templateBase": {
       "type": "string",
       "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master",
       "metadata": {
         "description": "Change this value to your repo name if deploying from a fork"
-      } 
+      }
     }
   },
   "variables": {
-    "apiVersion": "2015-11-01",  
-	  "deployTypeParam": {  
-        "Nodes": "nodes.json",
-        "Server": "server.json"
+    "apiVersion": "2015-11-01",
+    "deployTypeParam": {
+      "Nodes": "nodes.json",
+      "Server": "server.json"
     },
-	"deployTypeParamValue": "[variables('deployTypeParam')[parameters('deploymentType')]]",
-	"templateBaseUrl": "[concat(parameters('templateBase'), '/docker-rancher/')]",
-	"templateDeployUrl": "[concat(variables('templateBaseUrl'), variables('deployTypeParamValue'))]"
+    "deployTypeParamValue": "[variables('deployTypeParam')[parameters('deploymentType')]]",
+    "templateBaseUrl": "[concat(parameters('templateBase'), '/docker-rancher/')]",
+    "templateDeployUrl": "[concat(variables('templateBaseUrl'), variables('deployTypeParamValue'))]"
   },
   "resources": [
     {
       "name": "rancherdeploy",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-11-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -138,25 +138,25 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-			    "adminUsername": {
-			      "value": "[parameters('adminUsername')]"
-			    },
-			    "adminPassword": {
-			      "value": "[parameters('adminPassword')]"
-			    },
-			    "rancherApi": {
-			      "value": "[parameters('nodesApi')]"
-			    },
-			    "rancherNodeName": {
-			      "value": "[parameters('uniqueDeployPrefix')]"
-			    },
-			    "rancherVmSize": {
-				    "value": "[parameters('vmSize')]"
-			    },
-			    "rancherCount": {
-			      "value": "[parameters('nodesCount')]"
-			    }
-		    }
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "rancherApi": {
+            "value": "[parameters('nodesApi')]"
+          },
+          "rancherNodeName": {
+            "value": "[parameters('uniqueDeployPrefix')]"
+          },
+          "rancherVmSize": {
+            "value": "[parameters('vmSize')]"
+          },
+          "rancherCount": {
+            "value": "[parameters('nodesCount')]"
+          }
+        }
       }
     }
   ]

--- a/docker-rancher/nodes.json
+++ b/docker-rancher/nodes.json
@@ -20,87 +20,86 @@
         "description": "The api link to your RancherHost. Example : http://myrancherhost.kvaes.be:8080/v1/scripts/AA12A123A1A1234A12A1:1234567890000:aAaaaaA1AaAaAlaAAaaaaAAAaaA"
       }
     },
-	"rancherNodeName": {
+    "rancherNodeName": {
       "type": "string",
       "metadata": {
         "description": "The prefix you want to use as hostname"
       }
     },
-	"rancherVmSize": {
-	  "type": "string",
-	  "metadata": {
-	    "description": "The size of the virtual machine used for the nodes"
-	  },
-	  "allowedValues": [
-		"Standard_A0",
-		"Standard_A1",
-		"Standard_A2",
-		"Standard_A3",
-		"Standard_A4",
-		"Basic_A0",
-		"Basic_A1",
-		"Basic_A2",
-		"Basic_A3",
-		"Basic_A4",
-		"Standard_A5",
-		"Standard_A6",
-		"Standard_A7",
-		"Standard_D1",
-		"Standard_D2",
-		"Standard_D3",
-		"Standard_D4",
-		"Standard_D11",
-		"Standard_D12",
-		"Standard_D13",
-		"Standard_D14",
-		"Standard_D1_v2",
-		"Standard_D2_v2",
-		"Standard_D3_v2",
-		"Standard_D4_v2",
-		"Standard_D5_v2",
-		"Standard_D11_v2",
-		"Standard_D12_v2",
-		"Standard_D13_v2",
-		"Standard_D14_v2",
-		"Standard_DS1",
-		"Standard_DS2",
-		"Standard_DS3",
-		"Standard_DS4",
-		"Standard_DS11",
-		"Standard_DS12",
-		"Standard_DS13",
-		"Standard_DS14",
-		"Standard_G1",
-		"Standard_G2",
-		"Standard_G3",
-		"Standard_G4",
-		"Standard_G5",
-		"Standard_GS1",
-		"Standard_GS2",
-		"Standard_GS3",
-		"Standard_GS4",
-		"Standard_GS5",
-		"Standard_A8",
-		"Standard_A9",
-		"Standard_A10",
-		"Standard_A11"
-	  ],
-	  "defaultValue": "Standard_A2"
-	},
-	"rancherCount": {
+    "rancherVmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The size of the virtual machine used for the nodes"
+      },
+      "allowedValues": [
+        "Standard_A0",
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Basic_A0",
+        "Basic_A1",
+        "Basic_A2",
+        "Basic_A3",
+        "Basic_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_D1",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14",
+        "Standard_D1_v2",
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_D5_v2",
+        "Standard_D11_v2",
+        "Standard_D12_v2",
+        "Standard_D13_v2",
+        "Standard_D14_v2",
+        "Standard_DS1",
+        "Standard_DS2",
+        "Standard_DS3",
+        "Standard_DS4",
+        "Standard_DS11",
+        "Standard_DS12",
+        "Standard_DS13",
+        "Standard_DS14",
+        "Standard_G1",
+        "Standard_G2",
+        "Standard_G3",
+        "Standard_G4",
+        "Standard_G5",
+        "Standard_GS1",
+        "Standard_GS2",
+        "Standard_GS3",
+        "Standard_GS4",
+        "Standard_GS5",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11"
+      ],
+      "defaultValue": "Standard_A2"
+    },
+    "rancherCount": {
       "type": "int",
       "metadata": {
         "description": "The amount of nodes to be provisioned"
       },
-	  "minValue": 1,
-	  "maxValue": 250
+      "minValue": 1,
+      "maxValue": 250
     }
   },
   "variables": {
-    "apiVersion": "2015-06-15",  
+    "apiVersion": "2015-06-15",
     "availabilitySet": "[parameters('rancherNodeName')]",
-    "storageAccountName": "[parameters('rancherNodeName')]",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'ranchernode')]",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'ranchernode')]",
     "networkSecurityGroupName": "[parameters('rancherNodeName')]",
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
@@ -123,28 +122,27 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
-	{
+    {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySet')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
-    
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('networkSecurityGroupName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "securityRules": [
-		  {
+          {
             "name": "SSH",
             "properties": {
               "description": "SSH",
@@ -158,7 +156,6 @@
               "direction": "Inbound"
             }
           },
-		  
           {
             "name": "rVPN500",
             "properties": {
@@ -173,7 +170,6 @@
               "direction": "Inbound"
             }
           },
-
           {
             "name": "rVPN4500",
             "properties": {
@@ -188,7 +184,6 @@
               "direction": "Inbound"
             }
           },
-
           {
             "name": "Docker",
             "properties": {
@@ -203,13 +198,11 @@
               "direction": "Inbound"
             }
           }
-
         ]
       }
     },
-    
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -236,7 +229,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('rancherNodeName'), copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -252,11 +245,11 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('rancherNodeName'), copyIndex(), '-nic')]",
       "location": "[resourceGroup().location]",
-	  "copy": {
+      "copy": {
         "name": "nicLoopNode",
         "count": "[parameters('rancherCount')]"
       },
@@ -282,9 +275,9 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(parameters('rancherNodeName'), copyIndex())]",	  
+      "name": "[concat(parameters('rancherNodeName'), copyIndex())]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "vmLoopNode",
@@ -311,7 +304,7 @@
             "version": "latest"
           },
           "osDisk": {
-			"name": "[concat(parameters('rancherNodeName'), copyIndex(),'-osdisk')]",
+            "name": "[concat(parameters('rancherNodeName'), copyIndex(),'-osdisk')]",
             "vhd": {
               "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',parameters('rancherNodeName'), copyIndex(),'-osdisk','.vhd')]"
             },
@@ -331,9 +324,9 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('rancherNodeName'), copyIndex(),'/', variables('extensionName'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-	  "copy": {
+      "copy": {
         "name": "extLoopNode",
         "count": "[parameters('rancherCount')]"
       },
@@ -353,8 +346,8 @@
             "rancheragent": {
               "image": "rancher/agent:latest",
               "restart": "always",
-			  "privileged": true,
-			  "volumes": [
+              "privileged": true,
+              "volumes": [
                 "/var/run/docker.sock:/var/run/docker.sock"
               ],
               "command": "[parameters('rancherApi')]"

--- a/docker-rancher/server.json
+++ b/docker-rancher/server.json
@@ -14,91 +14,91 @@
         "description": "Password for the Virtual Machine."
       }
     },
-	"rancherNodeName": {
-		"type": "string",
-		"metadata": {
-			"description": "The prefix you want to use as hostname"
-		}
-	},
-	"rancherApi": {
+    "rancherNodeName": {
+      "type": "string",
+      "metadata": {
+        "description": "The prefix you want to use as hostname"
+      }
+    },
+    "rancherApi": {
       "type": "string",
       "metadata": {
         "description": "Will be ignored, solely for integration purposes"
       }
     },
-	"rancherVmSize": {
-		"type": "string",
-		"metadata": {
-			"description": "The size of the virtual machine used for the nodes"
-		},
-		"allowedValues": [
-			"Standard_A0",
-			"Standard_A1",
-			"Standard_A2",
-			"Standard_A3",
-			"Standard_A4",
-			"Basic_A0",
-			"Basic_A1",
-			"Basic_A2",
-			"Basic_A3",
-			"Basic_A4",
-			"Standard_A5",
-			"Standard_A6",
-			"Standard_A7",
-			"Standard_D1",
-			"Standard_D2",
-			"Standard_D3",
-			"Standard_D4",
-			"Standard_D11",
-			"Standard_D12",
-			"Standard_D13",
-			"Standard_D14",
-			"Standard_D1_v2",
-			"Standard_D2_v2",
-			"Standard_D3_v2",
-			"Standard_D4_v2",
-			"Standard_D5_v2",
-			"Standard_D11_v2",
-			"Standard_D12_v2",
-			"Standard_D13_v2",
-			"Standard_D14_v2",
-			"Standard_DS1",
-			"Standard_DS2",
-			"Standard_DS3",
-			"Standard_DS4",
-			"Standard_DS11",
-			"Standard_DS12",
-			"Standard_DS13",
-			"Standard_DS14",
-			"Standard_G1",
-			"Standard_G2",
-			"Standard_G3",
-			"Standard_G4",
-			"Standard_G5",
-			"Standard_GS1",
-			"Standard_GS2",
-			"Standard_GS3",
-			"Standard_GS4",
-			"Standard_GS5",
-			"Standard_A8",
-			"Standard_A9",
-			"Standard_A10",
-			"Standard_A11"
-		],
-		"defaultValue": "Standard_A2"
-	},
-	"rancherCount": {
+    "rancherVmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "The size of the virtual machine used for the nodes"
+      },
+      "allowedValues": [
+        "Standard_A0",
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Basic_A0",
+        "Basic_A1",
+        "Basic_A2",
+        "Basic_A3",
+        "Basic_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7",
+        "Standard_D1",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14",
+        "Standard_D1_v2",
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_D5_v2",
+        "Standard_D11_v2",
+        "Standard_D12_v2",
+        "Standard_D13_v2",
+        "Standard_D14_v2",
+        "Standard_DS1",
+        "Standard_DS2",
+        "Standard_DS3",
+        "Standard_DS4",
+        "Standard_DS11",
+        "Standard_DS12",
+        "Standard_DS13",
+        "Standard_DS14",
+        "Standard_G1",
+        "Standard_G2",
+        "Standard_G3",
+        "Standard_G4",
+        "Standard_G5",
+        "Standard_GS1",
+        "Standard_GS2",
+        "Standard_GS3",
+        "Standard_GS4",
+        "Standard_GS5",
+        "Standard_A8",
+        "Standard_A9",
+        "Standard_A10",
+        "Standard_A11"
+      ],
+      "defaultValue": "Standard_A2"
+    },
+    "rancherCount": {
       "type": "int",
       "metadata": {
         "description": "Will be ignored, solely for integration purposes"
       },
-	  "minValue": 1,
-	  "maxValue": 1
+      "minValue": 1,
+      "maxValue": 1
     }
   },
   "variables": {
     "rancherCount": 1,
-    "apiVersion": "2015-06-15",  
+    "apiVersion": "2015-06-15",
     "availabilitySet": "[parameters('rancherNodeName')]",
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'rancherhost')]",
     "networkSecurityGroupName": "[parameters('rancherNodeName')]",
@@ -123,28 +123,27 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
-	{
+    {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySet')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
-    
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('networkSecurityGroupName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "securityRules": [
-		  {
+          {
             "name": "SSH",
             "properties": {
               "description": "SSH",
@@ -158,7 +157,6 @@
               "direction": "Inbound"
             }
           },
-		  
           {
             "name": "Rancher",
             "properties": {
@@ -173,7 +171,6 @@
               "direction": "Inbound"
             }
           },
-
           {
             "name": "Docker",
             "properties": {
@@ -188,13 +185,11 @@
               "direction": "Inbound"
             }
           }
-
         ]
       }
     },
-    
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -221,7 +216,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('rancherNodeName'))]",
       "location": "[resourceGroup().location]",
@@ -237,11 +232,11 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('rancherNodeName'), '-nic')]",
       "location": "[resourceGroup().location]",
-	  "copy": {
+      "copy": {
         "name": "nicLoopNode",
         "count": "[variables('rancherCount')]"
       },
@@ -267,9 +262,9 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(parameters('rancherNodeName'))]",	  
+      "name": "[concat(parameters('rancherNodeName'))]",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "vmLoopNode",
@@ -296,7 +291,7 @@
             "version": "latest"
           },
           "osDisk": {
-			"name": "[concat(parameters('rancherNodeName'),'-osdisk')]",
+            "name": "[concat(parameters('rancherNodeName'),'-osdisk')]",
             "vhd": {
               "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',parameters('rancherNodeName'),'-osdisk','.vhd')]"
             },
@@ -316,9 +311,9 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('rancherNodeName'),'/', variables('extensionName'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-	  "copy": {
+      "copy": {
         "name": "extLoopNode",
         "count": "[variables('rancherCount')]"
       },
@@ -338,7 +333,9 @@
             "rancheragent": {
               "image": "rancher/server:stable",
               "restart": "always",
-              "ports": [ "8080:8080" ]
+              "ports": [
+                "8080:8080"
+              ]
             }
           }
         }

--- a/elasticsearch-centos-3node/azuredeploy.json
+++ b/elasticsearch-centos-3node/azuredeploy.json
@@ -32,40 +32,39 @@
     "vmSize": "Standard_D1",
     "clusterName": "elasticcluster",
     "logTableName": "elasticscriptlog",
-    "imagePublisher" : "OpenLogic",
-    "imageOffer" : "CentOS",
-    "imageSku" : "7.1",
+    "imagePublisher": "OpenLogic",
+    "imageOffer": "CentOS",
+    "imageSku": "7.1",
     "availabilitySetName": "[concat(parameters('VMPrefix'), 'AvSet')]",
-    "storageName" : "[toLower(concat(parameters('commonPrefix'), uniqueString(resourceGroup().id)))]",
+    "storageName": "[toLower(concat(parameters('commonPrefix'), uniqueString(resourceGroup().id)))]",
     "storageAccountType": "Standard_LRS",
     "dataDiskSize": "1023",
-    "virtualNetworkName":  "[concat(parameters('commonPrefix'), 'VNet')]" ,
+    "virtualNetworkName": "[concat(parameters('commonPrefix'), 'VNet')]",
     "publicIPAddressName": "JumpboxIP",
     "publicIPAddressType": "Dynamic",
     "JBNSGName": "JumpboxNSG",
     "subnetName": "elasticSubnet",
-	  "subnetAdmin": "adminSubnet",
+    "subnetAdmin": "adminSubnet",
     "networkInterfaceName": "NIC",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
-	  "subnetAdminRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetAdmin'))]",
+    "subnetAdminRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetAdmin'))]",
     "numberOfNodes": 3,
     "scriptBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch-centos-3node/",
     "elasticScript": "elasticinstall.py",
-    "jumpboxScript" : "prep-jumpbox.ps1",
+    "jumpboxScript": "prep-jumpbox.ps1",
     "installScripts": [
-        "[concat(variables('scriptBaseUrl'), variables('elasticScript'))]",
-        "[concat(variables('scriptBaseUrl'), 'sdc.layout')]"
+      "[concat(variables('scriptBaseUrl'), variables('elasticScript'))]",
+      "[concat(variables('scriptBaseUrl'), 'sdc.layout')]"
     ],
     "jumpboxScripts": [
-        "[concat(variables('scriptBaseUrl'), variables('jumpboxScript'))]",
-        "[concat(variables('scriptBaseUrl'), 'get-started.ps1')]"
+      "[concat(variables('scriptBaseUrl'), variables('jumpboxScript'))]",
+      "[concat(variables('scriptBaseUrl'), 'get-started.ps1')]"
     ]
-    
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageName')]",
       "location": "[resourceGroup().location]",
@@ -77,7 +76,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -86,7 +85,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
       "location": "[resourceGroup().location]",
@@ -95,7 +94,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('JBNSGName')]",
       "location": "[resourceGroup().location]",
@@ -119,7 +118,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -154,9 +153,8 @@
         ]
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('vmPrefix'), variables('networkInterfaceName'), copyindex())]",
       "location": "[resourceGroup().location]",
@@ -186,7 +184,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmPrefix'), copyindex())]",
       "copy": {
@@ -254,7 +252,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmPrefix'), copyindex(), '/installelasticsearch')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "virtualMachineExtensions",
         "count": "[variables('numberOfNodes')]"
@@ -275,7 +273,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "JumpboxNic",
       "location": "[resourceGroup().location]",
@@ -305,7 +303,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "Jumpbox",
       "location": "[resourceGroup().location]",
@@ -353,7 +351,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "Jumpbox/PrepExtension",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "Microsoft.Compute/virtualMachines/Jumpbox"

--- a/elasticsearch-jmeter/azuredeploy.json
+++ b/elasticsearch-jmeter/azuredeploy.json
@@ -1,395 +1,395 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Admin username used when provisioning virtual machines"
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Admin password used when provisioning virtual machines"
-            }
-        },
-        "existingVirtualNetworkName": {
-            "type": "string",
-            "defaultValue": "es-vnet",
-            "metadata": {
-                "description": "Existing virtual network name to deploy into which contains Elasticsearch nodes"
-            }
-        },
-        "subNodeCount": {
-            "type": "int",
-            "defaultValue": 2,
-            "allowedValues": [
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9
-            ],
-            "metadata": {
-                "description": "Number of subordinate JMeter nodes to provision"
-            }
-        },
-        "subNodeSize": {
-            "type": "string",
-            "defaultValue": "Standard_D2_v2",
-            "allowedValues": [
-                "Standard_D2_v2",
-                "Standard_D3_v2",
-                "Standard_D4_v2",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_A4",
-                "Standard_A5",
-                "Standard_A6",
-                "Standard_A7"
-            ],
-            "metadata": {
-                "description": "Size of the subordinate JMeter nodes"
-            }
-        },
-        "bossNodeSize": {
-            "type": "string",
-            "defaultValue": "Standard_D2_v2",
-            "allowedValues": [
-                "Standard_D2_v2",
-                "Standard_D3_v2",
-                "Standard_D4_v2",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_A4"
-            ],
-            "metadata": {
-                "description": "Size of the boss JMeter node"
-            }
-        },
-        "jarball": {
-            "type": "string",
-            "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch-jmeter/resources/jarball.zip",
-            "metadata": {
-                "description": "The location of the test library and jar dependencies. This is extracted to every node under /opt/jmeter/apache-jmeter-2.13/lib/junit"
-            }  
-        },
-        "testpack": {
-            "type": "string",
-            "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch-jmeter/resources/testpack.zip",
-            "metadata": {
-                "description": "The location of the test jmx and run properties. This is extracted to the JMeter master node only, in /opt/jmeter"
-            }  
-        },
-        "esClusterName": {
-            "type": "string",
-            "defaultValue": "elasticsearch",
-            "metadata": {
-                "description": "The name of the Elasticsearch cluster to target"
-            }
-        },
-        "templateBase": {
-            "type": "string",
-            "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master",
-            "metadata": {
-                "description": "Change this value to your repo name if deploying from a fork"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Admin username used when provisioning virtual machines"
+      }
     },
-    "variables": {
-        "apiVersion": "2015-06-15",
-        "templateBaseUrl": "[concat(parameters('templateBase'), '/elasticsearch-jmeter/')]",
-        "storageAccountName": "[concat(substring(uniqueString(resourceGroup().id, 'jmeter'), 0, 6), 'jmeter')]",
-        "bossNodeIp": "10.0.4.10",
-        "subNodesIpPrefix": "10.0.4.2",
-        "networkSettings": {
-            "virtualNetworkName": "[parameters('existingVirtualNetworkName')]",
-            "addressPrefix": "10.0.0.0/16",
-            "subnet": {
-                "jmeter": {
-                    "name": "jmeter",
-                    "prefix": "10.0.4.0/24",
-                    "vnet": "[parameters('existingVirtualNetworkName')]"
-                }
-            }
-        },
-        "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('existingVirtualNetworkName')), '/subnets/jmeter')]",
-        "nicName": "jmeter-nic",
-        "vmName": "jmeter-vm",
-        "setupScripts": [
-            "[concat(variables('templateBaseUrl'), 'jmeter-install.sh')]"
-        ],
-        "settings": {
-            "imageReference": {
-                "publisher": "Canonical",
-                "offer": "UbuntuServer",
-                "sku": "14.04.2-LTS",
-                "version": "latest"
-            },
-            "managementPort": "22",
-            "extensionSettings": {
-                "boss": {
-                    "publisher": "Microsoft.Azure.Extensions",
-                    "type": "CustomScript",
-                    "typeHandlerVersion": "2.0",
-                    "autoUpgradeMinorVersion": true,
-                    "settings": {
-                        "fileUris": "[variables('setupScripts')]",
-                        "commandToExecute": "[concat('bash jmeter-install.sh -mr ', variables('subNodesIpPrefix'), '-', parameters('subNodeCount'), ' -j ', parameters('jarball'), ' -t ', parameters('testpack'))]"
-                    }
-                },
-                "sub": {
-                    "publisher": "Microsoft.Azure.Extensions",
-                    "type": "CustomScript",
-                    "typeHandlerVersion": "2.0",
-                    "autoUpgradeMinorVersion": true,
-                    "settings": {
-                        "fileUris": "[variables('setupScripts')]",
-                        "commandToExecute": "[concat('bash jmeter-install.sh -j ', parameters('jarball'))]"
-                    }
-                }
-            }
-        }
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin password used when provisioning virtual machines"
+      }
     },
-    "resources": [
-      {
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[variables('storageAccountName')]",
-        "apiVersion": "[variables('apiVersion')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "accountType": "Standard_LRS"
+    "existingVirtualNetworkName": {
+      "type": "string",
+      "defaultValue": "es-vnet",
+      "metadata": {
+        "description": "Existing virtual network name to deploy into which contains Elasticsearch nodes"
+      }
+    },
+    "subNodeCount": {
+      "type": "int",
+      "defaultValue": 2,
+      "allowedValues": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9
+      ],
+      "metadata": {
+        "description": "Number of subordinate JMeter nodes to provision"
+      }
+    },
+    "subNodeSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2_v2",
+      "allowedValues": [
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7"
+      ],
+      "metadata": {
+        "description": "Size of the subordinate JMeter nodes"
+      }
+    },
+    "bossNodeSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2_v2",
+      "allowedValues": [
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4"
+      ],
+      "metadata": {
+        "description": "Size of the boss JMeter node"
+      }
+    },
+    "jarball": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch-jmeter/resources/jarball.zip",
+      "metadata": {
+        "description": "The location of the test library and jar dependencies. This is extracted to every node under /opt/jmeter/apache-jmeter-2.13/lib/junit"
+      }
+    },
+    "testpack": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/elasticsearch-jmeter/resources/testpack.zip",
+      "metadata": {
+        "description": "The location of the test jmx and run properties. This is extracted to the JMeter master node only, in /opt/jmeter"
+      }
+    },
+    "esClusterName": {
+      "type": "string",
+      "defaultValue": "elasticsearch",
+      "metadata": {
+        "description": "The name of the Elasticsearch cluster to target"
+      }
+    },
+    "templateBase": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master",
+      "metadata": {
+        "description": "Change this value to your repo name if deploying from a fork"
+      }
+    }
+  },
+  "variables": {
+    "apiVersion": "2015-06-15",
+    "templateBaseUrl": "[concat(parameters('templateBase'), '/elasticsearch-jmeter/')]",
+    "storageAccountName": "[concat(substring(uniqueString(resourceGroup().id, 'jmeter'), 0, 6), 'jmeter')]",
+    "bossNodeIp": "10.0.4.10",
+    "subNodesIpPrefix": "10.0.4.2",
+    "networkSettings": {
+      "virtualNetworkName": "[parameters('existingVirtualNetworkName')]",
+      "addressPrefix": "10.0.0.0/16",
+      "subnet": {
+        "jmeter": {
+          "name": "jmeter",
+          "prefix": "10.0.4.0/24",
+          "vnet": "[parameters('existingVirtualNetworkName')]"
         }
+      }
+    },
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('existingVirtualNetworkName')), '/subnets/jmeter')]",
+    "nicName": "jmeter-nic",
+    "vmName": "jmeter-vm",
+    "setupScripts": [
+      "[concat(variables('templateBaseUrl'), 'jmeter-install.sh')]"
+    ],
+    "settings": {
+      "imageReference": {
+        "publisher": "Canonical",
+        "offer": "UbuntuServer",
+        "sku": "14.04.2-LTS",
+        "version": "latest"
       },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "jmeter-pip",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "Static"
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/networkSecurityGroups",
-        "name": "jmeter-nsg",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "securityRules": [
-            {
-              "name": "SSH",
-              "properties": {
-                "description": "Allows SSH traffic",
-                "protocol": "Tcp",
-                "sourcePortRange": "[variables('settings').managementPort]",
-                "destinationPortRange": "[variables('settings').managementPort]",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 100,
-                "direction": "Inbound"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/virtualNetworks/subnets",
-        "name": "[concat(variables('networkSettings').virtualNetworkName, '/jmeter')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "addressPrefix": "[variables('networkSettings').subnet.jmeter.prefix]"
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[concat(variables('nicName'), '-sub', copyindex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "subNodesNicLoop",
-          "count": "[parameters('subNodeCount')]"
-        },
-        "dependsOn": [
-          "[concat('Microsoft.Network/virtualNetworks/', variables('networkSettings').virtualNetworkName, '/subnets/jmeter')]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfigsub",
-              "properties": {
-                "privateIPAllocationMethod": "Static",
-                "privateIPAddress": "[concat(variables('subNodesIpPrefix'), copyindex())]",
-                "subnet": {
-                  "id": "[variables('subnetRef')]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[concat(variables('nicName'), '-boss')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', 'jmeter-pip')]",
-          "[concat('Microsoft.Network/networkSecurityGroups/', 'jmeter-nsg')]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfigboss",
-              "properties": {
-                "privateIPAllocationMethod": "Static",
-                "privateIPAddress": "[variables('bossNodeIp')]",
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'jmeter-pip')]"
-                },
-                "subnet": {
-                  "id": "[variables('subnetRef')]"
-                },
-                "networkSecurityGroup": {
-                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'jmeter-nsg')]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[concat(variables('vmName'), '-boss')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), '-boss')]",
-          "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]"
-        ],
-        "properties": {
-          "hardwareProfile": {
-            "vmSize": "[parameters('bossNodeSize')]"
-          },
-          "osProfile": {
-            "computerName": "[concat('jmeter-boss')]",
-            "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPassword')]"
-          },
-          "storageProfile": {
-            "imageReference": "[variables('settings').imageReference]",
-            "osDisk": {
-              "name": "osdisk",
-              "vhd": {
-                "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/vhds/', variables('vmName'), '-boss', '-osdisk.vhd')]"
-              },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
-            }
-          },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), '-boss'))]"
-              }
-            ]
+      "managementPort": "22",
+      "extensionSettings": {
+        "boss": {
+          "publisher": "Microsoft.Azure.Extensions",
+          "type": "CustomScript",
+          "typeHandlerVersion": "2.0",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "fileUris": "[variables('setupScripts')]",
+            "commandToExecute": "[concat('bash jmeter-install.sh -mr ', variables('subNodesIpPrefix'), '-', parameters('subNodeCount'), ' -j ', parameters('jarball'), ' -t ', parameters('testpack'))]"
           }
         },
-        "resources": [
+        "sub": {
+          "publisher": "Microsoft.Azure.Extensions",
+          "type": "CustomScript",
+          "typeHandlerVersion": "2.0",
+          "autoUpgradeMinorVersion": true,
+          "settings": {
+            "fileUris": "[variables('setupScripts')]",
+            "commandToExecute": "[concat('bash jmeter-install.sh -j ', parameters('jarball'))]"
+          }
+        }
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "jmeter-pip",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Static"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "jmeter-nsg",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
           {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(variables('vmName'), '-boss', '/installjmeter')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-              "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '-boss')]"
-            ],
+            "name": "SSH",
             "properties": {
-              "publisher": "[variables('settings').extensionSettings.boss.publisher]",
-              "type": "[variables('settings').extensionSettings.boss.type]",
-              "typeHandlerVersion": "[variables('settings').extensionSettings.boss.typeHandlerVersion]",
-              "settings": {
-                "fileUris": "[variables('settings').extensionSettings.boss.settings.fileUris]",
-                "commandToExecute": "[concat(variables('settings').extensionSettings.boss.settings.commandToExecute)]"
-              }
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "[variables('settings').managementPort]",
+              "destinationPortRange": "[variables('settings').managementPort]",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
             }
           }
         ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "name": "[concat(variables('networkSettings').virtualNetworkName, '/jmeter')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressPrefix": "[variables('networkSettings').subnet.jmeter.prefix]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('nicName'), '-sub', copyindex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "subNodesNicLoop",
+        "count": "[parameters('subNodeCount')]"
       },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[concat(variables('vmName'), '-sub', copyindex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "subVmLoop",
-          "count": "[parameters('subNodeCount')]"
-        },
-        "dependsOn": [
-          "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), '-sub', copyindex())]",
-          "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]"
-        ],
-        "properties": {
-          "hardwareProfile": {
-            "vmSize": "[parameters('subNodeSize')]"
-          },
-          "osProfile": {
-            "computerName": "[concat('jmeter-sub', copyIndex())]",
-            "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPassword')]"
-          },
-          "storageProfile": {
-            "imageReference": "[variables('settings').imageReference]",
-            "osDisk": {
-              "name": "osdisk",
-              "vhd": {
-                "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/vhds/', variables('vmName'), '-sub', copyindex(), '-osdisk.vhd')]"
-              },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
-            }
-          },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), '-sub', copyindex()))]"
-              }
-            ]
-          }
-        },
-        "resources": [
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('networkSettings').virtualNetworkName, '/subnets/jmeter')]"
+      ],
+      "properties": {
+        "ipConfigurations": [
           {
-            "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(variables('vmName'), '-sub', copyindex(), '/installjmeter')]",
-            "apiVersion": "[variables('apiVersion')]",
-            "location": "[resourceGroup().location]",
-            "dependsOn": [
-              "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '-sub', copyindex())]"
-            ],
+            "name": "ipconfigsub",
             "properties": {
-              "publisher": "[variables('settings').extensionSettings.sub.publisher]",
-              "type": "[variables('settings').extensionSettings.sub.type]",
-              "typeHandlerVersion": "[variables('settings').extensionSettings.sub.typeHandlerVersion]",
-              "settings": {
-                "fileUris": "[variables('settings').extensionSettings.sub.settings.fileUris]",
-                "commandToExecute": "[concat(variables('settings').extensionSettings.sub.settings.commandToExecute)]"
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[concat(variables('subNodesIpPrefix'), copyindex())]",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
               }
             }
           }
         ]
       }
-    ],
-    "outputs": {
-        "boss-pip": {
-            "type": "string",
-            "value": "[reference(concat('Microsoft.Network/publicIPAddresses/', 'jmeter-pip')).ipAddress]"
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('nicName'), '-boss')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', 'jmeter-pip')]",
+        "[concat('Microsoft.Network/networkSecurityGroups/', 'jmeter-nsg')]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfigboss",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[variables('bossNodeIp')]",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'jmeter-pip')]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              },
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', 'jmeter-nsg')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(variables('vmName'), '-boss')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), '-boss')]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('bossNodeSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat('jmeter-boss')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": "[variables('settings').imageReference]",
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/vhds/', variables('vmName'), '-boss', '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), '-boss'))]"
+            }
+          ]
         }
+      },
+      "resources": [
+        {
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "[concat(variables('vmName'), '-boss', '/installjmeter')]",
+          "apiVersion": "[variables('apiVersion')]",
+          "location": "[resourceGroup().location]",
+          "dependsOn": [
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '-boss')]"
+          ],
+          "properties": {
+            "publisher": "[variables('settings').extensionSettings.boss.publisher]",
+            "type": "[variables('settings').extensionSettings.boss.type]",
+            "typeHandlerVersion": "[variables('settings').extensionSettings.boss.typeHandlerVersion]",
+            "settings": {
+              "fileUris": "[variables('settings').extensionSettings.boss.settings.fileUris]",
+              "commandToExecute": "[concat(variables('settings').extensionSettings.boss.settings.commandToExecute)]"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(variables('vmName'), '-sub', copyindex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "subVmLoop",
+        "count": "[parameters('subNodeCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), '-sub', copyindex())]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('subNodeSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat('jmeter-sub', copyIndex())]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": "[variables('settings').imageReference]",
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/vhds/', variables('vmName'), '-sub', copyindex(), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), '-sub', copyindex()))]"
+            }
+          ]
+        }
+      },
+      "resources": [
+        {
+          "type": "Microsoft.Compute/virtualMachines/extensions",
+          "name": "[concat(variables('vmName'), '-sub', copyindex(), '/installjmeter')]",
+          "apiVersion": "[variables('apiVersion')]",
+          "location": "[resourceGroup().location]",
+          "dependsOn": [
+            "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '-sub', copyindex())]"
+          ],
+          "properties": {
+            "publisher": "[variables('settings').extensionSettings.sub.publisher]",
+            "type": "[variables('settings').extensionSettings.sub.type]",
+            "typeHandlerVersion": "[variables('settings').extensionSettings.sub.typeHandlerVersion]",
+            "settings": {
+              "fileUris": "[variables('settings').extensionSettings.sub.settings.fileUris]",
+              "commandToExecute": "[concat(variables('settings').extensionSettings.sub.settings.commandToExecute)]"
+            }
+          }
+        }
+      ]
     }
+  ],
+  "outputs": {
+    "boss-pip": {
+      "type": "string",
+      "value": "[reference(concat('Microsoft.Network/publicIPAddresses/', 'jmeter-pip')).ipAddress]"
+    }
+  }
 }

--- a/eris-platform/azuredeploy.json
+++ b/eris-platform/azuredeploy.json
@@ -76,14 +76,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -95,7 +95,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -116,7 +116,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -142,7 +142,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -187,7 +187,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/docker-for-eris')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
@@ -197,13 +197,13 @@
         "type": "DockerExtension",
         "typeHandlerVersion": "1.0",
         "autoUpgradeMinorVersion": true,
-        "settings": { }
+        "settings": {}
       }
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '/extensions/docker-for-eris')]"

--- a/ethereum-consortium-blockchain-network/azuredeploy.json
+++ b/ethereum-consortium-blockchain-network/azuredeploy.json
@@ -213,13 +213,15 @@
       "10.0.1.0/24",
       "10.0.2.0/24",
       "10.0.3.0/24",
-      "10.0.4.0/24"],
+      "10.0.4.0/24"
+    ],
     "mnSubnetRefArray": [
       "[concat(variables('vnetID'),'/subnets/', variables('mnSubnetNameArray')[0])]",
       "[concat(variables('vnetID'),'/subnets/', variables('mnSubnetNameArray')[1])]",
       "[concat(variables('vnetID'),'/subnets/', variables('mnSubnetNameArray')[2])]",
       "[concat(variables('vnetID'),'/subnets/', variables('mnSubnetNameArray')[3])]",
-      "[concat(variables('vnetID'),'/subnets/', variables('mnSubnetNameArray')[4])]"],
+      "[concat(variables('vnetID'),'/subnets/', variables('mnSubnetNameArray')[4])]"
+    ],
     "numSubnets": "[add(parameters('numConsortiumMembers'), 1)]",
     "subnetPropertiesArray": [
       {
@@ -227,7 +229,7 @@
         "properties": {
           "addressPrefix": "[variables('txSubnetPrefix')]",
           "networkSecurityGroup": {
-              "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('txNsgName'))]"
+            "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('txNsgName'))]"
           }
         }
       },
@@ -286,14 +288,14 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersionAvailabilitySets')]",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
       "location": "[variables('location')]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersionDeployments')]",
+      "apiVersion": "2016-09-01",
       "name": "loadBalancerLinkedTemplate",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -303,23 +305,47 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "loadBalancerName": {"value": "[variables('loadBalancerName')]"},
-          "dnsHostName":{"value": "[variables('namingInfix')]"},
-          "loadBalancerBackendAddressPoolName":{"value": "[variables('loadBalancerBackendAddressPoolName')]"},
-          "loadBalancerInboundNatRuleNamePrefix":{"value": "[variables('loadBalancerInboundNatRuleNamePrefix')]"},
-          "frontendPort1":{"value": "[variables('httpPort')]"},
-          "backendPort1":{"value": "[variables('adminSitePort')]"},
-          "frontendPort2":{"value": "[variables('gethRPCPort')]"},
-          "backendPort2":{"value": "[variables('gethRPCPort')]"},
-          "numInboundNATRules":{"value": "[parameters('numTXNodes')]"},
-          "inboundNATRuleFrontendStartingPort":{"value": "[variables('sshNATFrontEndStartingPort')]"},
-          "inboundNATRuleBackendPort":{"value": "[variables('sshPort')]"},
-          "location":{"value": "[variables('location')]"}
+          "loadBalancerName": {
+            "value": "[variables('loadBalancerName')]"
+          },
+          "dnsHostName": {
+            "value": "[variables('namingInfix')]"
+          },
+          "loadBalancerBackendAddressPoolName": {
+            "value": "[variables('loadBalancerBackendAddressPoolName')]"
+          },
+          "loadBalancerInboundNatRuleNamePrefix": {
+            "value": "[variables('loadBalancerInboundNatRuleNamePrefix')]"
+          },
+          "frontendPort1": {
+            "value": "[variables('httpPort')]"
+          },
+          "backendPort1": {
+            "value": "[variables('adminSitePort')]"
+          },
+          "frontendPort2": {
+            "value": "[variables('gethRPCPort')]"
+          },
+          "backendPort2": {
+            "value": "[variables('gethRPCPort')]"
+          },
+          "numInboundNATRules": {
+            "value": "[parameters('numTXNodes')]"
+          },
+          "inboundNATRuleFrontendStartingPort": {
+            "value": "[variables('sshNATFrontEndStartingPort')]"
+          },
+          "inboundNATRuleBackendPort": {
+            "value": "[variables('sshPort')]"
+          },
+          "location": {
+            "value": "[variables('location')]"
+          }
         }
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetworkSecurityGroups')]",
+      "apiVersion": "2016-09-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('mnNsgName')]",
       "location": "[variables('location')]",
@@ -346,7 +372,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionNetworkSecurityGroups')]",
+      "apiVersion": "2016-09-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('txNsgName')]",
       "location": "[variables('location')]",
@@ -415,7 +441,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionVirtualNetworks')]",
+      "apiVersion": "2016-09-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
@@ -433,7 +459,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionDeployments')]",
+      "apiVersion": "2016-09-01",
       "name": "txVMLinkedTemplate",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -448,31 +474,71 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "apiVersionVirtualMachines":{"value": "[variables('apiVersionVirtualMachines')]"},
-          "apiVersionNetworkInterfaces":{"value": "[variables('apiVersionNetworkInterfaces')]"},
-          "apiVersionStorageAccounts":{"value": "[variables('apiVersionStorageAccounts')]"},
-          "loadBalancerName":{"value": "[variables('loadBalancerName')]"},
-          "loadBalancerBackendAddressPoolName":{"value": "[variables('loadBalancerBackendAddressPoolName')]"},
-          "loadBalancerInboundNatRuleNamePrefix":{"value": "[variables('loadBalancerInboundNatRuleNamePrefix')]"},
-          "txSubnetRef":{"value": "[variables('txSubnetRef')]"},
-          "txVMNamePrefix":{"value": "[variables('txVMNamePrefix')]"},
-          "numTXNodes":{"value": "[parameters('numTXNodes')]"},
-          "txStorageAcctName":{"value": "[variables('txStorageAcctName')]"},
-          "txNIPrefix":{"value": "[variables('txNIPrefix')]"},
-          "storageAccountType":{"value": "[variables('storageAccountType')]"},
-          "availabilitySetName":{"value": "[variables('availabilitySetName')]"},
-          "txNodeVMSize":{"value": "[parameters('txNodeVMSize')]"},
-          "adminUsername":{"value": "[parameters('adminUsername')]"},
-          "adminPassword":{"value": "[parameters('adminPassword')]"},
-          "adminSSHKey":{"value": ""},
-          "ubuntuImage":{"value": "[variables('ubuntuImage')]"},
-          "namingInfix":{"value": "[variables('namingInfix')]"},
-          "location":{"value": "[variables('location')]"}
+          "apiVersionVirtualMachines": {
+            "value": "[variables('apiVersionVirtualMachines')]"
+          },
+          "apiVersionNetworkInterfaces": {
+            "value": "[variables('apiVersionNetworkInterfaces')]"
+          },
+          "apiVersionStorageAccounts": {
+            "value": "[variables('apiVersionStorageAccounts')]"
+          },
+          "loadBalancerName": {
+            "value": "[variables('loadBalancerName')]"
+          },
+          "loadBalancerBackendAddressPoolName": {
+            "value": "[variables('loadBalancerBackendAddressPoolName')]"
+          },
+          "loadBalancerInboundNatRuleNamePrefix": {
+            "value": "[variables('loadBalancerInboundNatRuleNamePrefix')]"
+          },
+          "txSubnetRef": {
+            "value": "[variables('txSubnetRef')]"
+          },
+          "txVMNamePrefix": {
+            "value": "[variables('txVMNamePrefix')]"
+          },
+          "numTXNodes": {
+            "value": "[parameters('numTXNodes')]"
+          },
+          "txStorageAcctName": {
+            "value": "[variables('txStorageAcctName')]"
+          },
+          "txNIPrefix": {
+            "value": "[variables('txNIPrefix')]"
+          },
+          "storageAccountType": {
+            "value": "[variables('storageAccountType')]"
+          },
+          "availabilitySetName": {
+            "value": "[variables('availabilitySetName')]"
+          },
+          "txNodeVMSize": {
+            "value": "[parameters('txNodeVMSize')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "adminSSHKey": {
+            "value": ""
+          },
+          "ubuntuImage": {
+            "value": "[variables('ubuntuImage')]"
+          },
+          "namingInfix": {
+            "value": "[variables('namingInfix')]"
+          },
+          "location": {
+            "value": "[variables('location')]"
+          }
         }
       }
     },
     {
-      "apiVersion": "[variables('apiVersionDeployments')]",
+      "apiVersion": "2016-09-01",
       "name": "mnVMLinkedTemplate",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -485,29 +551,65 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "apiVersionVirtualMachines":{"value": "[variables('apiVersionVirtualMachines')]"},
-          "apiVersionNetworkInterfaces":{"value": "[variables('apiVersionNetworkInterfaces')]"},
-          "apiVersionStorageAccounts":{"value": "[variables('apiVersionStorageAccounts')]"},
-          "mnVMNamePrefix":{"value": "[variables('mnVMNamePrefix')]"},
-          "numMNNodes":{"value": "[variables('numMNNodes')]"},
-          "mnNICPrefix":{"value": "[variables('mnNICPrefix')]"},
-          "mnStorageAcctNames":{"value": "[variables('mnStorageAcctNames')]"},
-          "mnStorageAcctCount":{"value": "[variables('mnStorageAcctCount')]"},
-          "mnSubnetRefArray":{"value": "[variables('mnSubnetRefArray')]"},
-          "numConsortiumMembers":{"value": "[parameters('numConsortiumMembers')]"},
-          "storageAccountType":{"value": "[variables('storageAccountType')]"},
-          "mnNodeVMSize":{"value": "[parameters('mnNodeVMSize')]"},
-          "adminUsername":{"value": "[parameters('adminUsername')]"},
-          "adminPassword":{"value": "[parameters('adminPassword')]"},
-          "adminSSHKey":{"value": ""},
-          "ubuntuImage":{"value": "[variables('ubuntuImage')]"},
-          "namingInfix":{"value": "[variables('namingInfix')]"},
-          "location":{"value": "[variables('location')]"}
+          "apiVersionVirtualMachines": {
+            "value": "[variables('apiVersionVirtualMachines')]"
+          },
+          "apiVersionNetworkInterfaces": {
+            "value": "[variables('apiVersionNetworkInterfaces')]"
+          },
+          "apiVersionStorageAccounts": {
+            "value": "[variables('apiVersionStorageAccounts')]"
+          },
+          "mnVMNamePrefix": {
+            "value": "[variables('mnVMNamePrefix')]"
+          },
+          "numMNNodes": {
+            "value": "[variables('numMNNodes')]"
+          },
+          "mnNICPrefix": {
+            "value": "[variables('mnNICPrefix')]"
+          },
+          "mnStorageAcctNames": {
+            "value": "[variables('mnStorageAcctNames')]"
+          },
+          "mnStorageAcctCount": {
+            "value": "[variables('mnStorageAcctCount')]"
+          },
+          "mnSubnetRefArray": {
+            "value": "[variables('mnSubnetRefArray')]"
+          },
+          "numConsortiumMembers": {
+            "value": "[parameters('numConsortiumMembers')]"
+          },
+          "storageAccountType": {
+            "value": "[variables('storageAccountType')]"
+          },
+          "mnNodeVMSize": {
+            "value": "[parameters('mnNodeVMSize')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "adminSSHKey": {
+            "value": ""
+          },
+          "ubuntuImage": {
+            "value": "[variables('ubuntuImage')]"
+          },
+          "namingInfix": {
+            "value": "[variables('namingInfix')]"
+          },
+          "location": {
+            "value": "[variables('location')]"
+          }
         }
       }
     },
     {
-      "apiVersion": "[variables('apiVersionDeployments')]",
+      "apiVersion": "2016-09-01",
       "name": "vmExtensionLinkedTemplate",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -521,20 +623,48 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "numBootNodes":{"value": "[parameters('numConsortiumMembers')]"},
-          "txVMNamePrefix":{"value": "[variables('txVMNamePrefix')]"},
-          "numTXNodes":{"value": "[parameters('numTXNodes')]"},
-          "mnVMNamePrefix":{"value": "[variables('mnVMNamePrefix')]"},
-          "numMNNodes":{"value": "[variables('numMNNodes')]"},
-          "artifactsLocationURL":{"value": "[variables('artifactsLocationURL')]"},
-          "adminUsername":{"value": "[parameters('adminUsername')]"},
-          "ethereumAccountPsswd":{"value": "[parameters('ethereumAccountPsswd')]"},
-          "ethereumAccountPassphrase": {"value": "[parameters('ethereumAccountPassphrase')]"},
-          "ethereumNetworkID":{"value": "[parameters('ethereumNetworkID')]"},
-          "gethIPCPort":{"value": "[variables('gethIPCPort')]"},
-          "adminSitePort":{"value": "[variables('adminSitePort')]"},
-          "apiVersionStorageAccounts":{"value": "[variables('apiVersionStorageAccounts')]"},
-          "location":{"value": "[variables('location')]"}
+          "numBootNodes": {
+            "value": "[parameters('numConsortiumMembers')]"
+          },
+          "txVMNamePrefix": {
+            "value": "[variables('txVMNamePrefix')]"
+          },
+          "numTXNodes": {
+            "value": "[parameters('numTXNodes')]"
+          },
+          "mnVMNamePrefix": {
+            "value": "[variables('mnVMNamePrefix')]"
+          },
+          "numMNNodes": {
+            "value": "[variables('numMNNodes')]"
+          },
+          "artifactsLocationURL": {
+            "value": "[variables('artifactsLocationURL')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "ethereumAccountPsswd": {
+            "value": "[parameters('ethereumAccountPsswd')]"
+          },
+          "ethereumAccountPassphrase": {
+            "value": "[parameters('ethereumAccountPassphrase')]"
+          },
+          "ethereumNetworkID": {
+            "value": "[parameters('ethereumNetworkID')]"
+          },
+          "gethIPCPort": {
+            "value": "[variables('gethIPCPort')]"
+          },
+          "adminSitePort": {
+            "value": "[variables('adminSitePort')]"
+          },
+          "apiVersionStorageAccounts": {
+            "value": "[variables('apiVersionStorageAccounts')]"
+          },
+          "location": {
+            "value": "[variables('location')]"
+          }
         }
       }
     }

--- a/ethereum-consortium-blockchain-network/nested/loadBalancer.json
+++ b/ethereum-consortium-blockchain-network/nested/loadBalancer.json
@@ -52,7 +52,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersionPublicIPAddresses')]",
+      "apiVersion": "2016-09-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('lbPublicIPAddressName')]",
       "location": "[parameters('location')]",
@@ -64,7 +64,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionLoadBalancers')]",
+      "apiVersion": "2016-09-01",
       "name": "[parameters('loadBalancerName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[parameters('location')]",
@@ -150,7 +150,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionLoadBalanceInboundNATRules')]",
+      "apiVersion": "2016-09-01",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
       "name": "[concat(parameters('loadBalancerName'), '/', parameters('loadBalancerInboundNatRuleNamePrefix'), copyIndex())]",
       "location": "[parameters('location')]",

--- a/ethereum-consortium-blockchain-network/nested/mnVMAuth-password.json
+++ b/ethereum-consortium-blockchain-network/nested/mnVMAuth-password.json
@@ -59,7 +59,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersionStorageAccounts')]",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('mnStorageAcctNames')[copyIndex()]]",
       "location": "[parameters('location')]",
@@ -74,7 +73,6 @@
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('apiVersionNetworkInterfaces')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('mnNICPrefix'), copyindex())]",
       "location": "[parameters('location')]",
@@ -97,7 +95,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('apiVersionVirtualMachines')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('mnVMNamePrefix'), copyIndex())]",
       "location": "[parameters('location')]",
@@ -123,7 +120,7 @@
           "osDisk": {
             "name": "[concat(parameters('namingInfix'), '-osdisk')]",
             "vhd": {
-              "uri" :"[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('mnStorageAcctNames')[mod(copyIndex(), parameters('mnStorageAcctCount'))]), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhds/osdisk', copyIndex(), '.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('mnStorageAcctNames')[mod(copyIndex(), parameters('mnStorageAcctCount'))]), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhds/osdisk', copyIndex(), '.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"

--- a/ethereum-consortium-blockchain-network/nested/mnVMAuth-password.json
+++ b/ethereum-consortium-blockchain-network/nested/mnVMAuth-password.json
@@ -59,6 +59,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('mnStorageAcctNames')[copyIndex()]]",
       "location": "[parameters('location')]",
@@ -73,6 +74,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('mnNICPrefix'), copyindex())]",
       "location": "[parameters('location')]",
@@ -95,6 +97,7 @@
       }
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('mnVMNamePrefix'), copyIndex())]",
       "location": "[parameters('location')]",

--- a/ethereum-consortium-blockchain-network/nested/mnVMAuth-sshPublicKey.json
+++ b/ethereum-consortium-blockchain-network/nested/mnVMAuth-sshPublicKey.json
@@ -62,7 +62,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersionStorageAccounts')]",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('mnStorageAcctNames')[copyIndex()]]",
       "location": "[parameters('location')]",
@@ -77,7 +76,6 @@
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('apiVersionNetworkInterfaces')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('mnNICPrefix'), copyindex())]",
       "location": "[parameters('location')]",
@@ -100,7 +98,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('apiVersionVirtualMachines')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('mnVMNamePrefix'), copyIndex())]",
       "location": "[parameters('location')]",
@@ -136,7 +133,7 @@
           "osDisk": {
             "name": "[concat(parameters('namingInfix'), '-osdisk')]",
             "vhd": {
-              "uri" :"[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('mnStorageAcctNames')[mod(copyIndex(), parameters('mnStorageAcctCount'))]), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhds/osdisk', copyIndex(), '.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('mnStorageAcctNames')[mod(copyIndex(), parameters('mnStorageAcctCount'))]), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhds/osdisk', copyIndex(), '.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"

--- a/ethereum-consortium-blockchain-network/nested/mnVMAuth-sshPublicKey.json
+++ b/ethereum-consortium-blockchain-network/nested/mnVMAuth-sshPublicKey.json
@@ -62,6 +62,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('mnStorageAcctNames')[copyIndex()]]",
       "location": "[parameters('location')]",
@@ -76,6 +77,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('mnNICPrefix'), copyindex())]",
       "location": "[parameters('location')]",
@@ -98,6 +100,7 @@
       }
     },
     {
+      "apiVersion": "2016-08-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('mnVMNamePrefix'), copyIndex())]",
       "location": "[parameters('location')]",

--- a/ethereum-consortium-blockchain-network/nested/txVMAuth-password.json
+++ b/ethereum-consortium-blockchain-network/nested/txVMAuth-password.json
@@ -70,7 +70,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersionNetworkInterfaces')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('txNIPrefix'), copyindex())]",
       "location": "[parameters('location')]",
@@ -103,7 +102,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('apiVersionStorageAccounts')]",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('txStorageAcctName')]",
       "location": "[parameters('location')]",
@@ -114,7 +112,6 @@
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('apiVersionVirtualMachines')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('txVMNamePrefix'), copyIndex())]",
       "location": "[parameters('location')]",
@@ -143,7 +140,7 @@
           "osDisk": {
             "name": "[concat(parameters('namingInfix'), '-osdisk')]",
             "vhd": {
-              "uri" :"[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('txStorageAcctName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhds/osdisk', copyIndex(), '.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('txStorageAcctName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhds/osdisk', copyIndex(), '.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"

--- a/ethereum-consortium-blockchain-network/nested/txVMAuth-password.json
+++ b/ethereum-consortium-blockchain-network/nested/txVMAuth-password.json
@@ -70,6 +70,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('txNIPrefix'), copyindex())]",
       "location": "[parameters('location')]",
@@ -102,6 +103,7 @@
       }
     },
     {
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('txStorageAcctName')]",
       "location": "[parameters('location')]",
@@ -112,6 +114,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('txVMNamePrefix'), copyIndex())]",
       "location": "[parameters('location')]",

--- a/ethereum-consortium-blockchain-network/nested/txVMAuth-sshPublicKey.json
+++ b/ethereum-consortium-blockchain-network/nested/txVMAuth-sshPublicKey.json
@@ -71,7 +71,6 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('apiVersionNetworkInterfaces')]",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('txNIPrefix'), copyindex())]",
       "location": "[parameters('location')]",
@@ -104,7 +103,6 @@
       }
     },
     {
-      "apiVersion": "[parameters('apiVersionStorageAccounts')]",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('txStorageAcctName')]",
       "location": "[parameters('location')]",
@@ -115,7 +113,6 @@
       "properties": {}
     },
     {
-      "apiVersion": "[parameters('apiVersionVirtualMachines')]",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('txVMNamePrefix'), copyIndex())]",
       "location": "[parameters('location')]",
@@ -154,7 +151,7 @@
           "osDisk": {
             "name": "[concat(parameters('namingInfix'), '-osdisk')]",
             "vhd": {
-              "uri" :"[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('txStorageAcctName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhds/osdisk', copyIndex(), '.vhd')]"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('txStorageAcctName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, 'vhds/osdisk', copyIndex(), '.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"

--- a/ethereum-consortium-blockchain-network/nested/txVMAuth-sshPublicKey.json
+++ b/ethereum-consortium-blockchain-network/nested/txVMAuth-sshPublicKey.json
@@ -71,6 +71,7 @@
   },
   "resources": [
     {
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('txNIPrefix'), copyindex())]",
       "location": "[parameters('location')]",
@@ -103,6 +104,7 @@
       }
     },
     {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('txStorageAcctName')]",
       "location": "[parameters('location')]",
@@ -113,6 +115,7 @@
       "properties": {}
     },
     {
+      "apiVersion": "2016-08-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('txVMNamePrefix'), copyIndex())]",
       "location": "[parameters('location')]",

--- a/ethereum-consortium-blockchain-network/nested/vmExtension.json
+++ b/ethereum-consortium-blockchain-network/nested/vmExtension.json
@@ -53,7 +53,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersionVirtualMachinesExtensions')]",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('txVMNamePrefix'), copyIndex(), '/newuserscript')]",
       "copy": {
@@ -77,7 +77,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersionVirtualMachinesExtensions')]",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('mnVMNamePrefix'), copyIndex(), '/newuserscript')]",
       "copy": {

--- a/ethereum-cpp-on-ubuntu/azuredeploy.json
+++ b/ethereum-cpp-on-ubuntu/azuredeploy.json
@@ -148,7 +148,7 @@
           "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
-          "computername": "[variables('vmName')]",
+          "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]"
         },

--- a/ethereum-cpp-on-ubuntu/azuredeploy.json
+++ b/ethereum-cpp-on-ubuntu/azuredeploy.json
@@ -69,14 +69,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -88,7 +88,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -135,7 +135,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -180,7 +180,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/github-enterprise/azuredeploy.json
+++ b/github-enterprise/azuredeploy.json
@@ -1,349 +1,349 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "accountPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique prefix for your Storage Account and VM name. Must be all lower case letters or numbers. No spaces or special characters."
-            }
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Username for the VM. This value is ignored."
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for the VM. This value is ignored."
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "metadata": {
-                "description": "VM Size. Select a DS v2 Series VM with at least 14 GB of RAM. Default value: Standard_DS3_v2"
-            },
-            "defaultValue": "Standard_DS3_v2",
-            "allowedValues": [
-                "Standard_DS3_v2",
-                "Standard_DS4_v2",
-                "Standard_DS12_v2",
-                "Standard_DS13_v2",
-                "Standard_DS14_v2",
-                "Standard_DS15_v2"
-            ]
-        },
-        "storageDiskSizeGB": {
-            "type": "string",
-            "metadata": {
-                "description": "Select a Premium Storage disk capacity for your source code, in GB. Default value: 512."
-            },
-            "defaultValue": "512"
-        }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "accountPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique prefix for your Storage Account and VM name. Must be all lower case letters or numbers. No spaces or special characters."
+      }
     },
-    "variables": {
-        "imagePublisher": "GitHub",
-        "imageOffer": "GitHub-Enterprise",
-        "OSDiskName": "osdiskforlinuxsimple",
-        "nicName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-nic')]",
-        "addressPrefix": "10.0.0.0/16",
-        "subnetName": "Subnet",
-        "subnetPrefix": "10.0.0.0/24",
-        "storageAccountType": "Premium_LRS",
-        "storageAccountName": "[concat(replace(replace(replace(parameters('accountPrefix'),'.',''),'_',''),'-',''), 'data')]",
-        "publicIPAddressName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-pub-ip')]",
-        "publicIPAddressType": "Dynamic",
-        "dnsNameForPublicIP": "[concat(parameters('accountPrefix'), '-ghe')]",
-        "vmStorageAccountContainerName": "vhds",
-        "vmName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-ghe-vm')]",
-        "virtualNetworkName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-vnet')]",
-        "networkSecurityGroupName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-nsg')]",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-        "dataDiskName": "ghe-data",
-        "dataDiskVHDName": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/','data-disks','/',variables('dataDiskName'),'.vhd')]",
-        "apiVersion": "2015-06-15"
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the VM. This value is ignored."
+      }
     },
-    "resources": [
-      {
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[variables('storageAccountName')]",
-        "apiVersion": "[variables('apiVersion')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "accountType": "[variables('storageAccountType')]"
-        }
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the VM. This value is ignored."
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "metadata": {
+        "description": "VM Size. Select a DS v2 Series VM with at least 14 GB of RAM. Default value: Standard_DS3_v2"
       },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[variables('publicIPAddressName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-          "dnsSettings": {
-            "domainNameLabel": "[variables('dnsNameForPublicIP')]"
+      "defaultValue": "Standard_DS3_v2",
+      "allowedValues": [
+        "Standard_DS3_v2",
+        "Standard_DS4_v2",
+        "Standard_DS12_v2",
+        "Standard_DS13_v2",
+        "Standard_DS14_v2",
+        "Standard_DS15_v2"
+      ]
+    },
+    "storageDiskSizeGB": {
+      "type": "string",
+      "metadata": {
+        "description": "Select a Premium Storage disk capacity for your source code, in GB. Default value: 512."
+      },
+      "defaultValue": "512"
+    }
+  },
+  "variables": {
+    "imagePublisher": "GitHub",
+    "imageOffer": "GitHub-Enterprise",
+    "OSDiskName": "osdiskforlinuxsimple",
+    "nicName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-nic')]",
+    "addressPrefix": "10.0.0.0/16",
+    "subnetName": "Subnet",
+    "subnetPrefix": "10.0.0.0/24",
+    "storageAccountType": "Premium_LRS",
+    "storageAccountName": "[concat(replace(replace(replace(parameters('accountPrefix'),'.',''),'_',''),'-',''), 'data')]",
+    "publicIPAddressName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-pub-ip')]",
+    "publicIPAddressType": "Dynamic",
+    "dnsNameForPublicIP": "[concat(parameters('accountPrefix'), '-ghe')]",
+    "vmStorageAccountContainerName": "vhds",
+    "vmName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-ghe-vm')]",
+    "virtualNetworkName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-vnet')]",
+    "networkSecurityGroupName": "[concat(replace(replace(parameters('accountPrefix'),'.',''),'_','-'), '-nsg')]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "dataDiskName": "ghe-data",
+    "dataDiskVHDName": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/','data-disks','/',variables('dataDiskName'),'.vhd')]",
+    "apiVersion": "2015-06-15"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[variables('dnsNameForPublicIP')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkSecurityGroups/', variables('networkSecurityGroupName'))]"
+      ],
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
+            }
           }
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[variables('virtualNetworkName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/networkSecurityGroups/', variables('networkSecurityGroupName'))]"
-        ],
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[variables('addressPrefix')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[variables('subnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('subnetPrefix')]",
-                "networkSecurityGroup": {
-                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[variables('nicName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfig1",
-              "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-                },
-                "subnet": {
-                  "id": "[variables('subnetRef')]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[variables('vmName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
-          "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-        ],
-        "properties": {
-          "hardwareProfile": {
-            "vmSize": "[parameters('vmSize')]"
-          },
-          "osProfile": {
-            "computerName": "[variables('vmName')]",
-            "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPassword')]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "[variables('imagePublisher')]",
-              "offer": "[variables('imageOffer')]",
-              "sku": "[variables('imageOffer')]",
-              "version": "latest"
-            },
-            "osDisk": {
-              "name": "osdisk",
-              "vhd": {
-                "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
               },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
-            },
-            "dataDisks": [
-              {
-                "name": "[variables('dataDiskName')]",
-                "diskSizeGB": "[parameters('storageDiskSizeGB')]",
-                "createOption": "empty",
-                "lun": 0,
-                "vhd": {
-                  "uri": "[variables('dataDiskVHDName')]"
-                }
+              "subnet": {
+                "id": "[variables('subnetRef')]"
               }
-            ]
-          },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-              }
-            ]
+            }
           }
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/networkSecurityGroups",
-        "name": "[variables('networkSecurityGroupName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "securityRules": [
-            {
-              "name": "https_8443",
-              "properties": {
-                "description": "https",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "8443",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 100,
-                "direction": "Inbound"
-              }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[variables('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('imageOffer')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
             },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          },
+          "dataDisks": [
             {
-              "name": "http_8080",
-              "properties": {
-                "description": "http plain text",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "8080",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 101,
-                "direction": "Inbound"
+              "name": "[variables('dataDiskName')]",
+              "diskSizeGB": "[parameters('storageDiskSizeGB')]",
+              "createOption": "empty",
+              "lun": 0,
+              "vhd": {
+                "uri": "[variables('dataDiskVHDName')]"
               }
-            },
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
             {
-              "name": "ssh_port_122",
-              "properties": {
-                "description": "Allow RDP",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "122",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 102,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "vpn_1194",
-              "properties": {
-                "description": "Allow VPN",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "1194",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 103,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "snmp_161",
-              "properties": {
-                "description": "Allow RDP",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "161",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 104,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "https_443",
-              "properties": {
-                "description": "Allow RDP",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "443",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 105,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "http_80",
-              "properties": {
-                "description": "Allow RDP",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "80",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 106,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "ssh_22",
-              "properties": {
-                "description": "Allow RDP",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "22",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 107,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "git_9418",
-              "properties": {
-                "description": "Allow RDP",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "9418",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 108,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "smtp_25",
-              "properties": {
-                "description": "Allow RDP",
-                "protocol": "*",
-                "sourcePortRange": "*",
-                "destinationPortRange": "25",
-                "sourceAddressPrefix": "Internet",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 109,
-                "direction": "Inbound"
-              }
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
             }
           ]
         }
       }
-    ]
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "https_8443",
+            "properties": {
+              "description": "https",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8443",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "http_8080",
+            "properties": {
+              "description": "http plain text",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8080",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 101,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "ssh_port_122",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "122",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 102,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "vpn_1194",
+            "properties": {
+              "description": "Allow VPN",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "1194",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 103,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "snmp_161",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "161",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 104,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "https_443",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 105,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "http_80",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 106,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "ssh_22",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 107,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "git_9418",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "9418",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 108,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "smtp_25",
+            "properties": {
+              "description": "Allow RDP",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "25",
+              "sourceAddressPrefix": "Internet",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 109,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/go-ethereum-on-ubuntu/azuredeploy.json
+++ b/go-ethereum-on-ubuntu/azuredeploy.json
@@ -70,14 +70,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -89,7 +89,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -110,7 +110,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -136,7 +136,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -181,7 +181,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/go-expanse-on-ubuntu/azuredeploy.json
+++ b/go-expanse-on-ubuntu/azuredeploy.json
@@ -63,14 +63,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -82,7 +82,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -103,7 +103,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -129,7 +129,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -174,7 +174,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/haproxy-redundant-floatingip-ubuntu/azuredeploy.json
+++ b/haproxy-redundant-floatingip-ubuntu/azuredeploy.json
@@ -58,9 +58,7 @@
   "variables": {
     "scriptsBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/haproxy-redundant-floatingip-ubuntu/",
     "apiVersion": "2015-06-15",
-
     "storageAccountName": "[concat(uniqueString(resourceGroup().id), 'haproxysa')]",
-
     "numberOfHAproxyInstances": 2,
     "masterHAproxyInstanceIndex": 0,
     "haproxyVMScripts": {
@@ -71,7 +69,6 @@
       ],
       "commandToExecute": "[concat('sudo bash -x haproxyvm-configure.sh ', ' -a ', parameters('appVMNamePrefix'), '0 -a ', parameters('appVMNamePrefix'), '1 -p ', variables('appVMPort'), ' -l ', parameters('lbDNSLabelPrefix'), '.', resourceGroup().location, '.cloudapp.azure.com -t ', variables('lbVIPPort'), ' -m ', parameters('haproxyVMNamePrefix'), '0 -b ', parameters('haproxyVMNamePrefix'), '1')]"
     },
-
     "numberOfAppInstances": 2,
     "appVMScripts": {
       "fileUris": [
@@ -80,23 +77,19 @@
       "commandToExecute": "sudo bash apache-setup.sh"
     },
     "appVMPort": 80,
-
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "nicNamePrefix": "nic-",
-
     "storageAccountType": "Standard_LRS",
     "haproxyAvailabilitySetName": "haproxyAvSet",
     "appAvailabilitySetName": "appAvSet",
-
     "vnetName": "haproxyVNet",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('vnetName'))]",
     "addressPrefix": "10.0.0.0/16",
     "subnetName": "Subnet-1",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables ('subnetName'))]",
     "subnetPrefix": "10.0.0.0/24",
-
     "lbName": "haproxyLB",
     "lbPublicIPAddressType": "Static",
     "lbPublicIPAddressName": "[concat(variables('lbName'), '-publicip')]",
@@ -108,7 +101,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -117,21 +110,21 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('haproxyAvailabilitySetName')]",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('appAvailabilitySetName')]",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('lbPublicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -143,7 +136,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('vnetName')]",
       "location": "[resourceGroup().location]",
@@ -164,7 +157,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -248,7 +241,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('haproxyVMNamePrefix'), variables('nicNamePrefix'), copyindex())]",
       "location": "[resourceGroup().location]",
@@ -285,7 +278,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('haproxyVMNamePrefix'), copyindex())]",
       "copy": {
@@ -352,7 +345,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('appVMNamePrefix'), variables('nicNamePrefix'), copyindex())]",
       "location": "[resourceGroup().location]",
@@ -378,7 +371,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('appVMNamePrefix'), copyindex())]",
       "copy": {
@@ -445,7 +438,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('appVMNamePrefix'), copyindex(), '/configureAppVM')]",
       "copy": {
@@ -468,7 +461,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('haproxyVMNamePrefix'), copyindex(), '/configureHAproxyVM')]",
       "copy": {

--- a/hazelcast-vm-cluster/azuredeploy.json
+++ b/hazelcast-vm-cluster/azuredeploy.json
@@ -182,214 +182,231 @@
       "[concat(parameters('templateBaseUrl'), 'pom.xml')]"
     ]
   },
-  "resources": [{
-    "type": "Microsoft.Storage/storageAccounts",
-    "name": "[variables('newStorageAccountName')]",
-    "apiVersion": "[variables('apiVersion')]",
-    "location": "[resourceGroup().location]",
-    "properties": {
-      "accountType": "[variables('storageAccountType')]"
-    }
-  }, {
-    "apiVersion": "[variables('apiVersion')]",
-    "type": "Microsoft.Network/publicIPAddresses",
-    "name": "[variables('publicIPAddressName')]",
-    "location": "[resourceGroup().location]",
-    "properties": {
-      "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-      "dnsSettings": {
-        "domainNameLabel": "[parameters('dnsPrefix')]"
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('newStorageAccountName')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
       }
-    }
-  }, {
-    "apiVersion": "[variables('apiVersion')]",
-    "type": "Microsoft.Network/virtualNetworks",
-    "name": "[variables('virtualNetworkName')]",
-    "location": "[resourceGroup().location]",
-    "properties": {
-      "addressSpace": {
-        "addressPrefixes": [
-          "[variables('addressPrefix')]"
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsPrefix')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('nicName'), '0')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('nicName'), copyIndex(1))]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
         ]
       },
-      "subnets": [{
-        "name": "[variables('subnetName')]",
-        "properties": {
-          "addressPrefix": "[variables('subnetPrefix')]"
-        }
-      }]
-    }
-  }, {
-    "apiVersion": "[variables('apiVersion')]",
-    "type": "Microsoft.Network/networkInterfaces",
-    "name": "[concat(variables('nicName'), '0')]",
-    "location": "[resourceGroup().location]",
-    "dependsOn": [
-      "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-      "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-    ],
-    "properties": {
-      "ipConfigurations": [{
-        "name": "ipconfig1",
-        "properties": {
-          "privateIPAllocationMethod": "Dynamic",
-          "publicIPAddress": {
-            "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-          },
-          "subnet": {
-            "id": "[variables('subnetRef')]"
-          }
-        }
-      }]
-    }
-  }, {
-    "apiVersion": "[variables('apiVersion')]",
-    "type": "Microsoft.Network/networkInterfaces",
-    "name": "[concat(variables('nicName'), copyIndex(1))]",
-    "location": "[resourceGroup().location]",
-    "dependsOn": [
-      "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-    ],
-    "properties": {
-      "ipConfigurations": [{
-        "name": "ipconfig1",
-        "properties": {
-          "privateIPAllocationMethod": "Dynamic",
-          "subnet": {
-            "id": "[variables('subnetRef')]"
-          }
-        }
-      }]
+      "copy": {
+        "name": "createNics",
+        "count": "[sub(parameters('instanceCount'), 1)]"
+      }
     },
-    "copy": {
-      "name": "createNics",
-      "count": "[sub(parameters('instanceCount'), 1)]"
-    }
-  }, {
-    "apiVersion": "[variables('apiVersion')]",
-    "type": "Microsoft.Compute/virtualMachines",
-    "name": "[concat(variables('vmName'), '0')]",
-    "location": "[resourceGroup().location]",
-    "dependsOn": [
-      "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
-      "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), '0')]"
-    ],
-    "tags": {
-      "[parameters('clusterName')]": "[parameters('clusterPort')]"
-    },
-    "properties": {
-      "hardwareProfile": {
-        "vmSize": "[parameters('vmSize')]"
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(variables('vmName'), '0')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), '0')]"
+      ],
+      "tags": {
+        "[parameters('clusterName')]": "[parameters('clusterPort')]"
       },
-      "osProfile": "[variables('osProfile')]",
-      "storageProfile": {
-        "imageReference": {
-          "publisher": "[variables('imagePublisher')]",
-          "offer": "[variables('imageOffer')]",
-          "sku": "[parameters('ubuntuOSVersion')]",
-          "version": "latest"
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
         },
-        "osDisk": {
-          "name": "osdisk1",
-          "vhd": {
-            "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'), '0', '.vhd')]"
+        "osProfile": "[variables('osProfile')]",
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('ubuntuOSVersion')]",
+            "version": "latest"
           },
-          "caching": "ReadWrite",
-          "createOption": "FromImage"
-        }
-      },
-      "networkProfile": {
-        "networkInterfaces": [{
-          "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), '0'))]"
-        }]
-      }
-    }
-  },
-  {
-    "apiVersion": "[variables('apiVersion')]",
-    "type": "Microsoft.Compute/virtualMachines",
-    "name": "[concat(variables('vmName'), copyIndex(1))]",
-    "location": "[resourceGroup().location]",
-    "dependsOn": [
-      "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
-      "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex(1))]",
-      "createNics"
-    ],
-    "tags": {
-      "[parameters('clusterName')]": "[parameters('clusterPort')]"
-    },
-    "properties": {
-      "hardwareProfile": {
-        "vmSize": "[parameters('vmSize')]"
-      },
-      "osProfile": "[variables('osProfile')]",
-      "storageProfile": {
-        "imageReference": {
-          "publisher": "[variables('imagePublisher')]",
-          "offer": "[variables('imageOffer')]",
-          "sku": "[parameters('ubuntuOSVersion')]",
-          "version": "latest"
+          "osDisk": {
+            "name": "osdisk1",
+            "vhd": {
+              "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'), '0', '.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
         },
-        "osDisk": {
-          "name": "osdisk1",
-          "vhd": {
-            "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'), copyIndex(1), '.vhd')]"
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('nicName'), '0'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(variables('vmName'), copyIndex(1))]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('newStorageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex(1))]",
+        "createNics"
+      ],
+      "tags": {
+        "[parameters('clusterName')]": "[parameters('clusterPort')]"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": "[variables('osProfile')]",
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[parameters('ubuntuOSVersion')]",
+            "version": "latest"
           },
-          "caching": "ReadWrite",
-          "createOption": "FromImage"
+          "osDisk": {
+            "name": "osdisk1",
+            "vhd": {
+              "uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'), copyIndex(1), '.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'), copyIndex(1)))]"
+            }
+          ]
         }
       },
-      "networkProfile": {
-        "networkInterfaces": [{
-          "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'), copyIndex(1)))]"
-        }]
+      "copy": {
+        "name": "createVms",
+        "count": "[sub(parameters('instanceCount'), 1)]"
       }
     },
-    "copy": {
-      "name": "createVms",
-      "count": "[sub(parameters('instanceCount'), 1)]"
-    }
-  },
-  {
-    "type": "Microsoft.Compute/virtualMachines/extensions",
-    "name": "[concat(variables('vmName'), 0, '/initHazelcast')]",
-    "apiVersion": "[variables('apiVersion')]",
-    "location": "[resourceGroup().location]",
-    "dependsOn": [
-      "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '0')]"
-    ],
-    "properties": {
-      "publisher": "Microsoft.Azure.Extensions",
-      "type": "CustomScript",
-      "typeHandlerVersion": "2.0",
-      "autoUpgradeMinorVersion": true,
-      "settings": {
-        "fileUris": "[variables('bootstrapFiles')]",
-        "commandToExecute": "[concat('sh bootstrap_hazelcast ', parameters('minHeapSizeInGB'), ' ', parameters('maxHeapSizeInGB'), ' ', parameters('clusterUserName'), ' ', parameters('clusterPassword'), ' ', subscription().subscriptionId, ' ', parameters('aadClientId'), ' ',  parameters('aadClientSecret'), ' ',  parameters('aadTenantId'), ' ', resourceGroup().name, ' ', parameters('clusterName'))]"
-      }
-    }
-  },
-  {
-    "type": "Microsoft.Compute/virtualMachines/extensions",
-    "name": "[concat(variables('vmName'), copyIndex(1),'/initHazelcast')]",
-    "apiVersion": "[variables('apiVersion')]",
-    "location": "[resourceGroup().location]",
-    "dependsOn": [
-      "createVms"
-    ],
-    "properties": {
-      "publisher": "Microsoft.Azure.Extensions",
-      "type": "CustomScript",
-      "typeHandlerVersion": "2.0",
-      "autoUpgradeMinorVersion": true,
-      "settings": {
-        "fileUris": "[variables('bootstrapFiles')]",
-        "commandToExecute": "[concat('sh bootstrap_hazelcast ', parameters('minHeapSizeInGB'), ' ', parameters('maxHeapSizeInGB'), ' ', parameters('clusterUserName'), ' ', parameters('clusterPassword'), ' ', subscription().subscriptionId, ' ', parameters('aadClientId'), ' ',  parameters('aadClientSecret'), ' ',  parameters('aadTenantId'), ' ', resourceGroup().name, ' ', parameters('clusterName'))]"
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmName'), 0, '/initHazelcast')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '0')]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": "[variables('bootstrapFiles')]",
+          "commandToExecute": "[concat('sh bootstrap_hazelcast ', parameters('minHeapSizeInGB'), ' ', parameters('maxHeapSizeInGB'), ' ', parameters('clusterUserName'), ' ', parameters('clusterPassword'), ' ', subscription().subscriptionId, ' ', parameters('aadClientId'), ' ',  parameters('aadClientSecret'), ' ',  parameters('aadTenantId'), ' ', resourceGroup().name, ' ', parameters('clusterName'))]"
+        }
       }
     },
-    "copy": {
-      "name": "createExtensions",
-      "count": "[sub(parameters('instanceCount'), 1)]"
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmName'), copyIndex(1),'/initHazelcast')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "createVms"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": "[variables('bootstrapFiles')]",
+          "commandToExecute": "[concat('sh bootstrap_hazelcast ', parameters('minHeapSizeInGB'), ' ', parameters('maxHeapSizeInGB'), ' ', parameters('clusterUserName'), ' ', parameters('clusterPassword'), ' ', subscription().subscriptionId, ' ', parameters('aadClientId'), ' ',  parameters('aadClientSecret'), ' ',  parameters('aadTenantId'), ' ', resourceGroup().name, ' ', parameters('clusterName'))]"
+        }
+      },
+      "copy": {
+        "name": "createExtensions",
+        "count": "[sub(parameters('instanceCount'), 1)]"
+      }
     }
-  }
-]}
+  ]
+}

--- a/hdInsight-apache-spark/azuredeploy.json
+++ b/hdInsight-apache-spark/azuredeploy.json
@@ -1,206 +1,203 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "clusterName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the HDInsight cluster to create."
-            }
-        },
-        "loginUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "These credentials can be used to submit jobs to the cluster, log into cluster dashboards, log into Ambari, and SSH into the cluster."
-            }
-        },
-        "loginPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-            }
-        },
-        "clusterNodeSize": {
-            "type": "string",
-            "defaultValue": "Standard_D12",
-            "allowedValues": [
-                "Standard_D12",
-                "Standard_D13",
-                "Standard_D14"
-            ],
-            "metadata": {
-                "description": "All nodes will be deployed using the specified hardware profile: D12(4 CPU Cores, 28GB of RAM), D13(8 CPU Cores, 56GB of RAM), D14(16 CPU Cores, 112 GB of RAM)."
-            }
-        },
-        "clusterWorkerNodeCount": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "The number of worker nodes in the HDInsight cluster."
-            }
-        }
-     },
-    "variables": {
-        "defaultApiVersion": "2015-06-15",
-        "clusterApiVersion": "2015-03-01-preview",
-        "clusterType": "hadoop",
-        "clusterVnetSubnetName": "[concat(parameters('clusterName'),'-subnet')]",
-        "clusterVnetAddressSpace": "172.16.228.0/23",
-        "clusterVNetSubnetAddressRange": "172.16.229.0/24",
-        "clusterStorageAccountName": "[concat(parameters('clusterName'),'storeacc')]",
-        "clusterVNetName": "[concat(parameters('clusterName'),'-vnet')]",
-        "hadoopZookeeperSize": "Small",
-        "hbaseZookeeperSize": "Medium"
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the HDInsight cluster to create."
+      }
     },
-    "resources": [
-      {
-        "name": "[variables('clusterVNetName')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('defaultApiVersion')]",
-        "dependsOn": [ ],
-        "tags": { },
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[variables('clusterVNetAddressSpace')]"
-            ]
-          },
-          "subnets": [
+    "loginUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "These credentials can be used to submit jobs to the cluster, log into cluster dashboards, log into Ambari, and SSH into the cluster."
+      }
+    },
+    "loginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+      }
+    },
+    "clusterNodeSize": {
+      "type": "string",
+      "defaultValue": "Standard_D12",
+      "allowedValues": [
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14"
+      ],
+      "metadata": {
+        "description": "All nodes will be deployed using the specified hardware profile: D12(4 CPU Cores, 28GB of RAM), D13(8 CPU Cores, 56GB of RAM), D14(16 CPU Cores, 112 GB of RAM)."
+      }
+    },
+    "clusterWorkerNodeCount": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "The number of worker nodes in the HDInsight cluster."
+      }
+    }
+  },
+  "variables": {
+    "defaultApiVersion": "2015-06-15",
+    "clusterApiVersion": "2015-03-01-preview",
+    "clusterType": "hadoop",
+    "clusterVnetSubnetName": "[concat(parameters('clusterName'),'-subnet')]",
+    "clusterVnetAddressSpace": "172.16.228.0/23",
+    "clusterVNetSubnetAddressRange": "172.16.229.0/24",
+    "clusterStorageAccountName": "[concat(parameters('clusterName'),'storeacc')]",
+    "clusterVNetName": "[concat(parameters('clusterName'),'-vnet')]",
+    "hadoopZookeeperSize": "Small",
+    "hbaseZookeeperSize": "Medium"
+  },
+  "resources": [
+    {
+      "name": "[variables('clusterVNetName')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
+      "tags": {},
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('clusterVNetAddressSpace')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('clusterVNetSubnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('clusterVNetSubnetAddressRange')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[variables('clusterStorageAccountName')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
+      "tags": {},
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "name": "[parameters('clusterName')]",
+      "type": "Microsoft.HDInsight/clusters",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-03-01-preview",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/',variables('clusterVNetName'))]"
+      ],
+      "tags": {},
+      "properties": {
+        "clusterVersion": "3.2",
+        "osType": "Linux",
+        "clusterDefinition": {
+          "kind": "[variables('clusterType')]",
+          "configurations": {
+            "gateway": {
+              "restAuthCredential.isEnabled": true,
+              "restAuthCredential.username": "[parameters('loginUsername')]",
+              "restAuthCredential.password": "[parameters('loginPassword')]"
+            },
+            "hive-site": {
+              "hive.metastore.client.connect.retry.delay": "5",
+              "hive.execution.engine": "mr",
+              "hive.security.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider"
+            }
+          }
+        },
+        "storageProfile": {
+          "storageaccounts": [
             {
-              "name": "[variables('clusterVNetSubnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('clusterVNetSubnetAddressRange')]"
+              "name": "[concat(variables('clusterStorageAccountName'),'.blob.core.windows.net')]",
+              "isDefault": true,
+              "container": "[parameters('clusterName')]",
+              "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
+            }
+          ]
+        },
+        "computeProfile": {
+          "roles": [
+            {
+              "name": "headnode",
+              "targetInstanceCount": "2",
+              "hardwareProfile": {
+                "vmSize": "[parameters('clusterNodeSize')]"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('loginUsername')]",
+                  "password": "[parameters('loginPassword')]"
+                }
+              },
+              "virtualNetworkProfile": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
+                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
+              },
+              "scriptActions": [
+                {
+                  "name": "Apache Spark 1.4.1",
+                  "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/hdInsight-apache-spark/spark141-installer-v04.sh",
+                  "parameters": ""
+                }
+              ]
+            },
+            {
+              "name": "workernode",
+              "targetInstanceCount": "[parameters('clusterWorkerNodeCount')]",
+              "hardwareProfile": {
+                "vmSize": "[parameters('clusterNodeSize')]"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('loginUsername')]",
+                  "password": "[parameters('loginPassword')]"
+                }
+              },
+              "virtualNetworkProfile": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
+                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
+              }
+            },
+            {
+              "name": "zookeepernode",
+              "targetInstanceCount": "3",
+              "hardwareProfile": {
+                "vmSize": "[variables(concat(variables('clusterType'),'ZookeeperSize'))]"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('loginUsername')]",
+                  "password": "[parameters('loginPassword')]"
+                }
+              },
+              "virtualNetworkProfile": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
+                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
               }
             }
           ]
         }
-      },
-      {
-        "name": "[variables('clusterStorageAccountName')]",
-        "type": "Microsoft.Storage/storageAccounts",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('defaultApiVersion')]",
-        "dependsOn": [ ],
-        "tags": { },
-        "properties": {
-          "accountType": "Standard_LRS"
-        }
-      },
-      {
-        "name": "[parameters('clusterName')]",
-        "type": "Microsoft.HDInsight/clusters",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('clusterApiVersion')]",
-        "dependsOn": [
-          "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/',variables('clusterVNetName'))]"
-        ],
-        "tags": { },
-        "properties": {
-          "clusterVersion": "3.2",
-          "osType": "Linux",
-          "clusterDefinition": {
-            "kind": "[variables('clusterType')]",
-
-            "configurations": {
-              "gateway": {
-                "restAuthCredential.isEnabled": true,
-                "restAuthCredential.username": "[parameters('loginUsername')]",
-                "restAuthCredential.password": "[parameters('loginPassword')]"
-              },
-              "hive-site": {
-                "hive.metastore.client.connect.retry.delay": "5",
-                "hive.execution.engine": "mr",
-                "hive.security.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider"
-              }
-            }
-          },
-          "storageProfile": {
-            "storageaccounts": [
-              {
-                "name": "[concat(variables('clusterStorageAccountName'),'.blob.core.windows.net')]",
-                "isDefault": true,
-                "container": "[parameters('clusterName')]",
-                "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
-              }
-            ]
-          },
-          "computeProfile": {
-            "roles": [
-              {
-                "name": "headnode",
-                "targetInstanceCount": "2",
-                "hardwareProfile": {
-                  "vmSize": "[parameters('clusterNodeSize')]"
-                },
-                "osProfile": {
-                  "linuxOperatingSystemProfile": {
-                    "username": "[parameters('loginUsername')]",
-                    "password": "[parameters('loginPassword')]"
-                  }
-                },
-                "virtualNetworkProfile": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
-                  "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
-                },
-                "scriptActions": [
-                  {
-                    "name": "Apache Spark 1.4.1",
-                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/hdInsight-apache-spark/spark141-installer-v04.sh",
-                    "parameters": ""
-                  }
-                ]
-              },
-              {
-                "name": "workernode",
-                "targetInstanceCount": "[parameters('clusterWorkerNodeCount')]",
-                "hardwareProfile": {
-                  "vmSize": "[parameters('clusterNodeSize')]"
-                },
-                "osProfile": {
-                  "linuxOperatingSystemProfile": {
-                    "username": "[parameters('loginUsername')]",
-                    "password": "[parameters('loginPassword')]"
-                  }
-                },
-                "virtualNetworkProfile": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
-                  "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
-                }
-              },
-              {
-                "name": "zookeepernode",
-                "targetInstanceCount": "3",
-                "hardwareProfile": {
-                  "vmSize": "[variables(concat(variables('clusterType'),'ZookeeperSize'))]"
-                },
-                "osProfile": {
-                  "linuxOperatingSystemProfile": {
-                    "username": "[parameters('loginUsername')]",
-                    "password": "[parameters('loginPassword')]"
-                  }
-                },
-                "virtualNetworkProfile": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
-                  "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
-                }
-              }
-            ]
-          }
-        }
       }
-
-    ],
-    "outputs": {
-        "vnet": {
-            "type": "object",
-            "value": "[reference(resourceId('Microsoft.Network/virtualNetworks',variables('clusterVNetName')))]"
-        },
-        "cluster":{
-            "type" : "object",
-            "value" : "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
-        }
     }
+  ],
+  "outputs": {
+    "vnet": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks',variables('clusterVNetName')))]"
+    },
+    "cluster": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
+    }
+  }
 }
-

--- a/hdinsight-genomics-adam/azuredeploy.json
+++ b/hdinsight-genomics-adam/azuredeploy.json
@@ -1,206 +1,203 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "clusterName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the HDInsight cluster to create."
-            }
-        },
-        "loginUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "These credentials can be used to submit jobs to the cluster, log into cluster dashboards, log into Ambari, and SSH into the cluster."
-            }
-        },
-        "loginPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-            }
-        },
-        "clusterNodeSize": {
-            "type": "string",
-            "defaultValue": "Standard_D12",
-            "allowedValues": [
-                "Standard_D12",
-                "Standard_D13",
-                "Standard_D14"
-            ],
-            "metadata": {
-                "description": "All nodes will be deployed using the specified hardware profile: D12(4 CPU Cores, 28GB of RAM), D13(8 CPU Cores, 56GB of RAM), D14(16 CPU Cores, 112 GB of RAM)."
-            }
-        },
-        "clusterWorkerNodeCount": {
-            "type": "int",
-            "defaultValue": 2,
-            "metadata": {
-                "description": "The number of worker nodes in the HDInsight cluster."
-            }
-        }
-     },
-    "variables": {
-        "defaultApiVersion": "2015-06-15",
-        "clusterApiVersion": "2015-03-01-preview",
-        "clusterType": "hadoop",
-        "clusterVnetSubnetName": "[concat(parameters('clusterName'),'-subnet')]",
-        "clusterVnetAddressSpace": "172.16.228.0/23",
-        "clusterVNetSubnetAddressRange": "172.16.229.0/24",
-        "clusterStorageAccountName": "[concat(parameters('clusterName'),'storeacc')]",
-        "clusterVNetName": "[concat(parameters('clusterName'),'-vnet')]",
-        "hadoopZookeeperSize": "Small",
-        "hbaseZookeeperSize": "Medium"
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the HDInsight cluster to create."
+      }
     },
-    "resources": [
-      {
-        "name": "[variables('clusterVNetName')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('defaultApiVersion')]",
-        "dependsOn": [ ],
-        "tags": { },
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[variables('clusterVNetAddressSpace')]"
-            ]
-          },
-          "subnets": [
+    "loginUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "These credentials can be used to submit jobs to the cluster, log into cluster dashboards, log into Ambari, and SSH into the cluster."
+      }
+    },
+    "loginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+      }
+    },
+    "clusterNodeSize": {
+      "type": "string",
+      "defaultValue": "Standard_D12",
+      "allowedValues": [
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14"
+      ],
+      "metadata": {
+        "description": "All nodes will be deployed using the specified hardware profile: D12(4 CPU Cores, 28GB of RAM), D13(8 CPU Cores, 56GB of RAM), D14(16 CPU Cores, 112 GB of RAM)."
+      }
+    },
+    "clusterWorkerNodeCount": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "The number of worker nodes in the HDInsight cluster."
+      }
+    }
+  },
+  "variables": {
+    "defaultApiVersion": "2015-06-15",
+    "clusterApiVersion": "2015-03-01-preview",
+    "clusterType": "hadoop",
+    "clusterVnetSubnetName": "[concat(parameters('clusterName'),'-subnet')]",
+    "clusterVnetAddressSpace": "172.16.228.0/23",
+    "clusterVNetSubnetAddressRange": "172.16.229.0/24",
+    "clusterStorageAccountName": "[concat(parameters('clusterName'),'storeacc')]",
+    "clusterVNetName": "[concat(parameters('clusterName'),'-vnet')]",
+    "hadoopZookeeperSize": "Small",
+    "hbaseZookeeperSize": "Medium"
+  },
+  "resources": [
+    {
+      "name": "[variables('clusterVNetName')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
+      "tags": {},
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('clusterVNetAddressSpace')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('clusterVNetSubnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('clusterVNetSubnetAddressRange')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[variables('clusterStorageAccountName')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
+      "tags": {},
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "name": "[parameters('clusterName')]",
+      "type": "Microsoft.HDInsight/clusters",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-03-01-preview",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/',variables('clusterVNetName'))]"
+      ],
+      "tags": {},
+      "properties": {
+        "clusterVersion": "3.2",
+        "osType": "Linux",
+        "clusterDefinition": {
+          "kind": "[variables('clusterType')]",
+          "configurations": {
+            "gateway": {
+              "restAuthCredential.isEnabled": true,
+              "restAuthCredential.username": "[parameters('loginUsername')]",
+              "restAuthCredential.password": "[parameters('loginPassword')]"
+            },
+            "hive-site": {
+              "hive.metastore.client.connect.retry.delay": "5",
+              "hive.execution.engine": "mr",
+              "hive.security.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider"
+            }
+          }
+        },
+        "storageProfile": {
+          "storageaccounts": [
             {
-              "name": "[variables('clusterVNetSubnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('clusterVNetSubnetAddressRange')]"
+              "name": "[concat(variables('clusterStorageAccountName'),'.blob.core.windows.net')]",
+              "isDefault": true,
+              "container": "[parameters('clusterName')]",
+              "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
+            }
+          ]
+        },
+        "computeProfile": {
+          "roles": [
+            {
+              "name": "headnode",
+              "targetInstanceCount": "2",
+              "hardwareProfile": {
+                "vmSize": "[parameters('clusterNodeSize')]"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('loginUsername')]",
+                  "password": "[parameters('loginPassword')]"
+                }
+              },
+              "virtualNetworkProfile": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
+                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
+              },
+              "scriptActions": [
+                {
+                  "name": "Genome Analysis Platform -- ADAM",
+                  "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/hdinsight-genomics-adam/adam-installer-v03.sh",
+                  "parameters": ""
+                }
+              ]
+            },
+            {
+              "name": "workernode",
+              "targetInstanceCount": "[parameters('clusterWorkerNodeCount')]",
+              "hardwareProfile": {
+                "vmSize": "[parameters('clusterNodeSize')]"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('loginUsername')]",
+                  "password": "[parameters('loginPassword')]"
+                }
+              },
+              "virtualNetworkProfile": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
+                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
+              }
+            },
+            {
+              "name": "zookeepernode",
+              "targetInstanceCount": "3",
+              "hardwareProfile": {
+                "vmSize": "[variables(concat(variables('clusterType'),'ZookeeperSize'))]"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('loginUsername')]",
+                  "password": "[parameters('loginPassword')]"
+                }
+              },
+              "virtualNetworkProfile": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
+                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
               }
             }
           ]
         }
-      },
-      {
-        "name": "[variables('clusterStorageAccountName')]",
-        "type": "Microsoft.Storage/storageAccounts",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('defaultApiVersion')]",
-        "dependsOn": [ ],
-        "tags": { },
-        "properties": {
-          "accountType": "Standard_LRS"
-        }
-      },
-      {
-        "name": "[parameters('clusterName')]",
-        "type": "Microsoft.HDInsight/clusters",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('clusterApiVersion')]",
-        "dependsOn": [
-          "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/',variables('clusterVNetName'))]"
-        ],
-        "tags": { },
-        "properties": {
-          "clusterVersion": "3.2",
-          "osType": "Linux",
-          "clusterDefinition": {
-            "kind": "[variables('clusterType')]",
-
-            "configurations": {
-              "gateway": {
-                "restAuthCredential.isEnabled": true,
-                "restAuthCredential.username": "[parameters('loginUsername')]",
-                "restAuthCredential.password": "[parameters('loginPassword')]"
-              },
-              "hive-site": {
-                "hive.metastore.client.connect.retry.delay": "5",
-                "hive.execution.engine": "mr",
-                "hive.security.authorization.manager": "org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider"
-              }
-            }
-          },
-          "storageProfile": {
-            "storageaccounts": [
-              {
-                "name": "[concat(variables('clusterStorageAccountName'),'.blob.core.windows.net')]",
-                "isDefault": true,
-                "container": "[parameters('clusterName')]",
-                "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
-              }
-            ]
-          },
-          "computeProfile": {
-            "roles": [
-              {
-                "name": "headnode",
-                "targetInstanceCount": "2",
-                "hardwareProfile": {
-                  "vmSize": "[parameters('clusterNodeSize')]"
-                },
-                "osProfile": {
-                  "linuxOperatingSystemProfile": {
-                    "username": "[parameters('loginUsername')]",
-                    "password": "[parameters('loginPassword')]"
-                  }
-                },
-                "virtualNetworkProfile": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
-                  "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
-                },
-                "scriptActions": [
-                  {
-                    "name": "Genome Analysis Platform -- ADAM",
-                    "uri": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/hdinsight-genomics-adam/adam-installer-v03.sh",
-                    "parameters": ""
-                  }
-                ]
-              },
-              {
-                "name": "workernode",
-                "targetInstanceCount": "[parameters('clusterWorkerNodeCount')]",
-                "hardwareProfile": {
-                  "vmSize": "[parameters('clusterNodeSize')]"
-                },
-                "osProfile": {
-                  "linuxOperatingSystemProfile": {
-                    "username": "[parameters('loginUsername')]",
-                    "password": "[parameters('loginPassword')]"
-                  }
-                },
-                "virtualNetworkProfile": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
-                  "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
-                }
-              },
-              {
-                "name": "zookeepernode",
-                "targetInstanceCount": "3",
-                "hardwareProfile": {
-                  "vmSize": "[variables(concat(variables('clusterType'),'ZookeeperSize'))]"
-                },
-                "osProfile": {
-                  "linuxOperatingSystemProfile": {
-                    "username": "[parameters('loginUsername')]",
-                    "password": "[parameters('loginPassword')]"
-                  }
-                },
-                "virtualNetworkProfile": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
-                  "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', variables('clusterVNetSubnetName'))]"
-                }
-              }
-            ]
-          }
-        }
       }
-
-    ],
-    "outputs": {
-        "vnet": {
-            "type": "object",
-            "value": "[reference(resourceId('Microsoft.Network/virtualNetworks',variables('clusterVNetName')))]"
-        },
-        "cluster":{
-            "type" : "object",
-            "value" : "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
-        }
     }
+  ],
+  "outputs": {
+    "vnet": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks',variables('clusterVNetName')))]"
+    },
+    "cluster": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
+    }
+  }
 }
-

--- a/hdinsight-linux-run-script-action/azuredeploy.json
+++ b/hdinsight-linux-run-script-action/azuredeploy.json
@@ -1,254 +1,252 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "clusterVNetAddressSpace": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/16",
-            "metadata": {
-                "description": "The virtual network's address range in CIDR notion. It must be contained in one of the standard private address spaces: 10.0.0.0/8, 172.160.0.0/12, or 192.168.0.0/16."
-            }
-        },
-        "clusterVNetSubnetName": {
-            "type": "string",
-            "defaultValue": "default",
-            "metadata": {
-                "description": "The name of the subnet to create in the virtual network."
-            }
-        },
-        "clusterVNetSubnetAddressRange": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/24",
-            "metadata": {
-                "description": "The subnet's address range in CIDR notation. It must be contained by the address space of the virtual network."
-            }
-        },
-        "clusterName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the HDInsight cluster to create."
-            }
-        },
-        "clusterType": {
-            "type": "string",
-            "defaultValue": "hadoop",
-            "allowedValues": [
-                "hadoop",
-                "hbase"
-            ],
-            "metadata": {
-                "description": "The type of HDInsight cluster to create."
-            }
-        },
-        "clusterLoginUserName": {
-            "type": "string",
-            "metadata": {
-                "description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
-            }
-        },
-        "clusterLoginPassword": {
-            "type": "securestring",
-            "metadata": { 
-                "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-            }
-        },
-        "sshUserName": {
-            "type": "string",
-            "metadata": {
-                "description": "These credentials can be used to remotely access the cluster and the edge node virtual machine."
-            }
-        },
-        "sshPassword": {
-            "type": "securestring",
-            "metadata": { 
-                "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-            }
-        },
-        "clusterStorageAccountName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the storage account to be created and be used as the cluster's storage."
-            }
-        },
-        "clusterWorkerNodeCount": {
-            "type": "int",
-            "defaultValue": 4,
-            "metadata": {
-                "description": "The number of nodes in the HDInsight cluster."
-            }
-        },
-        "scriptActionUri": {
-            "type": "string",
-            "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/hdinsight-linux-run-script-action/setEnvVar.sh",
-            "metadata": { 
-                "description": "A public http(s) uri that points to a script action which will set an environment variable on each node."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterVNetAddressSpace": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "The virtual network's address range in CIDR notion. It must be contained in one of the standard private address spaces: 10.0.0.0/8, 172.160.0.0/12, or 192.168.0.0/16."
+      }
     },
-    "variables": {
-        "defaultApiVersion": "2015-05-01-preview",
-        "clusterApiVersion": "2015-03-01-preview",
-        "clusterVNetName": "[concat(parameters('clusterName'),'-vnet')]",
-        "hadoopZookeeperSize": "Small",
-        "hbaseZookeeperSize": "Medium"
+    "clusterVNetSubnetName": {
+      "type": "string",
+      "defaultValue": "default",
+      "metadata": {
+        "description": "The name of the subnet to create in the virtual network."
+      }
     },
-    "resources": [
-      {
-        "name": "[variables('clusterVNetName')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('defaultApiVersion')]",
-        "dependsOn": [ ],
-        "tags": { },
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[parameters('clusterVNetAddressSpace')]"
-            ]
-          },
-          "subnets": [
+    "clusterVNetSubnetAddressRange": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/24",
+      "metadata": {
+        "description": "The subnet's address range in CIDR notation. It must be contained by the address space of the virtual network."
+      }
+    },
+    "clusterName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the HDInsight cluster to create."
+      }
+    },
+    "clusterType": {
+      "type": "string",
+      "defaultValue": "hadoop",
+      "allowedValues": [
+        "hadoop",
+        "hbase"
+      ],
+      "metadata": {
+        "description": "The type of HDInsight cluster to create."
+      }
+    },
+    "clusterLoginUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "These credentials can be used to submit jobs to the cluster and to log into cluster dashboards."
+      }
+    },
+    "clusterLoginPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+      }
+    },
+    "sshUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "These credentials can be used to remotely access the cluster and the edge node virtual machine."
+      }
+    },
+    "sshPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+      }
+    },
+    "clusterStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the storage account to be created and be used as the cluster's storage."
+      }
+    },
+    "clusterWorkerNodeCount": {
+      "type": "int",
+      "defaultValue": 4,
+      "metadata": {
+        "description": "The number of nodes in the HDInsight cluster."
+      }
+    },
+    "scriptActionUri": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/hdinsight-linux-run-script-action/setEnvVar.sh",
+      "metadata": {
+        "description": "A public http(s) uri that points to a script action which will set an environment variable on each node."
+      }
+    }
+  },
+  "variables": {
+    "defaultApiVersion": "2015-05-01-preview",
+    "clusterApiVersion": "2015-03-01-preview",
+    "clusterVNetName": "[concat(parameters('clusterName'),'-vnet')]",
+    "hadoopZookeeperSize": "Small",
+    "hbaseZookeeperSize": "Medium"
+  },
+  "resources": [
+    {
+      "name": "[variables('clusterVNetName')]",
+      "type": "Microsoft.Network/virtualNetworks",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-05-01-preview",
+      "dependsOn": [],
+      "tags": {},
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('clusterVNetAddressSpace')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('clusterVNetSubnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('clusterVNetSubnetAddressRange')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[parameters('clusterStorageAccountName')]",
+      "type": "Microsoft.Storage/storageAccounts",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-05-01-preview",
+      "dependsOn": [],
+      "tags": {},
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "name": "[parameters('clusterName')]",
+      "type": "Microsoft.HDInsight/clusters",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-03-01-preview",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/',parameters('clusterStorageAccountName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/',variables('clusterVNetName'))]"
+      ],
+      "tags": {},
+      "properties": {
+        "clusterVersion": "3.2",
+        "osType": "Linux",
+        "clusterDefinition": {
+          "kind": "[parameters('clusterType')]",
+          "configurations": {
+            "gateway": {
+              "restAuthCredential.isEnabled": true,
+              "restAuthCredential.username": "[parameters('clusterLoginUserName')]",
+              "restAuthCredential.password": "[parameters('clusterLoginPassword')]"
+            }
+          }
+        },
+        "storageProfile": {
+          "storageaccounts": [
             {
-              "name": "[parameters('clusterVNetSubnetName')]",
-              "properties": {
-                "addressPrefix": "[parameters('clusterVNetSubnetAddressRange')]"
-              }
+              "name": "[concat(parameters('clusterStorageAccountName'),'.blob.core.windows.net')]",
+              "isDefault": true,
+              "container": "[parameters('clusterName')]",
+              "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
+            }
+          ]
+        },
+        "computeProfile": {
+          "roles": [
+            {
+              "name": "headnode",
+              "targetInstanceCount": "2",
+              "hardwareProfile": {
+                "vmSize": "Large"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('sshUserName')]",
+                  "password": "[parameters('sshPassword')]"
+                }
+              },
+              "virtualNetworkProfile": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
+                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', parameters('clusterVNetSubnetName'))]"
+              },
+              "scriptActions": [
+                {
+                  "name": "setenvironmentvariable",
+                  "uri": "[parameters('scriptActionUri')]",
+                  "parameters": "headnode"
+                }
+              ]
+            },
+            {
+              "name": "workernode",
+              "targetInstanceCount": "[parameters('clusterWorkerNodeCount')]",
+              "hardwareProfile": {
+                "vmSize": "Large"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('sshUserName')]",
+                  "password": "[parameters('sshPassword')]"
+                }
+              },
+              "virtualNetworkProfile": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
+                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', parameters('clusterVNetSubnetName'))]"
+              },
+              "scriptActions": [
+                {
+                  "name": "setenvironmentvariable",
+                  "uri": "[parameters('scriptActionUri')]",
+                  "parameters": "workernode"
+                }
+              ]
+            },
+            {
+              "name": "zookeepernode",
+              "targetInstanceCount": "3",
+              "hardwareProfile": {
+                "vmSize": "[variables(concat(parameters('clusterType'),'ZookeeperSize'))]"
+              },
+              "osProfile": {
+                "linuxOperatingSystemProfile": {
+                  "username": "[parameters('sshUserName')]",
+                  "password": "[parameters('sshPassword')]"
+                }
+              },
+              "virtualNetworkProfile": {
+                "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
+                "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', parameters('clusterVNetSubnetName'))]"
+              },
+              "scriptActions": [
+                {
+                  "name": "setenvironmentvariable",
+                  "uri": "[parameters('scriptActionUri')]",
+                  "parameters": "zookeepernode"
+                }
+              ]
             }
           ]
         }
-      },
-      {
-        "name": "[parameters('clusterStorageAccountName')]",
-        "type": "Microsoft.Storage/storageAccounts",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('defaultApiVersion')]",
-        "dependsOn": [ ],
-        "tags": { },
-        "properties": {
-          "accountType": "Standard_LRS"
-        }
-      },
-      {
-        "name": "[parameters('clusterName')]",
-        "type": "Microsoft.HDInsight/clusters",
-        "location": "[resourceGroup().location]",
-        "apiVersion": "[variables('clusterApiVersion')]",
-        "dependsOn": [
-          "[concat('Microsoft.Storage/storageAccounts/',parameters('clusterStorageAccountName'))]",
-          "[concat('Microsoft.Network/virtualNetworks/',variables('clusterVNetName'))]"
-        ],
-        "tags": { },
-        "properties": {
-          "clusterVersion": "3.2",
-          "osType": "Linux",
-          "clusterDefinition": {
-            "kind": "[parameters('clusterType')]",
-
-            "configurations": {
-              "gateway": {
-                "restAuthCredential.isEnabled": true,
-                "restAuthCredential.username": "[parameters('clusterLoginUserName')]",
-                "restAuthCredential.password": "[parameters('clusterLoginPassword')]"
-              }
-            }
-          },
-          "storageProfile": {
-            "storageaccounts": [
-              {
-                "name": "[concat(parameters('clusterStorageAccountName'),'.blob.core.windows.net')]",
-                "isDefault": true,
-                "container": "[parameters('clusterName')]",
-                "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('clusterStorageAccountName')), variables('defaultApiVersion')).key1]"
-              }
-            ]
-          },
-          "computeProfile": {
-            "roles": [
-              {
-                "name": "headnode",
-                "targetInstanceCount": "2",
-                "hardwareProfile": {
-                  "vmSize": "Large"
-                },
-                "osProfile": {
-                  "linuxOperatingSystemProfile": {
-                    "username": "[parameters('sshUserName')]",
-                    "password": "[parameters('sshPassword')]"
-                  }
-                },
-                "virtualNetworkProfile": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
-                  "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', parameters('clusterVNetSubnetName'))]"
-                },
-                "scriptActions": [
-                  {
-                    "name": "setenvironmentvariable",
-                    "uri": "[parameters('scriptActionUri')]",
-                    "parameters": "headnode"
-                  }
-                ]
-              },
-              {
-                "name": "workernode",
-                "targetInstanceCount": "[parameters('clusterWorkerNodeCount')]",
-                "hardwareProfile": {
-                  "vmSize": "Large"
-                },
-                "osProfile": {
-                  "linuxOperatingSystemProfile": {
-                    "username": "[parameters('sshUserName')]",
-                    "password": "[parameters('sshPassword')]"
-                  }
-                },
-                "virtualNetworkProfile": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
-                  "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', parameters('clusterVNetSubnetName'))]"
-                },
-                "scriptActions": [
-                  {
-                    "name": "setenvironmentvariable",
-                    "uri": "[parameters('scriptActionUri')]",
-                    "parameters": "workernode"
-                  }
-                ]
-              },
-              {
-                "name": "zookeepernode",
-                "targetInstanceCount": "3",
-                "hardwareProfile": {
-                  "vmSize": "[variables(concat(parameters('clusterType'),'ZookeeperSize'))]"
-                },
-                "osProfile": {
-                  "linuxOperatingSystemProfile": {
-                    "username": "[parameters('sshUserName')]",
-                    "password": "[parameters('sshPassword')]"
-                  }
-                },
-                "virtualNetworkProfile": {
-                  "id": "[resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName'))]",
-                  "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('clusterVNetName')), '/subnets/', parameters('clusterVNetSubnetName'))]"
-                },
-                "scriptActions": [
-                  {
-                    "name": "setenvironmentvariable",
-                    "uri": "[parameters('scriptActionUri')]",
-                    "parameters": "zookeepernode"
-                  }
-                ]
-              }
-            ]
-          }
-        }
       }
-
-    ],
-    "outputs": {
-        "vnet": {
-            "type": "object",
-            "value": "[reference(resourceId('Microsoft.Network/virtualNetworks',variables('clusterVNetName')))]"
-        },
-        "cluster":{
-            "type" : "object",
-            "value" : "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
-        }
     }
+  ],
+  "outputs": {
+    "vnet": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks',variables('clusterVNetName')))]"
+    },
+    "cluster": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
+    }
+  }
 }

--- a/iis-2vm-sql-1vm/azuredeploy.json
+++ b/iis-2vm-sql-1vm/azuredeploy.json
@@ -1,21 +1,21 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",  
+  "contentVersion": "1.0.0.0",
   "parameters": {
     "_artifactsLocation": {
-        "type": "string",
-        "metadata": {
-            "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
-        },
-        "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/iis-2vm-sql-1vm/"
-    },
-      "_artifactsLocationSasToken": {
-          "type": "securestring",
-          "metadata": {
-              "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
-          },
-          "defaultValue": ""
+      "type": "string",
+      "metadata": {
+        "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
       },
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/iis-2vm-sql-1vm/"
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+      },
+      "defaultValue": ""
+    },
     "envPrefixName": {
       "type": "string",
       "metadata": {
@@ -140,7 +140,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('feNSGName')]",
       "location": "[resourceGroup().location]",
@@ -182,7 +182,7 @@
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('dbNSGName')]",
       "location": "[resourceGroup().location]",
       "tags": {
@@ -250,7 +250,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -293,8 +293,8 @@
       "name": "[variables('storageName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
       "tags": {
         "displayName": "StorageForEnv"
       },
@@ -306,7 +306,7 @@
       "name": "[variables('sqlPublicIP')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "tags": {
         "displayName": "SqlPIP"
       },
@@ -319,7 +319,7 @@
       "name": "[variables('sqlSrvDBNicName')]",
       "type": "Microsoft.Network/networkInterfaces",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
       ],
@@ -347,7 +347,7 @@
       "name": "[concat(parameters('envPrefixName'), 'sqlSrv14')]",
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('sqlSrvDBNicName'))]",
@@ -381,7 +381,6 @@
             "createOption": "FromImage"
           }
         },
-
         "networkProfile": {
           "networkInterfaces": [
             {
@@ -394,18 +393,18 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('webSrvAvailabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "tags": {
         "displayName": "WebSrvAvailabilitySet"
       },
-      "properties": { }
+      "properties": {}
     },
     {
       "name": "[variables('webSrvPublicIP')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "tags": {
         "displayName": "WebSrvPIP for LB"
       },
@@ -418,7 +417,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('webLbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -508,7 +507,7 @@
       "name": "[concat(variables('webSrvNicName'), copyindex())]",
       "type": "Microsoft.Network/networkInterfaces",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicLoop",
         "count": "[variables('webSrvNumbOfInstances')]"
@@ -539,7 +538,6 @@
                   "id": "[concat(variables('webLbId'),'/inboundNatRules/RDP-VM', copyindex())]"
                 }
               ]
-
             }
           }
         ]
@@ -549,7 +547,7 @@
       "name": "[concat(variables('webSrvName'), copyindex())]",
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "webSrvMachineLoop",
         "count": "[variables('webSrvNumbOfInstances')]"
@@ -602,7 +600,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('webSrvName'), copyindex(),'/', variables('vmExtensionName'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "webSrvMachineLoop",
@@ -624,10 +622,9 @@
           "SasToken": "",
           "ConfigurationFunction": "[variables('configurationFunction')]",
           "wmfVersion": "4.0",
-          "Properties": {
-          }
+          "Properties": {}
         },
-        "protectedSettings": { }
+        "protectedSettings": {}
       }
     }
   ]

--- a/informatica-adf-hdinsight-powerbi/nested/azuredatafactory.json
+++ b/informatica-adf-hdinsight-powerbi/nested/azuredatafactory.json
@@ -1,387 +1,387 @@
 {
-    "contentVersion": "1.0.0.0",
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "parameters": {
-        "sqlDWServerName": {
-            "type": "string",
-            "metadata": {
-                "description": "Ex- inforp2ptest"
-            }
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": "eastus",
-            "metadata": {
-                "description": "The location where all azure resources will be deployed."
-            }
-        },
-        "sqlDWDBName": {
-            "type": "string",
-            "metadata": {
-                "description": "SQL Datawarehouse Database Name"
-            }
-        },
-        "sqlDWDBAdminName": {
-            "type": "string",
-            "metadata": {
-                "description": "Sql Data Warehouse User Name"
-            }
-        },
-        "sqlDWAdminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Sql Data Warehouse Password"
-            }
-        },
-        "dataFactoryName": {
-            "type": "string",
-            "metadata": {
-                "description": "Name of the data factory. It must be globally unique"
-            }
-        },
-        "start": {
-            "type": "string",
-            "metadata": {
-                "description": "Start time of the data slice. ex: 2014-06-01T18:00:00"
-            }
-        },
-        "end": {
-            "type": "string",
-            "metadata": {
-                "description": "end time of the data slice. ex: 2014-06-01T18:00:00"
-            }
-        },
-        "tableName": {
-            "type": "string",
-            "defaultValue": "bi9"
-        },
-        "inputFolderPath": {
-            "type": "string",
-            "defaultValue": "adfgetstarted/inputdata"
-        },
-        "outputFolderPath": {
-            "type": "string",
-            "defaultValue": "adfgetstarted/inputdata"
-        },
-        "adfstorageAccountName": {
-            "type": "string"
-        },
-        "apiVersion": {
-            "type": "string",
-            "defaultValue": "2015-10-01"
-        },
-        "storageLinkedServiceName": {
-            "type": "string",
-            "defaultValue": "AzureStorageLinkedService"
-        },
-        "hdInsightOnDemandLinkedServiceName": {
-            "type": "string",
-            "defaultValue": "HDInsightOnDemandLinkedService"
-        },
-        "azureSqlDWLinkedServiceName": {
-            "type": "string",
-            "defaultValue": "AzureSqlDWLinkedService"
-        },
-        "blobInputDataset": {
-            "type": "string",
-            "defaultValue": "AzureBlobInput"
-        },
-        "blobOutputDataset": {
-            "type": "string",
-            "defaultValue": "AzureBlobOutput"
-        },
-        "sqlDWOutputDataset": {
-            "type": "string",
-            "defaultValue": "AzureSqlDWOutput"
-        },
-        "azureSqlDWLinkedServiceConnectionString": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "clusterSize": {
-            "type": "int",
-            "defaultValue": 1
-        },
-        "version": {
-            "type": "string",
-            "defaultValue": "3.2"
-        },
-        "timeToLive": {
-            "type": "string",
-            "defaultValue": "00:45:00"
-        },
-        "frequency": {
-            "type": "string",
-            "defaultValue": "Hour"
-        },
-        "interval": {
-            "type": "int",
-            "defaultValue": 1
-        },
-        "writeBatchSize": {
-            "type": "int",
-            "defaultValue": 0
-        },
-        "writeBatchTimeout": {
-            "type": "string",
-            "defaultValue": "00:00:00"
-        },
-        "timeout": {
-            "type": "string",
-            "defaultValue": "01:00:00"
-        },
-        "script": {
-            "type": "string",
-            "defaultValue": ""
-        },
-        "informaticaTags": {
-            "type": "object"
-        },
-        "quickstartTags": {
-            "type": "object"
-        }
+  "contentVersion": "1.0.0.0",
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "parameters": {
+    "sqlDWServerName": {
+      "type": "string",
+      "metadata": {
+        "description": "Ex- inforp2ptest"
+      }
     },
-    "variables": {
-        "storageApiVersion": "2015-06-15"
+    "location": {
+      "type": "string",
+      "defaultValue": "eastus",
+      "metadata": {
+        "description": "The location where all azure resources will be deployed."
+      }
     },
-    "resources": [
-        {
-            "name": "[parameters('dataFactoryName')]",
-            "apiVersion": "[parameters('apiVersion')]",
-            "type": "Microsoft.DataFactory/datafactories",
-            "location": "westus",
-            "tags": {
-                "displayName": "VM Storage Accounts",
-                "quickstartName": "[parameters('quickstartTags').name]",        
-                "provider": "[parameters('informaticaTags').provider]"
-            },
-            "resources": [
-                {
-                    "dependsOn": [
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]"
-                    ],
-                    "type": "linkedservices",
-                    "name": "[parameters('storageLinkedServiceName')]",
-                    "apiVersion": "[parameters('apiVersion')]",
-                    "properties": {
-                        "type": "AzureStorage",
-                        "typeProperties": {
-                            "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('adfstorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('adfstorageAccountName')),variables('storageApiVersion')).key1)]"
-                        }
-                    }
-                },
-                {
-                    "dependsOn": [
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]"
-                    ],
-                    "type": "linkedservices",
-                    "name": "hivestoredlinkedservice",
-                    "apiVersion": "[parameters('apiVersion')]",
-                    "properties": {
-                        "type": "AzureStorage",
-                        "typeProperties": {
-                            "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=hivestorage45',';AccountKey=HxaJ9xKgO3/1PS5bRO6fc+rTdS+KXWhGsxLubXweQaw75qbFu3AWHwuR6IggpKZeXtspV+RYfffDtFBO5pMRXA==')]"
-                        }
-                    }
-                },
-                {
-                    "dependsOn": [
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedservices/', parameters('storageLinkedServiceName'))]"
-                    ],
-                    "type": "linkedservices",
-                    "name": "[parameters('hdInsightOnDemandLinkedServiceName')]",
-                    "apiVersion": "[parameters('apiVersion')]",
-                    "properties": {
-                        "type": "HDInsightOnDemand",
-                        "typeProperties": {
-                            "clusterSize": "[parameters('clusterSize')]",
-                            "version": "[parameters('version')]",
-                            "timeToLive": "[parameters('timeToLive')]",
-                            "osType": "windows",
-                            "linkedServiceName": "[parameters('storageLinkedServiceName')]"
-                        }
-                    }
-                },
-                {
-                    "dependsOn": [
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]"
-                    ],
-                    "type": "linkedservices",
-                    "name": "[parameters('azureSqlDWLinkedServiceName')]",
-                    "apiVersion": "[parameters('apiVersion')]",
-                    "properties": {
-                        "type": "AzureSqlDW",
-                        "typeProperties": {
-                            "connectionString": "[parameters('azureSqlDWLinkedServiceConnectionString')]"
-                        }
-                    }
-                },
-                {
-                    "dependsOn": [
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('storageLinkedServiceName'))]"
-                    ],
-                    "type": "datasets",
-                    "name": "[parameters('blobInputDataset')]",
-                    "apiVersion": "[parameters('apiVersion')]",
-                    "properties": {
-                        "type": "AzureBlob",
-                        "linkedServiceName": "[parameters('storageLinkedServiceName')]",
-                        "typeProperties": {
-                            "folderPath": "[parameters('inputFolderPath')]",
-                            "format": {
-                                "type": "TextFormat",
-                                "columnDelimiter": ","
-                            }
-                        },
-                        "availability": {
-                            "frequency": "[parameters('frequency')]",
-                            "interval": "[parameters('interval')]"
-                        },
-                        "external": true,
-                        "policy": {}
-                    }
-                },
-                {
-                    "dependsOn": [
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('storageLinkedServiceName'))]"
-                    ],
-                    "type": "datasets",
-                    "name": "[parameters('blobOutputDataset')]",
-                    "apiVersion": "[parameters('apiVersion')]",
-                    "properties": {
-                        "published": false,
-                        "type": "AzureBlob",
-                        "linkedServiceName": "[parameters('storageLinkedServiceName')]",
-                        "typeProperties": {
-                            "folderPath": "[parameters('outputFolderPath')]",
-                            "format": {
-                                "type": "TextFormat",
-                                "columnDelimiter": ","
-                            }
-                        },
-                        "availability": {
-                            "frequency": "[parameters('frequency')]",
-                            "interval": "[parameters('interval')]"
-                        }
-                    }
-                },
-                {
-                    "dependsOn": [
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('azureSqlDWLinkedServiceName'))]"
-                    ],
-                    "type": "datasets",
-                    "name": "[parameters('sqlDWOutputDataset')]",
-                    "apiVersion": "[parameters('apiVersion')]",
-                    "properties": {
-                        "published": false,
-                        "type": "AzureSqlDWTable",
-                        "linkedServiceName": "[parameters('azureSqlDWLinkedServiceName')]",
-                        "typeProperties": {
-                            "tableName": "[parameters('tableName')]"
-                        },
-                        "availability": {
-                            "frequency": "[parameters('frequency')]",
-                            "interval": "[parameters('interval')]"
-                        }
-                    }
-                },
-                {
-                    "dependsOn": [
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('storageLinkedServiceName'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('hdInsightOnDemandLinkedServiceName'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('azureSqlDWLinkedServiceName'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/datasets/', parameters('blobInputDataset'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/datasets/', parameters('blobOutputDataset'))]",
-                        "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/datasets/', parameters('sqlDWOutputDataset'))]"
-                    ],
-                    "type": "datapipelines",
-                    "name": "[parameters('dataFactoryName')]",
-                    "apiVersion": "[parameters('apiVersion')]",
-                    "properties": {
-                        "description": "My first Azure Data Factory pipeline",
-                        "activities": [
-                            {
-                                "type": "HDInsightHive",
-                                "typeProperties": {
-                                    "scriptPath": "adfgetstarted/script/hiveinfop2p.hql",
-                                    "scriptLinkedService": "hivestoredlinkedservice",
-                                    "defines": {
-                                        "inputtable": "[concat('wasb://adfgetstarted@', parameters('adfstorageAccountName'), '.blob.core.windows.net/inputdata')]",
-                                        "partitionedtable": "[concat('wasb://adfgetstarted@', parameters('adfstorageAccountName'), '.blob.core.windows.net/partitioneddata')]"
-                                    }
-                                },
-                                "inputs": [
-                                    {
-                                        "name": "AzureBlobInput"
-                                    }
-                                ],
-                                "outputs": [
-                                    {
-                                        "name": "AzureBlobOutput"
-                                    }
-                                ],
-                                "policy": {
-                                    "concurrency": 1,
-                                    "retry": 3
-                                },
-                                "scheduler": {
-                                    "frequency": "[parameters('frequency')]",
-                                    "interval": "[parameters('interval')]"
-                                },
-                                "name": "RunSampleHiveActivity",
-                                "linkedServiceName": "HDInsightOnDemandLinkedService"
-                            },
-                            {
-                                "type": "Copy",
-                                "typeProperties": {
-                                    "source": {
-                                        "type": "BlobSource"
-                                    },
-                                    "sink": {
-                                        "type": "SqlDWSink",
-                                        "writeBatchSize": "[parameters('writeBatchSize')]",
-                                        "writeBatchTimeout": "[parameters('writeBatchTimeout')]"
-                                    }
-                                },
-                                "inputs": [
-                                    {
-                                        "name": "AzureBlobOutput"
-                                    }
-                                ],
-                                "outputs": [
-                                    {
-                                        "name": "AzureSqlDWOutput"
-                                    }
-                                ],
-                                "policy": {
-                                    "timeout": "[parameters('timeout')]",
-                                    "concurrency": 1
-                                },
-                                "scheduler": {
-                                    "frequency": "[parameters('frequency')]",
-                                    "interval": "[parameters('interval')]"
-                                },
-                                "name": "AzureBlobtoSQLDW",
-                                "description": "Copy Activity"
-                            }
-                        ],
-                        "start": "[parameters('start')]",
-                        "end": "[parameters('end')]",
-                        "isPaused": false
-                    }
-                }
-            ]
-        }
-    ],
-    "outputs": {
-        "ucpConsoleAddress": {
-            "value": "[parameters('script')]",
-            "type": "string"
-        }
+    "sqlDWDBName": {
+      "type": "string",
+      "metadata": {
+        "description": "SQL Datawarehouse Database Name"
+      }
+    },
+    "sqlDWDBAdminName": {
+      "type": "string",
+      "metadata": {
+        "description": "Sql Data Warehouse User Name"
+      }
+    },
+    "sqlDWAdminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Sql Data Warehouse Password"
+      }
+    },
+    "dataFactoryName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the data factory. It must be globally unique"
+      }
+    },
+    "start": {
+      "type": "string",
+      "metadata": {
+        "description": "Start time of the data slice. ex: 2014-06-01T18:00:00"
+      }
+    },
+    "end": {
+      "type": "string",
+      "metadata": {
+        "description": "end time of the data slice. ex: 2014-06-01T18:00:00"
+      }
+    },
+    "tableName": {
+      "type": "string",
+      "defaultValue": "bi9"
+    },
+    "inputFolderPath": {
+      "type": "string",
+      "defaultValue": "adfgetstarted/inputdata"
+    },
+    "outputFolderPath": {
+      "type": "string",
+      "defaultValue": "adfgetstarted/inputdata"
+    },
+    "adfstorageAccountName": {
+      "type": "string"
+    },
+    "apiVersion": {
+      "type": "string",
+      "defaultValue": "2015-10-01"
+    },
+    "storageLinkedServiceName": {
+      "type": "string",
+      "defaultValue": "AzureStorageLinkedService"
+    },
+    "hdInsightOnDemandLinkedServiceName": {
+      "type": "string",
+      "defaultValue": "HDInsightOnDemandLinkedService"
+    },
+    "azureSqlDWLinkedServiceName": {
+      "type": "string",
+      "defaultValue": "AzureSqlDWLinkedService"
+    },
+    "blobInputDataset": {
+      "type": "string",
+      "defaultValue": "AzureBlobInput"
+    },
+    "blobOutputDataset": {
+      "type": "string",
+      "defaultValue": "AzureBlobOutput"
+    },
+    "sqlDWOutputDataset": {
+      "type": "string",
+      "defaultValue": "AzureSqlDWOutput"
+    },
+    "azureSqlDWLinkedServiceConnectionString": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "clusterSize": {
+      "type": "int",
+      "defaultValue": 1
+    },
+    "version": {
+      "type": "string",
+      "defaultValue": "3.2"
+    },
+    "timeToLive": {
+      "type": "string",
+      "defaultValue": "00:45:00"
+    },
+    "frequency": {
+      "type": "string",
+      "defaultValue": "Hour"
+    },
+    "interval": {
+      "type": "int",
+      "defaultValue": 1
+    },
+    "writeBatchSize": {
+      "type": "int",
+      "defaultValue": 0
+    },
+    "writeBatchTimeout": {
+      "type": "string",
+      "defaultValue": "00:00:00"
+    },
+    "timeout": {
+      "type": "string",
+      "defaultValue": "01:00:00"
+    },
+    "script": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "informaticaTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
     }
+  },
+  "variables": {
+    "storageApiVersion": "2015-06-15"
+  },
+  "resources": [
+    {
+      "name": "[parameters('dataFactoryName')]",
+      "apiVersion": "2015-10-01",
+      "type": "Microsoft.DataFactory/datafactories",
+      "location": "westus",
+      "tags": {
+        "displayName": "VM Storage Accounts",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('informaticaTags').provider]"
+      },
+      "resources": [
+        {
+          "dependsOn": [
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]"
+          ],
+          "type": "linkedservices",
+          "name": "[parameters('storageLinkedServiceName')]",
+          "apiVersion": "[parameters('apiVersion')]",
+          "properties": {
+            "type": "AzureStorage",
+            "typeProperties": {
+              "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('adfstorageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('adfstorageAccountName')),variables('storageApiVersion')).key1)]"
+            }
+          }
+        },
+        {
+          "dependsOn": [
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]"
+          ],
+          "type": "linkedservices",
+          "name": "hivestoredlinkedservice",
+          "apiVersion": "[parameters('apiVersion')]",
+          "properties": {
+            "type": "AzureStorage",
+            "typeProperties": {
+              "connectionString": "[concat('DefaultEndpointsProtocol=https;AccountName=hivestorage45',';AccountKey=HxaJ9xKgO3/1PS5bRO6fc+rTdS+KXWhGsxLubXweQaw75qbFu3AWHwuR6IggpKZeXtspV+RYfffDtFBO5pMRXA==')]"
+            }
+          }
+        },
+        {
+          "dependsOn": [
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedservices/', parameters('storageLinkedServiceName'))]"
+          ],
+          "type": "linkedservices",
+          "name": "[parameters('hdInsightOnDemandLinkedServiceName')]",
+          "apiVersion": "[parameters('apiVersion')]",
+          "properties": {
+            "type": "HDInsightOnDemand",
+            "typeProperties": {
+              "clusterSize": "[parameters('clusterSize')]",
+              "version": "[parameters('version')]",
+              "timeToLive": "[parameters('timeToLive')]",
+              "osType": "windows",
+              "linkedServiceName": "[parameters('storageLinkedServiceName')]"
+            }
+          }
+        },
+        {
+          "dependsOn": [
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]"
+          ],
+          "type": "linkedservices",
+          "name": "[parameters('azureSqlDWLinkedServiceName')]",
+          "apiVersion": "[parameters('apiVersion')]",
+          "properties": {
+            "type": "AzureSqlDW",
+            "typeProperties": {
+              "connectionString": "[parameters('azureSqlDWLinkedServiceConnectionString')]"
+            }
+          }
+        },
+        {
+          "dependsOn": [
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('storageLinkedServiceName'))]"
+          ],
+          "type": "datasets",
+          "name": "[parameters('blobInputDataset')]",
+          "apiVersion": "[parameters('apiVersion')]",
+          "properties": {
+            "type": "AzureBlob",
+            "linkedServiceName": "[parameters('storageLinkedServiceName')]",
+            "typeProperties": {
+              "folderPath": "[parameters('inputFolderPath')]",
+              "format": {
+                "type": "TextFormat",
+                "columnDelimiter": ","
+              }
+            },
+            "availability": {
+              "frequency": "[parameters('frequency')]",
+              "interval": "[parameters('interval')]"
+            },
+            "external": true,
+            "policy": {}
+          }
+        },
+        {
+          "dependsOn": [
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('storageLinkedServiceName'))]"
+          ],
+          "type": "datasets",
+          "name": "[parameters('blobOutputDataset')]",
+          "apiVersion": "[parameters('apiVersion')]",
+          "properties": {
+            "published": false,
+            "type": "AzureBlob",
+            "linkedServiceName": "[parameters('storageLinkedServiceName')]",
+            "typeProperties": {
+              "folderPath": "[parameters('outputFolderPath')]",
+              "format": {
+                "type": "TextFormat",
+                "columnDelimiter": ","
+              }
+            },
+            "availability": {
+              "frequency": "[parameters('frequency')]",
+              "interval": "[parameters('interval')]"
+            }
+          }
+        },
+        {
+          "dependsOn": [
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('azureSqlDWLinkedServiceName'))]"
+          ],
+          "type": "datasets",
+          "name": "[parameters('sqlDWOutputDataset')]",
+          "apiVersion": "[parameters('apiVersion')]",
+          "properties": {
+            "published": false,
+            "type": "AzureSqlDWTable",
+            "linkedServiceName": "[parameters('azureSqlDWLinkedServiceName')]",
+            "typeProperties": {
+              "tableName": "[parameters('tableName')]"
+            },
+            "availability": {
+              "frequency": "[parameters('frequency')]",
+              "interval": "[parameters('interval')]"
+            }
+          }
+        },
+        {
+          "dependsOn": [
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('storageLinkedServiceName'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('hdInsightOnDemandLinkedServiceName'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/linkedServices/', parameters('azureSqlDWLinkedServiceName'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/datasets/', parameters('blobInputDataset'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/datasets/', parameters('blobOutputDataset'))]",
+            "[concat('Microsoft.DataFactory/dataFactories/', parameters('dataFactoryName'), '/datasets/', parameters('sqlDWOutputDataset'))]"
+          ],
+          "type": "datapipelines",
+          "name": "[parameters('dataFactoryName')]",
+          "apiVersion": "[parameters('apiVersion')]",
+          "properties": {
+            "description": "My first Azure Data Factory pipeline",
+            "activities": [
+              {
+                "type": "HDInsightHive",
+                "typeProperties": {
+                  "scriptPath": "adfgetstarted/script/hiveinfop2p.hql",
+                  "scriptLinkedService": "hivestoredlinkedservice",
+                  "defines": {
+                    "inputtable": "[concat('wasb://adfgetstarted@', parameters('adfstorageAccountName'), '.blob.core.windows.net/inputdata')]",
+                    "partitionedtable": "[concat('wasb://adfgetstarted@', parameters('adfstorageAccountName'), '.blob.core.windows.net/partitioneddata')]"
+                  }
+                },
+                "inputs": [
+                  {
+                    "name": "AzureBlobInput"
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "AzureBlobOutput"
+                  }
+                ],
+                "policy": {
+                  "concurrency": 1,
+                  "retry": 3
+                },
+                "scheduler": {
+                  "frequency": "[parameters('frequency')]",
+                  "interval": "[parameters('interval')]"
+                },
+                "name": "RunSampleHiveActivity",
+                "linkedServiceName": "HDInsightOnDemandLinkedService"
+              },
+              {
+                "type": "Copy",
+                "typeProperties": {
+                  "source": {
+                    "type": "BlobSource"
+                  },
+                  "sink": {
+                    "type": "SqlDWSink",
+                    "writeBatchSize": "[parameters('writeBatchSize')]",
+                    "writeBatchTimeout": "[parameters('writeBatchTimeout')]"
+                  }
+                },
+                "inputs": [
+                  {
+                    "name": "AzureBlobOutput"
+                  }
+                ],
+                "outputs": [
+                  {
+                    "name": "AzureSqlDWOutput"
+                  }
+                ],
+                "policy": {
+                  "timeout": "[parameters('timeout')]",
+                  "concurrency": 1
+                },
+                "scheduler": {
+                  "frequency": "[parameters('frequency')]",
+                  "interval": "[parameters('interval')]"
+                },
+                "name": "AzureBlobtoSQLDW",
+                "description": "Copy Activity"
+              }
+            ],
+            "start": "[parameters('start')]",
+            "end": "[parameters('end')]",
+            "isPaused": false
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {
+    "ucpConsoleAddress": {
+      "value": "[parameters('script')]",
+      "type": "string"
+    }
+  }
 }

--- a/informatica-adf-hdinsight-powerbi/nested/info-nsg.json
+++ b/informatica-adf-hdinsight-powerbi/nested/info-nsg.json
@@ -1,104 +1,104 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "brazilsouth",
-                "eastasia",
-                "eastus",
-                "japaneast",
-                "japanwest",
-                "northcentralus",
-                "northeurope",
-                "southcentralus",
-                "westeurope",
-                "westus",
-                "southeastasia",
-                "centralus",
-                "eastus2"
-            ],
-            "metadata": {
-                "description": "Deployments Location"
-            }
-        },
-        "networkApiVersion": {
-            "type": "string",
-            "defaultValue": "2016-03-30",
-            "allowedValues": [
-                "2015-05-01-preview",
-                "2015-06-15",
-                "2016-03-30"
-            ],
-            "metadata": {
-                "description": "API Version for the Network Resources"
-            }
-        },
-        "tag": {
-            "type": "object",
-            "defaultValue": {
-                "key1": "key",
-                "value1": "value"
-            }
-        },
-        "networkSecurityGroupsName": {
-            "type": "string",
-            "defaultValue": "wowza-nsg",
-            "metadata": {
-                "description": " Virtual machine name"
-            }
-        },
-        "informaticaTags": {
-            "type": "object"
-        },
-        "quickstartTags": {
-            "type": "object"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "westus",
+      "allowedValues": [
+        "brazilsouth",
+        "eastasia",
+        "eastus",
+        "japaneast",
+        "japanwest",
+        "northcentralus",
+        "northeurope",
+        "southcentralus",
+        "westeurope",
+        "westus",
+        "southeastasia",
+        "centralus",
+        "eastus2"
+      ],
+      "metadata": {
+        "description": "Deployments Location"
+      }
     },
-    "variables": {},
-    "resources": [
-        {
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "name": "[parameters('networkSecurityGroupsName')]",
-            "apiVersion":"[parameters('networkApiVersion')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "[parameters('tag').key1]": "[parameters('tag').value1]",
-                "quickstartName": "[parameters('quickstartTags').name]",        
-                "provider": "[parameters('informaticaTags').provider]"
-            },
+    "networkApiVersion": {
+      "type": "string",
+      "defaultValue": "2016-03-30",
+      "allowedValues": [
+        "2015-05-01-preview",
+        "2015-06-15",
+        "2016-03-30"
+      ],
+      "metadata": {
+        "description": "API Version for the Network Resources"
+      }
+    },
+    "tag": {
+      "type": "object",
+      "defaultValue": {
+        "key1": "key",
+        "value1": "value"
+      }
+    },
+    "networkSecurityGroupsName": {
+      "type": "string",
+      "defaultValue": "wowza-nsg",
+      "metadata": {
+        "description": " Virtual machine name"
+      }
+    },
+    "informaticaTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('networkSecurityGroupsName')]",
+      "apiVersion": "2016-03-30",
+      "location": "[parameters('location')]",
+      "tags": {
+        "[parameters('tag').key1]": "[parameters('tag').value1]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('informaticaTags').provider]"
+      },
+      "properties": {
+        "securityRules": [
+          {
+            "name": "HTTP",
             "properties": {
-                "securityRules": [
-                    {
-                        "name": "HTTP",
-                        "properties": {
-                            "priority": 1010,
-                            "sourceAddressPrefix": "*",
-                            "protocol": "TCP",
-                            "destinationPortRange": "80",
-                            "access": "Allow",
-                            "direction": "Inbound",
-                            "sourcePortRange": "*",
-                            "destinationAddressPrefix": "*"
-                        }
-                    },
-                    {
-                        "name": "default-allow-rdp",
-                        "properties": {
-                            "priority": 1020,
-                            "sourceAddressPrefix": "*",
-                            "protocol": "TCP",
-                            "destinationPortRange": "3389",
-                            "access": "Allow",
-                            "direction": "Inbound",
-                            "sourcePortRange": "*",
-                            "destinationAddressPrefix": "*"
-                        }
-                    }
-                ]
+              "priority": 1010,
+              "sourceAddressPrefix": "*",
+              "protocol": "TCP",
+              "destinationPortRange": "80",
+              "access": "Allow",
+              "direction": "Inbound",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
             }
-        }
-    ]
+          },
+          {
+            "name": "default-allow-rdp",
+            "properties": {
+              "priority": 1020,
+              "sourceAddressPrefix": "*",
+              "protocol": "TCP",
+              "destinationPortRange": "3389",
+              "access": "Allow",
+              "direction": "Inbound",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/informatica-adf-hdinsight-powerbi/nested/network-interface.json
+++ b/informatica-adf-hdinsight-powerbi/nested/network-interface.json
@@ -65,13 +65,13 @@
   "resources": [
     {
       "comments": "Network Interface Resource",
-      "apiVersion": "[parameters('networkApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceName')]",
       "location": "[parameters('location')]",
       "tags": {
         "[parameters('tag').key1]": "[parameters('tag').value1]",
-        "quickstartName": "[parameters('quickstartTags').name]",        
+        "quickstartName": "[parameters('quickstartTags').name]",
         "provider": "[parameters('informaticaTags').provider]"
       },
       "properties": {

--- a/informatica-adf-hdinsight-powerbi/nested/public-ip.json
+++ b/informatica-adf-hdinsight-powerbi/nested/public-ip.json
@@ -41,23 +41,23 @@
       }
     },
     "informaticaTags": {
-       "type": "object"
+      "type": "object"
     },
     "quickstartTags": {
-       "type": "object"
+      "type": "object"
     }
   },
   "variables": {},
   "resources": [
     {
       "comments": "Public IP Address Resource",
-      "apiVersion": "[parameters('networkApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIPAddressName')]",
       "location": "[parameters('location')]",
       "tags": {
         "[parameters('tag').key1]": "[parameters('tag').value1]",
-        "quickstartName": "[parameters('quickstartTags').name]",        
+        "quickstartName": "[parameters('quickstartTags').name]",
         "provider": "[parameters('informaticaTags').provider]"
       },
       "properties": {

--- a/informatica-adf-hdinsight-powerbi/nested/sqldatawarehouse.json
+++ b/informatica-adf-hdinsight-powerbi/nested/sqldatawarehouse.json
@@ -1,134 +1,134 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string",
-            "defaultValue": "South Central US",
-            "metadata": {
-                "description": "The location where all azure resources will be deployed."
-            }
-        },
-        "sqlDWServerName": {
-            "type": "string",
-            "metadata": {
-                "description": "SQL Datawarehouse Server Name, should be a unique name"
-            }
-        },
-        "sqlDWDBAdminName": {
-            "type": "string",
-            "metadata": {
-                "description": "SQL Datawarehouse Admin Name"
-            }
-        },
-        "sqlDWAdminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "SQL Datawarehouse Admin password. Ex: Testadmin@123"
-            }
-        },
-        "sqlDWDBName": {
-            "type": "string",
-            "defaultValue": "testdwdb",
-            "metadata": {
-                "description": "SQL Datawarehouse Database Name"
-            }
-        },
-        "serviceLevelObjective": {
-            "type": "string",
-            "defaultValue": "DW100"
-        },
-        "startIpAddress": {
-            "type": "string",
-            "defaultValue": "0.0.0.0"
-        },
-        "endIpAddress": {
-            "type": "string",
-            "defaultValue": "255.255.255.255"
-        },
-         "sql-api-version": {
-            "type": "string",
-            "defaultValue": "2014-04-01"
-         },
-          "sqldb-api-version": {
-            "type": "string",
-            "defaultValue": "2015-05-01-preview"
-         },
-          "sqlfirewallrules-api-version": {
-            "type": "string",
-            "defaultValue": "2014-04-01"
-         },
-          "collation": {
-            "type": "string",
-            "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
-         },
-          "maxSizeBytes": {
-            "type": "string",
-            "defaultValue": "10995116277760"
-         },
-          "version": {
-            "type": "string",
-            "defaultValue":"12.0"
-         },
-          "informaticaTags": {
-            "type": "object"
-         },
-          "quickstartTags": {
-            "type": "object"
-        }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "South Central US",
+      "metadata": {
+        "description": "The location where all azure resources will be deployed."
+      }
     },
-    "variables": {},
-    "resources": [
+    "sqlDWServerName": {
+      "type": "string",
+      "metadata": {
+        "description": "SQL Datawarehouse Server Name, should be a unique name"
+      }
+    },
+    "sqlDWDBAdminName": {
+      "type": "string",
+      "metadata": {
+        "description": "SQL Datawarehouse Admin Name"
+      }
+    },
+    "sqlDWAdminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SQL Datawarehouse Admin password. Ex: Testadmin@123"
+      }
+    },
+    "sqlDWDBName": {
+      "type": "string",
+      "defaultValue": "testdwdb",
+      "metadata": {
+        "description": "SQL Datawarehouse Database Name"
+      }
+    },
+    "serviceLevelObjective": {
+      "type": "string",
+      "defaultValue": "DW100"
+    },
+    "startIpAddress": {
+      "type": "string",
+      "defaultValue": "0.0.0.0"
+    },
+    "endIpAddress": {
+      "type": "string",
+      "defaultValue": "255.255.255.255"
+    },
+    "sql-api-version": {
+      "type": "string",
+      "defaultValue": "2014-04-01"
+    },
+    "sqldb-api-version": {
+      "type": "string",
+      "defaultValue": "2015-05-01-preview"
+    },
+    "sqlfirewallrules-api-version": {
+      "type": "string",
+      "defaultValue": "2014-04-01"
+    },
+    "collation": {
+      "type": "string",
+      "defaultValue": "SQL_Latin1_General_CP1_CI_AS"
+    },
+    "maxSizeBytes": {
+      "type": "string",
+      "defaultValue": "10995116277760"
+    },
+    "version": {
+      "type": "string",
+      "defaultValue": "12.0"
+    },
+    "informaticaTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "name": "[parameters('sqlDWServerName')]",
+      "type": "Microsoft.Sql/servers",
+      "location": "[parameters('location')]",
+      "apiVersion": "2014-04-01",
+      "tags": {
+        "displayName": "VM Storage Accounts",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('informaticaTags').provider]"
+      },
+      "properties": {
+        "administratorLogin": "[parameters('sqlDWDBAdminName')]",
+        "administratorLoginPassword": "[parameters('sqlDWAdminPassword')]",
+        "version": "[parameters('version')]"
+      },
+      "resources": [
         {
-            "name": "[parameters('sqlDWServerName')]",
-            "type": "Microsoft.Sql/servers",
-            "location": "[parameters('location')]",
-            "apiVersion": "[parameters('sql-api-version')]",
-            "tags": {
-                "displayName": "VM Storage Accounts",
-                "quickstartName": "[parameters('quickstartTags').name]",        
-                "provider": "[parameters('informaticaTags').provider]"
-            },
-            "properties": {
-                "administratorLogin": "[parameters('sqlDWDBAdminName')]",
-                "administratorLoginPassword": "[parameters('sqlDWAdminPassword')]",
-                "version": "[parameters('version')]"
-            },
-            "resources": [
-                {
-                    "name": "[parameters('sqlDWDBName')]",
-                    "type": "databases",
-                    "location": "[parameters('location')]",
-                    "apiVersion": "[parameters('sqldb-api-version')]",
-                    "tags": {
-                        "displayName": "VM Storage Accounts",
-                        "quickstartName": "[parameters('quickstartTags').name]",        
-                        "provider": "[parameters('informaticaTags').provider]"
-                    },
-                    "dependsOn": [
-                        "[concat('Microsoft.Sql/servers/', parameters('sqlDWServerName'))]"
-                    ],
-                    "properties": {
-                        "edition": "DataWarehouse",
-                        "collation": "[parameters('collation')]",
-                        "maxSizeBytes": "[parameters('maxSizeBytes')]",
-                        "serviceLevelObjective": "[parameters('serviceLevelObjective')]"
-                    }
-                },
-                {
-                    "apiVersion": "[parameters('sqlfirewallrules-api-version')]",
-                    "dependsOn": [
-                        "[concat('Microsoft.Sql/servers/', parameters('sqlDWServerName'))]"
-                    ],
-                    "location": "[parameters('location')]",
-                    "name": "AllowAllAzureIps",
-                    "properties": {
-                        "endIpAddress": "[parameters('endIpAddress')]",
-                        "startIpAddress": "[parameters('startIpAddress')]"
-                    },
-                    "type": "firewallrules"
-                }
-            ]
+          "name": "[parameters('sqlDWDBName')]",
+          "type": "databases",
+          "location": "[parameters('location')]",
+          "apiVersion": "[parameters('sqldb-api-version')]",
+          "tags": {
+            "displayName": "VM Storage Accounts",
+            "quickstartName": "[parameters('quickstartTags').name]",
+            "provider": "[parameters('informaticaTags').provider]"
+          },
+          "dependsOn": [
+            "[concat('Microsoft.Sql/servers/', parameters('sqlDWServerName'))]"
+          ],
+          "properties": {
+            "edition": "DataWarehouse",
+            "collation": "[parameters('collation')]",
+            "maxSizeBytes": "[parameters('maxSizeBytes')]",
+            "serviceLevelObjective": "[parameters('serviceLevelObjective')]"
+          }
+        },
+        {
+          "apiVersion": "[parameters('sqlfirewallrules-api-version')]",
+          "dependsOn": [
+            "[concat('Microsoft.Sql/servers/', parameters('sqlDWServerName'))]"
+          ],
+          "location": "[parameters('location')]",
+          "name": "AllowAllAzureIps",
+          "properties": {
+            "endIpAddress": "[parameters('endIpAddress')]",
+            "startIpAddress": "[parameters('startIpAddress')]"
+          },
+          "type": "firewallrules"
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/informatica-adf-hdinsight-powerbi/nested/storage.json
+++ b/informatica-adf-hdinsight-powerbi/nested/storage.json
@@ -1,85 +1,85 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "storageAccountName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Storage Account Name"
-            }
-        },
-        "storageApiVersion": {
-            "type": "string",
-            "defaultValue": "2015-06-15",
-            "allowedValues": [
-                "2015-05-01-preview",
-                "2015-06-15"
-            ],
-            "metadata": {
-                "description": "API Version for the Storage Account"
-            }
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": "westus",
-            "metadata": {
-                "description": "Storage Account Deployment Location"
-            }
-        },
-        "tag": {
-            "type": "object",
-            "defaultValue": {
-                "key1": "key",
-                "value1": "value"
-            },
-            "metadata": {
-                "description": "Tag Values"
-            }
-        },
-        "storageAccountType": {
-            "type": "string",
-            "defaultValue": "Standard_LRS",
-            "allowedValues": [
-                "Standard_LRS",
-                "Standard_ZRS",
-                "Standard_GRS",
-                "Standard_RAGRS",
-                "Premium_LRS"
-            ],
-            "metadata": {
-                "description": "Stoarge Account Type"
-            }
-        },
-        "informaticaTags": {
-            "type": "object"
-        },
-        "quickstartTags": {
-            "type": "object"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Storage Account Name"
+      }
     },
-    "variables": {},
-    "resources": [
-        {
-            "comments": "Storage Account Resource",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[parameters('storageAccountName')]",
-            "apiVersion": "[parameters('storageApiVersion')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "[parameters('tag').key1]": "[parameters('tag').value1]",
-                "quickstartName": "[parameters('quickstartTags').name]",        
-                "provider": "[parameters('informaticaTags').provider]"
-            },
-            "properties": {
-                "accountType": "[parameters('storageAccountType')]"
-            }
-        }
-    ],
-    "outputs": {
-        "primaryKey": {
-            "type": "string",
-            "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2015-06-15').key1]"
-        }
+    "storageApiVersion": {
+      "type": "string",
+      "defaultValue": "2015-06-15",
+      "allowedValues": [
+        "2015-05-01-preview",
+        "2015-06-15"
+      ],
+      "metadata": {
+        "description": "API Version for the Storage Account"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "westus",
+      "metadata": {
+        "description": "Storage Account Deployment Location"
+      }
+    },
+    "tag": {
+      "type": "object",
+      "defaultValue": {
+        "key1": "key",
+        "value1": "value"
+      },
+      "metadata": {
+        "description": "Tag Values"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_ZRS",
+        "Standard_GRS",
+        "Standard_RAGRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Stoarge Account Type"
+      }
+    },
+    "informaticaTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
     }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "comments": "Storage Account Resource",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('storageAccountName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[parameters('location')]",
+      "tags": {
+        "[parameters('tag').key1]": "[parameters('tag').value1]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('informaticaTags').provider]"
+      },
+      "properties": {
+        "accountType": "[parameters('storageAccountType')]"
+      }
+    }
+  ],
+  "outputs": {
+    "primaryKey": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2015-06-15').key1]"
+    }
+  }
 }

--- a/informatica-adf-hdinsight-powerbi/nested/virtual-machine-with-plan.json
+++ b/informatica-adf-hdinsight-powerbi/nested/virtual-machine-with-plan.json
@@ -108,32 +108,30 @@
       }
     },
     "informaticaTags": {
-       "type": "object"
+      "type": "object"
     },
     "quickstartTags": {
-       "type": "object"
+      "type": "object"
     }
   },
   "variables": {},
   "resources": [
     {
       "comments": "Virtual Machine Resource",
-      "apiVersion": "[parameters('computeApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[parameters('location')]",
       "tags": {
         "[parameters('tag').key1]": "[parameters('tag').value1]",
-        "quickstartName": "[parameters('quickstartTags').name]",        
+        "quickstartName": "[parameters('quickstartTags').name]",
         "provider": "[parameters('informaticaTags').provider]"
       },
-
-       "plan": {
-         "name": "[parameters('imageSKU')]",
-         "product": "[parameters('imageOffer')]",
+      "plan": {
+        "name": "[parameters('imageSKU')]",
+        "product": "[parameters('imageOffer')]",
         "publisher": "[parameters('imagePublisher')]"
-        },
-
+      },
       "properties": {
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"

--- a/informatica-adf-hdinsight-powerbi/nested/vnet-subnet.json
+++ b/informatica-adf-hdinsight-powerbi/nested/vnet-subnet.json
@@ -70,13 +70,13 @@
   "resources": [
     {
       "comments": "Virtual Network and Subnet Resource",
-      "apiVersion": "[parameters('networkApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('vnetName')]",
       "location": "[parameters('location')]",
       "tags": {
         "[parameters('tag').key1]": "[parameters('tag').value1]",
-        "quickstartName": "[parameters('quickstartTags').name]",        
+        "quickstartName": "[parameters('quickstartTags').name]",
         "provider": "[parameters('informaticaTags').provider]"
       },
       "properties": {

--- a/intel-lustre-clients-vmss-centos/azuredeploy.json
+++ b/intel-lustre-clients-vmss-centos/azuredeploy.json
@@ -216,7 +216,7 @@
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('uniqueStringArray')[copyIndex()], variables('newStorageAccountSuffix'))]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "storageLoop",
         "count": "[variables('saCount')]"
@@ -229,7 +229,7 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2016-03-30",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -241,7 +241,7 @@
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2016-03-30",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
       ],
@@ -261,8 +261,8 @@
             "name": "[variables('bePoolName')]"
           }
         ],
-        "loadBalancingRules": [ ],
-        "probes": [ ],
+        "loadBalancingRules": [],
+        "probes": [],
         "inboundNatPools": [
           {
             "name": "[variables('natPoolName')]",
@@ -283,7 +283,7 @@
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[parameters('vmssName')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2016-03-30",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStringArray')[0], variables('newStorageAccountSuffix'))]",
         "[concat('Microsoft.Storage/storageAccounts/', variables('uniqueStringArray')[1], variables('newStorageAccountSuffix'))]",

--- a/iomad-cluster-ubuntu/azuredeploy.json
+++ b/iomad-cluster-ubuntu/azuredeploy.json
@@ -26,19 +26,19 @@
         "description": "Full name of the IOMAD site displayed in the UI."
       }
     },
-    "shortNameOfSite":  {
+    "shortNameOfSite": {
       "type": "string",
       "metadata": {
         "description": "Short name of the IOMAD site."
       }
     },
-    "iomadAdminUsername":{
+    "iomadAdminUsername": {
       "type": "string",
       "metadata": {
         "description": "User name for the IOMAD site administrator."
       }
     },
-    "iomadAdminPassword":  {
+    "iomadAdminPassword": {
       "type": "securestring",
       "metadata": {
         "description": "Password for the IOMAD site administrator."
@@ -57,18 +57,18 @@
       }
     },
     "webVMCount": {
-        "type": "int",
-        "defaultValue": 2,
-        "allowedValues": [
-          1,
-          2,
-          3,
-          4,
-          5
-        ],
-        "metadata": {
-            "description": "Number of web front end VMs to create."
-        }
+      "type": "int",
+      "defaultValue": 2,
+      "allowedValues": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "metadata": {
+        "description": "Number of web front end VMs to create."
+      }
     },
     "vmSize": {
       "type": "string",
@@ -172,7 +172,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -183,12 +183,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -200,7 +200,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -227,7 +227,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -267,7 +267,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -448,7 +448,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -502,16 +502,16 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),copyIndex(),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),copyIndex()))]"
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-		"type": "CustomScript",
-		"typeHandlerVersion": "2.0",
-		"autoUpgradeMinorVersion": true,
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
             "[variables('installFrontendScriptUri')]"
@@ -526,15 +526,15 @@
         "count": "[parameters('webVMCount')]"
       }
     },
-	{
+    {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(variables('availabilitySetName'),'db')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicDBIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -546,7 +546,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -572,7 +572,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -621,16 +621,16 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'db','/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),'db'))]"
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-		"type": "CustomScript",
-		"typeHandlerVersion": "2.0",
-		"autoUpgradeMinorVersion": true,
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
             "[variables('installBackendScriptUri')]"

--- a/iomad-singlevm-ubuntu/azuredeploy.json
+++ b/iomad-singlevm-ubuntu/azuredeploy.json
@@ -81,7 +81,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -90,7 +90,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -102,7 +102,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -123,7 +123,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -149,7 +149,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -194,16 +194,16 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-		"type": "CustomScript",
-		"typeHandlerVersion": "2.0",
-		"autoUpgradeMinorVersion": true,
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
             "[variables('installScriptUri')]"

--- a/lamp-app/azuredeploy.json
+++ b/lamp-app/azuredeploy.json
@@ -67,7 +67,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountNamePrefix')]",
       "location": "[resourceGroup().location]",
@@ -76,7 +76,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -88,7 +88,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -135,7 +135,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -180,7 +180,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/lap-mysql-ubuntu/azuredeploy.json
+++ b/lap-mysql-ubuntu/azuredeploy.json
@@ -31,9 +31,9 @@
       "type": "string",
       "defaultValue": "Standard_D3",
       "allowedValues": [
-	    "Standard_A1",
-		"Standard_A2",
-		"Standard_A3",
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
         "Standard_D1",
         "Standard_D3",
         "Standard_D4"
@@ -53,9 +53,9 @@
       "type": "string",
       "defaultValue": "Standard_D3",
       "allowedValues": [
-	    "Standard_A1",
-		"Standard_A2",
-		"Standard_A3",
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
         "Standard_D1",
         "Standard_D3",
         "Standard_D4"
@@ -71,7 +71,7 @@
     "lampLapTemplateUrl": "[concat(variables('templateBaseUrl'), 'lamplap-resources.json')]",
     "lampMysqlTemplateUrl": "[concat(variables('templateBaseUrl'), 'lampmysql-resources.json')]",
     "namespace": "lamp-",
-	"apiVersion": "2015-01-01",
+    "apiVersion": "2015-01-01",
     "networkSettings": {
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
       "addressPrefix": "10.0.0.0/16",
@@ -88,7 +88,7 @@
           "start": 5
         },
         "lapip": "10.0.0.240",
-		"mysqlip": "10.0.0.10"
+        "mysqlip": "10.0.0.10"
       }
     },
     "lapOsSettings": {
@@ -118,7 +118,7 @@
     {
       "name": "shared",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -135,7 +135,7 @@
     {
       "name": "lampLapNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]"
       ],
@@ -182,7 +182,7 @@
     {
       "name": "[concat('lampMysqlNode', copyindex())]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'lampLapNode')]"
@@ -213,9 +213,9 @@
           "lapNode": {
             "value": "[variables('networkSettings').statics.lapip]"
           },
-		  "mysqlstaticIp": {
+          "mysqlstaticIp": {
             "value": "[variables('networkSettings').statics.mysqlip]"
-		  },
+          },
           "subnet": {
             "value": "[variables('networkSettings').subnet.dse]"
           },

--- a/lap-mysql-ubuntu/lamplap-resources.json
+++ b/lap-mysql-ubuntu/lamplap-resources.json
@@ -35,13 +35,13 @@
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"apiVersion": "2015-06-15",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
     "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -79,7 +79,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp')]",
       "location": "[resourceGroup().location]",
@@ -91,14 +91,14 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -127,7 +127,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -166,16 +166,16 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/lampInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-		"type": "CustomScript",
-		"typeHandlerVersion": "2.0",
-		"autoUpgradeMinorVersion": true,
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "autoUpgradeMinorVersion": true,
           "fileUris": "[parameters('osSettings').scripts]",

--- a/lap-mysql-ubuntu/lampmysql-resources.json
+++ b/lap-mysql-ubuntu/lampmysql-resources.json
@@ -23,7 +23,7 @@
     "vmSize": {
       "type": "string"
     },
-	"mysqlstaticIp": {
+    "mysqlstaticIp": {
       "type": "string"
     },
     "subnet": {
@@ -32,19 +32,19 @@
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15"
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'nic')]",
       "location": "[resourceGroup().location]",
@@ -64,7 +64,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[resourceGroup().location]",
@@ -103,7 +103,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/lampInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",
@@ -111,9 +111,9 @@
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-		"type": "CustomScript",
-		"typeHandlerVersion": "2.0",
-		"autoUpgradeMinorVersion": true,
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]",
           "commandToExecute": "[concat('bash install-mysql.sh ', parameters('lapNode'))]"

--- a/lap-mysql-ubuntu/shared-resources.json
+++ b/lap-mysql-ubuntu/shared-resources.json
@@ -11,12 +11,11 @@
   },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15"
-  
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -25,7 +24,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSettings').virtualNetworkName]",
       "location": "[resourceGroup().location]",

--- a/lap-neo4j-ubuntu/azuredeploy.json
+++ b/lap-neo4j-ubuntu/azuredeploy.json
@@ -1,223 +1,227 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Administrator user name used when provisioning virtual machines"
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Administrator password used when provisioning virtual machines"
-            }
-        },
-        "dnsLabelPrefix": {
-            "type": "string",
-            "metadata": {
-                "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
-            }
-        },
-        "lapVmSize": {
-            "type": "string",
-            "defaultValue": "Standard_D1_V2",
-            "allowedValues": [
-                "Standard_A1",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_D1_V2",
-                "Standard_D3_V2",
-                "Standard_D4_V2"
-            ],
-            "metadata": {
-                "description": "The size of the virtual machines used when provisioning the Lap node"
-            }
-        },
-        "neo4jNodes": {
-            "type": "int",
-            "defaultValue": 1,
-            "metadata": {
-                "description": "Number of Neo4J node (1 is the default)"
-            }
-        },
-        "neo4jVmSize": {
-            "type": "string",
-            "defaultValue": "Standard_D1_V2",
-            "allowedValues": [
-                "Standard_A1",
-                "Standard_A2",
-                "Standard_A3",
-                "Standard_D1_V2",
-                "Standard_D3_V2",
-                "Standard_D4_V2"
-            ],
-            "metadata": {
-                "description": "The size of the virtual machines used when provisioning Neo4J node(s)"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Administrator user name used when provisioning virtual machines"
+      }
     },
-    "variables": {
-        "templateBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/lap-neo4j-ubuntu/nested/",
-        "sharedTemplateUrl": "[concat(variables('templateBaseUrl'), 'shared-resources.json')]",
-        "lanpLapTemplateUrl": "[concat(variables('templateBaseUrl'), 'lanplap-resources.json')]",
-        "lanpneo4jTemplateUrl": "[concat(variables('templateBaseUrl'), 'lanpneo4j-resources.json')]",
-        "namespace": "lanp-",
-        "apiVersion": "2015-01-01",
-        "virtualNetworkName":"myVNET",
-        "networkSettings": {
-          "virtualNetworkName": "myVNET",
-          "addressPrefix": "10.0.0.0/16",
-            "subnet": {
-                "dse": {
-                    "name": "dse",
-                    "prefix": "10.0.0.0/24",
-                    "vnet": "myVNET"
-              }
-            },
-            "statics": {
-                "clusterRange": {
-                    "base": "10.0.0.",
-                    "start": 5
-                },
-                "lapip": "10.0.0.240",
-                "neo4jip": "10.0.0.10"
-            }
-        },
-        "lapOsSettings": {
-            "imageReference": {
-                "publisher": "Canonical",
-                "offer": "UbuntuServer",
-                "sku": "16.04.0-LTS",
-                "version": "latest"
-            },
-            "scripts": [
-                "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/lap-neo4j-ubuntu/scripts/install-lap.sh"
-            ]
-        },
-        "neo4jOsSettings": {
-            "imageReference": {
-                "publisher": "Canonical",
-                "offer": "UbuntuServer",
-                "sku": "16.04.0-LTS",
-                "version": "latest"
-            },
-            "scripts": [
-                "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/lap-neo4j-ubuntu/scripts/install-neo4j.sh"
-            ]
-        }
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Administrator password used when provisioning virtual machines"
+      }
     },
-    "resources": [{
-        "name": "shared",
-        "type": "Microsoft.Resources/deployments",
-        "apiVersion": "[variables('apiVersion')]",
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[variables('sharedTemplateUrl')]",
-                "contentVersion": "1.0.0.0"
-            },
-            "parameters": {
-                "networkSettings": {
-                    "value": "[variables('networkSettings')]"
-                }
-            }
+    "dnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
+    "lapVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D1_V2",
+      "allowedValues": [
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_D1_V2",
+        "Standard_D3_V2",
+        "Standard_D4_V2"
+      ],
+      "metadata": {
+        "description": "The size of the virtual machines used when provisioning the Lap node"
+      }
+    },
+    "neo4jNodes": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "Number of Neo4J node (1 is the default)"
+      }
+    },
+    "neo4jVmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D1_V2",
+      "allowedValues": [
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_D1_V2",
+        "Standard_D3_V2",
+        "Standard_D4_V2"
+      ],
+      "metadata": {
+        "description": "The size of the virtual machines used when provisioning Neo4J node(s)"
+      }
+    }
+  },
+  "variables": {
+    "templateBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/lap-neo4j-ubuntu/nested/",
+    "sharedTemplateUrl": "[concat(variables('templateBaseUrl'), 'shared-resources.json')]",
+    "lanpLapTemplateUrl": "[concat(variables('templateBaseUrl'), 'lanplap-resources.json')]",
+    "lanpneo4jTemplateUrl": "[concat(variables('templateBaseUrl'), 'lanpneo4j-resources.json')]",
+    "namespace": "lanp-",
+    "apiVersion": "2015-01-01",
+    "virtualNetworkName": "myVNET",
+    "networkSettings": {
+      "virtualNetworkName": "myVNET",
+      "addressPrefix": "10.0.0.0/16",
+      "subnet": {
+        "dse": {
+          "name": "dse",
+          "prefix": "10.0.0.0/24",
+          "vnet": "myVNET"
         }
-    }, {
-        "name": "lanpLapNode",
-        "type": "Microsoft.Resources/deployments",
-        "apiVersion": "[variables('apiVersion')]",
-        "dependsOn": [
-            "[concat('Microsoft.Resources/deployments/', 'shared')]"
-        ],
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[variables('lanpLapTemplateUrl')]",
-                "contentVersion": "1.0.0.0"
-            },
-            "parameters": {
-                "adminUsername": {
-                    "value": "[parameters('adminUsername')]"
-                },
-                "adminPassword": {
-                    "value": "[parameters('adminPassword')]"
-                },
-                "namespace": {
-                    "value": "[variables('namespace')]"
-                },
-                "vmbasename": {
-                    "value": "Lap"
-                },
-                "subnet": {
-                    "value": "[variables('networkSettings').subnet.dse]"
-                },
-                "dnsname": {
-                    "value": "[parameters('dnsLabelPrefix')]"
-                },
-                "staticIp": {
-                    "value": "[variables('networkSettings').statics.lapip]"
-                },
-                "vmSize": {
-                    "value": "[parameters('lapVmSize')]"
-                },
-                "neo4jNodes": {
-                    "value": "[parameters('neo4jNodes')]"
-                },
-                "osSettings": {
-                    "value": "[variables('lapOsSettings')]"
-                }
-            }
-        }
-    }, {
-        "name": "[concat('lanpNeo4jNode', copyindex())]",
-        "type": "Microsoft.Resources/deployments",
-        "apiVersion": "[variables('apiVersion')]",
-        "dependsOn": [
-            "[concat('Microsoft.Resources/deployments/', 'shared')]",
-            "[concat('Microsoft.Resources/deployments/', 'lanpLapNode')]"
-        ],
-        "copy": {
-            "name": "vmLoop",
-            "count": "[parameters('neo4jNodes')]"
+      },
+      "statics": {
+        "clusterRange": {
+          "base": "10.0.0.",
+          "start": 5
         },
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "[variables('lanpneo4jTemplateUrl')]",
-                "contentVersion": "1.0.0.0"
-            },
-            "parameters": {
-                "adminUsername": {
-                    "value": "[parameters('adminUsername')]"
-                },
-                "adminPassword": {
-                    "value": "[parameters('adminPassword')]"
-                },
-                "namespace": {
-                    "value": "[variables('namespace')]"
-                },
-                "vmbasename": {
-                    "value": "[concat('neo4j', copyindex())]"
-                },
-                "lapNode": {
-                    "value": "[variables('networkSettings').statics.lapip]"
-                },
-                "neo4jstaticIp": {
-                    "value": "[variables('networkSettings').statics.neo4jip]"
-                },
-                "subnet": {
-                    "value": "[variables('networkSettings').subnet.dse]"
-                },
-                "vmSize": {
-                    "value": "[parameters('neo4jVmSize')]"
-                },
-                "osSettings": {
-                    "value": "[variables('neo4jOsSettings')]"
-                }
-            }
+        "lapip": "10.0.0.240",
+        "neo4jip": "10.0.0.10"
+      }
+    },
+    "lapOsSettings": {
+      "imageReference": {
+        "publisher": "Canonical",
+        "offer": "UbuntuServer",
+        "sku": "16.04.0-LTS",
+        "version": "latest"
+      },
+      "scripts": [
+        "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/lap-neo4j-ubuntu/scripts/install-lap.sh"
+      ]
+    },
+    "neo4jOsSettings": {
+      "imageReference": {
+        "publisher": "Canonical",
+        "offer": "UbuntuServer",
+        "sku": "16.04.0-LTS",
+        "version": "latest"
+      },
+      "scripts": [
+        "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/lap-neo4j-ubuntu/scripts/install-neo4j.sh"
+      ]
+    }
+  },
+  "resources": [
+    {
+      "name": "shared",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('sharedTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          }
         }
-    }],
-    "outputs": {}
+      }
+    },
+    {
+      "name": "lanpLapNode",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'shared')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('lanpLapTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "namespace": {
+            "value": "[variables('namespace')]"
+          },
+          "vmbasename": {
+            "value": "Lap"
+          },
+          "subnet": {
+            "value": "[variables('networkSettings').subnet.dse]"
+          },
+          "dnsname": {
+            "value": "[parameters('dnsLabelPrefix')]"
+          },
+          "staticIp": {
+            "value": "[variables('networkSettings').statics.lapip]"
+          },
+          "vmSize": {
+            "value": "[parameters('lapVmSize')]"
+          },
+          "neo4jNodes": {
+            "value": "[parameters('neo4jNodes')]"
+          },
+          "osSettings": {
+            "value": "[variables('lapOsSettings')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "[concat('lanpNeo4jNode', copyindex())]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'shared')]",
+        "[concat('Microsoft.Resources/deployments/', 'lanpLapNode')]"
+      ],
+      "copy": {
+        "name": "vmLoop",
+        "count": "[parameters('neo4jNodes')]"
+      },
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('lanpneo4jTemplateUrl')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "namespace": {
+            "value": "[variables('namespace')]"
+          },
+          "vmbasename": {
+            "value": "[concat('neo4j', copyindex())]"
+          },
+          "lapNode": {
+            "value": "[variables('networkSettings').statics.lapip]"
+          },
+          "neo4jstaticIp": {
+            "value": "[variables('networkSettings').statics.neo4jip]"
+          },
+          "subnet": {
+            "value": "[variables('networkSettings').subnet.dse]"
+          },
+          "vmSize": {
+            "value": "[parameters('neo4jVmSize')]"
+          },
+          "osSettings": {
+            "value": "[variables('neo4jOsSettings')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {}
 }

--- a/lap-neo4j-ubuntu/nested/lanplap-resources.json
+++ b/lap-neo4j-ubuntu/nested/lanplap-resources.json
@@ -35,13 +35,13 @@
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"apiVersion": "2015-06-15",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
     "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -79,7 +79,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp')]",
       "location": "[resourceGroup().location]",
@@ -91,14 +91,14 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -127,7 +127,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -166,7 +166,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/lampInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
@@ -177,7 +177,7 @@
         "typeHandlerVersion": "2.0",
         "autoUpgradeMinorVersion": true,
         "settings": {
-		  "fileUris": "[parameters('osSettings').scripts]",
+          "fileUris": "[parameters('osSettings').scripts]",
           "commandToExecute": "sudo bash install-lap.sh"
         }
       }
@@ -185,4 +185,3 @@
   ],
   "outputs": {}
 }
-

--- a/lap-neo4j-ubuntu/nested/lanpneo4j-resources.json
+++ b/lap-neo4j-ubuntu/nested/lanpneo4j-resources.json
@@ -23,7 +23,7 @@
     "vmSize": {
       "type": "string"
     },
-	"neo4jstaticIp": {
+    "neo4jstaticIp": {
       "type": "string"
     },
     "subnet": {
@@ -32,19 +32,19 @@
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15"
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'nic')]",
       "location": "[resourceGroup().location]",
@@ -53,7 +53,7 @@
           {
             "name": "ipconfig1",
             "properties": {
-			  "privateIPAllocationMethod": "Static",
+              "privateIPAllocationMethod": "Static",
               "privateIPAddress": "[parameters('neo4jstaticIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -64,7 +64,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[resourceGroup().location]",
@@ -103,7 +103,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/lampInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",
@@ -123,4 +123,3 @@
   ],
   "outputs": {}
 }
-

--- a/lap-neo4j-ubuntu/nested/shared-resources.json
+++ b/lap-neo4j-ubuntu/nested/shared-resources.json
@@ -11,11 +11,11 @@
   },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-    "apiVersion": "2015-06-15"  
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -24,7 +24,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "myVNet",
       "location": "[resourceGroup().location]",
@@ -46,4 +46,3 @@
     }
   ]
 }
-

--- a/manifold-endpoint/azuredeploy.json
+++ b/manifold-endpoint/azuredeploy.json
@@ -62,14 +62,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -81,7 +81,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -102,7 +102,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -128,7 +128,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -173,16 +173,16 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-		"type": "CustomScript",
-		"typeHandlerVersion": "2.0",
-		"autoUpgradeMinorVersion": true,
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
             "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/manifold-endpoint/install_manifold.sh"

--- a/minecraft-on-ubuntu/azuredeploy.json
+++ b/minecraft-on-ubuntu/azuredeploy.json
@@ -150,7 +150,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('networkSecurityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -188,7 +188,7 @@
       }
     },
     {
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -200,7 +200,7 @@
       }
     },
     {
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -227,7 +227,7 @@
       }
     },
     {
-      "apiVersion": "[variables('networkApiVersion')]",
+      "apiVersion": "2017-04-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -253,7 +253,7 @@
       }
     },
     {
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -294,16 +294,16 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('computeApiVersion')]",
+      "apiVersion": "2017-03-30",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-		"type": "CustomScript",
-		"typeHandlerVersion": "2.0",
-		"autoUpgradeMinorVersion": true,
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
             "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/minecraft-on-ubuntu/install_minecraft.sh"

--- a/mongodb-replica-set-centos/azuredeploy.json
+++ b/mongodb-replica-set-centos/azuredeploy.json
@@ -60,7 +60,7 @@
         "6.7",
         "7.0",
         "7.1",
-        "7.2"		
+        "7.2"
       ],
       "metadata": {
         "description": "The CentOS version for the VM. This will pick a fully patched image of this given CentOS version."
@@ -119,9 +119,9 @@
       "type": "string",
       "defaultValue": "",
       "metadata": {
-	    "description": "The zabbix server IP which will monitor the mongodb nodes' mongodb status. Null means no zabbix server."
-	  }
-	}
+        "description": "The zabbix server IP which will monitor the mongodb nodes' mongodb status. Null means no zabbix server."
+      }
+    }
   },
   "variables": {
     "baseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mongodb-replica-set-centos/",
@@ -138,7 +138,7 @@
       "primaryNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/primary.sh')]",
       "secondaryNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/secondary.sh')]"
     },
-    "environment": "[variables(concat('environment', parameters('environment')))]",    
+    "environment": "[variables(concat('environment', parameters('environment')))]",
     "sharedTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'shared-resources.json')]",
     "primaryTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'primary-resources.json')]",
     "secondaryTemplateUrl": "[concat(variables('environment').templateBaseUrl, 'secondary-resources.json')]",
@@ -191,7 +191,7 @@
     {
       "name": "shared",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -211,7 +211,7 @@
     {
       "name": "[concat('secondaryNode', copyindex())]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]"
       ],
@@ -260,7 +260,7 @@
             "value": "[parameters('secondaryNodeVmSize')]"
           },
           "zabbixServerIPAddress": {
-             "value": "[parameters('zabbixServerIPAddress')]"
+            "value": "[parameters('zabbixServerIPAddress')]"
           },
           "osSettings": {
             "value": "[variables('secondaryOsSettings')]"
@@ -271,7 +271,7 @@
     {
       "name": "primaryNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "['vmLoop']"
@@ -329,7 +329,7 @@
             "value": "[parameters('primaryNodeVmSize')]"
           },
           "zabbixServerIPAddress": {
-             "value": "[parameters('zabbixServerIPAddress')]"
+            "value": "[parameters('zabbixServerIPAddress')]"
           },
           "osSettings": {
             "value": "[variables('primaryOsSettings')]"

--- a/mongodb-replica-set-centos/nested/primary-resources.json
+++ b/mongodb-replica-set-centos/nested/primary-resources.json
@@ -62,7 +62,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -96,7 +96,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -110,7 +110,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent1",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -128,7 +128,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp')]",
       "location": "[resourceGroup().location]",
@@ -140,7 +140,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -169,7 +169,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -187,48 +187,48 @@
         },
         "storageProfile": {
           "imageReference": "[parameters('osSettings').imageReference]",
-          "dataDisks": [ 
-             { 
-               "name": "datadisk1", 
-               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
-               "lun": 0, 
-               "vhd": { 
-                 "Uri": "[concat('http://', variables('storageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk1.vhd')]" 
-               }, 
-               "createOption": "Empty",
-               "caching": "ReadWrite"			   
-             }, 
-             { 
-               "name": "datadisk2", 
-               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
-               "lun": 1, 
-               "vhd": { 
-                 "Uri": "[concat('http://', variables('storageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk2.vhd')]" 
-               }, 
-               "caching": "ReadWrite",
-               "createOption": "Empty" 
-             }, 
-             { 
-               "name": "datadisk3", 
-               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
-               "lun": 2, 
-               "vhd": { 
-                 "Uri": "[concat('http://', variables('storageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk3.vhd')]" 
-               },
-               "caching": "ReadWrite",			   
-               "createOption": "Empty" 
-             }, 
-             { 
-               "name": "datadisk4", 
-               "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]", 
-               "lun": 3, 
-               "vhd": { 
-                 "Uri": "[concat('http://', variables('storageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk4.vhd')]" 
-               },
-               "caching": "ReadWrite",			   
-               "createOption": "Empty" 
-             } 
-           ], 
+          "dataDisks": [
+            {
+              "name": "datadisk1",
+              "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]",
+              "lun": 0,
+              "vhd": {
+                "Uri": "[concat('http://', variables('storageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk1.vhd')]"
+              },
+              "createOption": "Empty",
+              "caching": "ReadWrite"
+            },
+            {
+              "name": "datadisk2",
+              "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]",
+              "lun": 1,
+              "vhd": {
+                "Uri": "[concat('http://', variables('storageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk2.vhd')]"
+              },
+              "caching": "ReadWrite",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk3",
+              "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]",
+              "lun": 2,
+              "vhd": {
+                "Uri": "[concat('http://', variables('storageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk3.vhd')]"
+              },
+              "caching": "ReadWrite",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk4",
+              "diskSizeGB": "[parameters('sizeOfDataDiskInGB')]",
+              "lun": 3,
+              "vhd": {
+                "Uri": "[concat('http://', variables('storageAccountName'),'.blob.core.windows.net/vhds/', 'datadisk4.vhd')]"
+              },
+              "caching": "ReadWrite",
+              "createOption": "Empty"
+            }
+          ],
           "osDisk": {
             "name": "osdisk",
             "vhd": {
@@ -250,7 +250,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/primaryInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
@@ -262,8 +262,8 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash primary.sh ', parameters('dnsname'), ' ', parameters('secondaryNodeCount'), ' ', parameters('mongoAdminUsername'), ' ', parameters('mongoAdminPassword'), ' ', parameters('staticIp'), ' ', parameters('zabbixServerIPAddress'))]"
         }
       }

--- a/mongodb-replica-set-centos/nested/secondary-resources.json
+++ b/mongodb-replica-set-centos/nested/secondary-resources.json
@@ -50,7 +50,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -59,7 +59,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -125,7 +125,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp')]",
       "location": "[resourceGroup().location]",
@@ -137,7 +137,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -165,7 +165,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[resourceGroup().location]",
@@ -247,7 +247,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/secondaryInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",

--- a/mongodb-replica-set-centos/nested/shared-resources.json
+++ b/mongodb-replica-set-centos/nested/shared-resources.json
@@ -17,12 +17,11 @@
   },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15"
-  
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -31,14 +30,14 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSettings').virtualNetworkName]",
       "location": "[resourceGroup().location]",

--- a/mongodb-sharding-centos/azuredeploy.json
+++ b/mongodb-sharding-centos/azuredeploy.json
@@ -41,7 +41,7 @@
         "6.7",
         "7.0",
         "7.1",
-        "7.2"		
+        "7.2"
       ],
       "metadata": {
         "description": "The CentOS version for the VM. This will pick a fully patched image of this given CentOS version."
@@ -194,12 +194,12 @@
       "replicaPrimaryNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/replica_primary.sh')]",
       "replicaSecondaryNodeScript": "[concat(variables('baseChinaUrl'), 'scripts/replica_secondary.sh')]"
     },
-    "environment": "[variables(concat('environment', parameters('environment')))]",	
+    "environment": "[variables(concat('environment', parameters('environment')))]",
     "templateBaseUrl": "[variables('environment').templateBaseUrl]",
     "sharedTemplateUrl": "[concat(variables('templateBaseUrl'), 'shared-resources.json')]",
     "configPrimaryTemplateUrl": "[concat(variables('templateBaseUrl'), 'config-primary-resources.json')]",
     "configSecondaryTemplateUrl": "[concat(variables('templateBaseUrl'), 'config-secondary-resources.json')]",
-    "router1TemplateUrl": "[concat(variables('templateBaseUrl'), 'router1-resources.json')]",		
+    "router1TemplateUrl": "[concat(variables('templateBaseUrl'), 'router1-resources.json')]",
     "router2TemplateUrl": "[concat(variables('templateBaseUrl'), 'router2-resources.json')]",
     "replicaPrimaryTemplateUrl": "[concat(variables('templateBaseUrl'), 'replica-primary-resources.json')]",
     "replicaSecondaryTemplateUrl": "[concat(variables('templateBaseUrl'), 'replica-secondary-resources.json')]",
@@ -301,7 +301,7 @@
     {
       "name": "shared",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -321,7 +321,7 @@
     {
       "name": "configSecondaryNode1",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]"
       ],
@@ -365,7 +365,7 @@
     {
       "name": "configSecondaryNode2",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'configSecondaryNode1')]"
@@ -399,7 +399,7 @@
             "value": "[variables('networkSettings').statics.configSecondaryIp2]"
           },
           "zabbixServerIPAddress": {
-           "value": "[parameters('zabbixServerIPAddress')]"
+            "value": "[parameters('zabbixServerIPAddress')]"
           },
           "osSettings": {
             "value": "[variables('configSecondaryOsSettings')]"
@@ -410,7 +410,7 @@
     {
       "name": "configPrimaryNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'configSecondaryNode2')]"
@@ -461,7 +461,7 @@
     {
       "name": "[concat('aReplicaSecondaryNode', '0')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]"
       ],
@@ -517,7 +517,7 @@
     {
       "name": "[concat('aReplicaSecondaryNode', '1')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'aReplicaSecondaryNode0')]"
@@ -574,7 +574,7 @@
     {
       "name": "aReplicaPrimaryNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'aReplicaSecondaryNode1')]"
@@ -640,7 +640,7 @@
     {
       "name": "[concat('bReplicaSecondaryNode', '0')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'aReplicaPrimaryNode')]"
@@ -697,7 +697,7 @@
     {
       "name": "[concat('bReplicaSecondaryNode', '1')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'bReplicaSecondaryNode0')]"
@@ -754,7 +754,7 @@
     {
       "name": "bReplicaPrimaryNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'bReplicaSecondaryNode1')]"
@@ -820,7 +820,7 @@
     {
       "name": "routerNode1",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'configPrimaryNode')]",
@@ -875,7 +875,7 @@
     {
       "name": "routerNode2",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'routerNode1')]"

--- a/mongodb-sharding-centos/nested/config-primary-resources.json
+++ b/mongodb-sharding-centos/nested/config-primary-resources.json
@@ -8,7 +8,7 @@
     "adminPassword": {
       "type": "securestring"
     },
-	"mongoAdminUsername": {
+    "mongoAdminUsername": {
       "type": "string"
     },
     "mongoAdminPassword": {
@@ -29,22 +29,22 @@
     "subnet": {
       "type": "object"
     },
-	"zabbixServerIPAddress": {
-	  "type": "string"
-	},
+    "zabbixServerIPAddress": {
+      "type": "string"
+    },
     "staticIp": {
       "type": "string"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"apiVersion": "2015-06-15",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
     "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -78,7 +78,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -92,7 +92,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent1",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -110,7 +110,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -133,7 +133,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -172,7 +172,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/configPrimaryInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
@@ -184,8 +184,8 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash config_primary.sh ', parameters('mongoAdminUsername'), ' ', parameters('mongoAdminPassword'), ' ', parameters('zabbixServerIPAddress'))]"
         }
       }

--- a/mongodb-sharding-centos/nested/config-secondary-resources.json
+++ b/mongodb-sharding-centos/nested/config-secondary-resources.json
@@ -20,25 +20,25 @@
     "vmSize": {
       "type": "string"
     },
-	"zabbixServerIPAddress": {
-	  "type": "string"
-	},
+    "zabbixServerIPAddress": {
+      "type": "string"
+    },
     "subnet": {
       "type": "object"
     },
-	"staticIp": {
+    "staticIp": {
       "type": "string"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
     "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -72,7 +72,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -86,7 +86,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent1",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -103,8 +103,8 @@
         ]
       }
     },
-	{
-      "apiVersion": "[variables('apiVersion')]",
+    {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -114,11 +114,11 @@
             "name": "ipconfig1",
             "properties": {
               "privateIPAllocationMethod": "Static",
-			  "privateIPAddress": "[parameters('staticIp')]",
+              "privateIPAddress": "[parameters('staticIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
               },
-			  "networkSecurityGroup": {
+              "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
               }
             }
@@ -127,7 +127,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[resourceGroup().location]",
@@ -166,7 +166,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/configSecondaryInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",
@@ -179,8 +179,8 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash config_secondary.sh ', parameters('zabbixServerIPAddress'))]"
         }
       }

--- a/mongodb-sharding-centos/nested/replica-primary-resources.json
+++ b/mongodb-sharding-centos/nested/replica-primary-resources.json
@@ -11,7 +11,7 @@
     "adminPassword": {
       "type": "securestring"
     },
-	"mongoAdminUsername": {
+    "mongoAdminUsername": {
       "type": "string"
     },
     "mongoAdminPassword": {
@@ -44,22 +44,22 @@
     "subnet": {
       "type": "object"
     },
-	"zabbixServerIPAddress": {
-	  "type": "string"
-	},
+    "zabbixServerIPAddress": {
+      "type": "string"
+    },
     "staticIp": {
       "type": "string"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"apiVersion": "2015-06-15",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), parameters('storageAccountBasename'))]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), parameters('storageAccountBasename'))]",
     "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
   },
   "resources": [
-     {
-      "apiVersion": "[variables('apiVersion')]",
+    {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -67,34 +67,34 @@
         "accountType": "Standard_LRS"
       }
     },
-    { 
-      "apiVersion": "2015-01-01", 
-      "name": "diskSelection", 
-      "type": "Microsoft.Resources/deployments", 
-      "properties": { 
-        "mode": "Incremental", 
-        "templateLink": { 
-          "uri": "[concat(parameters('templateBaseUrl'), 'disksSelector', '.json')]", 
-            "contentVersion": "1.0.0.0" 
-        }, 
-        "parameters": { 
-          "numDataDisks": { 
-            "value": "[parameters('numDataDisks')]" 
-          }, 
-          "diskStorageAccountName": { 
-            "value": "[variables('storageAccountName')]" 
-          }, 
-          "diskCaching": { 
-            "value": "ReadWrite" 
-          }, 
-          "diskSizeGB": { 
-            "value": "[parameters('sizeOfDataDiskInGB')]" 
-          } 
-        } 
-      } 
-    }, 
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
+      "name": "diskSelection",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('templateBaseUrl'), 'disksSelector', '.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "numDataDisks": {
+            "value": "[parameters('numDataDisks')]"
+          },
+          "diskStorageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "diskCaching": {
+            "value": "ReadWrite"
+          },
+          "diskSizeGB": {
+            "value": "[parameters('sizeOfDataDiskInGB')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -128,7 +128,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -142,7 +142,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent1",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -160,7 +160,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -183,7 +183,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -225,7 +225,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/replicaPrimaryInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
@@ -237,8 +237,8 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash replica_primary.sh ', parameters('replSetName'), ' ', parameters('staticIp'), ' ', parameters('mongoAdminUsername'), ' ', parameters('mongoAdminPassword'), ' ', parameters('zabbixServerIPAddress'))]"
         }
       }

--- a/mongodb-sharding-centos/nested/replica-secondary-resources.json
+++ b/mongodb-sharding-centos/nested/replica-secondary-resources.json
@@ -35,22 +35,22 @@
     "vmSize": {
       "type": "string"
     },
-	"zabbixServerIPAddress": {
-	  "type": "string"
-	},
+    "zabbixServerIPAddress": {
+      "type": "string"
+    },
     "subnet": {
       "type": "object"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), parameters('storageAccountBasename'))]",
-	"apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), parameters('storageAccountBasename'))]",
+    "apiVersion": "2015-06-15",
     "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -58,34 +58,34 @@
         "accountType": "Standard_LRS"
       }
     },
-    { 
-      "apiVersion": "2015-01-01", 
-      "name": "diskSelection", 
-      "type": "Microsoft.Resources/deployments", 
-      "properties": { 
-        "mode": "Incremental", 
-        "templateLink": { 
-          "uri": "[concat(parameters('templateBaseUrl'), 'disksSelector', '.json')]", 
-            "contentVersion": "1.0.0.0" 
-        }, 
-        "parameters": { 
-          "numDataDisks": { 
-            "value": "[parameters('numDataDisks')]" 
-          }, 
-          "diskStorageAccountName": { 
-            "value": "[variables('storageAccountName')]" 
-          }, 
-          "diskCaching": { 
-            "value": "ReadWrite" 
-          }, 
-          "diskSizeGB": { 
-            "value": "[parameters('sizeOfDataDiskInGB')]" 
-          } 
-        } 
-      } 
-    }, 
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
+      "name": "diskSelection",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('templateBaseUrl'), 'disksSelector', '.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "numDataDisks": {
+            "value": "[parameters('numDataDisks')]"
+          },
+          "diskStorageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "diskCaching": {
+            "value": "ReadWrite"
+          },
+          "diskSizeGB": {
+            "value": "[parameters('sizeOfDataDiskInGB')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -119,7 +119,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -133,7 +133,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent1",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -150,8 +150,8 @@
         ]
       }
     },
-	{
-      "apiVersion": "[variables('apiVersion')]",
+    {
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -164,7 +164,7 @@
               "subnet": {
                 "id": "[variables('subnetRef')]"
               },
-			  "networkSecurityGroup": {
+              "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
               }
             }
@@ -173,7 +173,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[resourceGroup().location]",
@@ -215,7 +215,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/replicaSecondaryInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",
@@ -228,8 +228,8 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash replica_secondary.sh ', parameters('replSetName'), ' ', parameters('zabbixServerIPAddress'))]"
         }
       }

--- a/mongodb-sharding-centos/nested/router1-resources.json
+++ b/mongodb-sharding-centos/nested/router1-resources.json
@@ -8,7 +8,7 @@
     "adminPassword": {
       "type": "securestring"
     },
-	"mongoAdminUsername": {
+    "mongoAdminUsername": {
       "type": "string"
     },
     "mongoAdminPassword": {
@@ -32,22 +32,22 @@
     "subnet": {
       "type": "object"
     },
-	"zabbixServerIPAddress": {
-	  "type": "string"
-	},
+    "zabbixServerIPAddress": {
+      "type": "string"
+    },
     "staticIp": {
       "type": "string"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"apiVersion": "2015-06-15",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
     "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -81,7 +81,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -95,7 +95,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent1",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -113,7 +113,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp')]",
       "location": "[resourceGroup().location]",
@@ -125,7 +125,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -154,7 +154,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -193,7 +193,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/router1Install')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
@@ -205,8 +205,8 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash router1.sh ', parameters('mongoAdminUsername'), ' ', parameters('mongoAdminPassword'), ' ',  parameters('zabbixServerIPAddress'))]"
         }
       }

--- a/mongodb-sharding-centos/nested/router2-resources.json
+++ b/mongodb-sharding-centos/nested/router2-resources.json
@@ -26,22 +26,22 @@
     "subnet": {
       "type": "object"
     },
-	"zabbixServerIPAddress": {
-	  "type": "string"
-	},
+    "zabbixServerIPAddress": {
+      "type": "string"
+    },
     "staticIp": {
       "type": "string"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"apiVersion": "2015-06-15",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
     "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -75,7 +75,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -89,7 +89,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "zabbixAgent1",
             "properties": {
               "description": "Allows zabbix monitoring",
@@ -107,7 +107,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp')]",
       "location": "[resourceGroup().location]",
@@ -119,7 +119,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -148,7 +148,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -187,7 +187,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/router2Install')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
@@ -199,8 +199,8 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash router2.sh ', parameters('zabbixServerIPAddress'))]"
         }
       }

--- a/mongodb-sharding-centos/nested/shared-resources.json
+++ b/mongodb-sharding-centos/nested/shared-resources.json
@@ -17,12 +17,11 @@
   },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15"
-  
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -31,14 +30,14 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSettings').virtualNetworkName]",
       "location": "[resourceGroup().location]",

--- a/moodle-cluster-centos/azuredeploy.json
+++ b/moodle-cluster-centos/azuredeploy.json
@@ -32,19 +32,19 @@
         "description": "Full name of the Moodle site displayed in the UI."
       }
     },
-    "shortNameOfSite":  {
+    "shortNameOfSite": {
       "type": "string",
       "metadata": {
         "description": "Short name of the Moodle site."
       }
     },
-    "moodleAdminUsername":{
+    "moodleAdminUsername": {
       "type": "string",
       "metadata": {
         "description": "User name for the Moodle site administrator."
       }
     },
-    "moodleAdminPassword":  {
+    "moodleAdminPassword": {
       "type": "securestring",
       "metadata": {
         "description": "Password for the Moodle site administrator."
@@ -57,18 +57,18 @@
       }
     },
     "webVMCount": {
-        "type": "int",
-        "defaultValue": 2,
-        "allowedValues": [
-          1,
-          2,
-          3,
-          4,
-          5
-        ],
-        "metadata": {
-            "description": "Number of web front end VMs to create."
-        }
+      "type": "int",
+      "defaultValue": 2,
+      "allowedValues": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "metadata": {
+        "description": "Number of web front end VMs to create."
+      }
     },
     "vmSize": {
       "type": "string",
@@ -192,7 +192,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -203,12 +203,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
-   {
-      "apiVersion": "[variables('apiVersion')]",
+    {
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -220,7 +220,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -247,7 +247,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -287,7 +287,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -312,10 +312,10 @@
         ],
         "inboundNatRules": [
           {
-            "name":"Web-VM0",
+            "name": "Web-VM0",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 8080,
@@ -324,10 +324,10 @@
             }
           },
           {
-            "name":"SSH-VM0",
+            "name": "SSH-VM0",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2200,
@@ -336,10 +336,10 @@
             }
           },
           {
-            "name":"Web-VM1",
+            "name": "Web-VM1",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 8081,
@@ -348,10 +348,10 @@
             }
           },
           {
-            "name":"SSH-VM1",
+            "name": "SSH-VM1",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2201,
@@ -360,10 +360,10 @@
             }
           },
           {
-            "name":"Web-VM2",
+            "name": "Web-VM2",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 8082,
@@ -372,10 +372,10 @@
             }
           },
           {
-            "name":"SSH-VM2",
+            "name": "SSH-VM2",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2202,
@@ -384,10 +384,10 @@
             }
           },
           {
-            "name":"Web-VM3",
+            "name": "Web-VM3",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 8083,
@@ -396,10 +396,10 @@
             }
           },
           {
-            "name":"SSH-VM3",
+            "name": "SSH-VM3",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2203,
@@ -408,10 +408,10 @@
             }
           },
           {
-            "name":"Web-VM4",
+            "name": "Web-VM4",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 8084,
@@ -420,10 +420,10 @@
             }
           },
           {
-            "name":"SSH-VM4",
+            "name": "SSH-VM4",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2204,
@@ -468,7 +468,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -522,7 +522,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),copyIndex(),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),copyIndex()))]"
@@ -546,19 +546,15 @@
         "count": "[parameters('webVMCount')]"
       }
     },
-
-    
-    
-
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(variables('availabilitySetName'),'db')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicDBIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -570,7 +566,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -596,7 +592,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -645,7 +641,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'db','/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),'db'))]"

--- a/moodle-cluster-ubuntu/azuredeploy.json
+++ b/moodle-cluster-ubuntu/azuredeploy.json
@@ -191,7 +191,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -202,12 +202,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -219,7 +219,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -246,7 +246,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -286,7 +286,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -467,7 +467,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -521,7 +521,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),copyIndex(),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),copyIndex()))]"
@@ -548,12 +548,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(variables('availabilitySetName'),'db')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicDBIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -565,7 +565,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -591,7 +591,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -640,7 +640,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'db','/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),'db'))]"
@@ -662,4 +662,3 @@
     }
   ]
 }
-

--- a/moodle-scalable-cluster-ubuntu/azuredeploy.parameters.json
+++ b/moodle-scalable-cluster-ubuntu/azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
 

--- a/moodle-scalable-cluster-ubuntu/nested/controller.json
+++ b/moodle-scalable-cluster-ubuntu/nested/controller.json
@@ -77,7 +77,7 @@
 
 		{
 			"type":			"Microsoft.Compute/virtualMachines",
-			"apiVersion":	"[parameters('moodleCommon').computeApi]",
+			"apiVersion":	"2016-04-30-preview",
 			"name":			"[parameters('moodleCommon').jboxVmName]",
 			"location":		"[resourceGroup().location]",
 			

--- a/moodle-scalable-cluster-ubuntu/nested/diskSelection.json
+++ b/moodle-scalable-cluster-ubuntu/nested/diskSelection.json
@@ -1,4 +1,4 @@
-﻿{
+{
 	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 	"contentVersion": "1.0.0.0",
 

--- a/moodle-scalable-cluster-ubuntu/nested/gluster.json
+++ b/moodle-scalable-cluster-ubuntu/nested/gluster.json
@@ -18,7 +18,7 @@
 	"resources":   [
 		{
 			"type":			"Microsoft.Compute/availabilitySets",
-			"apiVersion":	"[parameters('moodleCommon').computeApi]",
+			"apiVersion":	"2016-04-30-preview",
 			"name":			"[parameters('moodleCommon').gfxAvailabilitySetName]",
 			"location":		"[resourceGroup().location]",
 

--- a/moodle-scalable-cluster-ubuntu/nested/glustervm.json
+++ b/moodle-scalable-cluster-ubuntu/nested/glustervm.json
@@ -55,7 +55,7 @@
 
 		{
 			"type":			"Microsoft.Compute/disks",
-			"apiVersion":	"[parameters('moodleCommon').computeApi]",
+			"apiVersion":	"2016-04-30-preview",
 			"name":			"[concat(variables('vmName'),'-datadisk',copyIndex(1))]",
 			"location":		"[resourceGroup().location]",
 
@@ -85,7 +85,7 @@
 
 		{
 			"type":			"Microsoft.Compute/virtualMachines",
-			"apiVersion":	"[parameters('moodleCommon').computeApi]",
+			"apiVersion":	"2016-04-30-preview",
 			"name":			"[variables('vmName')]",
 			"location":		"[resourceGroup().location]",
 			

--- a/moodle-scalable-cluster-ubuntu/nested/mariadb.json
+++ b/moodle-scalable-cluster-ubuntu/nested/mariadb.json
@@ -27,7 +27,7 @@
 	"resources":   [        
 		{
 			"type":			"Microsoft.Compute/availabilitySets",
-			"apiVersion":	"[parameters('moodleCommon').computeApi]",
+			"apiVersion":	"2016-04-30-preview",
 			"name":			"[parameters('moodleCommon').dbAvailabilitySetName]",
 			"location":		"[resourceGroup().location]",
 

--- a/moodle-scalable-cluster-ubuntu/nested/mariadbvm.json
+++ b/moodle-scalable-cluster-ubuntu/nested/mariadbvm.json
@@ -61,7 +61,7 @@
 
 		{
 			"type":			"Microsoft.Compute/disks",
-			"apiVersion":	"[parameters('moodleCommon').computeApi]",
+			"apiVersion":	"2016-04-30-preview",
 			"name":			"[concat(variables('vmName'),'-datadisk',copyIndex(1))]",
 			"location":		"[resourceGroup().location]",
 
@@ -75,7 +75,7 @@
 
 		{
 			"type":			"Microsoft.Compute/virtualMachines",
-			"apiVersion":	"[parameters('moodleCommon').computeApi]",
+			"apiVersion":	"2016-04-30-preview",
 			"name":			"[variables('vmName')]",
 			"location":		"[resourceGroup().location]",
 			

--- a/moodle-scalable-cluster-ubuntu/nested/redis.json
+++ b/moodle-scalable-cluster-ubuntu/nested/redis.json
@@ -1,4 +1,4 @@
-﻿{
+{
 	"$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
 	"contentVersion": "1.0.0.0",
 

--- a/moodle-scalable-cluster-ubuntu/nested/vmNameListSelecter.json
+++ b/moodle-scalable-cluster-ubuntu/nested/vmNameListSelecter.json
@@ -1,4 +1,4 @@
-﻿{
+{
 	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
 	"contentVersion": "1.0.0.0",
 

--- a/moodle-singlevm-centos/azuredeploy.json
+++ b/moodle-singlevm-centos/azuredeploy.json
@@ -81,7 +81,7 @@
     "imagePublisher": "OpenLogic",
     "imageOffer": "CentOS",
     "imageSKU": "7.0",
-    "centOSVersion": "latest" ,
+    "centOSVersion": "latest",
     "OSDiskName": "[concat(parameters('uniqueNamePrefix'),'Disk')]",
     "nicName": "[concat(parameters('uniqueNamePrefix'),'Nic')]",
     "addressPrefix": "10.0.0.0/16",
@@ -103,7 +103,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -112,7 +112,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -124,7 +124,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -145,7 +145,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -171,7 +171,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -216,7 +216,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/moodle-singlevm-ubuntu/azuredeploy.json
+++ b/moodle-singlevm-ubuntu/azuredeploy.json
@@ -101,7 +101,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -110,7 +110,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -122,7 +122,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -143,7 +143,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -169,7 +169,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -214,7 +214,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/mysql-mha-haproxy-ubuntu/azuredeploy.json
+++ b/mysql-mha-haproxy-ubuntu/azuredeploy.json
@@ -107,9 +107,9 @@
           "start": 5
         },
         "haproxyIp": "10.0.0.9",
-		"masterIp": "10.0.0.10",
-		"slaveIp01": "10.0.0.11",
-		"slaveIp02": "10.0.0.12"
+        "masterIp": "10.0.0.10",
+        "slaveIp01": "10.0.0.11",
+        "slaveIp02": "10.0.0.12"
       }
     },
     "haproxyOsSettings": {
@@ -161,7 +161,7 @@
     {
       "name": "shared",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -178,7 +178,7 @@
     {
       "name": "haproxyNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]"
       ],
@@ -195,7 +195,7 @@
           "adminPassword": {
             "value": "[parameters('adminPassword')]"
           },
-		  "mysqlPassword": {
+          "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
           "namespace": {
@@ -225,7 +225,7 @@
     {
       "name": "masterNode",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'haproxyNode')]"
@@ -243,7 +243,7 @@
           "adminPassword": {
             "value": "[parameters('adminPassword')]"
           },
-		  "mysqlPassword": {
+          "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
           "namespace": {
@@ -270,11 +270,11 @@
     {
       "name": "slaveNode01",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'haproxyNode')]",
-		"[concat('Microsoft.Resources/deployments/', 'masterNode')]"
+        "[concat('Microsoft.Resources/deployments/', 'masterNode')]"
       ],
       "properties": {
         "mode": "Incremental",
@@ -289,7 +289,7 @@
           "adminPassword": {
             "value": "[parameters('adminPassword')]"
           },
-		  "mysqlPassword": {
+          "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
           "namespace": {
@@ -301,9 +301,9 @@
           "masterNodeIp": {
             "value": "[variables('networkSettings').statics.masterIp]"
           },
-		  "slaveStaticIp": {
+          "slaveStaticIp": {
             "value": "[variables('networkSettings').statics.slaveIp01]"
-		  },
+          },
           "subnet": {
             "value": "[variables('networkSettings').subnet.dse]"
           },
@@ -319,11 +319,11 @@
     {
       "name": "slaveNode02",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', 'shared')]",
         "[concat('Microsoft.Resources/deployments/', 'haproxyNode')]",
-		"[concat('Microsoft.Resources/deployments/', 'masterNode')]"
+        "[concat('Microsoft.Resources/deployments/', 'masterNode')]"
       ],
       "properties": {
         "mode": "Incremental",
@@ -338,7 +338,7 @@
           "adminPassword": {
             "value": "[parameters('adminPassword')]"
           },
-		  "mysqlPassword": {
+          "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
           "namespace": {
@@ -350,9 +350,9 @@
           "masterNodeIp": {
             "value": "[variables('networkSettings').statics.masterIp]"
           },
-		  "slaveStaticIp": {
+          "slaveStaticIp": {
             "value": "[variables('networkSettings').statics.slaveIp02]"
-		  },
+          },
           "subnet": {
             "value": "[variables('networkSettings').subnet.dse]"
           },

--- a/mysql-mha-haproxy-ubuntu/nested/haproxy-resources.json
+++ b/mysql-mha-haproxy-ubuntu/nested/haproxy-resources.json
@@ -8,7 +8,7 @@
     "adminPassword": {
       "type": "securestring"
     },
-	"mysqlPassword": {
+    "mysqlPassword": {
       "type": "securestring"
     },
     "namespace": {
@@ -35,13 +35,13 @@
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"apiVersion": "2015-06-15",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
     "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -61,7 +61,7 @@
               "direction": "Inbound"
             }
           },
-		  {
+          {
             "name": "MySQL",
             "properties": {
               "description": "Allows MySQL traffic",
@@ -93,7 +93,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'PublicIp')]",
       "location": "[resourceGroup().location]",
@@ -105,14 +105,14 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[resourceGroup().location]",
@@ -141,7 +141,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm')]",
       "location": "[resourceGroup().location]",
@@ -180,7 +180,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/haproxyInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm')))]"
@@ -192,8 +192,8 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash haproxy.sh ', parameters('mysqlPassword'), ' ', parameters('adminUsername'))]"
         }
       }

--- a/mysql-mha-haproxy-ubuntu/nested/master-resources.json
+++ b/mysql-mha-haproxy-ubuntu/nested/master-resources.json
@@ -8,7 +8,7 @@
     "adminPassword": {
       "type": "securestring"
     },
-	"mysqlPassword": {
+    "mysqlPassword": {
       "type": "securestring"
     },
     "namespace": {
@@ -32,19 +32,19 @@
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15"
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'nic')]",
       "location": "[resourceGroup().location]",
@@ -53,7 +53,7 @@
           {
             "name": "ipconfig1",
             "properties": {
-			  "privateIPAllocationMethod": "Static",
+              "privateIPAllocationMethod": "Static",
               "privateIPAddress": "[parameters('masterNodeIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -64,7 +64,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[resourceGroup().location]",
@@ -103,7 +103,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/masterInstall')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",
@@ -116,8 +116,8 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash master.sh ', parameters('mysqlPassword'), ' ', parameters('adminUsername'))]"
         }
       }

--- a/mysql-mha-haproxy-ubuntu/nested/shared-resources.json
+++ b/mysql-mha-haproxy-ubuntu/nested/shared-resources.json
@@ -11,12 +11,11 @@
   },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15"
-  
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -25,7 +24,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSettings').virtualNetworkName]",
       "location": "[resourceGroup().location]",

--- a/mysql-mha-haproxy-ubuntu/nested/slave01-resources.json
+++ b/mysql-mha-haproxy-ubuntu/nested/slave01-resources.json
@@ -8,7 +8,7 @@
     "adminPassword": {
       "type": "securestring"
     },
-	"mysqlPassword": {
+    "mysqlPassword": {
       "type": "securestring"
     },
     "namespace": {
@@ -26,7 +26,7 @@
     "vmSize": {
       "type": "string"
     },
-	"slaveStaticIp": {
+    "slaveStaticIp": {
       "type": "string"
     },
     "subnet": {
@@ -35,19 +35,19 @@
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15"
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'nic')]",
       "location": "[resourceGroup().location]",
@@ -56,7 +56,7 @@
           {
             "name": "ipconfig1",
             "properties": {
-			  "privateIPAllocationMethod": "Static",
+              "privateIPAllocationMethod": "Static",
               "privateIPAddress": "[parameters('slaveStaticIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -67,7 +67,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[resourceGroup().location]",
@@ -106,7 +106,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/slave01Install')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",
@@ -119,10 +119,10 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
+        },
+        "protectedSettings": {
           "commandToExecute": "[concat('bash slave01.sh ', parameters('mysqlPassword'), ' ', parameters('adminUsername'))]"
-		}
+        }
       }
     }
   ],

--- a/mysql-mha-haproxy-ubuntu/nested/slave02-resources.json
+++ b/mysql-mha-haproxy-ubuntu/nested/slave02-resources.json
@@ -8,7 +8,7 @@
     "adminPassword": {
       "type": "securestring"
     },
-	"mysqlPassword": {
+    "mysqlPassword": {
       "type": "securestring"
     },
     "namespace": {
@@ -26,7 +26,7 @@
     "vmSize": {
       "type": "string"
     },
-	"slaveStaticIp": {
+    "slaveStaticIp": {
       "type": "string"
     },
     "subnet": {
@@ -35,19 +35,19 @@
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15"
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15"
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'nic')]",
       "location": "[resourceGroup().location]",
@@ -56,7 +56,7 @@
           {
             "name": "ipconfig1",
             "properties": {
-			  "privateIPAllocationMethod": "Static",
+              "privateIPAllocationMethod": "Static",
               "privateIPAddress": "[parameters('slaveStaticIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
@@ -67,7 +67,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[resourceGroup().location]",
@@ -106,7 +106,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm', '/slave02Install')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('namespace'), parameters('vmbasename'), 'vm')]",
@@ -119,10 +119,10 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": "[parameters('osSettings').scripts]"
-		},
-		"protectedSettings": {
-            "commandToExecute": "[concat('bash slave02.sh ', parameters('mysqlPassword'), ' ', parameters('adminUsername'))]"
-		}
+        },
+        "protectedSettings": {
+          "commandToExecute": "[concat('bash slave02.sh ', parameters('mysqlPassword'), ' ', parameters('adminUsername'))]"
+        }
       }
     }
   ],

--- a/mysql-replication/azuredeploy.json
+++ b/mysql-replication/azuredeploy.json
@@ -1,209 +1,209 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "dnsName": {
-            "type": "string",
-            "metadata": {
-                "description": "Connect to your cluster using dnsName.location.cloudapp.azure.com"
-            }
-        },
-        "vmUserName": {
-            "type": "string",
-            "metadata": {
-                "description": "user name to ssh to the VMs"
-            }
-        },
-        "vmPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "password to ssh to the VMs"
-            }
-        },
-        "mysqlRootPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "mysql root user password single quote not allowed"
-            }
-        },
-        "mysqlReplicationPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "mysql replication user password single quote not allowed"
-            }
-        },
-        "mysqlProbePassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "mysql probe password single quote not allowed"
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "defaultValue": "Standard_D2",
-            "metadata": {
-                "description": "size for the VMs"
-            }
-        },
-        "storageAccountType": {
-            "type": "string",
-            "defaultValue": "Standard_LRS",
-            "metadata": {
-                "description": "Storage account type for the cluster"
-            }
-        },
-        "virtualNetworkName": {
-            "type": "string",
-            "defaultValue": "mysqlvnet",
-            "metadata": {
-                "description": "Virtual network name for the cluster"
-            }
-        },
-        "vnetNewOrExisting": {
-            "type": "string",
-            "defaultValue": "new",
-            "allowedValues": [
-                "new",
-                "existing"
-            ],
-            "metadata": {
-                "description": "Identifies whether to use new or existing Virtual Network"
-            }
-        },
-        "virtualNetworkExistingRGName": {
-            "type": "string",
-            "defaultValue": "",
-            "metadata": {
-                "description": "If using existing VNet, specifies the resource group for the existing VNet"
-            }
-        },
-        "dbSubnetName": {
-            "type": "string",
-            "defaultValue": "dbsubnet",
-            "metadata": {
-                "description": "subnet name for the MySQL nodes"
-            }
-        },
-        "vnetAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.0.0/16",
-            "metadata": {
-                "description": "IP address in CIDR for virtual network"
-            }
-        },
-        "dbSubnetAddressPrefix": {
-            "type": "string",
-            "defaultValue": "10.0.1.0/24",
-            "metadata": {
-                "description": "IP address in CIDR for db subnetq"
-            }
-        },
-        "dbSubnetStartAddress": {
-            "type": "string",
-            "defaultValue": "10.0.1.4",
-            "metadata": {
-                "description": "Start IP address in the subnet for the VMs"
-            }
-        },
-        "imagePublisher": {
-            "type": "string",
-            "defaultValue": "OpenLogic",
-            "allowedValues": [
-              "OpenLogic",
-              "Canonical"
-            ],
-            "metadata": {
-                "description": "publisher for the VM OS image"
-            }
-        },
-        "imageOffer": {
-            "type": "string",
-            "defaultValue": "CentOS",
-            "allowedValues": [
-              "CentOS",
-              "UbuntuServer"
-            ],
-            "metadata": {
-                "description": "VM OS name"
-            }
-        },
-        "imageSKU": {
-            "type": "string",
-            "defaultValue": "6.6",
-          "allowedValues": [
-            "6.5",
-            "6.6",
-            "14.04.5-LTS"
-          ],
-            "metadata": {
-                "description": "VM OS version"
-            }
-        },
-        "mysqlFrontEndPort0": {
-            "type": "int",
-            "defaultValue": 3306,
-            "metadata": {
-                "description": "MySQL public port master"
-            }
-        },
-        "mysqlFrontEndPort1": {
-            "type": "int",
-            "defaultValue": 3307,
-            "metadata": {
-                "description": "MySQL public port slave"
-            }
-        },
-        "sshNatRuleFrontEndPort0": {
-            "type": "int",
-            "defaultValue": 64001,
-            "metadata": {
-                "description": "public ssh port for VM1"
-            }
-        },
-        "sshNatRuleFrontEndPort1": {
-            "type": "int",
-            "defaultValue": 64002,
-            "metadata": {
-                "description": "public ssh port for VM2"
-            }
-        },
-        "mysqlProbePort0": {
-            "type": "int",
-            "defaultValue": 9200,
-            "metadata": {
-                "description": "MySQL public port master"
-            }
-        },
-        "mysqlProbePort1": {
-            "type": "int",
-            "defaultValue": 9201,
-            "metadata": {
-                "description": "MySQL public port slave"
-            }
-        },
-        "artifactsPath": {
-            "type": "string",
-            "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-replication",
-            "metadata": {
-                "description": "template and script file location",
-                "artifactsBaseUrl": "Base URL of the Publisher Template gallery package"
-            }
-        },
-        "customScriptCommandToExecute": {
-            "type": "string",
-            "defaultValue": "bash azuremysql.sh",
-            "metadata": {
-                "description": "bash script command line"
-            }
-        },
-        "publicIPName": {
-            "type": "string",
-            "defaultValue": "mysqlIP01",
-            "metadata": {
-                "description": "public IP name for MySQL loadbalancer"
-            }
-        }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dnsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Connect to your cluster using dnsName.location.cloudapp.azure.com"
+      }
     },
+    "vmUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "user name to ssh to the VMs"
+      }
+    },
+    "vmPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "password to ssh to the VMs"
+      }
+    },
+    "mysqlRootPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql root user password single quote not allowed"
+      }
+    },
+    "mysqlReplicationPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql replication user password single quote not allowed"
+      }
+    },
+    "mysqlProbePassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql probe password single quote not allowed"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2",
+      "metadata": {
+        "description": "size for the VMs"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "metadata": {
+        "description": "Storage account type for the cluster"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "mysqlvnet",
+      "metadata": {
+        "description": "Virtual network name for the cluster"
+      }
+    },
+    "vnetNewOrExisting": {
+      "type": "string",
+      "defaultValue": "new",
+      "allowedValues": [
+        "new",
+        "existing"
+      ],
+      "metadata": {
+        "description": "Identifies whether to use new or existing Virtual Network"
+      }
+    },
+    "virtualNetworkExistingRGName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "If using existing VNet, specifies the resource group for the existing VNet"
+      }
+    },
+    "dbSubnetName": {
+      "type": "string",
+      "defaultValue": "dbsubnet",
+      "metadata": {
+        "description": "subnet name for the MySQL nodes"
+      }
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "IP address in CIDR for virtual network"
+      }
+    },
+    "dbSubnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.1.0/24",
+      "metadata": {
+        "description": "IP address in CIDR for db subnetq"
+      }
+    },
+    "dbSubnetStartAddress": {
+      "type": "string",
+      "defaultValue": "10.0.1.4",
+      "metadata": {
+        "description": "Start IP address in the subnet for the VMs"
+      }
+    },
+    "imagePublisher": {
+      "type": "string",
+      "defaultValue": "OpenLogic",
+      "allowedValues": [
+        "OpenLogic",
+        "Canonical"
+      ],
+      "metadata": {
+        "description": "publisher for the VM OS image"
+      }
+    },
+    "imageOffer": {
+      "type": "string",
+      "defaultValue": "CentOS",
+      "allowedValues": [
+        "CentOS",
+        "UbuntuServer"
+      ],
+      "metadata": {
+        "description": "VM OS name"
+      }
+    },
+    "imageSKU": {
+      "type": "string",
+      "defaultValue": "6.6",
+      "allowedValues": [
+        "6.5",
+        "6.6",
+        "14.04.5-LTS"
+      ],
+      "metadata": {
+        "description": "VM OS version"
+      }
+    },
+    "mysqlFrontEndPort0": {
+      "type": "int",
+      "defaultValue": 3306,
+      "metadata": {
+        "description": "MySQL public port master"
+      }
+    },
+    "mysqlFrontEndPort1": {
+      "type": "int",
+      "defaultValue": 3307,
+      "metadata": {
+        "description": "MySQL public port slave"
+      }
+    },
+    "sshNatRuleFrontEndPort0": {
+      "type": "int",
+      "defaultValue": 64001,
+      "metadata": {
+        "description": "public ssh port for VM1"
+      }
+    },
+    "sshNatRuleFrontEndPort1": {
+      "type": "int",
+      "defaultValue": 64002,
+      "metadata": {
+        "description": "public ssh port for VM2"
+      }
+    },
+    "mysqlProbePort0": {
+      "type": "int",
+      "defaultValue": 9200,
+      "metadata": {
+        "description": "MySQL public port master"
+      }
+    },
+    "mysqlProbePort1": {
+      "type": "int",
+      "defaultValue": 9201,
+      "metadata": {
+        "description": "MySQL public port slave"
+      }
+    },
+    "artifactsPath": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-replication",
+      "metadata": {
+        "description": "template and script file location",
+        "artifactsBaseUrl": "Base URL of the Publisher Template gallery package"
+      }
+    },
+    "customScriptCommandToExecute": {
+      "type": "string",
+      "defaultValue": "bash azuremysql.sh",
+      "metadata": {
+        "description": "bash script command line"
+      }
+    },
+    "publicIPName": {
+      "type": "string",
+      "defaultValue": "mysqlIP01",
+      "metadata": {
+        "description": "public IP name for MySQL loadbalancer"
+      }
+    }
+  },
   "variables": {
     "templateAPIVersion": "2015-01-01",
     "resourceAPIVersion": "2015-06-15",
@@ -224,322 +224,321 @@
     "customScriptFilePath": "[concat(parameters('artifactsPath'), '/azuremysql.sh')]",
     "mysqlConfigFilePath": "[concat(parameters('artifactsPath'), '/my.cnf.template')]",
     "singleQuote": "",
-
     "virtualNetworkSetupURL": "[concat(parameters('artifactsPath'),'/vnet-',parameters('vnetNewOrExisting'),'.json')]",
     "sa": "[parameters('dbSubnetStartAddress')]",
     "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
     "ipOctet2": "[int(split(variables('sa'), '.')[2])]",
     "ipOctet3": "[int(split(variables('sa'), '.')[3])]"
   },
-    "resources": [
-        {
-            "name": "SettingUpVirtualNetwork",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('templateAPIVersion')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('virtualNetworkSetupURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "virtualNetworkName": {
-                        "value": "[parameters('virtualNetworkName')]"
-                    },
-                    "virtualNetworkAddressPrefix": {
-                        "value": "[parameters('vnetAddressPrefix')]"
-                    },
-                    "dbSubnetName": {
-                        "value": "[parameters('dbSubnetName')]"
-                    },
-                    "dbSubnetAddressPrefix": {
-                        "value": "[parameters('dbSubnetAddressPrefix')]"
-                    },
-                    "virtualNetworkExistingRGName": {
-                        "value": "[parameters('virtualNetworkExistingRGName')]"
-                    }
-                }
-            }
+  "resources": [
+    {
+      "name": "SettingUpVirtualNetwork",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('virtualNetworkSetupURL')]",
+          "contentVersion": "1.0.0.0"
         },
-      {
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[variables('storageAccountName')]",
-        "apiVersion": "[variables('resourceAPIVersion')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "accountType": "[parameters('storageAccountType')]"
-        }
-      },
-      {
-        "apiVersion": "[variables('resourceAPIVersion')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[variables('lbPublicIPName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "Static",
-          "dnsSettings": {
-            "domainNameLabel": "[parameters('dnsName')]"
+        "parameters": {
+          "virtualNetworkName": {
+            "value": "[parameters('virtualNetworkName')]"
+          },
+          "virtualNetworkAddressPrefix": {
+            "value": "[parameters('vnetAddressPrefix')]"
+          },
+          "dbSubnetName": {
+            "value": "[parameters('dbSubnetName')]"
+          },
+          "dbSubnetAddressPrefix": {
+            "value": "[parameters('dbSubnetAddressPrefix')]"
+          },
+          "virtualNetworkExistingRGName": {
+            "value": "[parameters('virtualNetworkExistingRGName')]"
           }
         }
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[parameters('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('lbPublicIPName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsName')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[variables('availabilitySetName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {}
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('nicName'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "nicLoop",
+        "count": "[variables('nodeCount')]"
       },
-      {
-        "type": "Microsoft.Compute/availabilitySets",
-        "name": "[variables('availabilitySetName')]",
-        "apiVersion": "[variables('resourceAPIVersion')]",
-        "location": "[resourceGroup().location]",
-        "properties": { }
-      },
-      {
-        "apiVersion": "[variables('resourceAPIVersion')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[concat(variables('nicName'), copyIndex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "nicLoop",
-          "count": "[variables('nodeCount')]"
-        },
-        "dependsOn": [
-          "[concat('Microsoft.Resources/deployments/', 'SettingUpVirtualNetwork')]",
-          "[concat('Microsoft.Network/loadBalancers/', variables('lbName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "[concat('ipconfig', copyIndex())]",
-              "properties": {
-                "privateIPAllocationMethod": "Static",
-                "privateIPAddress": "[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255))]",
-                "subnet": {
-                  "id": "[reference('Microsoft.Resources/deployments/SettingUpVirtualNetwork', variables('templateAPIVersion')).outputs.dbSubnetRef.value]"
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'SettingUpVirtualNetwork')]",
+        "[concat('Microsoft.Network/loadBalancers/', variables('lbName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "[concat('ipconfig', copyIndex())]",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255))]",
+              "subnet": {
+                "id": "[reference('Microsoft.Resources/deployments/SettingUpVirtualNetwork', variables('templateAPIVersion')).outputs.dbSubnetRef.value]"
+              },
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "[variables('ilbBackendAddressPoolID')]"
+                }
+              ],
+              "loadBalancerInboundNatRules": [
+                {
+                  "id": "[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'NatRule', copyIndex())]"
                 },
-                "loadBalancerBackendAddressPools": [
-                  {
-                    "id": "[variables('ilbBackendAddressPoolID')]"
-                  }
-                ],
-                "loadBalancerInboundNatRules": [
-                  {
-                    "id": "[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'NatRule', copyIndex())]"
-                  },
-                  {
-                    "id": "[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'ProbeNatRule', copyIndex())]"
-                  },
-                  {
-                    "id": "[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'MySQLNatRule', copyIndex())]"
-                  }
-                ]
-              }
+                {
+                  "id": "[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'ProbeNatRule', copyIndex())]"
+                },
+                {
+                  "id": "[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'MySQLNatRule', copyIndex())]"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[concat(parameters('dnsName'), copyIndex())]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "vmLoop",
+        "count": "[variables('nodeCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex())]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('dnsName'), copyIndex())]",
+          "adminUsername": "[parameters('vmUserName')]",
+          "adminPassword": "[parameters('vmPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imagePublisher')]",
+            "offer": "[parameters('imageOffer')]",
+            "sku": "[parameters('imageSKU')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          },
+          "dataDisks": [
+            {
+              "name": "datadisk1",
+              "diskSizeGB": "1000",
+              "lun": 0,
+              "vhd": {
+                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'dataDisk1.vhd')]"
+              },
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk2",
+              "diskSizeGB": "1000",
+              "lun": 1,
+              "vhd": {
+                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'dataDisk2.vhd')]"
+              },
+              "createOption": "Empty"
             }
           ]
-        }
-      },
-      {
-        "name": "[concat(parameters('dnsName'), copyIndex())]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "apiVersion": "[variables('resourceAPIVersion')]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "vmLoop",
-          "count": "[variables('nodeCount')]"
         },
-        "dependsOn": [
-          "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]",
-          "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
-          "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex())]"
-        ],
-        "properties": {
-          "availabilitySet": {
-            "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
-          },
-          "hardwareProfile": {
-            "vmSize": "[parameters('vmSize')]"
-          },
-          "osProfile": {
-            "computerName": "[concat(parameters('dnsName'), copyIndex())]",
-            "adminUsername": "[parameters('vmUserName')]",
-            "adminPassword": "[parameters('vmPassword')]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "[parameters('imagePublisher')]",
-              "offer": "[parameters('imageOffer')]",
-              "sku": "[parameters('imageSKU')]",
-              "version": "latest"
-            },
-            "osDisk": {
-              "name": "osdisk",
-              "vhd": {
-                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'osdisk.vhd')]"
-              },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
-            },
-            "dataDisks": [
-              {
-                "name": "datadisk1",
-                "diskSizeGB": "1000",
-                "lun": 0,
-                "vhd": {
-                  "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'dataDisk1.vhd')]"
-                },
-                "createOption": "Empty"
-              },
-              {
-                "name": "datadisk2",
-                "diskSizeGB": "1000",
-                "lun": 1,
-                "vhd": {
-                  "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'dataDisk2.vhd')]"
-                },
-                "createOption": "Empty"
-              }
-            ]
-          },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[concat(resourceId('Microsoft.Network/networkInterfaces',variables('nicName')), copyIndex())]"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "type": "Microsoft.Compute/virtualMachines/extensions",
-        "name": "[concat(parameters('dnsName'), copyIndex(), '/setupMySQL')]",
-        "apiVersion": "[variables('resourceAPIVersion')]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "extLoop",
-          "count": "[variables('nodeCount')]"
-        },
-        "dependsOn": [
-          "[concat('Microsoft.Compute/virtualMachines/', parameters('dnsName'), copyIndex())]"
-        ],
-        "properties": {
-          "publisher": "Microsoft.Azure.Extensions",
-          "type": "CustomScript",
-          "typeHandlerVersion": "2.0",
-          "autoUpgradeMinorVersion": true,
-          "settings": {
-            "fileUris": [
-              "[variables('customScriptFilePath')]"
-            ]
-          },
-          "protectedSettings": {
-            "commandToExecute": "[concat(parameters('customScriptCommandToExecute'), ' ', copyIndex(1), ' ', variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255), ' ', variables('mysqlConfigFilePath'), ' ', variables('singleQuote'), parameters('mysqlReplicationPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlRootPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlProbePassword'), variables('singleQuote'), ' ', parameters('dbSubnetStartAddress'))]"
-          }
-        }
-      },
-      {
-        "apiVersion": "[variables('resourceAPIVersion')]",
-        "type": "Microsoft.Network/loadBalancers",
-        "name": "[variables('lbName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[concat('Microsoft.Network/publicIPAddresses/', variables('lbPublicIPName'))]"
-        ],
-        "properties": {
-          "frontendIPConfigurations": [
+        "networkProfile": {
+          "networkInterfaces": [
             {
-              "name": "[variables('sshIPConfigName')]",
-              "properties": {
-                "publicIPAddress": {
-                  "id": "[variables('lbPublicIPRef')]"
-                }
-              }
-            }
-          ],
-          "backendAddressPools": [
-            {
-              "name": "[variables('ilbBackendAddressPoolName')]"
-            }
-          ],
-          "inboundNatRules": [
-            {
-              "name": "[concat(parameters('dnsName'),'NatRule0')]",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('sshIPConfig')]"
-                },
-                "protocol": "tcp",
-                "frontendPort": "[parameters('sshNatRuleFrontEndPort0')]",
-                "backendPort": 22,
-                "enableFloatingIP": false
-              }
-            },
-            {
-              "name": "[concat(parameters('dnsName'),'NatRule1')]",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('sshIPConfig')]"
-                },
-                "protocol": "tcp",
-                "frontendPort": "[parameters('sshNatRuleFrontEndPort1')]",
-                "backendPort": 22,
-                "enableFloatingIP": false
-              }
-            },
-            {
-              "name": "[concat(parameters('dnsName'),'MySQLNatRule0')]",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('sshIPConfig')]"
-                },
-                "protocol": "tcp",
-                "frontendPort": "[parameters('mysqlFrontEndPort0')]",
-                "backendPort": 3306,
-                "enableFloatingIP": false
-              }
-            },
-            {
-              "name": "[concat(parameters('dnsName'),'MySQLNatRule1')]",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('sshIPConfig')]"
-                },
-                "protocol": "tcp",
-                "frontendPort": "[parameters('mysqlFrontEndPort1')]",
-                "backendPort": 3306,
-                "enableFloatingIP": false
-              }
-            },
-            {
-              "name": "[concat(parameters('dnsName'),'ProbeNatRule0')]",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('sshIPConfig')]"
-                },
-                "protocol": "tcp",
-                "frontendPort": "[parameters('mysqlProbePort0')]",
-                "backendPort": 9200,
-                "enableFloatingIP": false
-              }
-            },
-            {
-              "name": "[concat(parameters('dnsName'),'ProbeNatRule1')]",
-              "properties": {
-                "frontendIPConfiguration": {
-                  "id": "[variables('sshIPConfig')]"
-                },
-                "protocol": "tcp",
-                "frontendPort": "[parameters('mysqlProbePort1')]",
-                "backendPort": 9200,
-                "enableFloatingIP": false
-              }
+              "id": "[concat(resourceId('Microsoft.Network/networkInterfaces',variables('nicName')), copyIndex())]"
             }
           ]
         }
       }
-    ],
-    "outputs": {
-        "fqdn": {
-            "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn]",
-            "type": "string"
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('dnsName'), copyIndex(), '/setupMySQL')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "extLoop",
+        "count": "[variables('nodeCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('dnsName'), copyIndex())]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": [
+            "[variables('customScriptFilePath')]"
+          ]
         },
-        "ipaddress": {
-            "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).ipAddress]",
-            "type": "string"
+        "protectedSettings": {
+          "commandToExecute": "[concat(parameters('customScriptCommandToExecute'), ' ', copyIndex(1), ' ', variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255), ' ', variables('mysqlConfigFilePath'), ' ', variables('singleQuote'), parameters('mysqlReplicationPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlRootPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlProbePassword'), variables('singleQuote'), ' ', parameters('dbSubnetStartAddress'))]"
         }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/loadBalancers",
+      "name": "[variables('lbName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('lbPublicIPName'))]"
+      ],
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "[variables('sshIPConfigName')]",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[variables('lbPublicIPRef')]"
+              }
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "[variables('ilbBackendAddressPoolName')]"
+          }
+        ],
+        "inboundNatRules": [
+          {
+            "name": "[concat(parameters('dnsName'),'NatRule0')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('sshNatRuleFrontEndPort0')]",
+              "backendPort": 22,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'NatRule1')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('sshNatRuleFrontEndPort1')]",
+              "backendPort": 22,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'MySQLNatRule0')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('mysqlFrontEndPort0')]",
+              "backendPort": 3306,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'MySQLNatRule1')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('mysqlFrontEndPort1')]",
+              "backendPort": 3306,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'ProbeNatRule0')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('mysqlProbePort0')]",
+              "backendPort": 9200,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'ProbeNatRule1')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('mysqlProbePort1')]",
+              "backendPort": 9200,
+              "enableFloatingIP": false
+            }
+          }
+        ]
+      }
     }
+  ],
+  "outputs": {
+    "fqdn": {
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn]",
+      "type": "string"
+    },
+    "ipaddress": {
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).ipAddress]",
+      "type": "string"
+    }
+  }
 }

--- a/mysql-replication/vnet-new.json
+++ b/mysql-replication/vnet-new.json
@@ -1,56 +1,56 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "virtualNetworkName": {
-            "type": "string"
-        },
-        "virtualNetworkAddressPrefix": {
-            "type": "string"
-        },
-        "dbSubnetName": {
-            "type": "string"
-        },
-        "dbSubnetAddressPrefix": {
-            "type": "string"
-        },
-        "virtualNetworkExistingRGName": {
-            "type": "string",
-            "defaultValue": ""
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "virtualNetworkName": {
+      "type": "string"
     },
-    "variables": {
-        "resourceAPIVersion": "2015-06-15",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
-        "dbSubnet": "[concat(variables('vnetID'),'/subnets/',parameters('dbSubnetName'))]"
+    "virtualNetworkAddressPrefix": {
+      "type": "string"
     },
-    "resources": [
-      {
-        "apiVersion": "[variables('resourceAPIVersion')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[parameters('virtualNetworkName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[parameters('virtualNetworkAddressPrefix')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[parameters('dbSubnetName')]",
-              "properties": {
-                "addressPrefix": "[parameters('dbSubnetAddressPrefix')]"
-              }
-            }
-          ]
-        }
-      }
-    ],
-    "outputs": {
-        "dbSubnetRef": {
-            "value": "[variables('dbSubnet')]",
-            "type": "string"
-        }
+    "dbSubnetName": {
+      "type": "string"
+    },
+    "dbSubnetAddressPrefix": {
+      "type": "string"
+    },
+    "virtualNetworkExistingRGName": {
+      "type": "string",
+      "defaultValue": ""
     }
+  },
+  "variables": {
+    "resourceAPIVersion": "2015-06-15",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+    "dbSubnet": "[concat(variables('vnetID'),'/subnets/',parameters('dbSubnetName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('virtualNetworkAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('dbSubnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('dbSubnetAddressPrefix')]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "dbSubnetRef": {
+      "value": "[variables('dbSubnet')]",
+      "type": "string"
+    }
+  }
 }

--- a/mysql-standalone-server-ubuntu/azuredeploy.json
+++ b/mysql-standalone-server-ubuntu/azuredeploy.json
@@ -84,14 +84,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -103,7 +103,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -124,7 +124,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -150,7 +150,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -195,7 +195,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/nagios-on-ubuntu/azuredeploy.json
+++ b/nagios-on-ubuntu/azuredeploy.json
@@ -107,14 +107,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "Standard_LRS"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -135,7 +135,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat('publicIP', copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -151,7 +151,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[resourceGroup().location]",
@@ -175,7 +175,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat('nic', copyindex())]",
       "location": "[resourceGroup().location]",
@@ -209,7 +209,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat('nagiosSrv', copyindex())]",
       "location": "[resourceGroup().location]",
@@ -258,7 +258,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat('nagiosSrv', copyindex(), '/installnagios')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "virtualMachineExtensionsLoop",

--- a/netki-wns-api-server-on-ubuntu/azuredeploy.json
+++ b/netki-wns-api-server-on-ubuntu/azuredeploy.json
@@ -58,14 +58,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -77,7 +77,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -98,7 +98,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -124,7 +124,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -169,7 +169,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/', variables('extensionName'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
@@ -179,13 +179,13 @@
         "type": "DockerExtension",
         "typeHandlerVersion": "1.0",
         "autoUpgradeMinorVersion": true,
-        "settings": { }
+        "settings": {}
       }
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/dockerfile')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]",

--- a/nylas-email-sync-engine/azuredeploy.json
+++ b/nylas-email-sync-engine/azuredeploy.json
@@ -63,14 +63,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -82,7 +82,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -103,7 +103,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -133,9 +133,9 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('nsgName')]",      
+      "name": "[variables('nsgName')]",
       "location": "[resourceGroup().location]",
       "properties": {
         "securityRules": [
@@ -208,7 +208,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -260,7 +260,7 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/nylasScript')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       ],
@@ -270,7 +270,8 @@
         "typeHandlerVersion": "2.0",
         "autoUpgradeMinorVersion": true,
         "settings": {
-          "fileUris": [            "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/nylas-email-sync-engine/install.sh"
+          "fileUris": [
+            "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/nylas-email-sync-engine/install.sh"
           ],
           "commandToExecute": "[concat('sh install.sh ', parameters('adminUsername'))]"
         }
@@ -278,13 +279,13 @@
     }
   ],
   "outputs": {
-     "hostname": {
-         "type": "string",
-         "value": "[concat(parameters('dnsLabelPrefix'), '.', resourceGroup().location, '.cloudapp.azure.com')]"
-     },
+    "hostname": {
+      "type": "string",
+      "value": "[concat(parameters('dnsLabelPrefix'), '.', resourceGroup().location, '.cloudapp.azure.com')]"
+    },
     "sshCommand": {
       "type": "string",
       "value": "[concat('ssh ', parameters('adminUsername'), '@', parameters('dnsLabelPrefix'), '.', resourceGroup().location, '.cloudapp.azure.com')]"
-    } 
+    }
   }
 }

--- a/oms-all-deploy/azuredeploy.parameters.json
+++ b/oms-all-deploy/azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/oms-all-deploy/nestedtemplates/omsAutomation.json
+++ b/oms-all-deploy/nestedtemplates/omsAutomation.json
@@ -128,7 +128,7 @@
   },
   "resources": [
     {
-      "apiversion": "2015-10-31",
+      "apiVersion": "2015-10-31",
       "location": "[parameters('omsAutomationRegion')]",
       "name": "[parameters('omsAutomationAccountName')]",
       "type": "Microsoft.Automation/automationAccounts",

--- a/oms-azure-resource-usage-solution/azuredeployonlyautomation.json
+++ b/oms-azure-resource-usage-solution/azuredeployonlyautomation.json
@@ -478,7 +478,7 @@
     },
     "resources": [
         {
-            "apiversion": "2015-10-31",
+            "apiVersion": "2015-10-31",
             "location": "[parameters('omsAutomationRegion')]",
             "name": "[parameters('omsAutomationAccountName')]",
             "type": "Microsoft.Automation/automationAccounts",

--- a/oms-azure-storage-analytics-solution/azuredeploy.json
+++ b/oms-azure-storage-analytics-solution/azuredeploy.json
@@ -2085,7 +2085,7 @@
       ]
     },
     {
-      "apiversion": "2015-10-31",
+      "apiVersion": "2015-10-31",
       "location": "[parameters('omsAutomationRegion')]",
       "name": "[parameters('omsAutomationAccountName')]",
       "type": "Microsoft.Automation/automationAccounts",

--- a/oms-azure-vminventory-solution/azuredeploy.json
+++ b/oms-azure-vminventory-solution/azuredeploy.json
@@ -1188,7 +1188,7 @@
       ]
     },
     {
-      "apiversion": "2015-10-31",
+      "apiVersion": "2015-10-31",
       "location": "[parameters('omsAutomationRegion')]",
       "name": "[parameters('omsAutomationAccountName')]",
       "type": "Microsoft.Automation/automationAccounts",

--- a/oms-azure-vminventory-solution/azuredeployonlyautomation.json
+++ b/oms-azure-vminventory-solution/azuredeployonlyautomation.json
@@ -126,8 +126,8 @@
     "ingestScheduleName": "AzureVMInventory-Scheduler-Hourly"
   },
   "resources": [
-      {
-      "apiversion": "2015-10-31",
+    {
+      "apiVersion": "2015-10-31",
       "location": "[parameters('omsAutomationRegion')]",
       "name": "[parameters('omsAutomationAccountName')]",
       "type": "Microsoft.Automation/automationAccounts",
@@ -136,173 +136,172 @@
           "name": "[parameters('omsAutomationSku')]"
         }
       },
-        "resources": [
-          {
-            "name": "[variables('opsInsightWorkspaceID')]",
-            "type": "variables",
-            "apiVersion": "2015-10-31",
-            "dependsOn": [
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
-            ],
-            "tags": {},
-            "properties": {
-              "description": "[variables('opsInsightWorkspaceIDDescription')]",
-              "isEncrypted": 0,
-              "type": "[variables('opsInsightWorkspaceIDType')]",
-              "value": "[concat('\"',parameters('omsWorkspaceId'),'\"')]"
-            }
-          },
-          {
-            "name": "[variables('opsInsightWorkspaceKey') ]",
-            "type": "variables",
-            "apiVersion": "2015-10-31",
-            "dependsOn": [
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
-            ],
-            "tags": {},
-            "properties": {
-              "description": "[variables('opsInsightWorkspaceKeyDescription')]",
-              "isEncrypted": 1,
-              "type": "[variables('opsInsightWorkspaceKeyType')]",
-              "value": "[concat('\"',parameters('omsWorkspaceKey'),'\"')]"
-            }
-          },
-          {
-            "name": "[variables('createScheduleAutomationAccountName')]",
-            "type": "variables",
-            "apiVersion": "2015-10-31",
-            "dependsOn": [
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
-            ],
-            "tags": {},
-            "properties": {
-              "description": "[variables('createScheduleAutomationAccountDescription')]",
-              "isEncrypted": 0,
-              "type": "[variables('createScheduleAutomationAccountType')]",
-              "value": "[concat('\"', parameters('omsAutomationAccountName'),'\"')]"
-            }
-          },
-          {
-            "name": "[variables('createScheduleResourceGroupName')]",
-            "type": "variables",
-            "apiVersion": "2015-10-31",
-            "dependsOn": [
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
-            ],
-            "tags": {},
-            "properties": {
-              "description": "[variables('createScheduleResourceGroupDescription')]",
-              "isEncrypted": 0,
-              "type": "[variables('createScheduleResourceGroupType')]",
-              "value": "[concat('\"', resourceGroup().name, '\"')]"
-            }
-          },
-          {
-            "name": "[variables('runbooks').ingestParentRunbook.name]",
-            "type": "runbooks",
-            "apiVersion": "2015-10-31",
-            "location": "[parameters('omsAutomationRegion')]",
-            "dependsOn": [
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]",
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/variables/', variables('opsInsightWorkspaceID'))]",
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/variables/', variables('opsInsightWorkspaceKey'))]"
-            ],
-            "tags": {},
-            "properties": {
-              "runbookType": "[variables('runbooks').ingestParentRunbook.type]",
-              "logProgress": "false",
-              "logVerbose": "false",
-              "description": "[variables('runbooks').ingestParentRunbook.description]",
-              "publishContentLink": {
-                "uri": "[variables('parentRunbookUri')]",
-                "version": "[variables('runbooks').ingestParentRunbook.version]"
-              }
-            }
-          },
-          {
-            "name": "[variables('runbooks').ingestSchedulerRunbook.name]",
-            "type": "runbooks",
-            "apiVersion": "2015-10-31",
-            "location": "[parameters('omsAutomationRegion')]",
-            "dependsOn": [
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]",
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/variables/', variables('opsInsightWorkspaceID'))]",
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/variables/', variables('opsInsightWorkspaceKey'))]"
-            ],
-            "tags": {},
-            "properties": {
-              "runbookType": "[variables('runbooks').ingestSchedulerRunbook.type]",
-              "logProgress": "false",
-              "logVerbose": "false",
-              "description": "[variables('runbooks').ingestSchedulerRunbook.description]",
-              "publishContentLink": {
-                "uri": "[variables('schedulerRunbookUri')]",
-                "version": "[variables('runbooks').ingestSchedulerRunbook.version]"
-              }
-            }
-          },
-          {
-            "name": "[concat(parameters('omsAutomationAccountName'), '/', variables('ingestscheduleName'),'-',parameters('ingestSchedulerGuid'))]",
-            "type": "microsoft.automation/automationAccounts/schedules",
-            "apiVersion": "2015-10-31",
-            "location": "[parameters('omsAutomationRegion')]",
-            "dependsOn": [
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]",
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/runbooks/', variables('runbooks').ingestSchedulerRunbook.name)]"
-            ],
-            "tags": {},
-            "properties": {
-              "description": "OMS Ingestion API Scheduler",
-              "startTime": "",
-              "isEnabled": "true",
-              "interval": "[variables('ingestInterval')]",
-              "frequency": "[variables('ingestFrequency')]"
-            }
-          },
-          {
-            "name": "[concat(parameters('omsAutomationAccountName'), '/', parameters('ingestSchedulerGuid'))]",
-            "type": "microsoft.automation/automationAccounts/jobSchedules",
-            "apiVersion": "2015-10-31",
-            "location": "[parameters('omsAutomationRegion')]",
-            "dependsOn": [
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/schedules/', variables('ingestscheduleName'),'-',parameters('ingestSchedulerGuid'))]",
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
-            ],
-            "tags": {},
-            "properties": {
-              "schedule": {
-                "name": "[concat(variables('ingestscheduleName'),'-',parameters('ingestSchedulerGuid'))]"
-              },
-              "runbook": {
-                "name": "[variables('Runbooks').ingestSchedulerRunbook.name]"
-              }
-            }
-          },
-          {
-            "name": "[concat(parameters('omsAutomationAccountName'), '/', parameters('ingestSchedulerGuid'))]",
-            "type": "Microsoft.Automation/automationAccounts/jobs",
-            "apiVersion": "2015-10-31",
-            "location": "[parameters('omsAutomationRegion')]",
-            "dependsOn": [
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]",
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/runbooks/', variables('runbooks').ingestSchedulerRunbook.name)]",
-              "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/runbooks/', variables('runbooks').ingestParentRunbook.name)]"
-
-            ],
-            "tags": {},
-            "properties": {
-              "runbook": {
-                "name": "[variables('runbooks').ingestSchedulerRunbook.name]"
-              },
-              "parameters": {
-                "frequency": "[parameters('omsDataIngestionFrequency')]",
-                "getNICandNSG": "[variables('collectNICandNSGInventory')]",
-                "getDiskInfo": "[variables('collectDiskInventory')]",
-                "clearLocks": "1"
-              }
+      "resources": [
+        {
+          "name": "[variables('opsInsightWorkspaceID')]",
+          "type": "variables",
+          "apiVersion": "2015-10-31",
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
+          ],
+          "tags": {},
+          "properties": {
+            "description": "[variables('opsInsightWorkspaceIDDescription')]",
+            "isEncrypted": 0,
+            "type": "[variables('opsInsightWorkspaceIDType')]",
+            "value": "[concat('\"',parameters('omsWorkspaceId'),'\"')]"
+          }
+        },
+        {
+          "name": "[variables('opsInsightWorkspaceKey') ]",
+          "type": "variables",
+          "apiVersion": "2015-10-31",
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
+          ],
+          "tags": {},
+          "properties": {
+            "description": "[variables('opsInsightWorkspaceKeyDescription')]",
+            "isEncrypted": 1,
+            "type": "[variables('opsInsightWorkspaceKeyType')]",
+            "value": "[concat('\"',parameters('omsWorkspaceKey'),'\"')]"
+          }
+        },
+        {
+          "name": "[variables('createScheduleAutomationAccountName')]",
+          "type": "variables",
+          "apiVersion": "2015-10-31",
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
+          ],
+          "tags": {},
+          "properties": {
+            "description": "[variables('createScheduleAutomationAccountDescription')]",
+            "isEncrypted": 0,
+            "type": "[variables('createScheduleAutomationAccountType')]",
+            "value": "[concat('\"', parameters('omsAutomationAccountName'),'\"')]"
+          }
+        },
+        {
+          "name": "[variables('createScheduleResourceGroupName')]",
+          "type": "variables",
+          "apiVersion": "2015-10-31",
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
+          ],
+          "tags": {},
+          "properties": {
+            "description": "[variables('createScheduleResourceGroupDescription')]",
+            "isEncrypted": 0,
+            "type": "[variables('createScheduleResourceGroupType')]",
+            "value": "[concat('\"', resourceGroup().name, '\"')]"
+          }
+        },
+        {
+          "name": "[variables('runbooks').ingestParentRunbook.name]",
+          "type": "runbooks",
+          "apiVersion": "2015-10-31",
+          "location": "[parameters('omsAutomationRegion')]",
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/variables/', variables('opsInsightWorkspaceID'))]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/variables/', variables('opsInsightWorkspaceKey'))]"
+          ],
+          "tags": {},
+          "properties": {
+            "runbookType": "[variables('runbooks').ingestParentRunbook.type]",
+            "logProgress": "false",
+            "logVerbose": "false",
+            "description": "[variables('runbooks').ingestParentRunbook.description]",
+            "publishContentLink": {
+              "uri": "[variables('parentRunbookUri')]",
+              "version": "[variables('runbooks').ingestParentRunbook.version]"
             }
           }
-        ]
+        },
+        {
+          "name": "[variables('runbooks').ingestSchedulerRunbook.name]",
+          "type": "runbooks",
+          "apiVersion": "2015-10-31",
+          "location": "[parameters('omsAutomationRegion')]",
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/variables/', variables('opsInsightWorkspaceID'))]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/variables/', variables('opsInsightWorkspaceKey'))]"
+          ],
+          "tags": {},
+          "properties": {
+            "runbookType": "[variables('runbooks').ingestSchedulerRunbook.type]",
+            "logProgress": "false",
+            "logVerbose": "false",
+            "description": "[variables('runbooks').ingestSchedulerRunbook.description]",
+            "publishContentLink": {
+              "uri": "[variables('schedulerRunbookUri')]",
+              "version": "[variables('runbooks').ingestSchedulerRunbook.version]"
+            }
+          }
+        },
+        {
+          "name": "[concat(parameters('omsAutomationAccountName'), '/', variables('ingestscheduleName'),'-',parameters('ingestSchedulerGuid'))]",
+          "type": "microsoft.automation/automationAccounts/schedules",
+          "apiVersion": "2015-10-31",
+          "location": "[parameters('omsAutomationRegion')]",
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/runbooks/', variables('runbooks').ingestSchedulerRunbook.name)]"
+          ],
+          "tags": {},
+          "properties": {
+            "description": "OMS Ingestion API Scheduler",
+            "startTime": "",
+            "isEnabled": "true",
+            "interval": "[variables('ingestInterval')]",
+            "frequency": "[variables('ingestFrequency')]"
+          }
+        },
+        {
+          "name": "[concat(parameters('omsAutomationAccountName'), '/', parameters('ingestSchedulerGuid'))]",
+          "type": "microsoft.automation/automationAccounts/jobSchedules",
+          "apiVersion": "2015-10-31",
+          "location": "[parameters('omsAutomationRegion')]",
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/schedules/', variables('ingestscheduleName'),'-',parameters('ingestSchedulerGuid'))]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]"
+          ],
+          "tags": {},
+          "properties": {
+            "schedule": {
+              "name": "[concat(variables('ingestscheduleName'),'-',parameters('ingestSchedulerGuid'))]"
+            },
+            "runbook": {
+              "name": "[variables('Runbooks').ingestSchedulerRunbook.name]"
+            }
+          }
+        },
+        {
+          "name": "[concat(parameters('omsAutomationAccountName'), '/', parameters('ingestSchedulerGuid'))]",
+          "type": "Microsoft.Automation/automationAccounts/jobs",
+          "apiVersion": "2015-10-31",
+          "location": "[parameters('omsAutomationRegion')]",
+          "dependsOn": [
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'))]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/runbooks/', variables('runbooks').ingestSchedulerRunbook.name)]",
+            "[concat('Microsoft.Automation/automationAccounts/', parameters('omsAutomationAccountName'), '/runbooks/', variables('runbooks').ingestParentRunbook.name)]"
+          ],
+          "tags": {},
+          "properties": {
+            "runbook": {
+              "name": "[variables('runbooks').ingestSchedulerRunbook.name]"
+            },
+            "parameters": {
+              "frequency": "[parameters('omsDataIngestionFrequency')]",
+              "getNICandNSG": "[variables('collectNICandNSGInventory')]",
+              "getDiskInfo": "[variables('collectDiskInventory')]",
+              "clearLocks": "1"
+            }
+          }
+        }
+      ]
     }
   ],
   "outputs": {}

--- a/oms-cloudfoundry-solution/azuredeploy.parameters.json
+++ b/oms-cloudfoundry-solution/azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/oms-existing-storage-account/prereqs/prereq.azuredeploy.json
+++ b/oms-existing-storage-account/prereqs/prereq.azuredeploy.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/oms-existing-storage-account/prereqs/prereq.azuredeploy.parameters.json
+++ b/oms-existing-storage-account/prereqs/prereq.azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {

--- a/oms-hyperv-replica-solution/azuredeploy.json
+++ b/oms-hyperv-replica-solution/azuredeploy.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.1.0",
   "parameters": {

--- a/oms-hyperv-replica-solution/azuredeploy.parameters.json
+++ b/oms-hyperv-replica-solution/azuredeploy.parameters.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {

--- a/openchain-blockchain-coinprism/azuredeploy.json
+++ b/openchain-blockchain-coinprism/azuredeploy.json
@@ -113,14 +113,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -132,7 +132,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -159,7 +159,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -185,7 +185,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('nsgName')]",
       "location": "[resourceGroup().location]",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -268,7 +268,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), '/', variables('dockerExtensionName'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
@@ -278,15 +278,13 @@
         "type": "DockerExtension",
         "typeHandlerVersion": "1.0",
         "autoUpgradeMinorVersion": true,
-        "settings": {
-
-        }
+        "settings": {}
       }
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), '/', variables('scriptExtensionName'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'), '/extensions/', variables('dockerExtensionName'))]"
@@ -299,7 +297,6 @@
         "settings": {
           "fileUris": [
             "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/openchain-blockchain-coinprism/install_openchain.sh"
-
           ],
           "commandToExecute": "[concat('bash install_openchain.sh ', 'http://', reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).dnsSettings.fqdn, '/ ', parameters('openchainVersion'), ' ', parameters('openchainAdminKey'), ' ', parameters('openPermissions'))]"
         }

--- a/openedx-devstack-ubuntu/azuredeploy.json
+++ b/openedx-devstack-ubuntu/azuredeploy.json
@@ -52,7 +52,7 @@
     "vmName": "jumpbox2",
     "osImagePublisher": "Canonical",
     "osImageOffer": "UbuntuServer",
-    "osImageSKU" : "12.04.5-LTS",
+    "osImageSKU": "12.04.5-LTS",
     "publicIPAddressName": "myPublicIP",
     "publicIPAddressType": "Dynamic",
     "OSDiskName": "osdisk",
@@ -71,7 +71,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -80,7 +80,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -92,7 +92,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -119,7 +119,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('nsgName')]",
       "location": "[resourceGroup().location]",
@@ -171,7 +171,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('vmName'), '-nic')]",
       "location": "[resourceGroup().location]",
@@ -197,7 +197,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -240,7 +240,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), '/installscript')]",
       "location": "[resourceGroup().location]",

--- a/openedx-fullstack-ubuntu/azuredeploy.json
+++ b/openedx-fullstack-ubuntu/azuredeploy.json
@@ -66,7 +66,7 @@
     "vmName": "jumpbox2",
     "osImagePublisher": "Canonical",
     "osImageOffer": "UbuntuServer",
-    "osImageSKU" : "16.04-LTS",
+    "osImageSKU": "16.04-LTS",
     "publicIPAddressName": "myPublicIP",
     "publicIPAddressType": "Dynamic",
     "OSDiskName": "osdisk",
@@ -85,7 +85,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -94,7 +94,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -106,7 +106,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -133,7 +133,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('nsgName')]",
       "location": "[resourceGroup().location]",
@@ -185,7 +185,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('vmName'), '-nic')]",
       "location": "[resourceGroup().location]",
@@ -211,7 +211,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -254,7 +254,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), '/installscript')]",
       "location": "[resourceGroup().location]",

--- a/openedx-scalable-ubuntu/azuredeploy.json
+++ b/openedx-scalable-ubuntu/azuredeploy.json
@@ -21,7 +21,7 @@
         "description": "DNS Label for the Public IP. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
       }
     },
-    "appVmCount" : {
+    "appVmCount": {
       "type": "int",
       "maxValue": 20,
       "defaultValue": 1,
@@ -113,7 +113,7 @@
     "availabilitySetName": "avail-set",
     "osImagePublisher": "Canonical",
     "osImageOffer": "UbuntuServer",
-    "osImageSKU" : "12.04.5-LTS",
+    "osImageSKU": "12.04.5-LTS",
     "appVmName": "openedx-app",
     "mySqlVmName": "openedx-mysql",
     "mongoVmName": "openedx-mongo",
@@ -142,7 +142,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -151,14 +151,14 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('appPublicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -170,7 +170,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('mySqlPublicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -179,7 +179,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('mongoPublicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -188,7 +188,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -215,7 +215,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('nsgName')]",
       "location": "[resourceGroup().location]",
@@ -267,7 +267,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('appVmName'), copyIndex(), '-nic')]",
       "location": "[resourceGroup().location]",
@@ -305,7 +305,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('mySqlVmName'), '-nic')]",
       "location": "[resourceGroup().location]",
@@ -331,7 +331,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('mongoVmName'), '-nic')]",
       "location": "[resourceGroup().location]",
@@ -357,10 +357,10 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
-      "location":"[resourceGroup().location]",
+      "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/',variables('appPublicIPAddressName'))]"
       ],
@@ -462,29 +462,29 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers/inboundNatRules",
       "name": "[concat(variables('lbName'), '/SSH-VM', copyIndex())]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
-          "[concat('Microsoft.Network/loadBalancers/',variables('lbName'))]"
+        "[concat('Microsoft.Network/loadBalancers/',variables('lbName'))]"
       ],
       "properties": {
-          "frontendIPConfiguration": {
-              "id": "[variables('frontEndIPConfigID')]"
-          },
-          "protocol": "tcp",
-          "frontendPort": "[copyIndex(2220)]",
-          "backendPort": 22,
-          "enableFloatingIP": false
+        "frontendIPConfiguration": {
+          "id": "[variables('frontEndIPConfigID')]"
+        },
+        "protocol": "tcp",
+        "frontendPort": "[copyIndex(2220)]",
+        "backendPort": 22,
+        "enableFloatingIP": false
       },
       "copy": {
-          "name": "inboundNatRulesCopy",
-          "count": "[parameters('appVmCount')]"
+        "name": "inboundNatRulesCopy",
+        "count": "[parameters('appVmCount')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('appVmName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -535,7 +535,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('mySqlVmName')]",
       "location": "[resourceGroup().location]",
@@ -578,7 +578,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('mongoVmName')]",
       "location": "[resourceGroup().location]",
@@ -619,9 +619,9 @@
           ]
         }
       }
-    },    
+    },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('appVmName'), '0', '/installscript')]",
       "location": "[resourceGroup().location]",
@@ -640,7 +640,7 @@
             "[concat(variables('scriptDownloadUri'), 'inventory.ini')]"
           ]
         },
-        "protectedSettings": {        
+        "protectedSettings": {
           "commandToExecute": "[variables('installCommand')]"
         }
       }

--- a/openldap-cluster-ubuntu/azuredeploy.json
+++ b/openldap-cluster-ubuntu/azuredeploy.json
@@ -33,18 +33,18 @@
       }
     },
     "vmCount": {
-        "type": "int",
-        "defaultValue": 2,
-        "allowedValues": [
-          1,
-          2,
-          3,
-          4,
-          5
-        ],
-        "metadata": {
-            "description": "Number of VMs in the cluster."
-        }
+      "type": "int",
+      "defaultValue": 2,
+      "allowedValues": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "metadata": {
+        "description": "Number of VMs in the cluster."
+      }
     },
     "vmSize": {
       "type": "string",
@@ -111,7 +111,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -122,12 +122,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -139,7 +139,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -160,7 +160,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -174,7 +174,7 @@
             "name": "ipconfig1",
             "properties": {
               "privateIPAllocationMethod": "Static",
-              "privateIPAddress" :"[concat(variables('privateIPAddressPrefix'), copyindex())]",
+              "privateIPAddress": "[concat(variables('privateIPAddressPrefix'), copyindex())]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
               },
@@ -198,10 +198,10 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
-      "location":"[resourceGroup().location]",
+      "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/',variables('publicIPAddressName'))]"
       ],
@@ -223,10 +223,10 @@
         ],
         "inboundNatRules": [
           {
-            "name":"SSH-VM0",
+            "name": "SSH-VM0",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2200,
@@ -235,10 +235,10 @@
             }
           },
           {
-            "name":"SSH-VM1",
+            "name": "SSH-VM1",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2201,
@@ -247,10 +247,10 @@
             }
           },
           {
-            "name":"SSH-VM2",
+            "name": "SSH-VM2",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2202,
@@ -259,10 +259,10 @@
             }
           },
           {
-            "name":"SSH-VM3",
+            "name": "SSH-VM3",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2203,
@@ -271,10 +271,10 @@
             }
           },
           {
-            "name":"SSH-VM4",
+            "name": "SSH-VM4",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2204,
@@ -359,7 +359,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -412,7 +412,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(concat(variables('vmName'),copyIndex()),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),copyIndex()))]"

--- a/openldap-singlevm-ubuntu/azuredeploy.json
+++ b/openldap-singlevm-ubuntu/azuredeploy.json
@@ -88,7 +88,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -97,7 +97,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -109,7 +109,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -130,7 +130,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -156,7 +156,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -201,7 +201,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/opensis-cluster-ubuntu/azuredeploy.json
+++ b/opensis-cluster-ubuntu/azuredeploy.json
@@ -139,7 +139,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -150,12 +150,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -167,7 +167,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -194,7 +194,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -234,7 +234,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -415,7 +415,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -468,7 +468,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(concat(variables('vmName'),copyIndex()),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),copyIndex()))]"
@@ -495,12 +495,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(variables('availabilitySetName'),'db')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicDBIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -512,7 +512,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -538,7 +538,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -587,7 +587,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(concat(variables('vmName'),'db'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),'db'))]"

--- a/opensis-singlevm-ubuntu/azuredeploy.json
+++ b/opensis-singlevm-ubuntu/azuredeploy.json
@@ -81,7 +81,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -90,7 +90,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -102,7 +102,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -123,7 +123,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -149,7 +149,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -194,7 +194,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/pivotalcloudfoundry-apigee/pcf/pcfdeploy.json
+++ b/pivotalcloudfoundry-apigee/pcf/pcfdeploy.json
@@ -3,25 +3,23 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "apigeeEdge": {
-			"type": "string"
-		},
-     "managementUI": {
-			"type": "string"
-		},
-     "managementDNSName": {
-			"type": "string"
-
-		},
-     "runtimePublicDNSName": {
-			"type": "string"
-		},
+      "type": "string"
+    },
+    "managementUI": {
+      "type": "string"
+    },
+    "managementDNSName": {
+      "type": "string"
+    },
+    "runtimePublicDNSName": {
+      "type": "string"
+    },
     "apigeeAdminPassword": {
       "type": "securestring"
     },
-    "apigeeAdminEmail":{	
+    "apigeeAdminEmail": {
       "type": "string"
-		},
-    	
+    },
     "storageAccountNamePrefixString": {
       "type": "string",
       "metadata": {
@@ -181,35 +179,35 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('vmName'),'-devbox')]",
       "location": "[variables('location')]",
       "properties": {
-        "publicIPAllocationMethod": "dynamic",
+        "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
           "domainNameLabel": "[variables('vmName')]"
         }
       }
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('vmName'),'-bosh')]",
       "location": "[variables('location')]",
       "properties": {
-        "publicIPAllocationMethod": "static"
+        "publicIPAllocationMethod": "Static"
       }
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('vmName'), '-cf')]",
       "location": "[variables('location')]",
@@ -237,7 +235,8 @@
               "priority": 1000,
               "direction": "Inbound"
             }
-          }, {
+          },
+          {
             "name": "allow-https-to-jumpbox",
             "properties": {
               "description": "Allow Inbound HTTPS To Jumpbox",
@@ -261,7 +260,7 @@
       "location": "[variables('location')]"
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
@@ -280,8 +279,8 @@
             "name": "[variables('subnet1Name')]",
             "properties": {
               "addressPrefix": "[variables('subnet1Prefix')]",
-              "networkSecurityGroup":{
-                  "id":"[resourceId('Microsoft.Network/networkSecurityGroups', variables('subnet1NSG'))]"
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('subnet1NSG'))]"
               }
             }
           },
@@ -289,8 +288,8 @@
             "name": "[variables('subnet2Name')]",
             "properties": {
               "addressPrefix": "[variables('subnet2Prefix')]",
-              "networkSecurityGroup":{
-                  "id":"[resourceId('Microsoft.Network/networkSecurityGroups', variables('subnet2NSG'))]"
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('subnet2NSG'))]"
               }
             }
           }
@@ -298,7 +297,7 @@
       }
     },
     {
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[variables('location')]",
@@ -325,7 +324,7 @@
       }
     },
     {
-      "apiversion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[variables('location')]",
@@ -343,10 +342,12 @@
           "linuxConfiguration": {
             "disablePasswordAuthentication": "true",
             "ssh": {
-              "publicKeys": [{
-                "path": "[variables('sshKeyPath')]",
-                "keyData": "[parameters('adminSSHKey')]"
-              }]
+              "publicKeys": [
+                {
+                  "path": "[variables('sshKeyPath')]",
+                  "keyData": "[parameters('adminSSHKey')]"
+                }
+              ]
             }
           }
         },
@@ -392,8 +393,8 @@
       "name": "[variables('sqlServerName')]",
       "type": "Microsoft.Sql/servers",
       "location": "[resourceGroup().location]",
-      "apiVersion": "2014-04-01-preview",
-      "dependsOn": [ ],
+      "apiVersion": "2014-04-01",
+      "dependsOn": [],
       "tags": {
         "displayName": "SQL Server"
       },
@@ -405,9 +406,9 @@
       "resources": [
         {
           "name": "AllowAllWindowsAzureIps",
-          "type": "firewallrules",
+          "type": "firewallRules",
           "location": "[resourceGroup().location]",
-          "apiVersion": "2014-04-01-preview",
+          "apiVersion": "2014-04-01",
           "dependsOn": [
             "[concat('Microsoft.Sql/servers/', variables('sqlServerName'))]"
           ],
@@ -420,7 +421,7 @@
           "name": "[variables('sqlDatabaseName')]",
           "type": "databases",
           "location": "[resourceGroup().location]",
-          "apiVersion": "2014-04-01-preview",
+          "apiVersion": "2014-04-01-spreview",
           "dependsOn": [
             "[variables('sqlServerName')]"
           ],
@@ -433,7 +434,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/initdevbox')]",
-      "apiVersion": "[variables('api-version')]",
+      "apiVersion": "2015-06-15",
       "location": "[variables('location')]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
@@ -448,12 +449,12 @@
             "https://s3-us-west-2.amazonaws.com/test-epsilon/bootstrap.py"
           ],
           "managementUI": "[parameters('managementUI')]",
-	  "apigeeEdge": "[parameters('apigeeEdge')]",
-	  "managementDNSName": "[parameters('managementDNSName')]",
-	  "runtimePublicDNSName": "[parameters('runtimePublicDNSName')]",
-	  "adminUsername":"[parameters('adminUsername')]",
-	  "apigeeAdminPassword": "[parameters('apigeeAdminPassword')]",
-          "apigeeAdminEmail":"[parameters('apigeeAdminEmail')]", 	
+          "apigeeEdge": "[parameters('apigeeEdge')]",
+          "managementDNSName": "[parameters('managementDNSName')]",
+          "runtimePublicDNSName": "[parameters('runtimePublicDNSName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "apigeeAdminPassword": "[parameters('apigeeAdminPassword')]",
+          "apigeeAdminEmail": "[parameters('apigeeAdminEmail')]",
           "adminSSHKey": "[parameters('adminSSHKey')]",
           "commandToExecute": "[concat('python ./bootstrap.py ', parameters('installSize'), ' ', variables('webSessionPassword'))]",
           "location": "[variables('location')]",
@@ -484,24 +485,24 @@
           "metabrokerenvironment": "[parameters('metabrokerEnvironment')]",
           "pivnet-api-token": "[parameters('pivnetAPIToken')]"
         },
-        "protectedSettings" : {
-            "CLIENT-SECRET": "[parameters('clientSecret')]"
+        "protectedSettings": {
+          "CLIENT-SECRET": "[parameters('clientSecret')]"
         }
       }
     }
   ],
   "outputs": {
-      "scriptoutput": {
-          "value": "[split(split(reference(resourceId('Microsoft.Compute/virtualMachines/extensions',variables('vmName'),variables('extensionName')),providers('Microsoft.Compute', 'virtualMachines').apiVersions[0]).instanceView.statuses[0].message,'---')[2],'###QUOTACHECK###')[1]]",
-          "type": "string"
-      },
-      "ProgressMonitorURL" : {
-          "type" : "string",
-          "value": "[concat('https://gamma:', variables('webSessionPassword'), '@', reference(concat(variables('vmName'),'-devbox')).dnsSettings.fqdn)]"
-      },
-      "JumpboxFQDN": {
-          "type" : "string",
-          "value": "[reference(concat(variables('vmName'),'-devbox')).dnsSettings.fqdn]"
-      }
+    "scriptoutput": {
+      "value": "[split(split(reference(resourceId('Microsoft.Compute/virtualMachines/extensions',variables('vmName'),variables('extensionName')),providers('Microsoft.Compute', 'virtualMachines').apiVersions[0]).instanceView.statuses[0].message,'---')[2],'###QUOTACHECK###')[1]]",
+      "type": "string"
+    },
+    "ProgressMonitorURL": {
+      "type": "string",
+      "value": "[concat('https://gamma:', variables('webSessionPassword'), '@', reference(concat(variables('vmName'),'-devbox')).dnsSettings.fqdn)]"
+    },
+    "JumpboxFQDN": {
+      "type": "string",
+      "value": "[reference(concat(variables('vmName'),'-devbox')).dnsSettings.fqdn]"
+    }
   }
 }

--- a/postgresql-standalone-server-ubuntu/azuredeploy.json
+++ b/postgresql-standalone-server-ubuntu/azuredeploy.json
@@ -20,16 +20,16 @@
         "description": "DNS Name for the publicly accessible node. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
       }
     },
-	"vmSize": {
+    "vmSize": {
       "type": "string",
       "defaultValue": "Standard_A1",
       "allowedValues": [
-	    "Standard_A1",
-		"Standard_A2",
-		"Standard_A3",
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
         "Standard_D1",
         "Standard_D3",
-		"Standard_D4"
+        "Standard_D4"
       ],
       "metadata": {
         "description": "The size of the virtual machines used when provisioning"
@@ -56,8 +56,8 @@
     "addressPrefix": "10.0.0.0/16",
     "subnetName": "Subnet",
     "subnetPrefix": "10.0.0.0/24",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
     "storageAccountType": "Standard_LRS",
     "publicIPAddressName": "myPublicIP",
     "publicIPAddressType": "Dynamic",
@@ -71,14 +71,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -90,7 +90,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -111,7 +111,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -137,7 +137,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -182,7 +182,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
@@ -202,4 +202,3 @@
     }
   ]
 }
-

--- a/puppet-agent-linux/azuredeploy.json
+++ b/puppet-agent-linux/azuredeploy.json
@@ -44,21 +44,21 @@
       }
     },
     "pupmstrFQDN": {
-      "type":"string",
+      "type": "string",
       "metadata": {
         "description": "FQDN of your PE box, e.g: pupmstr.cloudapp.net"
       },
       "defaultValue": "pupmstr.cloudapp.net"
     },
     "pupmstrIP": {
-      "type":"string",
+      "type": "string",
       "metadata": {
         "description": "IP of your PE box, e.g: 192.168.1.1"
       },
       "defaultValue": "192.168.1.1"
     },
     "pupmstrInternalFQDN": {
-      "type":"string",
+      "type": "string",
       "metadata": {
         "description": "Internal FQDN of your PE box, e.g: pupmstr.pupmstr.d6.internal.cloudapp.net.  Get it from node requests page in PE Console."
       },
@@ -85,21 +85,21 @@
     "virtualNetworkName": "[concat(variables('scenarioPrefix'),'Vnet')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-    "fileUris":"https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/puppet-agent-linux/install_puppet_agent.sh",
+    "fileUris": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/puppet-agent-linux/install_puppet_agent.sh",
     "commandToExecute": "[concat('./install_puppet_agent.sh ', parameters('pupmstrIP'), ' ', parameters('pupmstrFQDN'), ' ', parameters('pupmstrInternalFQDN'))]"
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('newStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -111,7 +111,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -132,7 +132,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -158,7 +158,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -203,7 +203,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/installcustomscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
@@ -221,4 +221,3 @@
     }
   ]
 }
-

--- a/puppet-agent-windows/azuredeploy.json
+++ b/puppet-agent-windows/azuredeploy.json
@@ -42,7 +42,7 @@
     }
   },
   "variables": {
-    "apiVersion":"2015-06-15",
+    "apiVersion": "2015-06-15",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
     "vmExtensionName": "PuppetEnterpriseAgent",
@@ -66,14 +66,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -85,7 +85,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -106,7 +106,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -132,7 +132,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -177,7 +177,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/', variables('vmExtensionName'))]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/radium-blockchain-ubuntu/azuredeploy.json
+++ b/radium-blockchain-ubuntu/azuredeploy.json
@@ -1,76 +1,76 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"adminUsername": {
-			"type": "string",
-			"metadata": {
-				"description": "Username for the Virtual Machine."
-			}
-		},
-		"adminPassword": {
-			"type": "securestring",
-			"metadata": {
-				"description": "Password for the Virtual Machine."
-			}
-		},
-		"dnsLabelPrefix": {
-			"type": "string",
-			"metadata": {
-				"description": "Hostname assigned to the Public IP, also used as the VM Name. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
-			}
-		},
-		"installMethod": {
-			"type": "string",
-			"defaultValue": "From_Binary",
-			"allowedValues": [
-				"From_Binary",
-				"From_Source"
-			],
-			"metadata": {
-				"description": "Method to install Radium. From_Binary: download precompiled binary from GitHub. From_Source: official Radium repo on GitHub."
-			}
-		},
-		"vmSize": {
-			"type": "string",
-			"defaultValue": "Standard_A2",
-			"allowedValues": [
-				"Standard_A1",
-				"Standard_A2",
-				"Standard_A3",
-				"Standard_D1_V2",
-				"Standard_D2_V2",
-				"Standard_D3_V2"
-			],
-			"metadata": {
-				"description": "Size of VM"
-			}
-		},
-		"rpcUser": {
-			"type": "string",
-			"metadata": {
-				"description": "Username for the RPC connection."
-			}
-		},
-		"rpcPass": {
-			"type": "securestring",
-			"metadata": {
-				"description": "Password for the RPC connection."
-			}
-		},
-		"rpcPort": {
-			"type": "string",
-			"metadata": {
-				"description": "Port for the RPC connection."
-			}
-		},
-		"rpcAllowIp": {
-			"type": "string",
-			"metadata": {
-				"description": "Allowed IP for RPC connection."
-			}
-		}
-	},
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
+    },
+    "dnsLabelPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Hostname assigned to the Public IP, also used as the VM Name. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
+    },
+    "installMethod": {
+      "type": "string",
+      "defaultValue": "From_Binary",
+      "allowedValues": [
+        "From_Binary",
+        "From_Source"
+      ],
+      "metadata": {
+        "description": "Method to install Radium. From_Binary: download precompiled binary from GitHub. From_Source: official Radium repo on GitHub."
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_A2",
+      "allowedValues": [
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_D1_V2",
+        "Standard_D2_V2",
+        "Standard_D3_V2"
+      ],
+      "metadata": {
+        "description": "Size of VM"
+      }
+    },
+    "rpcUser": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the RPC connection."
+      }
+    },
+    "rpcPass": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the RPC connection."
+      }
+    },
+    "rpcPort": {
+      "type": "string",
+      "metadata": {
+        "description": "Port for the RPC connection."
+      }
+    },
+    "rpcAllowIp": {
+      "type": "string",
+      "metadata": {
+        "description": "Allowed IP for RPC connection."
+      }
+    }
+  },
   "variables": {
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
@@ -95,14 +95,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -114,7 +114,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -135,7 +135,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -161,7 +161,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -208,12 +208,12 @@
           }
         }
       }
-    },  
+    },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       ],
@@ -227,7 +227,7 @@
             "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/radium-blockchain-ubuntu/build_radium.sh"
           ],
           "commandToExecute": "[concat('sh build_radium.sh ', parameters('installMethod'), ' ', parameters('rpcUser'), ' ', parameters('rpcPass'), ' ', parameters('rpcPort'), ' ', parameters('rpcAllowIp'))]"
-          }
+        }
       }
     }
   ]

--- a/rds-deployment-ha-gateway/azuredeploy.json
+++ b/rds-deployment-ha-gateway/azuredeploy.json
@@ -134,6 +134,9 @@
       }
     },
     {
+      "properties": {
+        
+      },
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[Parameters('gw-availabilityset')]",
@@ -257,7 +260,7 @@
       "name": "[concat('gw-',copyindex(),'-nic')]",
       "type": "Microsoft.Network/networkInterfaces",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiversion')]",
+      "apiVersion": "2017-06-01",
       "copy": {
         "name": "gw-nic-loop",
         "count": "[parameters('numberOfWebGwInstances')]"
@@ -289,7 +292,7 @@
       "name": "[concat('gw-vm-',copyindex())]",
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiversion')]",
+      "apiVersion": "2015-05-01-preview",
       "copy": {
         "name": "gw-vm-loop",
         "count": "[parameters('numberOfWebGwInstances')]"
@@ -340,7 +343,7 @@
           "name": "[concat('gw-vm-',copyindex(),'/Gateway')]",
           "type": "Microsoft.Compute/virtualMachines/extensions",
           "location": "[resourceGroup().location]",
-          "apiVersion": "[variables('apiversion')]",
+          "apiVersion": "2015-05-01-preview",
           "dependsOn": [
             "[resourceId('Microsoft.Compute/virtualMachines', Concat('gw-vm-',copyindex()))]"
           ],
@@ -371,7 +374,7 @@
           "name": "[concat('gw-vm-',copyindex(),'/WebAndGwFarmAdd_PostConfig1.1')]",
           "type": "Microsoft.Compute/virtualMachines/extensions",
           "location": "[resourceGroup().location]",
-          "apiVersion": "[variables('apiversion')]",
+          "apiVersion": "2015-05-01-preview",
           "dependsOn": [
             "[resourceId('Microsoft.Compute/virtualMachines', Concat('gw-vm-',copyindex()))]",
             "[concat('Microsoft.Compute/virtualMachines/gw-vm-',copyindex(),'/extensions/','Gateway')]"

--- a/rds-deployment-ha-gateway/azuredeploy.json
+++ b/rds-deployment-ha-gateway/azuredeploy.json
@@ -125,7 +125,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -134,13 +134,13 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[Parameters('gw-availabilityset')]",
       "location": "[resourceGroup().location]"
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIpRef')]",
       "location": "[resourceGroup().location]",
@@ -152,7 +152,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers",
       "name": "[Parameters('Loadbalancer')]",
       "location": "[resourceGroup().location]",
@@ -175,7 +175,6 @@
             "name": "[parameters('backendAddressPools')]"
           }
         ],
-
         "loadBalancingRules": [
           {
             "name": "LBRule01",
@@ -238,7 +237,6 @@
             }
           }
         ],
-
         "inboundNatRules": [
           {
             "name": "rdp",
@@ -252,9 +250,7 @@
               "enableFloatingIP": false
             }
           }
-
         ]
-
       }
     },
     {
@@ -270,7 +266,6 @@
         "Microsoft.Network/loadBalancers/loadBalancer"
       ],
       "properties": {
-
         "ipConfigurations": [
           {
             "name": "ipconfig1",
@@ -284,7 +279,7 @@
                   "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/backendAddressPools/',parameters('backendAddressPools'))]"
                 }
               ],
-              "loadBalancerInboundNatRules": [ ]
+              "loadBalancerInboundNatRules": []
             }
           }
         ]
@@ -370,7 +365,6 @@
                 "AdminPassword": "[parameters('adminPassword')]"
               }
             }
-
           }
         },
         {
@@ -388,22 +382,20 @@
             "typeHandlerVersion": "1.8",
             "autoUpgradeMinorVersion": true,
             "settings": {
-              "fileUris": [ "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/rds-deployment-ha-gateway/Scripts/WebAndGwFarmAdd_PostConfig1.1.ps1" ]
-              
+              "fileUris": [
+                "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/rds-deployment-ha-gateway/Scripts/WebAndGwFarmAdd_PostConfig1.1.ps1"
+              ]
             },
             "protectedSettings": {
-              
-              "Items": { "AdminPassword": "[parameters('adminPassword')]" },
+              "Items": {
+                "AdminPassword": "[parameters('adminPassword')]"
+              },
               "storageAccountName": "[parameters('storageaccountname')]",
               "commandToExecute": "[Concat('powershell.exe -ExecutionPolicy Unrestricted -File', ' ', 'WebAndGwFarmAdd_PostConfig1.1.ps1',' ','-username \"',parameters('adminusername'),'\" ', '-password \"',parameters('adminpassword'),'\" ','-BrokerServer \"',parameters('BrokerServer'),'\" ','-WebURL \"',parameters('WebURL'),'\" ','-Domainname \"',parameters('adDomainName'),'\" ','-DomainNetbios \"',parameters('DomainNetbios'),'\" ','-numberofwebServers ',parameters('numberOfWebGwInstances'))]"
             }
-
           }
         }
-
       ]
-
     }
-
   ]
 }

--- a/sap-2-tier-marketplace-image/azuredeploy.json
+++ b/sap-2-tier-marketplace-image/azuredeploy.json
@@ -214,14 +214,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('internalStorageType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameVnet')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -247,7 +247,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameNIC')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -279,7 +279,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameProf')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -326,7 +326,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNamePIP')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -346,7 +346,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameNSG')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -391,7 +391,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentName')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -442,7 +442,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/', variables('cseExtName'))]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentName'))]"

--- a/sap-2-tier-marketplace-image/shared/loadbalancer.json
+++ b/sap-2-tier-marketplace-image/shared/loadbalancer.json
@@ -1,68 +1,68 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "loadBalancerName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the the load balancer"
-            }
-        },
-        "sapSystemCount": {
-            "type": "int",
-            "defaultValue": 1,
-            "metadata": {
-                "description": "The number of SAP systems for which the load balancer should be configured"
-            }
-        },
-        "stackType": {
-            "type": "string",
-            "defaultValue": "ABAP",
-            "metadata": {
-                "description": "The stack type of the SAP system."
-            }
-        },
-        "osType": {
-            "type": "string",
-            "defaultValue": "Windows",
-            "metadata": {
-                "description": "The type of the Operating System"
-            }
-        },
-        "createXSCS": {
-            "type": "bool",
-            "defaultValue": true,
-            "metadata": {
-                "description": "Determines if the load balancer should be configured for one or more ASCS/SCS."
-            }
-        },
-        "createDB": {
-            "type": "bool",
-            "defaultValue": true,
-            "metadata": {
-                "description": "Determines if the load balancer should be configured for one or more databases."
-            }
-        },
-        "dbType": {
-            "type": "string",
-            "defaultValue": "SQL",
-            "metadata": {
-                "description": "The type of the database"
-            }
-        },
-        "subnetId": {
-            "type": "string",
-            "metadata": {
-                "description": "The id of the subnet you want to use."
-            }
-        },
-        "github": {
-            "type": "string",
-            "metadata": {
-                "description": "The URL to github where the subtemplates are stored"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "loadBalancerName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the the load balancer"
+      }
     },
+    "sapSystemCount": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "The number of SAP systems for which the load balancer should be configured"
+      }
+    },
+    "stackType": {
+      "type": "string",
+      "defaultValue": "ABAP",
+      "metadata": {
+        "description": "The stack type of the SAP system."
+      }
+    },
+    "osType": {
+      "type": "string",
+      "defaultValue": "Windows",
+      "metadata": {
+        "description": "The type of the Operating System"
+      }
+    },
+    "createXSCS": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Determines if the load balancer should be configured for one or more ASCS/SCS."
+      }
+    },
+    "createDB": {
+      "type": "bool",
+      "defaultValue": true,
+      "metadata": {
+        "description": "Determines if the load balancer should be configured for one or more databases."
+      }
+    },
+    "dbType": {
+      "type": "string",
+      "defaultValue": "SQL",
+      "metadata": {
+        "description": "The type of the database"
+      }
+    },
+    "subnetId": {
+      "type": "string",
+      "metadata": {
+        "description": "The id of the subnet you want to use."
+      }
+    },
+    "github": {
+      "type": "string",
+      "metadata": {
+        "description": "The URL to github where the subtemplates are stored"
+      }
+    }
+  },
   "variables": {
     "apiVerion": "2015-06-15",
     "apiVersionDeployment": "2016-09-01",
@@ -90,254 +90,254 @@
     "ersTemplate": "[variables('ersTemplates')[string(parameters('createXSCS'))]]",
     "dbTemplate": "[variables('dbTemplates')[string(parameters('createDB'))]]"
   },
-    "resources": [
-        {
-            "apiVersion": "[variables('apiVersionDeployment')]",
-            "name": "[concat(variables('nestedDeploymentNameLBSCS'), '0')]",
-            "type": "Microsoft.Resources/deployments",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('github'), 'lb-SCS0.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "loadBalancerName": {
-                        "value": "[parameters('loadBalancerName')]"
-                    },
-                    "stackType": {
-                        "value": "[parameters('stackType')]"
-                    },
-                    "osType": {
-                        "value": "[parameters('osType')]"
-                    },
-                    "ascsInstanceNumber": {
-                        "value": "[variables('ascsInstanceNumber')]"
-                    },
-                    "scsInstanceNumber": {
-                        "value": "[variables('scsInstanceNumber')]"
-                    },
-                    "subnetId": {
-                        "value": "[parameters('subnetId')]"
-                    }
-                }
-            }
+  "resources": [
+    {
+      "apiVersion": "2016-09-01",
+      "name": "[concat(variables('nestedDeploymentNameLBSCS'), '0')]",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('github'), 'lb-SCS0.json')]",
+          "contentVersion": "1.0.0.0"
         },
-        {
-            "apiVersion": "[variables('apiVersionDeployment')]",
-            "name": "[concat(variables('nestedDeploymentNameLBSCS'), copyIndex(1))]",
-            "type": "Microsoft.Resources/deployments",
-            "dependsOn": [
-                "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameLBSCS'), '0')]"
-            ],
-            "copy": {
-                "name": "scsLoop",
-                "count": "[parameters('sapSystemCount')]"
-            },
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('github'), variables('scsTemplate'))]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "loadBalancerName": {
-                        "value": "[parameters('loadBalancerName')]"
-                    },
-                    "stackType": {
-                        "value": "[parameters('stackType')]"
-                    },
-                    "osType": {
-                        "value": "[parameters('osType')]"
-                    },
-                    "ascsInstanceNumber": {
-                        "value": "[add(mul(copyIndex(), 10), variables('ascsInstanceNumber'))]"
-                    },
-                    "scsInstanceNumber": {
-                        "value": "[add(mul(copyIndex(), 10), variables('scsInstanceNumber'))]"
-                    },
-                    "subnetId": {
-                        "value": "[parameters('subnetId')]"
-                    },
-                    "nicBackAddressPoolsArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.nicBackAddressPools.value]"
-                    },
-                    "frontendIPConfigurationsArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.frontendIPConfigurations.value]"
-                    },
-                    "backendAddressPoolsArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.backendAddressPools.value]"
-                    },
-                    "loadBalancingRulesArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.loadBalancingRules.value]"
-                    },
-                    "probesArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.probes.value]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionDeployment')]",
-            "name": "[concat(variables('nestedDeploymentNameLBERS'), '0')]",
-            "type": "Microsoft.Resources/deployments",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('github'), 'lb-ERS0.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "stackType": {
-                        "value": "[parameters('stackType')]"
-                    },
-                    "loadBalancerName": {
-                        "value": "[parameters('loadBalancerName')]"
-                    },
-                    "subnetId": {
-                        "value": "[parameters('subnetId')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionDeployment')]",
-            "name": "[concat(variables('nestedDeploymentNameLBERS'), copyIndex(1))]",
-            "type": "Microsoft.Resources/deployments",
-            "dependsOn": [
-                "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameLBERS'), '0')]"
-            ],
-            "copy": {
-                "name": "ersLoop",
-                "count": "[parameters('sapSystemCount')]"
-            },
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('github'), variables('ersTemplate'))]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "loadBalancerName": {
-                        "value": "[parameters('loadBalancerName')]"
-                    },
-                    "stackType": {
-                        "value": "[parameters('stackType')]"
-                    },
-                    "ersASCSInstanceNumber": {
-                        "value": "[add(mul(copyIndex(), 10), variables('ersASCSInstanceNumber'))]"
-                    },
-                    "ersSCSInstanceNumber": {
-                        "value": "[add(mul(copyIndex(), 10), variables('ersSCSInstanceNumber'))]"
-                    },
-                    "subnetId": {
-                        "value": "[parameters('subnetId')]"
-                    },
-                    "nicBackAddressPoolsArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.nicBackAddressPools.value]"
-                    },
-                    "frontendIPConfigurationsArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.frontendIPConfigurations.value]"
-                    },
-                    "backendAddressPoolsArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.backendAddressPools.value]"
-                    },
-                    "loadBalancingRulesArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.loadBalancingRules.value]"
-                    },
-                    "probesArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.probes.value]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionDeployment')]",
-            "name": "[concat(variables('nestedDeploymentNameLBDB'), '0')]",
-            "type": "Microsoft.Resources/deployments",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('github'), 'lb-DB0.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "loadBalancerName": {
-                        "value": "[parameters('loadBalancerName')]"
-                    },
-                    "subnetId": {
-                        "value": "[parameters('subnetId')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('apiVersionDeployment')]",
-            "name": "[concat(variables('nestedDeploymentNameLBDB'), copyIndex(1))]",
-            "type": "Microsoft.Resources/deployments",
-            "dependsOn": [
-                "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameLBDB'), '0')]"
-            ],
-            "copy": {
-                "name": "dbLoop",
-                "count": "[parameters('sapSystemCount')]"
-            },
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('github'), variables('dbTemplate'))]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "loadBalancerName": {
-                        "value": "[parameters('loadBalancerName')]"
-                    },
-                    "dbInstanceNumber": {
-                        "value": "[add(mul(copyIndex(), 10), variables('dbInstanceNumber'))]"
-                    },
-                    "subnetId": {
-                        "value": "[parameters('subnetId')]"
-                    },
-                    "nicBackAddressPoolsArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.nicBackAddressPools.value]"
-                    },
-                    "frontendIPConfigurationsArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.frontendIPConfigurations.value]"
-                    },
-                    "backendAddressPoolsArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.backendAddressPools.value]"
-                    },
-                    "loadBalancingRulesArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.loadBalancingRules.value]"
-                    },
-                    "probesArray": {
-                        "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.probes.value]"
-                    }
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Network/loadBalancers",
-            "name": "[parameters('loadBalancerName')]",
-            "apiVersion": "[variables('apiVerion')]",
-            "dependsOn": [
-                "scsLoop",
-                "ersLoop",
-                "dbLoop"
-            ],
-            "location": "[resourceGroup().location]",
-            "properties": {
-                "frontendIPConfigurations": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.frontendIPConfigurations.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.frontendIPConfigurations.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.frontendIPConfigurations.value)]",
-                "backendAddressPools": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.backendAddressPools.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.backendAddressPools.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.backendAddressPools.value)]",
-                "loadBalancingRules": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.loadBalancingRules.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.loadBalancingRules.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.loadBalancingRules.value)]",
-                "probes": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.probes.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.probes.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.probes.value)]"
-            }
+        "parameters": {
+          "loadBalancerName": {
+            "value": "[parameters('loadBalancerName')]"
+          },
+          "stackType": {
+            "value": "[parameters('stackType')]"
+          },
+          "osType": {
+            "value": "[parameters('osType')]"
+          },
+          "ascsInstanceNumber": {
+            "value": "[variables('ascsInstanceNumber')]"
+          },
+          "scsInstanceNumber": {
+            "value": "[variables('scsInstanceNumber')]"
+          },
+          "subnetId": {
+            "value": "[parameters('subnetId')]"
+          }
         }
-    ],
-    "outputs": {
-        "nicBackAddressPools": {
-            "value": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.nicBackAddressPools.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.nicBackAddressPools.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.nicBackAddressPools.value)]",
-            "type": "array"
+      }
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "name": "[concat(variables('nestedDeploymentNameLBSCS'), copyIndex(1))]",
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameLBSCS'), '0')]"
+      ],
+      "copy": {
+        "name": "scsLoop",
+        "count": "[parameters('sapSystemCount')]"
+      },
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('github'), variables('scsTemplate'))]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "loadBalancerName": {
+            "value": "[parameters('loadBalancerName')]"
+          },
+          "stackType": {
+            "value": "[parameters('stackType')]"
+          },
+          "osType": {
+            "value": "[parameters('osType')]"
+          },
+          "ascsInstanceNumber": {
+            "value": "[add(mul(copyIndex(), 10), variables('ascsInstanceNumber'))]"
+          },
+          "scsInstanceNumber": {
+            "value": "[add(mul(copyIndex(), 10), variables('scsInstanceNumber'))]"
+          },
+          "subnetId": {
+            "value": "[parameters('subnetId')]"
+          },
+          "nicBackAddressPoolsArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.nicBackAddressPools.value]"
+          },
+          "frontendIPConfigurationsArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.frontendIPConfigurations.value]"
+          },
+          "backendAddressPoolsArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.backendAddressPools.value]"
+          },
+          "loadBalancingRulesArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.loadBalancingRules.value]"
+          },
+          "probesArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBSCS'), copyIndex())).outputs.probes.value]"
+          }
         }
+      }
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "name": "[concat(variables('nestedDeploymentNameLBERS'), '0')]",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('github'), 'lb-ERS0.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "stackType": {
+            "value": "[parameters('stackType')]"
+          },
+          "loadBalancerName": {
+            "value": "[parameters('loadBalancerName')]"
+          },
+          "subnetId": {
+            "value": "[parameters('subnetId')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "name": "[concat(variables('nestedDeploymentNameLBERS'), copyIndex(1))]",
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameLBERS'), '0')]"
+      ],
+      "copy": {
+        "name": "ersLoop",
+        "count": "[parameters('sapSystemCount')]"
+      },
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('github'), variables('ersTemplate'))]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "loadBalancerName": {
+            "value": "[parameters('loadBalancerName')]"
+          },
+          "stackType": {
+            "value": "[parameters('stackType')]"
+          },
+          "ersASCSInstanceNumber": {
+            "value": "[add(mul(copyIndex(), 10), variables('ersASCSInstanceNumber'))]"
+          },
+          "ersSCSInstanceNumber": {
+            "value": "[add(mul(copyIndex(), 10), variables('ersSCSInstanceNumber'))]"
+          },
+          "subnetId": {
+            "value": "[parameters('subnetId')]"
+          },
+          "nicBackAddressPoolsArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.nicBackAddressPools.value]"
+          },
+          "frontendIPConfigurationsArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.frontendIPConfigurations.value]"
+          },
+          "backendAddressPoolsArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.backendAddressPools.value]"
+          },
+          "loadBalancingRulesArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.loadBalancingRules.value]"
+          },
+          "probesArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBERS'), copyIndex())).outputs.probes.value]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "name": "[concat(variables('nestedDeploymentNameLBDB'), '0')]",
+      "type": "Microsoft.Resources/deployments",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('github'), 'lb-DB0.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "loadBalancerName": {
+            "value": "[parameters('loadBalancerName')]"
+          },
+          "subnetId": {
+            "value": "[parameters('subnetId')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2016-09-01",
+      "name": "[concat(variables('nestedDeploymentNameLBDB'), copyIndex(1))]",
+      "type": "Microsoft.Resources/deployments",
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameLBDB'), '0')]"
+      ],
+      "copy": {
+        "name": "dbLoop",
+        "count": "[parameters('sapSystemCount')]"
+      },
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('github'), variables('dbTemplate'))]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "loadBalancerName": {
+            "value": "[parameters('loadBalancerName')]"
+          },
+          "dbInstanceNumber": {
+            "value": "[add(mul(copyIndex(), 10), variables('dbInstanceNumber'))]"
+          },
+          "subnetId": {
+            "value": "[parameters('subnetId')]"
+          },
+          "nicBackAddressPoolsArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.nicBackAddressPools.value]"
+          },
+          "frontendIPConfigurationsArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.frontendIPConfigurations.value]"
+          },
+          "backendAddressPoolsArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.backendAddressPools.value]"
+          },
+          "loadBalancingRulesArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.loadBalancingRules.value]"
+          },
+          "probesArray": {
+            "value": "[reference(concat(variables('nestedDeploymentNameLBDB'), copyIndex())).outputs.probes.value]"
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/loadBalancers",
+      "name": "[parameters('loadBalancerName')]",
+      "apiVersion": "2015-06-15",
+      "dependsOn": [
+        "scsLoop",
+        "ersLoop",
+        "dbLoop"
+      ],
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "frontendIPConfigurations": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.frontendIPConfigurations.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.frontendIPConfigurations.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.frontendIPConfigurations.value)]",
+        "backendAddressPools": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.backendAddressPools.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.backendAddressPools.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.backendAddressPools.value)]",
+        "loadBalancingRules": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.loadBalancingRules.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.loadBalancingRules.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.loadBalancingRules.value)]",
+        "probes": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.probes.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.probes.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.probes.value)]"
+      }
     }
+  ],
+  "outputs": {
+    "nicBackAddressPools": {
+      "value": "[concat(reference(concat(variables('nestedDeploymentNameLBSCS'), parameters('sapSystemCount'))).outputs.nicBackAddressPools.value, reference(concat(variables('nestedDeploymentNameLBERS'), parameters('sapSystemCount'))).outputs.nicBackAddressPools.value, reference(concat(variables('nestedDeploymentNameLBDB'), parameters('sapSystemCount'))).outputs.nicBackAddressPools.value)]",
+      "type": "array"
+    }
+  }
 }

--- a/sap-2-tier-marketplace-image/shared/newpip.json
+++ b/sap-2-tier-marketplace-image/shared/newpip.json
@@ -23,7 +23,7 @@
     {
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIpName')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "publicIPAllocationMethod": "[parameters('publicIPAddressType')]"

--- a/sap-2-tier-marketplace-image/shared/newvnet.json
+++ b/sap-2-tier-marketplace-image/shared/newvnet.json
@@ -32,11 +32,10 @@
     "apiVerionRm": "2015-01-01"
   },
   "resources": [
-
     {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('vnetName')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "addressSpace": {

--- a/sap-2-tier-marketplace-image/shared/newvnetnsg.json
+++ b/sap-2-tier-marketplace-image/shared/newvnetnsg.json
@@ -41,7 +41,7 @@
     {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('vnetName')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "addressSpace": {

--- a/sap-2-tier-user-disk/azuredeploy.json
+++ b/sap-2-tier-user-disk/azuredeploy.json
@@ -156,14 +156,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('internalStorageType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameVnet')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -189,7 +189,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameNIC')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -221,7 +221,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameProf')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -268,7 +268,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNamePIP')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -288,7 +288,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameNSG')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -333,7 +333,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentName')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -384,7 +384,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/', variables('cseExtName'))]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentName'))]"

--- a/sap-2-tier-user-image/azuredeploy.json
+++ b/sap-2-tier-user-image/azuredeploy.json
@@ -174,14 +174,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('internalStorageType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameVnet')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -207,7 +207,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameNIC')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -239,7 +239,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameProf')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -286,7 +286,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNamePIP')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -306,7 +306,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameNSG')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -351,7 +351,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentName')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -402,7 +402,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/', variables('cseExtName'))]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentName'))]"

--- a/sap-3-tier-marketplace-image-converged/azuredeploy.json
+++ b/sap-3-tier-marketplace-image-converged/azuredeploy.json
@@ -487,7 +487,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameNSG')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -507,7 +507,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameVnet')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -541,7 +541,7 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameCL')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
@@ -549,7 +549,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNamePIP'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -575,7 +575,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameCL'), copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "storageAccountCLLoop",
         "count": "[variables('clvmCount')]"
@@ -586,7 +586,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameLBCL')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -630,7 +630,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICCL'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -668,7 +668,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameCL'), '-', copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicCLLoop",
         "count": "[variables('clvmCount')]"
@@ -695,7 +695,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-cl-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -752,7 +752,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameCL'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -837,7 +837,7 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameDI')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
@@ -845,7 +845,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICDI'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -883,7 +883,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameDI'), '-', copyindex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameVnet'))]",
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameNICDI'), '-', copyIndex())]"
@@ -908,7 +908,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameDI'), copyindex()) ]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "storageAccountDILoop",
         "count": "[add(mul(mod(variables('divmCount'), 2), -1), 2)]"
@@ -919,7 +919,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-di-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -973,7 +973,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameDI'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {

--- a/sap-3-tier-marketplace-image-multi-sid-apps/azuredeploy.json
+++ b/sap-3-tier-marketplace-image-multi-sid-apps/azuredeploy.json
@@ -205,7 +205,7 @@
     "divmCount": "[variables('vmSizes')[parameters('sapSystemSize')][parameters('systemAvailability')].diservercount]",
     "sidlower": "[toLower(parameters('sapSystemId'))]",
     "vmName": "[variables('sidlower')]",
-    "storageAccountName": "[concat(variables('sidlower'), uniqueString(variables('sidlower'), resourceGroup().id))]",    
+    "storageAccountName": "[concat(variables('sidlower'), uniqueString(variables('sidlower'), resourceGroup().id))]",
     "selectedSubnetId": "[parameters('subnetId')]",
     "nestedDeploymentName": "nestedTemplate",
     "nestedDeploymentNameDI": "[concat(variables('nestedDeploymentName'), 'di')]",
@@ -225,7 +225,7 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameDI')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
@@ -233,7 +233,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICDI'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -271,7 +271,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameDI'), '-', copyindex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameNICDI'), '-', copyIndex())]"
       ],
@@ -295,7 +295,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameDI'), copyindex()) ]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "storageAccountDILoop",
         "count": "[add(mul(mod(variables('divmCount'), 2), -1), 2)]"
@@ -306,7 +306,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-di-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -360,7 +360,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameDI'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {

--- a/sap-3-tier-marketplace-image-multi-sid-db/azuredeploy.json
+++ b/sap-3-tier-marketplace-image-multi-sid-db/azuredeploy.json
@@ -24,7 +24,7 @@
       "metadata": {
         "description": "The type of the operating system you want to deploy."
       }
-    },    
+    },
     "dbtype": {
       "type": "string",
       "allowedValues": [
@@ -113,7 +113,7 @@
         "OSType": "Windows",
         "Plan": {},
         "UsePlan": false
-      },     
+      },
       "Windows Server 2016 Datacenter": {
         "sku": "2016-Datacenter",
         "offer": "WindowsServer",
@@ -414,7 +414,6 @@
     "sidlower": "[toLower(parameters('sapSystemId'))]",
     "vmName": "[variables('sidlower')]",
     "storageAccountName": "[concat(variables('sidlower'), uniqueString(variables('sidlower'), resourceGroup().id))]",
-    
     "publicIpNameDB": "[concat(variables('sidlower'), '-pip-db')]",
     "vnetName": "[concat(variables('sidlower'), '-vnet')]",
     "publicIPAddressType": "Dynamic",
@@ -426,7 +425,6 @@
       "existing": "[parameters('subnetId')]"
     },
     "selectedSubnetId": "[variables('subnets')[parameters('newOrExistingSubnet')]]",
-
     "nestedDeploymentName": "nestedTemplate",
     "nestedDeploymentNameVNet": "[concat(variables('nestedDeploymentName'), 'vnet')]",
     "nestedDeploymentNameLBDB": "[concat(variables('nestedDeploymentName'), 'lbdb')]",
@@ -434,7 +432,7 @@
     "nestedDeploymentNameProf": "[concat(variables('nestedDeploymentName'), 'prof')]",
     "nestedDeploymentNameNIC": "[concat(variables('nestedDeploymentName'), 'nic')]",
     "nestedDeploymentNameNICDB": "[concat(variables('nestedDeploymentNameNIC'), 'db')]",
-    "nestedDeploymentNamePIP": "[concat(variables('nestedDeploymentNameNIC'), 'pip')]",    
+    "nestedDeploymentNamePIP": "[concat(variables('nestedDeploymentNameNIC'), 'pip')]",
     "nestedDeploymentNameNSG": "[concat(variables('nestedDeploymentNameDB'), 'nsg')]",
     "nsgNameDB": "[concat(variables('sidlower'), '-nsg')]",
     "avSetNameDB": "[concat(variables('sidlower'), '-avset-db')]",
@@ -449,7 +447,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameNSG')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -469,7 +467,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameVnet')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -503,7 +501,7 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameDB')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
@@ -511,7 +509,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNamePIP'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -537,7 +535,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameDB'), copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "storageAccountDBLoop",
@@ -548,7 +546,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameLBDB')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -586,7 +584,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICDB'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -624,7 +622,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameDB'), '-', copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicDBLoop",
         "count": "[variables('dbvmCount')]"
@@ -651,7 +649,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-db-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -708,7 +706,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameDB'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {

--- a/sap-3-tier-marketplace-image-multi-sid-xscs/azuredeploy.json
+++ b/sap-3-tier-marketplace-image-multi-sid-xscs/azuredeploy.json
@@ -316,7 +316,7 @@
           }
         ]
       },
-      "9":{
+      "9": {
         "Size": "Large",
         "Disks": [
           {
@@ -416,7 +416,7 @@
         }
       }
     },
-    "xscsvmSize": "[variables('vmSizes')[ variables('systemCountSizes')[string(parameters('sapSystemCount'))].Size ] [parameters('systemAvailability')].xscsserversize]",    
+    "xscsvmSize": "[variables('vmSizes')[ variables('systemCountSizes')[string(parameters('sapSystemCount'))].Size ] [parameters('systemAvailability')].xscsserversize]",
     "xscsvmCount": "[variables('vmSizes')[ variables('systemCountSizes')[string(parameters('sapSystemCount'))].Size ] [parameters('systemAvailability')].xscsservercount]",
     "xscsvmDataDisks": "[variables('systemCountSizes')[string(parameters('sapSystemCount'))].Disks]",
     "sidlower": "[toLower(parameters('resourcePrefix'))]",
@@ -455,7 +455,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameNSG')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -475,7 +475,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameVnet')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -509,7 +509,7 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameXSCS')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
@@ -517,7 +517,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNamePIP'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -543,7 +543,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameXSCS'), copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "storageAccountXSCSLoop",
         "count": "[variables('xscsvmCount')]"
@@ -554,7 +554,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameLBXSCS')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -595,7 +595,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICXSCS'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -633,7 +633,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameXSCS'), '-', copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicXSCSLoop",
         "count": "[variables('xscsvmCount')]"
@@ -660,7 +660,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-xscs-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -717,7 +717,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameXSCS'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {

--- a/sap-3-tier-marketplace-image/azuredeploy.json
+++ b/sap-3-tier-marketplace-image/azuredeploy.json
@@ -491,7 +491,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameVnet')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -519,7 +519,7 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameASCS')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
@@ -527,7 +527,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNamePIP'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -551,7 +551,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNSG'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -577,7 +577,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameASCS'), copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "storageAccountASCSLoop",
         "count": "[variables('ascsvmCount')]"
@@ -588,7 +588,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameLBASCS')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -629,7 +629,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICASCS'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -667,7 +667,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameASCS'), '-', copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicASCSLoop",
         "count": "[variables('ascsvmCount')]"
@@ -696,7 +696,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-ascs-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -750,7 +750,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameASCS'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -839,7 +839,7 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameDB')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
@@ -849,7 +849,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameDB'), copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "copy": {
         "name": "storageAccountDBLoop",
@@ -860,7 +860,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameLBDB')]",
       "type": "Microsoft.Resources/deployments",
       "dependsOn": [
@@ -904,7 +904,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICDB'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -942,7 +942,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameDB'), '-', copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicDBLoop",
         "count": "[variables('dbvmCount')]"
@@ -967,7 +967,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-db-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1021,7 +1021,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameDB'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1106,7 +1106,7 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameDI')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
@@ -1114,7 +1114,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICDI'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1152,7 +1152,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameDI'), '-', copyindex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameVnet'))]",
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameNICDI'), '-', copyIndex())]"
@@ -1177,7 +1177,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameDI'), copyindex()) ]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "storageAccountDILoop",
         "count": "[add(mul(mod(variables('divmCount'), 2), -1), 2)]"
@@ -1188,7 +1188,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-di-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1242,7 +1242,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameDI'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {

--- a/sap-3-tier-user-image/azuredeploy.json
+++ b/sap-3-tier-user-image/azuredeploy.json
@@ -12,14 +12,22 @@
     },
     "osType": {
       "type": "string",
-      "allowedValues": [ "Windows", "Linux" ],
+      "allowedValues": [
+        "Windows",
+        "Linux"
+      ],
       "metadata": {
         "description": "The operating system type of the private OS image."
       }
     },
     "sapSystemSize": {
       "type": "string",
-      "allowedValues": [ "Small < 30.000 SAPS", "Medium < 70.000 SAPS", "Large < 180.000 SAPS", "X-Large < 250.000 SAPS" ],
+      "allowedValues": [
+        "Small < 30.000 SAPS",
+        "Medium < 70.000 SAPS",
+        "Large < 180.000 SAPS",
+        "X-Large < 250.000 SAPS"
+      ],
       "defaultValue": "Small < 30.000 SAPS",
       "metadata": {
         "description": "The size of the SAP System you want to deploy."
@@ -27,7 +35,10 @@
     },
     "systemAvailability": {
       "type": "string",
-      "allowedValues": [ "HA", "Not HA" ],
+      "allowedValues": [
+        "HA",
+        "Not HA"
+      ],
       "defaultValue": "Not HA",
       "metadata": {
         "description": "Determines whether this is a high available deployment or not. A HA deployment contains multiple instances of single point of failures."
@@ -60,7 +71,10 @@
     "newOrExistingSubnet": {
       "type": "string",
       "defaultValue": "new",
-      "allowedValues": [ "new", "existing" ],
+      "allowedValues": [
+        "new",
+        "existing"
+      ],
       "metadata": {
         "description": "Determines whether a new virtual network and subnet should be created or an existing subnet should be used."
       }
@@ -75,7 +89,6 @@
   },
   "variables": {
     "github": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/sap-2-tier-marketplace-image/shared/",
-
     "internalOSType": "[parameters('osType')]",
     "csExtension": {
       "Windows": {
@@ -99,12 +112,10 @@
     "cseExtVersion": "[variables('csExtension')[variables('internalOSType')].Version]",
     "csExtensionScript": "[variables('csExtension')[variables('internalOSType')].script]",
     "csExtensionscriptCall": "[variables('csExtension')[variables('internalOSType')].scriptCall]",
-
     "storageTypes": {
       "Premium": "Premium_LRS",
       "Standard": "Standard_LRS"
     },
-
     "vmSizes": {
       "Small < 30.000 SAPS": {
         "Not HA": {
@@ -142,7 +153,6 @@
           "diservercount": 4
         }
       },
-
       "Large < 180.000 SAPS": {
         "Not HA": {
           "dbserversize": "Standard_GS4",
@@ -210,7 +220,6 @@
     "nestedDeploymentNameNICASCS": "[concat(variables('nestedDeploymentNameNIC'), 'ascs')]",
     "nestedDeploymentNameNICDB": "[concat(variables('nestedDeploymentNameNIC'), 'db')]",
     "nestedDeploymentNameNICDI": "[concat(variables('nestedDeploymentNameNIC'), 'di')]",
-
     "publicIpNameASCS": "[concat(variables('sidlower'), '-pip-ascs')]",
     "avSetNameASCS": "[concat(variables('sidlower'), '-avset-ascs')]",
     "nestedDeploymentNameNSG": "[concat(variables('nestedDeploymentNameASCS'), 'nsg')]",
@@ -221,14 +230,12 @@
     "idleTimeoutInMinutesASCS": 30,
     "vmNameASCS": "[concat(variables('vmName'), '-ascs')]",
     "nicNameASCS": "[concat(variables('sidlower'), '-nic-ascs')]",
-
     "avSetNameDB": "[concat(variables('sidlower'), '-avset-db')]",
     "storageAccountNameDB": "[concat('db', variables('storageAccountName'))]",
     "internalStorageTypeDB": "Premium_LRS",
     "loadBalancerNameDB": "[concat(variables('sidlower'), '-lb-db')]",
     "nicNameDB": "[concat(variables('sidlower'), '-nic-db')]",
     "vmNameDB": "[concat(variables('vmName'), '-db')]",
-
     "avSetNameDI": "[concat(variables('sidlower'), '-avset-di')]",
     "nicNameDI": "[concat(variables('sidlower'), '-nic-di')]",
     "storageAccountNameDI": "[concat('di', variables('storageAccountName'))]",
@@ -237,21 +244,18 @@
     "osDiskType": "userImage",
     "apiVerion": "2015-06-15",
     "apiVerionRm": "2015-01-01",
-
     "BackendPoolASCS": "backendPoolASCS",
     "LoadBalancerFrontendASCS": "lbFrontendASCS",
     "lbProbeASCS": "lbProbeASCS",
     "lbProbePortInternalASCS": 62300,
-
     "BackendPoolDB": "backendPoolDB",
     "LoadBalancerFrontendDB": "lbFrontendDB",
     "LBProbePortDB": "lbProbeDB",
     "lbProbePortInternalDB": 62400
-
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[variables('nestedDeploymentNameVnet')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
@@ -261,27 +265,33 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "vnetName": { "value": "[variables('vnetName')]" },
-          "addressPrefix": { "value": "[variables('addressPrefix')]" },
-          "subnetName": { "value": "[variables('subnetName')]" },
-          "subnetPrefix": { "value": "[variables('subnetPrefix')]" }
+          "vnetName": {
+            "value": "[variables('vnetName')]"
+          },
+          "addressPrefix": {
+            "value": "[variables('addressPrefix')]"
+          },
+          "subnetName": {
+            "value": "[variables('subnetName')]"
+          },
+          "subnetPrefix": {
+            "value": "[variables('subnetPrefix')]"
+          }
         }
       }
     },
-
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameASCS')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
         "platformUpdateDomainCount": 20
       }
     },
-
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNamePIP'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -295,14 +305,17 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "publicIpName": { "value": "[concat(variables('publicIpNameASCS'), '-', copyIndex())]" },
-          "publicIPAddressType": { "value": "[variables('publicIPAddressType')]" }
+          "publicIpName": {
+            "value": "[concat(variables('publicIpNameASCS'), '-', copyIndex())]"
+          },
+          "publicIPAddressType": {
+            "value": "[variables('publicIPAddressType')]"
+          }
         }
       }
     },
-
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNSG'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -316,15 +329,19 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "nsgName": { "value": "[concat(variables('nsgNameASCS'), '-', copyIndex())]" },
-          "osType": { "value": "[variables('internalOSType')]" }
+          "nsgName": {
+            "value": "[concat(variables('nsgNameASCS'), '-', copyIndex())]"
+          },
+          "osType": {
+            "value": "[variables('internalOSType')]"
+          }
         }
       }
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameASCS'), copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicLoop",
         "count": "[variables('ascsvmCount')]"
@@ -337,7 +354,7 @@
     {
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerNameASCS')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameVnet'))]"
       ],
@@ -755,7 +772,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICASCS'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -769,19 +786,31 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "vnetName": { "value": "[variables('vnetName')]" },
-          "subnetName": { "value": "[variables('subnetName')]" },
-          "publicIpName": { "value": "[concat(variables('publicIpNameASCS'), '-', copyIndex())]" },
-          "nsgName": { "value": "[concat(variables('nsgNameASCS'), '-', copyIndex())]" },
-          "newOrExistingSubnet": { "value": "[parameters('newOrExistingSubnet')]" },
-          "subnetId": { "value": "[parameters('subnetId')]" }
+          "vnetName": {
+            "value": "[variables('vnetName')]"
+          },
+          "subnetName": {
+            "value": "[variables('subnetName')]"
+          },
+          "publicIpName": {
+            "value": "[concat(variables('publicIpNameASCS'), '-', copyIndex())]"
+          },
+          "nsgName": {
+            "value": "[concat(variables('nsgNameASCS'), '-', copyIndex())]"
+          },
+          "newOrExistingSubnet": {
+            "value": "[parameters('newOrExistingSubnet')]"
+          },
+          "subnetId": {
+            "value": "[parameters('subnetId')]"
+          }
         }
       }
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameASCS'), '-', copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicLoop",
         "count": "[variables('ascsvmCount')]"
@@ -813,9 +842,8 @@
         ]
       }
     },
-
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-ascs-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -832,22 +860,44 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "imageSku": { "value": "" },
-          "imagePublisher": { "value": "" },
-          "imageOffer": { "value": "" },
-          "userImageVhdUri": { "value": "[parameters('userImageVhdUri')]" },
-          "userImageStorageAccount": { "value": "[parameters('userImageStorageAccount')]" },
-          "osDiskVhdUri": { "value": "" },
-          "osDiskType": { "value": "[variables('osDiskType')]" },
-          "osType": { "value": "[variables('internalOSType')]" },
-          "sidlower": { "value": "[variables('sidlower')]" },
-          "vmName": { "value": "[concat(variables('vmNameASCS'), '-', copyIndex())]" },
-          "storageAccountName": { "value": "[concat(variables('storageAccountNameASCS'), copyIndex())]" }
+          "imageSku": {
+            "value": ""
+          },
+          "imagePublisher": {
+            "value": ""
+          },
+          "imageOffer": {
+            "value": ""
+          },
+          "userImageVhdUri": {
+            "value": "[parameters('userImageVhdUri')]"
+          },
+          "userImageStorageAccount": {
+            "value": "[parameters('userImageStorageAccount')]"
+          },
+          "osDiskVhdUri": {
+            "value": ""
+          },
+          "osDiskType": {
+            "value": "[variables('osDiskType')]"
+          },
+          "osType": {
+            "value": "[variables('internalOSType')]"
+          },
+          "sidlower": {
+            "value": "[variables('sidlower')]"
+          },
+          "vmName": {
+            "value": "[concat(variables('vmNameASCS'), '-', copyIndex())]"
+          },
+          "storageAccountName": {
+            "value": "[concat(variables('storageAccountNameASCS'), copyIndex())]"
+          }
         }
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameASCS'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -866,29 +916,61 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "imageReference": { "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-ascs-', copyIndex())).outputs.osDisk.value]" },
-          "osDisk": { "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-ascs-', copyIndex())).outputs.osDisk.value]" },
-          "osDiskType": { "value": "[variables('osDiskType')]" },
-          "sidlower": { "value": "[variables('sidlower')]" },
-          "vmName": { "value": "[concat(variables('vmNameASCS'), '-', copyIndex())]" },
-          "vmSize": { "value": "[variables('ascsvmSize')]" },
-          "adminUsername": { "value": "[parameters('adminUsername')]" },
-          "adminPassword": { "value": "[parameters('adminPassword')]" },
-          "cseExtPublisher": { "value": "[variables('cseExtPublisher')]" },
-          "cseExtName": { "value": "[variables('cseExtName')]" },
-          "cseExtVersion": { "value": "[variables('cseExtVersion')]" },
-          "csExtensionScript": { "value": "[variables('csExtensionScript')]" },
-          "csExtensionscriptCall": { "value": "[variables('csExtensionscriptCall')]" },
-          "avSetName": { "value": "[variables('avSetNameASCS')]" },
-          "storageAccountName": { "value": "[concat(variables('storageAccountNameASCS'), copyIndex())]" },
-          "nicName": { "value": "[concat(variables('nicNameASCS'), '-', copyIndex())]" }
+          "imageReference": {
+            "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-ascs-', copyIndex())).outputs.osDisk.value]"
+          },
+          "osDisk": {
+            "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-ascs-', copyIndex())).outputs.osDisk.value]"
+          },
+          "osDiskType": {
+            "value": "[variables('osDiskType')]"
+          },
+          "sidlower": {
+            "value": "[variables('sidlower')]"
+          },
+          "vmName": {
+            "value": "[concat(variables('vmNameASCS'), '-', copyIndex())]"
+          },
+          "vmSize": {
+            "value": "[variables('ascsvmSize')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "cseExtPublisher": {
+            "value": "[variables('cseExtPublisher')]"
+          },
+          "cseExtName": {
+            "value": "[variables('cseExtName')]"
+          },
+          "cseExtVersion": {
+            "value": "[variables('cseExtVersion')]"
+          },
+          "csExtensionScript": {
+            "value": "[variables('csExtensionScript')]"
+          },
+          "csExtensionscriptCall": {
+            "value": "[variables('csExtensionscriptCall')]"
+          },
+          "avSetName": {
+            "value": "[variables('avSetNameASCS')]"
+          },
+          "storageAccountName": {
+            "value": "[concat(variables('storageAccountNameASCS'), copyIndex())]"
+          },
+          "nicName": {
+            "value": "[concat(variables('nicNameASCS'), '-', copyIndex())]"
+          }
         }
       }
     },
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameDB')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
@@ -898,7 +980,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountNameDB')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('internalStorageTypeDB')]"
@@ -907,7 +989,7 @@
     {
       "type": "Microsoft.Network/loadBalancers",
       "name": "[variables('loadBalancerNameDB')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameVnet'))]"
       ],
@@ -962,7 +1044,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICDB'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -976,19 +1058,31 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "vnetName": { "value": "[variables('vnetName')]" },
-          "subnetName": { "value": "[variables('subnetName')]" },
-          "publicIpName": { "value": "" },
-          "nsgName": { "value": "" },
-          "newOrExistingSubnet": { "value": "[parameters('newOrExistingSubnet')]" },
-          "subnetId": { "value": "[parameters('subnetId')]" }
+          "vnetName": {
+            "value": "[variables('vnetName')]"
+          },
+          "subnetName": {
+            "value": "[variables('subnetName')]"
+          },
+          "publicIpName": {
+            "value": ""
+          },
+          "nsgName": {
+            "value": ""
+          },
+          "newOrExistingSubnet": {
+            "value": "[parameters('newOrExistingSubnet')]"
+          },
+          "subnetId": {
+            "value": "[parameters('subnetId')]"
+          }
         }
       }
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameDB'), '-', copyIndex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicLoop",
         "count": "[variables('dbvmCount')]"
@@ -1017,7 +1111,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-db-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1034,22 +1128,44 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "imageSku": { "value": "" },
-          "imagePublisher": { "value": "" },
-          "imageOffer": { "value": "" },
-          "userImageVhdUri": { "value": "[parameters('userImageVhdUri')]" },
-          "userImageStorageAccount": { "value": "[parameters('userImageStorageAccount')]" },
-          "osDiskVhdUri": { "value": "" },
-          "osDiskType": { "value": "[variables('osDiskType')]" },
-          "osType": { "value": "[variables('internalOSType')]" },
-          "sidlower": { "value": "[variables('sidlower')]" },
-          "vmName": { "value": "[concat(variables('vmNameDB'), '-', copyIndex())]" },
-          "storageAccountName": { "value": "[variables('storageAccountNameDB')]" }
+          "imageSku": {
+            "value": ""
+          },
+          "imagePublisher": {
+            "value": ""
+          },
+          "imageOffer": {
+            "value": ""
+          },
+          "userImageVhdUri": {
+            "value": "[parameters('userImageVhdUri')]"
+          },
+          "userImageStorageAccount": {
+            "value": "[parameters('userImageStorageAccount')]"
+          },
+          "osDiskVhdUri": {
+            "value": ""
+          },
+          "osDiskType": {
+            "value": "[variables('osDiskType')]"
+          },
+          "osType": {
+            "value": "[variables('internalOSType')]"
+          },
+          "sidlower": {
+            "value": "[variables('sidlower')]"
+          },
+          "vmName": {
+            "value": "[concat(variables('vmNameDB'), '-', copyIndex())]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountNameDB')]"
+          }
         }
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameDB'), '-', copyIndex())]",
       "copy": {
         "name": "nicLoop",
@@ -1068,39 +1184,69 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "imageReference": { "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-db-', copyIndex())).outputs.osDisk.value]" },
-          "osDisk": { "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-db-', copyIndex())).outputs.osDisk.value]" },
-          "osDiskType": { "value": "[variables('osDiskType')]" },
-          "sidlower": { "value": "[variables('sidlower')]" },
-          "vmName": { "value": "[concat(variables('vmNameDB'), '-', copyIndex())]" },
-          "vmSize": { "value": "[variables('dbvmSize')]" },
-          "adminUsername": { "value": "[parameters('adminUsername')]" },
-          "adminPassword": { "value": "[parameters('adminPassword')]" },
-          "cseExtPublisher": { "value": "[variables('cseExtPublisher')]" },
-          "cseExtName": { "value": "[variables('cseExtName')]" },
-          "cseExtVersion": { "value": "[variables('cseExtVersion')]" },
-          "csExtensionScript": { "value": "[variables('csExtensionScript')]" },
-          "csExtensionscriptCall": { "value": "[variables('csExtensionscriptCall')]" },
-          "avSetName": { "value": "[variables('avSetNameDB')]" },
-          "storageAccountName": { "value": "[variables('storageAccountNameDB')]" },
-          "nicName": { "value": "[concat(variables('nicNameDB'), '-', copyIndex())]" }
+          "imageReference": {
+            "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-db-', copyIndex())).outputs.osDisk.value]"
+          },
+          "osDisk": {
+            "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-db-', copyIndex())).outputs.osDisk.value]"
+          },
+          "osDiskType": {
+            "value": "[variables('osDiskType')]"
+          },
+          "sidlower": {
+            "value": "[variables('sidlower')]"
+          },
+          "vmName": {
+            "value": "[concat(variables('vmNameDB'), '-', copyIndex())]"
+          },
+          "vmSize": {
+            "value": "[variables('dbvmSize')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "cseExtPublisher": {
+            "value": "[variables('cseExtPublisher')]"
+          },
+          "cseExtName": {
+            "value": "[variables('cseExtName')]"
+          },
+          "cseExtVersion": {
+            "value": "[variables('cseExtVersion')]"
+          },
+          "csExtensionScript": {
+            "value": "[variables('csExtensionScript')]"
+          },
+          "csExtensionscriptCall": {
+            "value": "[variables('csExtensionscriptCall')]"
+          },
+          "avSetName": {
+            "value": "[variables('avSetNameDB')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountNameDB')]"
+          },
+          "nicName": {
+            "value": "[concat(variables('nicNameDB'), '-', copyIndex())]"
+          }
         }
       }
     },
-
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('avSetNameDI')]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "platformFaultDomainCount": 3,
         "platformUpdateDomainCount": 20
       }
     },
-
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameNICDI'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1114,19 +1260,31 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "vnetName": { "value": "[variables('vnetName')]" },
-          "subnetName": { "value": "[variables('subnetName')]" },
-          "publicIpName": { "value": "" },
-          "nsgName": { "value": "" },
-          "newOrExistingSubnet": { "value": "[parameters('newOrExistingSubnet')]" },
-          "subnetId": { "value": "[parameters('subnetId')]" }
+          "vnetName": {
+            "value": "[variables('vnetName')]"
+          },
+          "subnetName": {
+            "value": "[variables('subnetName')]"
+          },
+          "publicIpName": {
+            "value": ""
+          },
+          "nsgName": {
+            "value": ""
+          },
+          "newOrExistingSubnet": {
+            "value": "[parameters('newOrExistingSubnet')]"
+          },
+          "subnetId": {
+            "value": "[parameters('subnetId')]"
+          }
         }
       }
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicNameDI'), '-', copyindex())]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameVnet'))]",
         "[concat('Microsoft.Resources/deployments/', variables('nestedDeploymentNameNICDI'), '-', copyIndex())]"
@@ -1151,7 +1309,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(variables('storageAccountNameDI'), copyindex()) ]",
-      "apiVersion": "[variables('apiVerion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "nicLoop",
         "count": "[add(div(variables('divmCount'), 3), 1)]"
@@ -1162,7 +1320,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameProf'), '-di-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1179,22 +1337,44 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "imageSku": { "value": "" },
-          "imagePublisher": { "value": "" },
-          "imageOffer": { "value": "" },
-          "userImageVhdUri": { "value": "[parameters('userImageVhdUri')]" },
-          "userImageStorageAccount": { "value": "[parameters('userImageStorageAccount')]" },
-          "osDiskVhdUri": { "value": "" },
-          "osDiskType": { "value": "[variables('osDiskType')]" },
-          "osType": { "value": "[variables('internalOSType')]" },
-          "sidlower": { "value": "[variables('sidlower')]" },
-          "vmName": { "value": "[concat(variables('vmNameDI'), '-', copyIndex())]" },
-          "storageAccountName": { "value": "[concat(variables('storageAccountNameDI'), div(copyIndex(), 3))]" }
+          "imageSku": {
+            "value": ""
+          },
+          "imagePublisher": {
+            "value": ""
+          },
+          "imageOffer": {
+            "value": ""
+          },
+          "userImageVhdUri": {
+            "value": "[parameters('userImageVhdUri')]"
+          },
+          "userImageStorageAccount": {
+            "value": "[parameters('userImageStorageAccount')]"
+          },
+          "osDiskVhdUri": {
+            "value": ""
+          },
+          "osDiskType": {
+            "value": "[variables('osDiskType')]"
+          },
+          "osType": {
+            "value": "[variables('internalOSType')]"
+          },
+          "sidlower": {
+            "value": "[variables('sidlower')]"
+          },
+          "vmName": {
+            "value": "[concat(variables('vmNameDI'), '-', copyIndex())]"
+          },
+          "storageAccountName": {
+            "value": "[concat(variables('storageAccountNameDI'), div(copyIndex(), 3))]"
+          }
         }
       }
     },
     {
-      "apiVersion": "[variables('apiVerionRm')]",
+      "apiVersion": "2015-01-01",
       "name": "[concat(variables('nestedDeploymentNameDI'), '-', copyIndex())]",
       "type": "Microsoft.Resources/deployments",
       "copy": {
@@ -1213,22 +1393,54 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "imageReference": { "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-di-', copyIndex())).outputs.osDisk.value]" },
-          "osDisk": { "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-di-', copyIndex())).outputs.osDisk.value]" },
-          "osDiskType": { "value": "[variables('osDiskType')]" },
-          "sidlower": { "value": "[variables('sidlower')]" },
-          "vmName": { "value": "[concat(variables('vmNameDI'), '-', copyIndex())]" },
-          "vmSize": { "value": "[variables('divmSize')]" },
-          "adminUsername": { "value": "[parameters('adminUsername')]" },
-          "adminPassword": { "value": "[parameters('adminPassword')]" },
-          "cseExtPublisher": { "value": "[variables('cseExtPublisher')]" },
-          "cseExtName": { "value": "[variables('cseExtName')]" },
-          "cseExtVersion": { "value": "[variables('cseExtVersion')]" },
-          "csExtensionScript": { "value": "[variables('csExtensionScript')]" },
-          "csExtensionscriptCall": { "value": "[variables('csExtensionscriptCall')]" },
-          "avSetName": { "value": "[variables('avSetNameDI')]" },
-          "storageAccountName": { "value": "[concat(variables('storageAccountNameDI'), div(copyIndex(), 3))]" },
-          "nicName": { "value": "[concat(variables('nicNameDI'), '-', copyIndex())]" }
+          "imageReference": {
+            "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-di-', copyIndex())).outputs.osDisk.value]"
+          },
+          "osDisk": {
+            "value": "[reference(concat(variables('nestedDeploymentNameProf'), '-di-', copyIndex())).outputs.osDisk.value]"
+          },
+          "osDiskType": {
+            "value": "[variables('osDiskType')]"
+          },
+          "sidlower": {
+            "value": "[variables('sidlower')]"
+          },
+          "vmName": {
+            "value": "[concat(variables('vmNameDI'), '-', copyIndex())]"
+          },
+          "vmSize": {
+            "value": "[variables('divmSize')]"
+          },
+          "adminUsername": {
+            "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
+          "cseExtPublisher": {
+            "value": "[variables('cseExtPublisher')]"
+          },
+          "cseExtName": {
+            "value": "[variables('cseExtName')]"
+          },
+          "cseExtVersion": {
+            "value": "[variables('cseExtVersion')]"
+          },
+          "csExtensionScript": {
+            "value": "[variables('csExtensionScript')]"
+          },
+          "csExtensionscriptCall": {
+            "value": "[variables('csExtensionscriptCall')]"
+          },
+          "avSetName": {
+            "value": "[variables('avSetNameDI')]"
+          },
+          "storageAccountName": {
+            "value": "[concat(variables('storageAccountNameDI'), div(copyIndex(), 3))]"
+          },
+          "nicName": {
+            "value": "[concat(variables('nicNameDI'), '-', copyIndex())]"
+          }
         }
       }
     }

--- a/service-fabric-cluster-ubuntu-5-node-1-nodetype/azuredeploy.json
+++ b/service-fabric-cluster-ubuntu-5-node-1-nodetype/azuredeploy.json
@@ -36,19 +36,22 @@
       "type": "string",
       "defaultValue": "UbuntuServer",
       "metadata": {
-      "description": "VM image offer"}
+        "description": "VM image offer"
+      }
     },
     "vmImageSku": {
       "type": "string",
       "defaultValue": "16.04",
       "metadata": {
-      "description": "VM image SKU"}
+        "description": "VM image SKU"
+      }
     },
     "vmImageVersion": {
       "type": "string",
       "defaultValue": "6.0.11",
       "metadata": {
-      "description": "VM image version"}
+        "description": "VM image version"
+      }
     },
     "loadBalancedAppPort1": {
       "type": "int",
@@ -203,7 +206,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('supportLogStorageAccountName')]",
       "location": "[variables('computeLocation')]",
@@ -219,7 +222,7 @@
       }
     },
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('applicationDiagnosticsStorageAccountName')]",
       "location": "[variables('computeLocation')]",
@@ -235,7 +238,7 @@
       }
     },
     {
-      "apiVersion": "[variables('vNetApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('computeLocation')]",
@@ -260,7 +263,7 @@
       }
     },
     {
-      "apiVersion": "[variables('publicIPApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('lbIPName'),'-','0')]",
       "location": "[variables('computeLocation')]",
@@ -276,7 +279,7 @@
       }
     },
     {
-      "apiVersion": "[variables('lbApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers",
       "name": "[concat('LB','-', parameters('clusterName'),'-',variables('vmNodeType0Name'))]",
       "location": "[variables('computeLocation')]",
@@ -437,7 +440,7 @@
       }
     },
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('uniqueStringArray0')[copyIndex()]]",
       "location": "[variables('computeLocation')]",
@@ -457,7 +460,7 @@
       }
     },
     {
-      "apiVersion": "[variables('vmssApiVersion')]",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('vmNodeType0Name')]",
       "location": "[variables('computeLocation')]",

--- a/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
+++ b/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
@@ -31,25 +31,29 @@
       "type": "string",
       "defaultValue": "MicrosoftWindowsServer",
       "metadata": {
-      "description": "VM image Publisher"}
+        "description": "VM image Publisher"
+      }
     },
     "vmImageOffer": {
       "type": "string",
       "defaultValue": "WindowsServer",
       "metadata": {
-      "description": "VM image offer"}
+        "description": "VM image offer"
+      }
     },
     "vmImageSku": {
       "type": "string",
       "defaultValue": "2012-R2-Datacenter",
       "metadata": {
-      "description": "VM image SKU"}
+        "description": "VM image SKU"
+      }
     },
     "vmImageVersion": {
       "type": "string",
       "defaultValue": "latest",
       "metadata": {
-      "description": "VM image version"}
+        "description": "VM image version"
+      }
     },
     "loadBalancedAppPort1": {
       "type": "int",
@@ -198,7 +202,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('supportLogStorageAccountName')]",
       "location": "[variables('computeLocation')]",
@@ -214,7 +218,7 @@
       }
     },
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('applicationDiagnosticsStorageAccountName')]",
       "location": "[variables('computeLocation')]",
@@ -230,7 +234,7 @@
       }
     },
     {
-      "apiVersion": "[variables('vNetApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('computeLocation')]",
@@ -255,7 +259,7 @@
       }
     },
     {
-      "apiVersion": "[variables('publicIPApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('lbIPName'),'-','0')]",
       "location": "[variables('computeLocation')]",
@@ -271,7 +275,7 @@
       }
     },
     {
-      "apiVersion": "[variables('lbApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers",
       "name": "[concat('LB','-', parameters('clusterName'),'-',variables('vmNodeType0Name'))]",
       "location": "[variables('computeLocation')]",
@@ -432,7 +436,7 @@
       }
     },
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('uniqueStringArray0')[copyIndex()]]",
       "location": "[variables('computeLocation')]",
@@ -452,7 +456,7 @@
       }
     },
     {
-      "apiVersion": "[variables('vmssApiVersion')]",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('vmNodeType0Name')]",
       "location": "[variables('computeLocation')]",

--- a/service-fabric-secure-nsg-cluster-65-node-3-nodetype/azuredeploy.json
+++ b/service-fabric-secure-nsg-cluster-65-node-3-nodetype/azuredeploy.json
@@ -32,25 +32,29 @@
       "type": "string",
       "defaultValue": "MicrosoftWindowsServer",
       "metadata": {
-      "description": "VM image Publisher"}
+        "description": "VM image Publisher"
+      }
     },
     "vmImageOffer": {
       "type": "string",
       "defaultValue": "WindowsServer",
       "metadata": {
-      "description": "VM image offer"}
+        "description": "VM image offer"
+      }
     },
     "vmImageSku": {
       "type": "string",
       "defaultValue": "2012-R2-Datacenter",
       "metadata": {
-      "description": "VM image SKU"}
+        "description": "VM image SKU"
+      }
     },
     "vmImageVersion": {
       "type": "string",
       "defaultValue": "latest",
       "metadata": {
-      "description": "VM image version"}
+        "description": "VM image version"
+      }
     },
     "loadBalancedAppPort1": {
       "type": "int",
@@ -251,7 +255,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('supportLogStorageAccountName')]",
       "location": "[variables('computeLocation')]",
@@ -267,7 +271,7 @@
       }
     },
     {
-      "apiVersion": "[variables('vNetApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('computeLocation')]",
@@ -318,7 +322,7 @@
       }
     },
     {
-      "apiVersion": "[variables('publicIPApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('lbIPName'),'-','0')]",
       "location": "[variables('computeLocation')]",
@@ -334,7 +338,7 @@
       }
     },
     {
-      "apiVersion": "[variables('lbApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers",
       "name": "[concat('LB','-', parameters('clusterName'),'-',variables('vmNodeType0Name'))]",
       "location": "[variables('computeLocation')]",
@@ -649,7 +653,7 @@
       }
     },
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('uniqueStringArray0')[copyIndex()]]",
       "location": "[variables('computeLocation')]",
@@ -669,7 +673,7 @@
       }
     },
     {
-      "apiVersion": "[variables('vmssApiVersion')]",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('vmNodeType0Name')]",
       "location": "[variables('computeLocation')]",
@@ -798,7 +802,7 @@
       }
     },
     {
-      "apiVersion": "[variables('publicIPApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('lbIPName'),'-','1')]",
       "location": "[variables('computeLocation')]",
@@ -814,7 +818,7 @@
       }
     },
     {
-      "apiVersion": "[variables('lbApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers",
       "name": "[concat('LB','-', parameters('clusterName'),'-',variables('vmNodeType1Name'))]",
       "location": "[variables('computeLocation')]",
@@ -1129,7 +1133,7 @@
       }
     },
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('uniqueStringArray1')[copyIndex()]]",
       "location": "[variables('computeLocation')]",
@@ -1149,7 +1153,7 @@
       }
     },
     {
-      "apiVersion": "[variables('vmssApiVersion')]",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('vmNodeType1Name')]",
       "location": "[variables('computeLocation')]",
@@ -1278,7 +1282,7 @@
       }
     },
     {
-      "apiVersion": "[variables('publicIPApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('lbIPName'),'-','2')]",
       "location": "[variables('computeLocation')]",
@@ -1294,7 +1298,7 @@
       }
     },
     {
-      "apiVersion": "[variables('lbApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/loadBalancers",
       "name": "[concat('LB','-', parameters('clusterName'),'-',variables('vmNodeType2Name'))]",
       "location": "[variables('computeLocation')]",
@@ -1609,7 +1613,7 @@
       }
     },
     {
-      "apiVersion": "[variables('storageApiVersion')]",
+      "apiVersion": "2016-01-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('uniqueStringArray2')[copyIndex()]]",
       "location": "[variables('computeLocation')]",
@@ -1629,7 +1633,7 @@
       }
     },
     {
-      "apiVersion": "[variables('vmssApiVersion')]",
+      "apiVersion": "2016-03-30",
       "type": "Microsoft.Compute/virtualMachineScaleSets",
       "name": "[variables('vmNodeType2Name')]",
       "location": "[variables('computeLocation')]",

--- a/shibboleth-cluster-ubuntu/azuredeploy.json
+++ b/shibboleth-cluster-ubuntu/azuredeploy.json
@@ -39,18 +39,18 @@
       }
     },
     "vmCountFrontend": {
-        "type": "int",
-        "defaultValue": 2,
-        "allowedValues": [
-          1,
-          2,
-          3,
-          4,
-          5
-        ],
-        "metadata": {
-            "description": "Number of web front end VMs to create."
-        }
+      "type": "int",
+      "defaultValue": 2,
+      "allowedValues": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "metadata": {
+        "description": "Number of web front end VMs to create."
+      }
     },
     "vmSizeFrontend": {
       "type": "string",
@@ -151,7 +151,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -162,12 +162,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -179,7 +179,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "dependsOn": [
@@ -212,7 +212,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -249,7 +249,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
       "location": "[resourceGroup().location]",
@@ -370,7 +370,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -423,12 +423,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(variables('availabilitySetName'),'db')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicDBIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -440,7 +440,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -470,7 +470,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(variables('virtualNetworkName'), '-sg')]",
       "location": "[resourceGroup().location]",
@@ -508,7 +508,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -557,7 +557,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'db','/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),'db'))]"
@@ -580,7 +580,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),copyIndex(),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),copyIndex()))]"

--- a/shibboleth-cluster-windows/azuredeploy.json
+++ b/shibboleth-cluster-windows/azuredeploy.json
@@ -51,18 +51,18 @@
       }
     },
     "vmCountFrontend": {
-        "type": "int",
-        "defaultValue": 2,
-        "allowedValues": [
-          1,
-          2,
-          3,
-          4,
-          5
-        ],
-        "metadata": {
-            "description": "Number of web front end VMs to create."
-        }
+      "type": "int",
+      "defaultValue": 2,
+      "allowedValues": [
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "metadata": {
+        "description": "Number of web front end VMs to create."
+      }
     },
     "vmSizeFrontend": {
       "type": "string",
@@ -163,7 +163,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -174,12 +174,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('availabilitySetName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -191,7 +191,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "dependsOn": [
@@ -216,7 +216,7 @@
             "properties": {
               "addressPrefix": "[variables('subnetPrefixDB')]",
               "networkSecurityGroup": {
-                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', concat(variables('virtualNetworkName'), '-sg'))]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', concat(variables('virtualNetworkName'), '-sg'))]"
               }
             }
           }
@@ -224,7 +224,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -261,10 +261,10 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('lbName')]",
       "type": "Microsoft.Network/loadBalancers",
-      "location":"[resourceGroup().location]",
+      "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Network/publicIPAddresses/',variables('publicIPAddressName'))]"
       ],
@@ -286,10 +286,10 @@
         ],
         "inboundNatRules": [
           {
-            "name":"SSH-VM0",
+            "name": "SSH-VM0",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2200,
@@ -298,10 +298,10 @@
             }
           },
           {
-            "name":"SSH-VM1",
+            "name": "SSH-VM1",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2201,
@@ -310,10 +310,10 @@
             }
           },
           {
-            "name":"SSH-VM2",
+            "name": "SSH-VM2",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2202,
@@ -322,10 +322,10 @@
             }
           },
           {
-            "name":"SSH-VM3",
+            "name": "SSH-VM3",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2203,
@@ -334,10 +334,10 @@
             }
           },
           {
-            "name":"SSH-VM4",
+            "name": "SSH-VM4",
             "properties": {
               "frontendIPConfiguration": {
-                "id":"[variables('frontEndIPConfigID')]"
+                "id": "[variables('frontEndIPConfigID')]"
               },
               "protocol": "tcp",
               "frontendPort": 2204,
@@ -382,7 +382,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),copyIndex())]",
       "location": "[resourceGroup().location]",
@@ -435,12 +435,12 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(variables('availabilitySetName'),'db')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {}
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicDBIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -452,7 +452,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -482,7 +482,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(variables('virtualNetworkName'), '-sg')]",
       "location": "[resourceGroup().location]",
@@ -544,11 +544,11 @@
               "direction": "Inbound"
             }
           }
-      	 ]
-        }
-	  },
+        ]
+      }
+    },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'),'db')]",
       "location": "[resourceGroup().location]",
@@ -597,7 +597,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'db','/CustomScriptExtension')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),'db'))]"
@@ -620,7 +620,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),copyIndex(),'/CustomScriptExtension')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/',concat(variables('vmName'),copyIndex()))]"

--- a/shibboleth-singlevm-ubuntu/azuredeploy.json
+++ b/shibboleth-singlevm-ubuntu/azuredeploy.json
@@ -75,7 +75,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -84,7 +84,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -96,7 +96,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -117,7 +117,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -143,7 +143,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -188,7 +188,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/shibboleth-singlevm-windows/azuredeploy.json
+++ b/shibboleth-singlevm-windows/azuredeploy.json
@@ -86,7 +86,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
@@ -95,7 +95,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -107,7 +107,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -128,7 +128,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -154,7 +154,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -199,7 +199,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/CustomScriptExtension')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
@@ -214,10 +214,10 @@
             "[variables('installScriptUri')]"
           ]
         },
-          "protectedSettings": {
-            "commandToExecute": "[variables('installCommand')]"
-          }
+        "protectedSettings": {
+          "commandToExecute": "[variables('installCommand')]"
         }
       }
+    }
   ]
 }

--- a/slurm-on-sles12-hpc/azuredeploy.json
+++ b/slurm-on-sles12-hpc/azuredeploy.json
@@ -39,17 +39,17 @@
         "Standard_A10",
         "Standard_A11",
         "Standard_D4",
-		"Standard_D13",
-		"Standard_D14",
+        "Standard_D13",
+        "Standard_D14",
         "Standard_DS4",
-		"Standard_DS13",
-		"Standard_DS14",
-		"Standard_G3",
-		"Standard_G4",
-		"Standard_G5",
-		"Standard_GS3",
-		"Standard_GS4",
-		"Standard_GS5"
+        "Standard_DS13",
+        "Standard_DS14",
+        "Standard_G3",
+        "Standard_G4",
+        "Standard_G5",
+        "Standard_GS3",
+        "Standard_GS4",
+        "Standard_GS5"
       ],
       "metadata": {
         "description": "Size of the head node."
@@ -70,36 +70,36 @@
         "Standard_A9",
         "Standard_A10",
         "Standard_A11",
-		"Standard_D1",
-		"Standard_D2",
-		"Standard_D3",
+        "Standard_D1",
+        "Standard_D2",
+        "Standard_D3",
         "Standard_D4",
-		"Standard_D11",
-		"Standard_D12",
-		"Standard_D13",
-		"Standard_D14",
-		"Standard_DS1",
-		"Standard_DS2",
-		"Standard_DS3",
-		"Standard_DS4",
-		"Standard_D11",
-		"Standard_D12",
-		"Standard_D13",
-		"Standard_D14",
-		"Standard_DS11",
-		"Standard_DS12",
-		"Standard_DS13",
-		"Standard_DS14",
-		"Standard_G1",
-		"Standard_G2",
-		"Standard_G3",
-		"Standard_G4",
-		"Standard_G5",
-		"Standard_GS1",
-		"Standard_GS2",
-		"Standard_GS3",
-		"Standard_GS4",
-		"Standard_GS5"
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14",
+        "Standard_DS1",
+        "Standard_DS2",
+        "Standard_DS3",
+        "Standard_DS4",
+        "Standard_D11",
+        "Standard_D12",
+        "Standard_D13",
+        "Standard_D14",
+        "Standard_DS11",
+        "Standard_DS12",
+        "Standard_DS13",
+        "Standard_DS14",
+        "Standard_G1",
+        "Standard_G2",
+        "Standard_G3",
+        "Standard_G4",
+        "Standard_G5",
+        "Standard_GS1",
+        "Standard_GS2",
+        "Standard_GS3",
+        "Standard_GS4",
+        "Standard_GS5"
       ],
       "metadata": {
         "description": "Size of the worker nodes."
@@ -131,7 +131,7 @@
     "publicIPAddressName": "publicips",
     "masterVMName": "master",
     "workerVMName": "worker",
-	"armApiVersion": "2015-06-15",
+    "armApiVersion": "2015-06-15",
     "nicName": "nic",
     "networkSettings": {
       "virtualNetworkName": "virtualnetwork",
@@ -161,14 +161,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('newStorageAccountName')]",
-      "apiVersion": "[variables('armApiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('armApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('networkSettings').virtualNetworkName]",
       "location": "[resourceGroup().location]",
@@ -190,7 +190,7 @@
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "[variables('armApiVersion')]",
+      "apiVersion": "2015-06-15",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
       "properties": {
@@ -201,7 +201,7 @@
       }
     },
     {
-      "apiVersion": "[variables('armApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -228,7 +228,7 @@
       }
     },
     {
-      "apiVersion": "[variables('armApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('masterVMName')]",
       "location": "[resourceGroup().location]",
@@ -266,7 +266,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 0,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk0.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk0.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -276,7 +276,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 1,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk1.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk1.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -286,7 +286,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 2,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk2.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk2.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -296,7 +296,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 3,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk3.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk3.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -306,7 +306,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 4,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk4.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk4.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -316,7 +316,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 5,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk5.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk5.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -326,7 +326,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 6,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk6.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk6.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -336,7 +336,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 7,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk7.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk7.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -346,7 +346,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 8,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk8.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk8.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -356,7 +356,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 9,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk9.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk9.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -366,7 +366,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 10,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk10.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk10.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -376,7 +376,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 11,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk11.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk11.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -386,7 +386,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 12,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk12.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk12.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -396,7 +396,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 13,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk13.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk13.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -406,7 +406,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 14,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk14.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk14.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -416,7 +416,7 @@
               "diskSizeGB": "[parameters('dataDiskSize')]",
               "lun": 15,
               "vhd": {
-                "Uri":  "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk15.vhd')]"
+                "Uri": "[concat('http://',variables('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('masterVMName'),'-datadisk15.vhd')]"
               },
               "caching": "None",
               "createOption": "Empty"
@@ -433,7 +433,7 @@
       }
     },
     {
-      "apiVersion": "[variables('armApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('masterVMName'), '/Installation')]",
       "location": "[resourceGroup().location]",
@@ -454,12 +454,12 @@
       }
     },
     {
-      "apiVersion": "[variables('armApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('workerVMName'), copyindex(), '/Installation')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [
-	    "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMName'),'/extensions/Installation')]",
+        "[concat('Microsoft.Compute/virtualMachines/', variables('masterVMName'),'/extensions/Installation')]",
         "[concat('Microsoft.Compute/virtualMachines/', variables('workerVMName'), copyindex())]"
       ],
       "copy": {
@@ -480,7 +480,7 @@
       }
     },
     {
-      "apiVersion": "[variables('armApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), 'worker', copyindex())]",
       "location": "[resourceGroup().location]",
@@ -507,7 +507,7 @@
       }
     },
     {
-      "apiVersion": "[variables('armApiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('workerVMName'), copyindex())]",
       "location": "[resourceGroup().location]",

--- a/spark-and-cassandra-on-centos/azuredeploy.json
+++ b/spark-and-cassandra-on-centos/azuredeploy.json
@@ -136,68 +136,53 @@
     "osImagePublisher": "OpenLogic",
     "osImageOffer": "CentOS",
     "osVersion": "7.1",
-
     "apiVersion": "2015-06-15",
-
     "artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/spark-and-cassandra-on-centos/CustomScripts",
-    "artifactsLocationSasToken":  "?key=change_me",
-
+    "artifactsLocationSasToken": "?key=change_me",
     "vnetSparkPrefix": "10.0.0.0/16",
     "vnetSparkSubnet1Name": "Subnet-Master",
     "vnetSparkSubnet1Prefix": "10.0.0.0/24",
-
     "vnetSparkSubnet2Name": "Subnet-Slave",
     "vnetSparkSubnet2Prefix": "10.0.1.0/24",
-
     "vnetSparkSubnet3Name": "Subnet-Cassandra",
     "vnetSparkSubnet3Prefix": "10.0.2.0/24",
-
     "storageMasterName": "[concat('master', uniqueString(resourceGroup().id))]",
     "storageSlaveNamePrefix": "[concat('slave', uniqueString(resourceGroup().id))]",
     "storageCassandraName": "[concat('cass', uniqueString(resourceGroup().id))]",
-
     "nsgSparkMasterName": "nsg-spark-master",
     "nsgSparkSlaveName": "nsg-spark-slave",
     "nsgCassandraName": "nsg-cassandra",
-
     "nicMasterName": "nic-master",
     "nicMasterVnetID": "[resourceId('Microsoft.Network/virtualNetworks', 'vnet-spark')]",
     "nicMasterSubnetRef": "[concat(variables('nicMasterVnetID'), '/subnets/', variables('vnetSparkSubnet1Name'))]",
     "nicMasterNodeIP": "10.0.0.5",
-
     "nicCassandraName": "nic-cassandra",
     "nicCassandraVnetID": "[resourceId('Microsoft.Network/virtualNetworks', 'vnet-spark')]",
     "nicCassandraSubnetRef": "[concat(variables('nicMasterVnetID'), '/subnets/', variables('vnetSparkSubnet3Name'))]",
     "nicCassandraNodeIP": "10.0.2.5",
-
     "nicSlaveNamePrefix": "nic-slave-",
     "nicSlaveNodeIPPrefix": "10.0.1.",
     "nicSlaveNodeIPStart": 5,
     "nicSlaveVnetID": "[resourceId('Microsoft.Network/virtualNetworks', 'vnet-spark')]",
     "nicSlaveSubnetRef": "[concat(variables('nicSlaveVnetID'), '/subnets/', variables('vnetSparkSubnet2Name'))]",
-
     "publicIPMasterName": "public-ip-master",
     "publicIPSlaveNamePrefix": "public-ip-slave-",
     "publicIPCassandraName": "public-ip-cassandra",
-
     "vmMasterName": "spark-master",
     "vmMasterOSDiskName": "vmMasterOSDisk",
     "vmMasterVnetID": "[resourceId('Microsoft.Network/virtualNetworks', 'vnet-spark')]",
     "vmMasterSubnetRef": "[concat(variables('vmMasterVnetID'), '/subnets/', variables('vnetSparkSubnet1Name'))]",
     "vmMasterStorageAccountContainerName": "vhds",
-
     "vmSlaveNamePrefix": "spark-slave-",
     "vmSlaveOSDiskNamePrefix": "vmSlaveOSDisk-",
     "vmSlaveVnetID": "[resourceId('Microsoft.Network/virtualNetworks', 'vnet-spark')]",
     "vmSlaveSubnetRef": "[concat(variables('vmSlaveVnetID'), '/subnets/', variables('vnetSparkSubnet2Name'))]",
     "vmSlaveStorageAccountContainerName": "vhds",
-
     "vmCassandraName": "cassandra",
     "vmCassandraOSDiskName": "vmCassandraOSDisk",
     "vmCassandraVnetID": "[resourceId('Microsoft.Network/virtualNetworks', 'vnet-spark')]",
     "vmCassandraSubnetRef": "[concat(variables('vmMasterVnetID'), '/subnets/', variables('vnetSparkSubnet3Name'))]",
     "vmCassandraStorageAccountContainerName": "vhds",
-
     "availabilitySlaveName": "availability-slave",
     "scriptSparkProvisionerScriptFileName": "scriptSparkProvisioner.sh",
     "scriptCassandraProvisionerScriptFileName": "scriptCassandraProvisioner.sh"
@@ -207,8 +192,8 @@
       "name": "[variables('storageMasterName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
       "tags": {
         "displayName": "storageMaster"
       },
@@ -216,7 +201,6 @@
         "accountType": "[parameters('storageMasterType')]"
       }
     },
-
     {
       "copy": {
         "name": "storageSlaveLoop",
@@ -225,8 +209,8 @@
       "name": "[concat(variables('storageSlaveNamePrefix'), copyIndex())]",
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
       "tags": {
         "displayName": "storageSlave"
       },
@@ -234,13 +218,12 @@
         "accountType": "[parameters('storageSlaveType')]"
       }
     },
-
     {
       "name": "[variables('storageCassandraName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
       "tags": {
         "displayName": "storageCassandra"
       },
@@ -248,13 +231,12 @@
         "accountType": "[parameters('storageMasterType')]"
       }
     },
-
     {
       "name": "vnet-spark",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
       "tags": {
         "displayName": "vnetSpark"
       },
@@ -286,13 +268,12 @@
         ]
       }
     },
-
     {
       "name": "[variables('publicIPMasterName')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
       "tags": {
         "displayName": "publicIPMaster"
       },
@@ -300,14 +281,13 @@
         "publicIPAllocationMethod": "Static"
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "copy": {
         "name": "publicIPSlaveLoop",
         "count": "[parameters('vmNumberOfSlaves')]"
       },
-      "dependsOn": [ ],
+      "dependsOn": [],
       "location": "[resourceGroup().location]",
       "name": "[concat(variables('publicIPSlaveNamePrefix'), copyIndex())]",
       "properties": {
@@ -318,14 +298,12 @@
       },
       "type": "Microsoft.Network/publicIPAddresses"
     },
-
-
     {
       "name": "[variables('publicIPCassandraName')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
       "tags": {
         "displayName": "publicIPCassandra"
       },
@@ -333,9 +311,8 @@
         "publicIPAllocationMethod": "Static"
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('nsgSparkMasterName')]",
       "location": "[resourceGroup().location]",
@@ -386,9 +363,8 @@
         ]
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('nsgSparkSlaveName')]",
       "location": "[resourceGroup().location]",
@@ -411,9 +387,8 @@
         ]
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('nsgCassandraName')]",
       "location": "[resourceGroup().location]",
@@ -436,12 +411,11 @@
         ]
       }
     },
-
     {
       "name": "[variables('nicMasterName')]",
       "type": "Microsoft.Network/networkInterfaces",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', 'vnet-spark')]",
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgSparkMasterName'))]",
@@ -471,7 +445,6 @@
         }
       }
     },
-
     {
       "copy": {
         "name": "nicSlaveLoop",
@@ -480,7 +453,7 @@
       "name": "[concat(variables('nicSlaveNamePrefix'), copyIndex())]",
       "type": "Microsoft.Network/networkInterfaces",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', 'vnet-spark')]",
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgSparkSlaveName'))]",
@@ -510,12 +483,11 @@
         }
       }
     },
-
     {
       "name": "[variables('nicCassandraName')]",
       "type": "Microsoft.Network/networkInterfaces",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', 'vnet-spark')]",
         "[concat('Microsoft.Network/networkSecurityGroups/', variables('nsgCassandraName'))]",
@@ -545,13 +517,12 @@
         }
       }
     },
-
     {
       "name": "[variables('availabilitySlaveName')]",
       "type": "Microsoft.Compute/availabilitySets",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
       "tags": {
         "displayName": "availability-set"
       },
@@ -560,12 +531,11 @@
         "platformUpdateDomainCount": "5"
       }
     },
-
     {
       "name": "[variables('vmMasterName')]",
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageMasterName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicMasterName'))]"
@@ -633,7 +603,6 @@
         }
       ]
     },
-
     {
       "copy": {
         "name": "vmSlaveLoop",
@@ -642,7 +611,7 @@
       "name": "[concat(variables('vmSlaveNamePrefix'), copyIndex())]",
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat(variables('storageSlaveNamePrefix'), copyIndex())]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicSlaveNamePrefix'), copyIndex())]"
@@ -713,12 +682,11 @@
         }
       ]
     },
-
     {
       "name": "[variables('vmCassandraName')]",
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageCassandraName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicCassandraName'))]"

--- a/splunk-on-ubuntu/azuredeploy-gov.json
+++ b/splunk-on-ubuntu/azuredeploy-gov.json
@@ -52,7 +52,7 @@
     }
   },
   "variables": {
-    "storageAccountType":"Standard_LRS",
+    "storageAccountType": "Standard_LRS",
     "standaloneVmSize": "Standard_D3_v2",
     "clusterMasterVmSize": "Standard_D3_v2",
     "clusterSearchheadVmSize": "Standard_D3_v2",
@@ -72,7 +72,6 @@
     "forwardedDataFrom": "0.0.0.0/0",
     "publicIPName": "splunksh-publicip",
     "templateLocation": "https://raw.githubusercontent.com/azure/azure-quickstart-templates/master/splunk-on-ubuntu",
-
     "templateAPIVersion": "2015-01-01",
     "resourceAPIVersion": "2015-06-15",
     "storageAccountNamePrefix": "[concat(uniqueString(resourceGroup().id, deployment().name), 'splunk')]",
@@ -127,11 +126,28 @@
         "domainNamePrefix": "[parameters('domainNamePrefix')]",
         "count": "[add(2, variables('clusterIndexerVmCount'))]",
         "map": [
-          "", "-cm",
-          "-cp0", "-cp1", "-cp2", "-cp3", "-cp4",
-          "-cp5", "-cp6", "-cp7", "-cp8", "-cp9",
-          "-cp10", "-cp11", "-cp12", "-cp13", "-cp14",
-          "-cp15", "-cp16", "-cp17", "-cp18", "-cp19"
+          "",
+          "-cm",
+          "-cp0",
+          "-cp1",
+          "-cp2",
+          "-cp3",
+          "-cp4",
+          "-cp5",
+          "-cp6",
+          "-cp7",
+          "-cp8",
+          "-cp9",
+          "-cp10",
+          "-cp11",
+          "-cp12",
+          "-cp13",
+          "-cp14",
+          "-cp15",
+          "-cp16",
+          "-cp17",
+          "-cp18",
+          "-cp19"
         ]
       },
       "storage": {
@@ -139,9 +155,28 @@
         "type": "[variables('storageAccountType')]",
         "count": "[div(sub(add(add(2, variables('clusterIndexerVmCount')), variables('nodesPerStorageAccount')), 1), variables('nodesPerStorageAccount'))]",
         "map": [
-          0, 1, 1, 0, 1, 1,
-          2, 2, 2, 2, 3, 3, 3, 3,
-          4, 4, 4, 4, 5, 5, 5, 5
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          2,
+          2,
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          5,
+          5,
+          5,
+          5
         ]
       }
     },
@@ -199,13 +234,13 @@
     "vnetId-existing": "[resourceId(variables('virtualNetworkExistingRGName'),'Microsoft.Network/virtualNetworks/',variables('virtualNetworkName'))]",
     "vnetId": "[variables(concat('vnetId-', variables('virtualNetworkNewOrExisting')))]",
     "subnet1Ref": "[concat(variables('vnetId'),'/subnets/',variables('subnet1Name'))]",
-    "subnet2Ref": "[concat(variables('vnetId'),'/subnets/',variables('subnet2Name'))]"   
+    "subnet2Ref": "[concat(variables('vnetId'),'/subnets/',variables('subnet2Name'))]"
   },
   "resources": [
     {
       "name": "shared",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -231,7 +266,7 @@
     {
       "name": "virtual-network",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -249,7 +284,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "standalone-deployment",
       "dependsOn": [
@@ -306,7 +341,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "clustermaster-deployment",
       "dependsOn": [
@@ -362,7 +397,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "clustersearchhead-deployment",
       "dependsOn": [
@@ -419,7 +454,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "clusterpeers-deployment",
       "dependsOn": [

--- a/splunk-on-ubuntu/azuredeploy.json
+++ b/splunk-on-ubuntu/azuredeploy.json
@@ -245,11 +245,28 @@
         "domainNamePrefix": "[parameters('domainNamePrefix')]",
         "count": "[add(2, parameters('clusterIndexerVmCount'))]",
         "map": [
-          "", "-cm",
-          "-cp0", "-cp1", "-cp2", "-cp3", "-cp4",
-          "-cp5", "-cp6", "-cp7", "-cp8", "-cp9",
-          "-cp10", "-cp11", "-cp12", "-cp13", "-cp14",
-          "-cp15", "-cp16", "-cp17", "-cp18", "-cp19"
+          "",
+          "-cm",
+          "-cp0",
+          "-cp1",
+          "-cp2",
+          "-cp3",
+          "-cp4",
+          "-cp5",
+          "-cp6",
+          "-cp7",
+          "-cp8",
+          "-cp9",
+          "-cp10",
+          "-cp11",
+          "-cp12",
+          "-cp13",
+          "-cp14",
+          "-cp15",
+          "-cp16",
+          "-cp17",
+          "-cp18",
+          "-cp19"
         ]
       },
       "storage": {
@@ -257,9 +274,28 @@
         "type": "[parameters('storageAccountType')]",
         "count": "[div(sub(add(add(2, parameters('clusterIndexerVmCount')), variables('nodesPerStorageAccount')), 1), variables('nodesPerStorageAccount'))]",
         "map": [
-          0, 1, 1, 0, 1, 1,
-          2, 2, 2, 2, 3, 3, 3, 3,
-          4, 4, 4, 4, 5, 5, 5, 5
+          0,
+          1,
+          1,
+          0,
+          1,
+          1,
+          2,
+          2,
+          2,
+          2,
+          3,
+          3,
+          3,
+          3,
+          4,
+          4,
+          4,
+          4,
+          5,
+          5,
+          5,
+          5
         ]
       }
     },
@@ -317,13 +353,13 @@
     "vnetId-existing": "[resourceId(parameters('virtualNetworkExistingRGName'),'Microsoft.Network/virtualNetworks/',parameters('virtualNetworkName'))]",
     "vnetId": "[variables(concat('vnetId-', parameters('virtualNetworkNewOrExisting')))]",
     "subnet1Ref": "[concat(variables('vnetId'),'/subnets/',parameters('subnet1Name'))]",
-    "subnet2Ref": "[concat(variables('vnetId'),'/subnets/',parameters('subnet2Name'))]"   
+    "subnet2Ref": "[concat(variables('vnetId'),'/subnets/',parameters('subnet2Name'))]"
   },
   "resources": [
     {
       "name": "shared",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -349,7 +385,7 @@
     {
       "name": "virtual-network",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "properties": {
         "mode": "Incremental",
         "templateLink": {
@@ -367,7 +403,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "standalone-deployment",
       "dependsOn": [
@@ -424,7 +460,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "clustermaster-deployment",
       "dependsOn": [
@@ -480,7 +516,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "clustersearchhead-deployment",
       "dependsOn": [
@@ -537,7 +573,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "clusterpeers-deployment",
       "dependsOn": [

--- a/splunk-on-ubuntu/nested/clustermaster-resources.json
+++ b/splunk-on-ubuntu/nested/clustermaster-resources.json
@@ -42,7 +42,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[parameters('location')]",
@@ -108,7 +108,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "clustermaster",
       "dependsOn": [

--- a/splunk-on-ubuntu/nested/clusterpeers-resources.json
+++ b/splunk-on-ubuntu/nested/clusterpeers-resources.json
@@ -42,7 +42,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[parameters('location')]",
@@ -150,7 +150,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "clusterpeers",
       "dependsOn": [

--- a/splunk-on-ubuntu/nested/clustersearchhead-resources.json
+++ b/splunk-on-ubuntu/nested/clustersearchhead-resources.json
@@ -42,7 +42,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[parameters('location')]",
@@ -108,7 +108,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "clustersearchhead",
       "dependsOn": [

--- a/splunk-on-ubuntu/nested/shared-resources.json
+++ b/splunk-on-ubuntu/nested/shared-resources.json
@@ -33,7 +33,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[concat(parameters('storageSettings').name, copyindex())]",
       "copy": {
@@ -46,7 +46,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('availabilitySetSettings').name, copyindex())]",
       "copy": {
@@ -60,7 +60,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('publicIPAddressSettings').name, parameters('publicIPAddressSettings').map[copyindex()])]",
       "copy": {

--- a/splunk-on-ubuntu/nested/splunk-2disk-resources-loop.json
+++ b/splunk-on-ubuntu/nested/splunk-2disk-resources-loop.json
@@ -55,7 +55,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyindex())]",
       "location": "[parameters('location')]",
@@ -85,7 +85,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
@@ -118,7 +118,7 @@
           "osDisk": {
             "name": "osdisk",
             "vhd": {
-              "uri": "[concat(reference(concat(variables('storageReferencePrefix'), parameters('storageSettings').map[copyindex()]), variables('storageApiVersion')).primaryEndpoints.blob, 'vhds/', variables('vmName'), copyindex(), '-osdisk.vhd')]"            
+              "uri": "[concat(reference(concat(variables('storageReferencePrefix'), parameters('storageSettings').map[copyindex()]), variables('storageApiVersion')).primaryEndpoints.blob, 'vhds/', variables('vmName'), copyindex(), '-osdisk.vhd')]"
             },
             "caching": "ReadWrite",
             "createOption": "FromImage"
@@ -156,7 +156,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "singleQuote": "'",
       "name": "[concat(variables('vmName'), copyindex(), '/node-setup')]",

--- a/splunk-on-ubuntu/nested/splunk-2disk-resources.json
+++ b/splunk-on-ubuntu/nested/splunk-2disk-resources.json
@@ -51,7 +51,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",
@@ -77,7 +77,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
@@ -144,7 +144,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), '/node-setup')]",
       "location": "[parameters('location')]",
@@ -172,7 +172,7 @@
       "value": "[variables('storageReferenceName')]"
     },
     "storageApiVersion": {
-      "type":"string",
+      "type": "string",
       "value": "[variables('storageApiVersion')]"
     },
     "blobEndpoint": {

--- a/splunk-on-ubuntu/nested/splunk-8disk-resources-loop.json
+++ b/splunk-on-ubuntu/nested/splunk-8disk-resources-loop.json
@@ -55,7 +55,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyindex())]",
       "location": "[parameters('location')]",
@@ -85,7 +85,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(variables('vmName'), copyindex())]",
       "location": "[parameters('location')]",
@@ -216,7 +216,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), copyindex(), '/node-setup')]",
       "location": "[parameters('location')]",
@@ -242,5 +242,5 @@
       }
     }
   ],
-  "outputs": { }
+  "outputs": {}
 }

--- a/splunk-on-ubuntu/nested/splunk-8disk-resources.json
+++ b/splunk-on-ubuntu/nested/splunk-8disk-resources.json
@@ -51,7 +51,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",
@@ -77,7 +77,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
@@ -204,7 +204,7 @@
       }
     },
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'), '/node-setup')]",
       "location": "[parameters('location')]",
@@ -232,7 +232,7 @@
       "value": "[variables('storageReferenceName')]"
     },
     "storageApiVersion": {
-      "type":"string",
+      "type": "string",
       "value": "[variables('storageApiVersion')]"
     },
     "blobEndpoint": {

--- a/splunk-on-ubuntu/nested/standalone-instance-resources.json
+++ b/splunk-on-ubuntu/nested/standalone-instance-resources.json
@@ -42,7 +42,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('securityGroupName')]",
       "location": "[parameters('location')]",
@@ -136,7 +136,7 @@
       }
     },
     {
-      "apiVersion": "[variables('templateAPIVersion')]",
+      "apiVersion": "2015-01-01",
       "type": "Microsoft.Resources/deployments",
       "name": "standalone",
       "dependsOn": [

--- a/splunk-on-ubuntu/nested/vnet-new.json
+++ b/splunk-on-ubuntu/nested/vnet-new.json
@@ -12,22 +12,22 @@
       }
     }
   },
-  "variables" : {
+  "variables": {
     "templateAPIVersion": "2015-01-01",
     "resourceAPIVersion": "2015-06-15",
     "virtualNetworkName": "[parameters('networkSettings').virtualNetworkName]",
     "virtualNetworkAddressPrefix": "[parameters('networkSettings').virtualNetworkAddressPrefix]",
-    "virtualNetworkId" : "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "virtualNetworkId": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "subnet1Name": "[parameters('networkSettings').subnet.sh.name]",
     "subnet2Name": "[parameters('networkSettings').subnet.idx.name]",
     "subnet1Prefix": "[parameters('networkSettings').subnet.sh.prefix]",
     "subnet2Prefix": "[parameters('networkSettings').subnet.idx.prefix]",
-    "subnet1Ref" : "[concat(variables('virtualNetworkId'),'/subnets/',variables('subnet1Name'))]",
-    "subnet2Ref" : "[concat(variables('virtualNetworkId'),'/subnets/',variables('subnet2Name'))]"
+    "subnet1Ref": "[concat(variables('virtualNetworkId'),'/subnets/',variables('subnet1Name'))]",
+    "subnet2Ref": "[concat(variables('virtualNetworkId'),'/subnets/',variables('subnet2Name'))]"
   },
   "resources": [
     {
-      "apiVersion": "[variables('resourceAPIVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",

--- a/sql-reporting-services-sql-server/azuredeploy.json
+++ b/sql-reporting-services-sql-server/azuredeploy.json
@@ -121,13 +121,12 @@
     "wadmetricsresourceid": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name , '/providers/', 'Microsoft.Compute/virtualMachines/')]",
     "wadcfgxend": "\"><MetricAggregation scheduledTransferPeriod=\"PT1H\"/><MetricAggregation scheduledTransferPeriod=\"PT1M\"/></Metrics></DiagnosticMonitorConfiguration></WadCfg>",
     "apiVersion": "2015-06-15"
-
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('vhdStorageNameRs')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "tags": {
         "displayName": "DataStorageAccountRs"
@@ -139,7 +138,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('vhdStorageNameCatalog')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "tags": {
         "displayName": "DataStorageAccountCatalog"
@@ -152,7 +151,7 @@
       "name": "[variables('diagnosticsStorageAccountName')]",
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "tags": {
         "displayName": "DiagnosticsStorageAccount"
       },
@@ -161,7 +160,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressName'), copyindex())]",
       "location": "[resourceGroup().location]",
@@ -180,7 +179,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -204,7 +203,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('nicName'), copyindex())]",
       "location": "[resourceGroup().location]",
@@ -237,7 +236,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmNameRs')]",
       "location": "[resourceGroup().location]",
@@ -363,12 +362,10 @@
             }
           }
         }
-
-
       ]
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmNameCatalog')]",
       "location": "[resourceGroup().location]",
@@ -416,7 +413,6 @@
               "diskSizeGB": "1023"
             }
           ]
-
         },
         "networkProfile": {
           "networkInterfaces": [
@@ -509,7 +505,7 @@
       "name": "[variables('nicName')]",
       "type": "Microsoft.Network/networkInterfaces",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
         "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
@@ -538,8 +534,8 @@
       "name": "[variables('publicIPAddressName')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
-      "dependsOn": [ ],
+      "apiVersion": "2015-06-15",
+      "dependsOn": [],
       "tags": {
         "displayName": "PublicRSIPAddress"
       },

--- a/stampery-trailbot-ubuntu/azuredeploy.json
+++ b/stampery-trailbot-ubuntu/azuredeploy.json
@@ -21,10 +21,10 @@
       }
     },
     "dnsLabelPrefix": {
-       "type": "string",
-       "metadata": {
-          "description": "Hostname assigned to the Public IP, also used as the VM Name. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
-       }
+      "type": "string",
+      "metadata": {
+        "description": "Hostname assigned to the Public IP, also used as the VM Name. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
+      }
     },
     "clientPubKey": {
       "type": "string",
@@ -35,14 +35,14 @@
     "_artifactsLocation": {
       "type": "string",
       "metadata": {
-          "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+        "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
       },
       "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/stampery-trailbot-ubuntu/"
     },
     "_artifactsLocationSasToken": {
       "type": "securestring",
       "metadata": {
-          "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
       },
       "defaultValue": ""
     }
@@ -74,14 +74,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -93,7 +93,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -114,7 +114,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -140,7 +140,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -192,7 +192,7 @@
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
       "location": "[resourceGroup().location]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
       ],

--- a/thinkbox-deadline/azuredeploy.json
+++ b/thinkbox-deadline/azuredeploy.json
@@ -1,52 +1,52 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "clusterName": {
-            "type": "string",
-            "metadata": {
-                "description": "Prefix for all items created by this template."
-            }
-        },
-        "publicDnsName": {
-            "type": "string",
-            "metadata": {
-                "description": "Unique public DNS prefix for the deployment. The fqdn will look something like '<dnsname>.westus.cloudapp.azure.com'. Up to 62 chars, digits or dashes, lowercase, should start with a letter: must conform to '^[a-z][a-z0-9-]{1,61}[a-z0-9]$'."
-            }
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the administrator of the new VM. Exclusion list: 'admin','administrator'"
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "The password for the administrator account of the new VM"
-            }
-        },
-        "repositoryVMSize": {
-            "type": "string",
-            "defaultValue": "Standard_A1",
-            "metadata": {
-                "description": "Size of the repository."
-            }
-        },
-        "slaveVMSize": {
-            "type": "string",
-            "defaultValue": "Standard_A1",
-            "metadata": {
-                "description": "Size of the slave."
-            }
-        },
-        "numberOfSlaves": {
-            "type": "int",
-            "metadata": {
-                "description": "The number of slave vms to start."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterName": {
+      "type": "string",
+      "metadata": {
+        "description": "Prefix for all items created by this template."
+      }
     },
+    "publicDnsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique public DNS prefix for the deployment. The fqdn will look something like '<dnsname>.westus.cloudapp.azure.com'. Up to 62 chars, digits or dashes, lowercase, should start with a letter: must conform to '^[a-z][a-z0-9-]{1,61}[a-z0-9]$'."
+      }
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the administrator of the new VM. Exclusion list: 'admin','administrator'"
+      }
+    },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The password for the administrator account of the new VM"
+      }
+    },
+    "repositoryVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_A1",
+      "metadata": {
+        "description": "Size of the repository."
+      }
+    },
+    "slaveVMSize": {
+      "type": "string",
+      "defaultValue": "Standard_A1",
+      "metadata": {
+        "description": "Size of the slave."
+      }
+    },
+    "numberOfSlaves": {
+      "type": "int",
+      "metadata": {
+        "description": "The number of slave vms to start."
+      }
+    }
+  },
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id),'storage')]",
     "virtualNetworkName": "[concat( parameters('clusterName'), '-vnet')]",
@@ -62,285 +62,285 @@
     "networkInterfaceName": "[concat( parameters('clusterName'), '-nif')]",
     "fullDnsName": "[concat( parameters('clusterName'), parameters('publicDnsName'))]"
   },
-    "resources": [
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[variables('publicIpName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "publicIPAllocationMethod": "Dynamic",
-          "dnsSettings": {
-            "domainNameLabel": "[variables('fullDnsName')]"
-          }
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[concat( variables('publicIpName'), copyindex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "ipLoop",
-          "count": "[parameters('numberOfSlaves')]"
-        },
-        "properties": {
-          "publicIPAllocationMethod": "Dynamic",
-          "dnsSettings": {
-            "domainNameLabel": "[concat(variables('fullDnsName'), copyindex())]"
-          }
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Storage/storageAccounts",
-        "name": "[variables('storageAccountName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "accountType": "Standard_LRS"
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/networkSecurityGroups",
-        "name": "[variables('networkSecurityGroupName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "securityRules": [
-            {
-              "name": "mongo",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "27070",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 100,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "rdp",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "3389",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 200,
-                "direction": "Inbound"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[variables('virtualNetworkName')]",
-        "dependsOn": [
-          "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
-        ],
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[variables('vnetAddressRange')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[variables('subnetName')]",
-              "properties": {
-                "addressPrefix": "[variables('subnetAddressRange')]",
-                "networkSecurityGroup": {
-                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[variables('networkInterfaceName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-          "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfig",
-              "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "[variables('subnet-id')]"
-                },
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[concat( variables('networkInterfaceName'), copyindex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "nifLoop",
-          "count": "[parameters('numberOfSlaves')]"
-        },
-        "dependsOn": [
-          "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-          "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIpName'), copyindex()))]"
-        ],
-        "properties": {
-          "ipConfigurations": [
-            {
-              "name": "ipconfig",
-              "properties": {
-                "privateIPAllocationMethod": "Dynamic",
-                "subnet": {
-                  "id": "[variables('subnet-id')]"
-                },
-                "publicIPAddress": {
-                  "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIpName'), copyindex()))]"
-                }
-              }
-            }
-          ]
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[variables('repositoryName')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",
-          "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
-        ],
-        "plan": {
-          "name": "deadline-repository-7-2",
-          "publisher": "thinkboxsoftware",
-          "product": "deadline7-2"
-        },
-        "properties": {
-          "hardwareProfile": {
-            "vmSize": "[parameters('repositoryVMSize')]"
-          },
-          "osProfile": {
-            "computername": "azure-repo",
-            "adminUsername": "[parameters('adminUserName')]",
-            "adminPassword": "[parameters('adminPassword')]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "thinkboxsoftware",
-              "offer": "deadline7-2",
-              "sku": "deadline-repository-7-2",
-              "version": "1.0.0"
-            },
-            "osDisk": {
-              "name": "osdisk",
-              "vhd": {
-                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob,'vhds/', variables('repositoryName'),'osdisk.vhd')]"
-              },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
-            }
-          },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
-              }
-            ]
-          }
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Compute/virtualMachines/extensions",
-        "name": "[concat( variables('repositoryName'), '/autoconf')]",
-        "location": "[resourceGroup().location]",
-        "dependsOn": [
-          "[resourceId('Microsoft.Compute/virtualMachines', variables('repositoryName'))]"
-        ],
-        "properties": {
-          "publisher": "Microsoft.Compute",
-          "type": "CustomScriptExtension",
-          "typeHandlerVersion": "1.4",
-          "settings": {
-            "fileUris": [
-              "https://deadline.blob.core.windows.net/scripts/repo-autoconf.py"
-            ],
-            "commandToExecute": "[concat('python', ' repo-autoconf.py')]"
-          }
-        }
-      },
-      {
-        "apiVersion": "[variables('apiVersion')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[concat(variables('slaveName'), copyindex())]",
-        "location": "[resourceGroup().location]",
-        "copy": {
-          "name": "nifLoop",
-          "count": "[parameters('numberOfSlaves')]"
-        },
-        "plan": {
-          "name": "deadline-slave-7-2",
-          "publisher": "thinkboxsoftware",
-          "product": "deadline7-2"
-        },
-        "dependsOn": [
-          "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",
-          "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('networkInterfaceName'), copyindex()))]",
-          "[resourceId('Microsoft.Compute/virtualMachines', variables('repositoryName'))]",
-          "[concat( 'Microsoft.Compute/virtualMachines/', variables('repositoryName'), '/extensions/autoconf')]"
-        ],
-        "properties": {
-          "hardwareProfile": {
-            "vmSize": "[parameters('slaveVMSize')]"
-          },
-          "osProfile": {
-            "computername": "[concat('azure-slave', copyindex())]",
-            "adminUsername": "[parameters('adminUserName')]",
-            "adminPassword": "[parameters('adminPassword')]",
-            "customData": "[base64(reference(variables('networkInterfaceName')).ipConfigurations[0].properties.privateIPAddress)]"
-          },
-          "storageProfile": {
-            "imageReference": {
-              "publisher": "thinkboxsoftware",
-              "offer": "deadline7-2",
-              "sku": "deadline-slave-7-2",
-              "version": "1.0.0"
-            },
-            "osDisk": {
-              "name": "osdisk",
-              "vhd": {
-                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob,'vhds/', variables('slaveName') , copyindex(), '-osdisk.vhd')]"
-              },
-              "caching": "ReadWrite",
-              "createOption": "FromImage"
-            }
-          },
-          "networkProfile": {
-            "networkInterfaces": [
-              {
-                "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('networkInterfaceName'), copyindex()) )]"
-              }
-            ]
-          }
+  "resources": [
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIpName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[variables('fullDnsName')]"
         }
       }
-    ]
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat( variables('publicIpName'), copyindex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "ipLoop",
+        "count": "[parameters('numberOfSlaves')]"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[concat(variables('fullDnsName'), copyindex())]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "Standard_LRS"
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "mongo",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "27070",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "rdp",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "3389",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 200,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnetAddressRange')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetAddressRange')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('networkInterfaceName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnet-id')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat( variables('networkInterfaceName'), copyindex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "nifLoop",
+        "count": "[parameters('numberOfSlaves')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+        "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIpName'), copyindex()))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('subnet-id')]"
+              },
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIpName'), copyindex()))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('repositoryName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
+      ],
+      "plan": {
+        "name": "deadline-repository-7-2",
+        "publisher": "thinkboxsoftware",
+        "product": "deadline7-2"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('repositoryVMSize')]"
+        },
+        "osProfile": {
+          "computername": "azure-repo",
+          "adminUsername": "[parameters('adminUserName')]",
+          "adminPassword": "[parameters('adminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "thinkboxsoftware",
+            "offer": "deadline7-2",
+            "sku": "deadline-repository-7-2",
+            "version": "1.0.0"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob,'vhds/', variables('repositoryName'),'osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat( variables('repositoryName'), '/autoconf')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachines', variables('repositoryName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Compute",
+        "type": "CustomScriptExtension",
+        "typeHandlerVersion": "1.4",
+        "settings": {
+          "fileUris": [
+            "https://deadline.blob.core.windows.net/scripts/repo-autoconf.py"
+          ],
+          "commandToExecute": "[concat('python', ' repo-autoconf.py')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[concat(variables('slaveName'), copyindex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "nifLoop",
+        "count": "[parameters('numberOfSlaves')]"
+      },
+      "plan": {
+        "name": "deadline-slave-7-2",
+        "publisher": "thinkboxsoftware",
+        "product": "deadline7-2"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountName'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('networkInterfaceName'), copyindex()))]",
+        "[resourceId('Microsoft.Compute/virtualMachines', variables('repositoryName'))]",
+        "[concat( 'Microsoft.Compute/virtualMachines/', variables('repositoryName'), '/extensions/autoconf')]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('slaveVMSize')]"
+        },
+        "osProfile": {
+          "computername": "[concat('azure-slave', copyindex())]",
+          "adminUsername": "[parameters('adminUserName')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "customData": "[base64(reference(variables('networkInterfaceName')).ipConfigurations[0].properties.privateIPAddress)]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "thinkboxsoftware",
+            "offer": "deadline7-2",
+            "sku": "deadline-slave-7-2",
+            "version": "1.0.0"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob,'vhds/', variables('slaveName') , copyindex(), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('networkInterfaceName'), copyindex()) )]"
+            }
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/trend-chef-splunk-security/azuredeploy.json
+++ b/trend-chef-splunk-security/azuredeploy.json
@@ -183,14 +183,14 @@
     },
     "vmAdminPasswordSplunkEnterprise": {
       "defaultValue": "",
-      "type": "SecureString",
+      "type": "securestring",
       "metadata": {
         "description": "Splunk Enterprise Virtual Machine admin password"
       }
     },
     "splunkAdminPassword": {
       "defaultValue": "",
-      "type": "SecureString",
+      "type": "securestring",
       "metadata": {
         "description": "Splunk Enterprise Virtual Machine admin password"
       }

--- a/trend-chef-splunk-security/azuredeploy.json
+++ b/trend-chef-splunk-security/azuredeploy.json
@@ -1,1284 +1,1284 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string",
-            "defaultValue": "westus",
-            "allowedValues": [
-                "westus",
-                "eastus",
-                "centralus"
-            ],
-            "metadata": {
-                "description": "Location where all the resources deploy"
-            }
-        },
-        "vmAdminNameTrendDSM": {
-            "type": "string",
-            "defaultValue": "trend",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager Virtual Machine admin username"
-            }
-        },
-        "vmAdminPasswordTrendDSM": {
-            "type": "securestring",
-            "defaultValue": "",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager Virtual Machine admin password"
-            }
-        },
-        "vmSizeTrendDSM": {
-            "type": "string",
-            "defaultValue": "Standard_D2_v2",
-            "allowedValues": [
-                "Standard_D2_v2",
-                "Standard_D3_v2",
-                "Standard_D4_v2",
-                "Standard_D5_v2"
-            ],
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager Virtual Machine size"
-            }
-        },
-        "dsmAdminName": {
-            "type": "string",
-            "defaultValue": "trend",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager application username (To login to Trend DSM from browser)"
-            }
-        },
-        "dsmAdminPassword": {
-            "type": "securestring",
-            "defaultValue": "",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager application password (To login to Trend DSM from browser)"
-            }
-        },
-        "dbName": {
-            "type": "string",
-            "defaultValue": "dsm",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager database name"
-            }
-        },
-        "dbAdminName": {
-            "type": "string",
-            "defaultValue": "trend",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager database admin user"
-            }
-        },
-        "dbAdminPassword": {
-            "type": "securestring",
-            "defaultValue": "",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager database admin password"
-            }
-        },
-        "publicIPDomainNameLabelTrendDSM": {
-            "type": "string",
-            "defaultValue": "publicdnstrenddsm",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager unique public DNS prefix"
-            }
-        },
-        "managerPortTrendDSM": {
-            "type": "string",
-            "defaultValue": "443",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager management port"
-            }
-        },
-        "heartbeatPortTrendDSM": {
-            "type": "string",
-            "defaultValue": "4120",
-            "metadata": {
-                "description": "TrendMicro Deep Security Manager heartbeat port"
-            }
-        },
-        "vmAdminUsernameOrchServer": {
-            "defaultValue": "trend",
-            "type": "string",
-            "metadata": {
-                "description": "Orchestrator Server Virtual Machine admin username"
-            }
-        },
-        "vmAdminPasswordOrchServer": {
-            "defaultValue": "",
-            "type": "securestring",
-            "metadata": {
-                "description": "Orchestrator Server Virtual Machine admin password"
-            }
-        },
-        "publicIPDomainNameLabelOrchServer": {
-            "defaultValue": "publicdnsorcserver",
-            "type": "string",
-            "metadata": {
-                "description": "Orchestrator Server unique public DNS prefix"
-            }
-        },
-        "vmAdminUsernameChefAutomate": {
-            "defaultValue": "trend",
-            "type": "string",
-            "metadata": {
-                "description": "Chef Automate Virtual Machine admin username"
-            }
-        },
-        "vmAdminPasswordChefAutomate": {
-            "defaultValue": "",
-            "type": "SecureString",
-            "metadata": {
-                "description": "Chef Automate Virtual Machine admin password"
-            }
-        },
-        "vmSizeChefAutomate": {
-            "type": "string",
-            "defaultValue": "Standard_DS2_v2",
-            "metadata": {
-                "description": "Chef Automate Virtual Machine size"
-            }
-        },
-        "chefAutoDns": {
-            "type": "string",
-            "defaultValue": "chefautomate",
-            "metadata": {
-                "description": "Chef Automate unique public DNS prefix"
-            }
-        },
-        "chefUserFirstName": {
-            "type": "string",
-            "defaultValue": "chef",
-            "metadata": {
-                "description": "Chef user first name"
-            }
-        },
-        "chefUserLastName": {
-            "type": "string",
-            "defaultValue": "user",
-            "metadata": {
-                "description": "Chef user last name"
-            }
-        },
-        "chefUserEmail": {
-            "type": "string",
-            "defaultValue": "chef@noone.com",
-            "metadata": {
-                "description": "Chef user email"
-            }
-        },
-        "chefOrgShortName": {
-            "type": "string",
-            "defaultValue": "ct",
-            "metadata": {
-                "description": "Chef org short name"
-            }
-        },
-        "vmAdminUsernameSplunkEnterprise": {
-            "defaultValue": "trend",
-            "type": "string",
-            "metadata": {
-                "description": "Splunk Enterprise Virtual Machine admin username"
-            }
-        },
-        "vmAdminPasswordSplunkEnterprise": {
-            "defaultValue": "",
-            "type": "SecureString",
-            "metadata": {
-                "description": "Splunk Enterprise Virtual Machine admin password"
-            }
-        },
-        "splunkAdminPassword": {
-            "defaultValue": "",
-            "type": "SecureString",
-            "metadata": {
-                "description": "Splunk Enterprise Virtual Machine admin password"
-            }
-        },
-        "vmSizeSplunk": {
-            "type": "string",
-            "defaultValue": "Standard_D4_v2",
-            "allowedValues": [
-                "Standard_D4_v2"
-            ],
-            "metadata": {
-                "description": "Splunk Enterprise Virtual Machine size"
-            }
-        },
-        "publicIPDomainNameLabelSplunkEnterprise": {
-            "type": "string",
-            "defaultValue": "publicdnssplunkenterprise",
-            "metadata": {
-                "description": "Splunk Enterprise unique public DNS prefix"
-            }
-        },
-        "adminUsernameChefWorkstation": {
-            "type": "string",
-            "defaultValue": "trend",
-            "metadata": {
-                "description": "Chef Workstation Virtual Machine admin username"
-            }
-        },
-        "adminPasswordChefWorkstation": {
-            "type": "securestring",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Chef Workstation Virtual Machine admin password"
-            }
-        },
-        "vmSizeChefWorkstation": {
-            "type": "string",
-            "defaultValue": "Standard_D2_v2",
-            "allowedValues": [
-                "Standard_D2_v2",
-                "Standard_D3_v2",
-                "Standard_D4_v2"
-            ],
-            "metadata": {
-                "description": "Chef Workstation Virtual Machine size"
-            }
-        },
-        "publicIPDomainNameLabelChefWorkstation": {
-            "type": "string",
-            "defaultValue": "publicdnschefws",
-            "metadata": {
-                "description": "Chef Workstation unique public DNS prefix"
-            }
-        },
-        "adminUsernameDSAgentWindows": {
-            "type": "string",
-            "defaultValue": "trend",
-            "metadata": {
-                "description": "Windows Deep Security Agent Virtual Machine admin username"
-            }
-        },
-        "adminPasswordDSAgentWindows": {
-            "type": "securestring",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Windows Deep Security Agent Virtual Machine admin password"
-            }
-        },
-        "publicIPDomainNameLabelDSAgentWindows": {
-            "type": "string",
-            "defaultValue": "dnsdsagentwindow",
-            "metadata": {
-                "description": "Windows Deep Security Agent unique public DNS prefix"
-            }
-        },
-        "windowsvmcount": {
-            "type": "int",
-            "defaultValue": 1,
-            "metadata": {
-                "description": "Count of Windows Deep Security Agents to deploy"
-            }
-        },
-        "adminUsernameDSAgent": {
-            "type": "string",
-            "defaultValue": "trend",
-            "metadata": {
-                "description": "Linux Deep Security Agent Virtual Machine admin username"
-            }
-        },
-        "adminPasswordDSAgent": {
-            "type": "securestring",
-            "defaultValue": "",
-            "metadata": {
-                "description": "Linux Deep Security Agent Virtual Machine admin password"
-            }
-        },
-        "publicIPDomainNameLabelDSAgent": {
-            "type": "string",
-            "defaultValue": "dnsdsagentlinux",
-            "metadata": {
-                "description": "Linux Deep Security Agent unique public DNS prefix"
-            }
-        },
-        "linuxvmcount": {
-            "type": "int",
-            "defaultValue": 1,
-            "metadata": {
-                "description": "Count of Linux Deep Security Agents to deploy"
-            }
-        },
-        "baseUrl": {
-            "type": "string",
-            "metadata": {
-                "description": "The base URL for dependent deployment files",
-                "artifactsBaseUrl": ""
-            },
-            "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/trend-chef-splunk-security"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "westus",
+      "allowedValues": [
+        "westus",
+        "eastus",
+        "centralus"
+      ],
+      "metadata": {
+        "description": "Location where all the resources deploy"
+      }
     },
-    "variables": {
-        "computeSettings": {
-            "computeApiVersion": "2016-04-30-preview",
-            "location": "[variables('location')]",
-            "chefAutoVmName": "chefautomate",
-            "imagePublisher": "chef-software",
-            "imageOffer": "chef-automate",
-            "imageSKU": "byol",
-            "imageVersion": "latest",
-            "storageAccountType": "Standard_LRS",
-            "firstname": "[parameters('chefUserFirstName')]",
-            "lastname": "[parameters('chefUserLastName')]",
-            "orguser": "[parameters('chefOrgShortName')]",
-            "mailid": "[parameters('chefUserEmail')]",
-            "adminUsername": "[parameters('vmAdminUsernameChefAutomate')]",
-            "adminPassword": "[parameters('vmAdminPasswordChefAutomate')]",
-            "virtualMachineSize": "[parameters('vmSizeChefAutomate')]",
-            "chefAutoNic": "[variables('chefAutoNic')]",
-            "rubyPath": "/opt/chef-marketplace/embedded/bin/ruby",
-            "chefAutoScriptUrl1": "[concat(parameters('baseUrl'), '/scripts/automate_setup.rb')]",
-            "chefAutoScriptUrl2": "[concat(parameters('baseUrl'),'/scripts/chefautomate_setup.sh')]",
-            "automateLicenseUri": ""
-        },
-        "networkSettings": {
-            "networkApiVersion": "2015-06-15",
-            "location": "[variables('location')]",
-            "chefAutoPip": "chefauto-pip",
-            "chefAutoNsg": "chefauto-nsg",
-            "chefAutoNic": "[variables('chefAutoNic')]",
-            "publicIpAddressType": "Dynamic",
-            "chefAutoDns": "[concat(parameters('chefAutoDns'),substring(variables('prefix') ,0 ,5))]"
-        },
-        "prefix": "[uniqueString(resourceGroup().id)]",
-        "deploymentApiVersion": "2015-01-01",
-        "chefAutoNic": "chefauto-nic",
-        "location": "[parameters('location')]",
-        "vmNameTrendDSM": "trendMicroDSM",
-        "vmNameSplunkEnterprise": "splunkEnterprise",
-        "vmNameChefWorkstation": "chefWS",
-        "vmNameDSAWindows": "dsawindows",
-        "vmNameDSAgent": "dsalinux",
-        "vmNameOrchServer": "orchestratorServer",
-        "nicNameTrendDSM": "[concat(variables('vmNameTrendDSM'),'-nic')]",
-        "networkInterfaceNameSplunkEnterprise": "[concat(variables('vmNameSplunkEnterprise'),'-nic')]",
-        "networkInterfaceNameOrchServer": "[concat(variables('vmNameOrchServer'),'-nic')]",
-        "securityGroupNameTrendDSM": "[concat(variables('nicNameTrendDSM'),'-nsg')]",
-        "networkSecurityGroupNameSplunkEnterprise": "[concat(variables('networkInterfaceNameSplunkEnterprise'),'-nsg')]",
-        "networkSecurityGroupNameOrchServer": "[concat(variables('networkInterfaceNameOrchServer'),'-nsg')]",
-        "virtualNetworkName": "trendMicroP2PVnet",
-        "vnetAddressPrefix": "10.7.0.0/16",
-        "subnet1Name": "trendMicroDSMsubnet",
-        "subnet1Prefix": "10.7.0.0/24",
-        "subnet2Name": "chefAutomateSubnet",
-        "subnet2Prefix": "10.7.1.0/24",
-        "subnet3Name": "splunkEnterprisesubnet",
-        "subnet3Prefix": "10.7.2.0/24",
-        "subnet3StartAddress": "10.7.2.5",
-        "subnet4Name": "vmsubnet",
-        "subnet4Prefix": "10.7.3.0/24",
-        "publicIPAddressType": "Dynamic",
-        "publicIPAddressNameTrendDSM": "publicIPTrendDSM",
-        "publicIPAddressNameSplunkEnterprise": "publicIPSplunkEnterprise",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-        "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
-        "subnet2Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet2Name'))]",
-        "subnet3Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet3Name'))]",
-        "subnet4Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet4Name'))]",
-        "storageAccountName": "[tolower(concat(trim(substring(concat(variables('vmNameTrendDSM'),'       '),0,6)),uniquestring(resourceGroup().id)))]",
-        "storageAccountType": "Standard_LRS",
-        "vmStorageAccountContainerName": "vhds",
-        "newsqlServerName": "[tolower(concat(variables('vmNameTrendDSM'),uniquestring(resourceGroup().id),'-sql'))]",
-        "storage-api-version": "2015-06-15",
-        "deployment-api-version": "2015-11-01",
-        "deployment-api-version2": "2015-01-01",
-        "network-api-version": "2015-06-15",
-        "compute-api-version": "2015-06-15",
-        "publisherTrendDSM": "trendmicro",
-        "databaseOption": "new",
-        "offerChoosedTrendDSM": "[variables(concat('offer', parameters('vmSizeTrendDSM')))]",
-        "offerStandard_D2_v2": {
-            "vmSize": "Standard_D2_v2",
-            "vmSku": "dxxn25d2v2",
-            "product": "deep-security-vm"
-        },
-        "offerStandard_D3_v2": {
-            "vmSize": "Standard_D3_v2",
-            "vmSku": "dxxn50d3v2",
-            "product": "deep-security-vm"
-        },
-        "offerStandard_D4_v2": {
-            "vmSize": "Standard_D4_v2",
-            "vmSku": "dxxn100d4v2",
-            "product": "deep-security-vm"
-        },
-        "offerStandard_D5_v2": {
-            "vmSize": "Standard_D5_v2",
-            "vmSku": "dxxn200d5v2",
-            "product": "deep-security-vm"
-        },
-        "offerBYOL": {
-            "vmSize": "[parameters('vmSizeTrendDSM')]",
-            "vmSku": "dxxnbyol",
-            "product": "deep-security-vm-byol"
-        },
-        "offerStandard_DS2_v2": {
-            "vmSize": "Standard_DS2_v2",
-            "vmSku": "byol",
-            "product": "chef-automate"
-        },
-        "availabilitySetSettings": {
-            "name": "[concat(variables('virtualNetworkName'), '-aset')]",
-            "count": "[variables('tshirtSizeSplunk').availabilitySetCount]",
-            "fdCount": 3,
-            "udCount": 5
-        },
-        "sshFrom": "0.0.0.0/0",
-        "forwardedDataFrom": "0.0.0.0/0",
-        "deploymentSizeSplunk": "Standalone",
-        "emptyTemplateUrl": "[concat(parameters('baseUrl'),'/nested/empty-resources.json')]",
-        "tshirtSizeSplunk": "[variables(concat('tshirtSizeSplunk', variables('deploymentSizeSplunk')))]",
-        "tshirtSizeSplunkStandalone": {
-            "vmSize": "[parameters('vmSizeSplunk')]",
-            "vmSizeClusterMaster": "Standard_D3",
-            "diskSize": 1023,
-            "standaloneTemplateUrl": "[concat(parameters('baseUrl'), '/nested/trendp2p-splunkenterprise.json')]",
-            "clusterMasterTemplateUrl": "[variables('emptyTemplateUrl')]",
-            "clusterSearchheadTemplateUrl": "[variables('emptyTemplateUrl')]",
-            "clusterPeersTemplateUrl": "[variables('emptyTemplateUrl')]",
-            "clusterPeersCount": 0,
-            "availabilitySetCount": 1,
-            "publicIPAddress": {
-                "name": "[variables('publicIPAddressNameSplunkEnterprise')]",
-                "domainNamePrefix": "[concat(parameters('publicIPDomainNameLabelSplunkEnterprise'),variables('uniqueString'))]",
-                "count": 1,
-                "map": [
-                    ""
-                ]
-            }
-        },
-        "osSettingsSplunk": {
-            "imageReference": {
-                "publisher": "splunk",
-                "offer": "splunk-enterprise-base-image",
-                "sku": "splunk-on-ubuntu-14-04-lts",
-                "version": "1.0.8"
-            },
-            "scripts": [
-                "[concat(parameters('baseUrl'), '/scripts/', 'vm-disk-utils-0.1.sh')]",
-                "[concat(parameters('baseUrl'), '/scripts/', 'node-setup.sh')]",
-                "[concat(parameters('baseUrl'), '/scripts/', 'splunkscript.sh')]"
-            ]
-        },
-        "networkSettingsSplunk": {
-            "virtualNetworkName": "[variables('virtualNetworkName')]",
-            "subnet": {
-                "sh": {
-                    "name": "[variables('subnet1Name')]",
-                    "prefix": "[variables('subnet1Prefix')]",
-                    "vnet": "[variables('virtualNetworkName')]"
-                },
-                "idx": {
-                    "name": "[variables('subnet2Name')]",
-                    "prefix": "[variables('subnet2Prefix')]",
-                    "vnet": "[variables('virtualNetworkName')]"
-                }
-            },
-            "statics": {
-                "standaloneIp": "[variables('subnet3StartAddress')]",
-                "clusterSearchheadIp": "[variables('subnet3StartAddress')]",
-                "clusterMasterIp": "[variables('subnet3StartAddress')]"
-            }
-        },
-        "linuxConfigurationChoosenTrendDSM": "[variables(concat('linuxConfiguration', variables('vmAuthTypeTrendDSM')))]",
-        "linuxConfigurationpassword": {
-            "disablePasswordAuthentication": "false"
-        },
-        "linuxConfigurationsshPublicKey": {
-            "disablePasswordAuthentication": "true",
-            "ssh": {
-                "publicKeys": [
-                    {
-                        "path": "[concat('/home/',parameters('vmAdminNameTrendDSM'),'/.ssh/authorized_keys')]",
-                        "keyData": "[variables('vmAdminSshPublicKeyTrendDSM')]"
-                    }
-                ]
-            }
-        },
-        "imagePublisherWindows": "MicrosoftWindowsServer",
-        "imageOfferWindows": "WindowsServer",
-        "imagePublisherLinux": "Canonical",
-        "imageOfferLinux": "UbuntuServer",
-        "TenantIdentifier": "NA",
-        "TenantActivationPassword": "NA",
-        "tagvalues": {
-            "program": "p2p",
-            "project": "TrendMicro"
-        },
-        "vmAuthTypeTrendDSM": "password",
-        "vmAdminSshPublicKeyTrendDSM": "",
-        "existingSQLServerName": "",
-        "ManagerAddress": "[concat(parameters('publicIPDomainNameLabelTrendDSM'),variables('uniqueString'),'.',parameters('location'),'.cloudapp.azure.com')]",
-        "udpPort": "5005",
-        "chefprefix": "chef",
-        "vmSizeDSAWindows": "Standard_D1",
-        "windowsOSVersion": "2012-R2-Datacenter",
-        "vmSizeDSAgent": "Standard_D1",
-        "ubuntuOSVersion": "14.04.2-LTS",
-        "uniqueString": "[uniquestring(resourceGroup().id)]",
-        "keyName": "validatorkey",
-        "resourcegroupName": "[resourceGroup().name]",
-        "kmServerUrl": "[concat(parameters('publicIPDomainNameLabelOrchServer'),variables('uniqueString'),'.',variables('location'),'.cloudapp.azure.com')]",
-        "chef_node_name": "chefnodedsagent",
-        "chef_automate_url": "[concat('https://',variables('networkSettings').chefAutoDns,'.',parameters('location'),'.cloudapp.azure.com/organizations/',parameters('chefOrgShortName'))]",
-        "validation_client_name": "[concat(parameters('chefOrgShortName'),'-validator')]",
-        "validation_key_format": "base64encoded",
-        "runlist": "recipe[trendmicro]",
-        "vmSizeOrcServer": "Standard_D1",
-        "orcServerubuntuOSVersion": "14.04.2-LTS",
-        "installOrchTemplateurl": "[concat(parameters('baseUrl'),'/nested/orchestrator-server-setup-trend.json')]",
-        "chefnodeCustomScripturl": "[concat(parameters('baseUrl'),'/scripts/p2pchefnodebootstrap.sh')]",
-        "chefAutomateURL": "[concat(parameters('baseUrl'),'/nested/trendp2p-chefautomate.json')]",
-        "trendmicroTags": {
-            "type": "object",
-            "provider": "F0253A01-8156-4D41-BD91-E182158D4972"
-        },
-        "chefSoftwareTags": {
-            "type": "object",
-            "provider": "33194f91-eb5f-4110-827a-e95f640a9e46"
-        },
-        "splunkTags": {
-            "type": "object",
-            "provider": "7d69ff10-1a05-4353-b69d-0e87c3382e96"
-        },
-        "quickstartTags": {
-            "type": "object",
-            "name": "trend-chef-splunk-security"
-        }
+    "vmAdminNameTrendDSM": {
+      "type": "string",
+      "defaultValue": "trend",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager Virtual Machine admin username"
+      }
     },
-    "resources": [
-        {
-            "comments": "Gene",
-            "name": "vnetstorage",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deployment-api-version2')]",
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-vnetstorage.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "storageAccountName": {
-                        "value": "[variables('storageAccountName')]"
-                    },
-                    "storage-api-version": {
-                        "value": "[variables('storage-api-version')]"
-                    },
-                    "storageAccountType": {
-                        "value": "[variables('storageAccountType')]"
-                    },
-                    "location": {
-                        "value": "[variables('location')]"
-                    },
-                    "network-api-version": {
-                        "value": "[variables('network-api-version')]"
-                    },
-                    "virtualNetworkName": {
-                        "value": "[variables('virtualNetworkName')]"
-                    },
-                    "vnetAddressPrefix": {
-                        "value": "[variables('vnetAddressPrefix')]"
-                    },
-                    "subnet1Name": {
-                        "value": "[variables('subnet1Name')]"
-                    },
-                    "subnet1Prefix": {
-                        "value": "[variables('subnet1Prefix')]"
-                    },
-                    "subnet2Name": {
-                        "value": "[variables('subnet2Name')]"
-                    },
-                    "subnet2Prefix": {
-                        "value": "[variables('subnet2Prefix')]"
-                    },
-                    "subnet3Name": {
-                        "value": "[variables('subnet3Name')]"
-                    },
-                    "subnet3Prefix": {
-                        "value": "[variables('subnet3Prefix')]"
-                    },
-                    "subnet4Name": {
-                        "value": "[variables('subnet4Name')]"
-                    },
-                    "subnet4Prefix": {
-                        "value": "[variables('subnet4Prefix')]"
-                    },
-                    "tagvalues": {
-                        "value": "[variables('tagvalues')]"
-                    },
-                    "availabilitySetSettings": {
-                        "value": "[variables('availabilitySetSettings')]"
-                    },
-                    "trendmicroTags": {
-                        "value": "[variables('trendmicroTags')]"
-                    },
-                    "chefSoftwareTags": {
-                        "value": "[variables('chefSoftwareTags')]"
-                    },
-                    "splunkTags": {
-                        "value": "[variables('splunkTags')]"
-                    },
-                    "quickstartTags": {
-                        "value": "[variables('quickstartTags')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "trendmicrodsm",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deployment-api-version2')]",
-            "dependsOn": [
-                "['Microsoft.Resources/deployments/vnetstorage']"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-trenddsm.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "storageAccountName": {
-                        "value": "[variables('storageAccountName')]"
-                    },
-                    "vmStorageAccountContainerName": {
-                        "value": "[variables('vmStorageAccountContainerName')]"
-                    },
-                    "location": {
-                        "value": "[variables('location')]"
-                    },
-                    "network-api-version": {
-                        "value": "[variables('network-api-version')]"
-                    },
-                    "compute-api-version": {
-                        "value": "[variables('compute-api-version')]"
-                    },
-                    "tagvalues": {
-                        "value": "[variables('tagvalues')]"
-                    },
-                    "publicIPDomainNameLabelTrendDSM": {
-                        "value": "[concat(parameters('publicIPDomainNameLabelTrendDSM'),variables('uniqueString'))]"
-                    },
-                    "publicIPAddressType": {
-                        "value": "[variables('publicIPAddressType')]"
-                    },
-                    "publicIPAddressNameTrendDSM": {
-                        "value": "[variables('publicIPAddressNameTrendDSM')]"
-                    },
-                    "nicNameTrendDSM": {
-                        "value": "[variables('nicNameTrendDSM')]"
-                    },
-                    "virtualNetworkName": {
-                        "value": "[variables('virtualNetworkName')]"
-                    },
-                    "subnet1Ref": {
-                        "value": "[variables('subnet1Ref')]"
-                    },
-                    "securityGroupNameTrendDSM": {
-                        "value": "[variables('securityGroupNameTrendDSM')]"
-                    },
-                    "managerPortTrendDSM": {
-                        "value": "[parameters('managerPortTrendDSM')]"
-                    },
-                    "heartbeatPortTrendDSM": {
-                        "value": "[parameters('heartbeatPortTrendDSM')]"
-                    },
-                    "vmNameTrendDSM": {
-                        "value": "[variables('vmNameTrendDSM')]"
-                    },
-                    "publisherTrendDSM": {
-                        "value": "[variables('publisherTrendDSM')]"
-                    },
-                    "offerChoosedTrendDSM": {
-                        "value": "[variables('offerChoosedTrendDSM')]"
-                    },
-                    "vmAdminNameTrendDSM": {
-                        "value": "[parameters('vmAdminNameTrendDSM')]"
-                    },
-                    "vmAdminPasswordTrendDSM": {
-                        "value": "[parameters('vmAdminPasswordTrendDSM')]"
-                    },
-                    "linuxConfigurationChoosenTrendDSM": {
-                        "value": "[variables('linuxConfigurationChoosenTrendDSM')]"
-                    },
-                    "deployment-api-version": {
-                        "value": "[variables('deployment-api-version')]"
-                    },
-                    "baseUrl": {
-                        "value": "[parameters('baseUrl')]"
-                    },
-                    "databaseOption": {
-                        "value": "[variables('databaseOption')]"
-                    },
-                    "newsqlServerName": {
-                        "value": "[variables('newsqlServerName')]"
-                    },
-                    "existingSQLServerName": {
-                        "value": "[variables('existingSQLServerName')]"
-                    },
-                    "dbAdminName": {
-                        "value": "[parameters('dbAdminName')]"
-                    },
-                    "dbAdminPassword": {
-                        "value": "[parameters('dbAdminPassword')]"
-                    },
-                    "dbName": {
-                        "value": "[parameters('dbName')]"
-                    },
-                    "dsmAdminName": {
-                        "value": "[parameters('dsmAdminName')]"
-                    },
-                    "dsmAdminPassword": {
-                        "value": "[parameters('dsmAdminPassword')]"
-                    },
-                    "trendmicroTags": {
-                        "value": "[variables('trendmicroTags')]"
-                    },
-                    "chefSoftwareTags": {
-                        "value": "[variables('chefSoftwareTags')]"
-                    },
-                    "splunkTags": {
-                        "value": "[variables('splunkTags')]"
-                    },
-                    "quickstartTags": {
-                        "value": "[variables('quickstartTags')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "orchestrator",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deployment-api-version2')]",
-            "dependsOn": [
-                "['Microsoft.Resources/deployments/vnetstorage']"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-orchestrator.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "storageAccountName": {
-                        "value": "[variables('storageAccountName')]"
-                    },
-                    "location": {
-                        "value": "[variables('location')]"
-                    },
-                    "network-api-version": {
-                        "value": "[variables('network-api-version')]"
-                    },
-                    "compute-api-version": {
-                        "value": "[variables('compute-api-version')]"
-                    },
-                    "deployment-api-version2": {
-                        "value": "[variables('deployment-api-version2')]"
-                    },
-                    "tagvalues": {
-                        "value": "[variables('tagvalues')]"
-                    },
-                    "publicIPDomainNameLabelOrchServer": {
-                        "value": "[concat(parameters('publicIPDomainNameLabelOrchServer'),variables('uniqueString'))]"
-                    },
-                    "vmNameOrchServer": {
-                        "value": "[variables('vmNameOrchServer')]"
-                    },
-                    "networkInterfaceNameOrchServer": {
-                        "value": "[variables('networkInterfaceNameOrchServer')]"
-                    },
-                    "networkSecurityGroupNameOrchServer": {
-                        "value": "[variables('networkSecurityGroupNameOrchServer')]"
-                    },
-                    "vmAdminUsernameOrchServer": {
-                        "value": "[parameters('vmAdminUsernameOrchServer')]"
-                    },
-                    "vmAdminPasswordOrchServer": {
-                        "value": "[parameters('vmAdminPasswordOrchServer')]"
-                    },
-                    "vmStorageAccountContainerName": {
-                        "value": "[variables('vmStorageAccountContainerName')]"
-                    },
-                    "imagePublisherLinux": {
-                        "value": "[variables('imagePublisherLinux')]"
-                    },
-                    "imageOfferLinux": {
-                        "value": "[variables('imageOfferLinux')]"
-                    },
-                    "orcServerubuntuOSVersion": {
-                        "value": "[variables('orcServerubuntuOSVersion')]"
-                    },
-                    "vmSizeOrcServer": {
-                        "value": "[variables('vmSizeOrcServer')]"
-                    },
-                    "subnet2Ref": {
-                        "value": "[variables('subnet2Ref')]"
-                    },
-                    "installOrchTemplateurl": {
-                        "value": "[variables('installOrchTemplateurl')]"
-                    },
-                    "trendmicroTags": {
-                        "value": "[variables('trendmicroTags')]"
-                    },
-                    "chefSoftwareTags": {
-                        "value": "[variables('chefSoftwareTags')]"
-                    },
-                    "splunkTags": {
-                        "value": "[variables('splunkTags')]"
-                    },
-                    "quickstartTags": {
-                        "value": "[variables('quickstartTags')]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "chefAutomate",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "[variables('deploymentApiVersion')]",
-            "dependsOn": [
-                "['Microsoft.Resources/deployments/vnetstorage']",
-                "['Microsoft.Resources/deployments/trendmicrodsm']",
-                "['Microsoft.Resources/deployments/orchestrator']"
-            ],
-            "properties": {
-                "mode": "incremental",
-                "templateLink": {
-                    "uri": "[variables('chefAutomateURL')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "computeSettings": {
-                        "value": "[variables('computeSettings')]"
-                    },
-                    "networkSettings": {
-                        "value": "[variables('networkSettings')]"
-                    },
-                    "subnet2Ref": {
-                        "value": "[variables('subnet2Ref')]"
-                    },
-                    "publicIPDomainNameLabelOrchServer": {
-                        "value": "[concat(parameters('publicIPDomainNameLabelOrchServer'),variables('uniqueString'))]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('deployment-api-version2')]",
-            "type": "Microsoft.Resources/deployments",
-            "name": "splunkstandalonedeployment",
-            "dependsOn": [
-                "['Microsoft.Resources/deployments/vnetstorage']"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('tshirtSizeSplunk').standaloneTemplateUrl]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "location": {
-                        "value": "[variables('location')]"
-                    },
-                    "network-api-version": {
-                        "value": "[variables('network-api-version')]"
-                    },
-                    "compute-api-version": {
-                        "value": "[variables('compute-api-version')]"
-                    },
-                    "vmNameSplunkEnterprise": {
-                        "value": "[variables('vmNameSplunkEnterprise')]"
-                    },
-                    "vmAdminUsernameSplunkEnterprise": {
-                        "value": "[parameters('vmAdminUsernameSplunkEnterprise')]"
-                    },
-                    "vmAdminPasswordSplunkEnterprise": {
-                        "value": "[parameters('vmAdminPasswordSplunkEnterprise')]"
-                    },
-                    "splunkAdminPassword": {
-                        "value": "[parameters('splunkAdminPassword')]"
-                    },
-                    "publicIPAddressSettingsSplunk": {
-                        "value": "[variables('tshirtSizeSplunk').publicIPAddress]"
-                    },
-                    "networkSecurityGroupNameSplunkEnterprise": {
-                        "value": "[variables('networkSecurityGroupNameSplunkEnterprise')]"
-                    },
-                    "networkInterfaceNameSplunkEnterprise": {
-                        "value": "[variables('networkInterfaceNameSplunkEnterprise')]"
-                    },
-                    "machineSettings": {
-                        "value": {
-                            "vmSize": "[variables('tshirtSizeSplunk').vmSize]",
-                            "diskSize": "[variables('tshirtSizeSplunk').diskSize]",
-                            "staticIp": "[variables('networkSettingsSplunk').statics.standaloneIp]",
-                            "clusterMasterIp": "NA",
-                            "publicIPName": "[concat(variables('tshirtSizeSplunk').publicIPAddress.name, '')]",
-                            "sshFrom": "[concat(variables('sshFrom'), '')]",
-                            "forwardedDataFrom": "[concat(variables('forwardedDataFrom'), '')]",
-                            "availabilitySet": "[concat(variables('availabilitySetSettings').name, '0')]"
-                        }
-                    },
-                    "subnet3Ref": {
-                        "value": "[variables('subnet3Ref')]"
-                    },
-                    "osSettingsSplunk": {
-                        "value": "[variables('osSettingsSplunk')]"
-                    },
-                    "tagvalues": {
-                        "value": "[variables('tagvalues')]"
-                    },
-                    "storageAccountName": {
-                        "value": "[variables('storageAccountName')]"
-                    },
-                    "udpPort": {
-                        "value": "[variables('udpPort')]"
-                    },
-                    "trendmicroTags": {
-                        "value": "[variables('trendmicroTags')]"
-                    },
-                    "chefSoftwareTags": {
-                        "value": "[variables('chefSoftwareTags')]"
-                    },
-                    "splunkTags": {
-                        "value": "[variables('splunkTags')]"
-                    },
-                    "quickstartTags": {
-                        "value": "[variables('quickstartTags')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('deployment-api-version2')]",
-            "type": "Microsoft.Resources/deployments",
-            "name": "dsagents",
-            "dependsOn": [
-                "['Microsoft.Resources/deployments/vnetstorage']",
-                "['Microsoft.Resources/deployments/trendmicrodsm']",
-                "['Microsoft.Resources/deployments/chefAutomate']"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-dsagents.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "location": {
-                        "value": "[variables('location')]"
-                    },
-                    "network-api-version": {
-                        "value": "[variables('network-api-version')]"
-                    },
-                    "compute-api-version": {
-                        "value": "[variables('compute-api-version')]"
-                    },
-                    "vmNameDSAWindows": {
-                        "value": "[variables('vmNameDSAWindows')]"
-                    },
-                    "vmSizeDSAWindows": {
-                        "value": "[variables('vmSizeDSAWindows')]"
-                    },
-                    "adminUsernameDSAgentWindows": {
-                        "value": "[parameters('adminUsernameDSAgentWindows')]"
-                    },
-                    "adminPasswordDSAgentWindows": {
-                        "value": "[parameters('adminPasswordDSAgentWindows')]"
-                    },
-                    "publicIPDomainNameLabelDSAgentWindows": {
-                        "value": "[concat(parameters('publicIPDomainNameLabelDSAgentWindows'),variables('uniqueString'))]"
-                    },
-                    "windowsOSVersion": {
-                        "value": "[variables('windowsOSVersion')]"
-                    },
-                    "windowsvmcount": {
-                        "value": "[parameters('windowsvmcount')]"
-                    },
-                    "vmNameDSAgent": {
-                        "value": "[variables('vmNameDSAgent')]"
-                    },
-                    "vmSizeDSAgent": {
-                        "value": "[variables('vmSizeDSAgent')]"
-                    },
-                    "adminUsernameDSAgent": {
-                        "value": "[parameters('adminUsernameDSAgent')]"
-                    },
-                    "adminPasswordDSAgent": {
-                        "value": "[parameters('adminPasswordDSAgent')]"
-                    },
-                    "publicIPDomainNameLabelDSAgent": {
-                        "value": "[concat(parameters('publicIPDomainNameLabelDSAgent'),variables('uniqueString'))]"
-                    },
-                    "ubuntuOSVersion": {
-                        "value": "[variables('ubuntuOSVersion')]"
-                    },
-                    "linuxvmcount": {
-                        "value": "[parameters('linuxvmcount')]"
-                    },
-                    "ManagerAddress": {
-                        "value": "[variables('ManagerAddress')]"
-                    },
-                    "subnet4Ref": {
-                        "value": "[variables('subnet4Ref')]"
-                    },
-                    "imagePublisherWindows": {
-                        "value": "[variables('imagePublisherWindows')]"
-                    },
-                    "imageOfferWindows": {
-                        "value": "[variables('imageOfferWindows')]"
-                    },
-                    "imagePublisherLinux": {
-                        "value": "[variables('imagePublisherLinux')]"
-                    },
-                    "imageOfferLinux": {
-                        "value": "[variables('imageOfferLinux')]"
-                    },
-                    "storageAccountName": {
-                        "value": "[variables('storageAccountName')]"
-                    },
-                    "vmStorageAccountContainerName": {
-                        "value": "[variables('vmStorageAccountContainerName')]"
-                    },
-                    "ActivationPort": {
-                        "value": "[parameters('heartbeatPortTrendDSM')]"
-                    },
-                    "TenantIdentifier": {
-                        "value": "[variables('TenantIdentifier')]"
-                    },
-                    "TenantActivationPassword": {
-                        "value": "[variables('TenantActivationPassword')]"
-                    },
-                    "tagvalues": {
-                        "value": "[variables('tagvalues')]"
-                    },
-                    "trendmicroTags": {
-                        "value": "[variables('trendmicroTags')]"
-                    },
-                    "chefSoftwareTags": {
-                        "value": "[variables('chefSoftwareTags')]"
-                    },
-                    "splunkTags": {
-                        "value": "[variables('splunkTags')]"
-                    },
-                    "quickstartTags": {
-                        "value": "[variables('quickstartTags')]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "[variables('deployment-api-version2')]",
-            "type": "Microsoft.Resources/deployments",
-            "name": "chefnodes",
-            "dependsOn": [
-                "['Microsoft.Resources/deployments/vnetstorage']",
-                "['Microsoft.Resources/deployments/trendmicrodsm']",
-                "['Microsoft.Resources/deployments/chefAutomate']"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-chefnodes.json')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "location": {
-                        "value": "[variables('location')]"
-                    },
-                    "network-api-version": {
-                        "value": "[variables('network-api-version')]"
-                    },
-                    "compute-api-version": {
-                        "value": "[variables('compute-api-version')]"
-                    },
-                    "deployment-api-version2": {
-                        "value": "[variables('deployment-api-version2')]"
-                    },
-                    "vmNameChefWorkstation": {
-                        "value": "[variables('vmNameChefWorkstation')]"
-                    },
-                    "vmSizeChefWorkstation": {
-                        "value": "[parameters('vmSizeChefWorkstation')]"
-                    },
-                    "adminUsernameChefWorkstation": {
-                        "value": "[parameters('adminUsernameChefWorkstation')]"
-                    },
-                    "adminPasswordChefWorkstation": {
-                        "value": "[parameters('adminPasswordChefWorkstation')]"
-                    },
-                    "publicIPDomainNameLabelChefWorkstation": {
-                        "value": "[concat(parameters('publicIPDomainNameLabelChefWorkstation'),variables('uniqueString'))]"
-                    },
-                    "vmNameDSAWindows": {
-                        "value": "[variables('vmNameDSAWindows')]"
-                    },
-                    "vmSizeDSAWindows": {
-                        "value": "[variables('vmSizeDSAWindows')]"
-                    },
-                    "adminUsernameDSAgentWindows": {
-                        "value": "[parameters('adminUsernameDSAgentWindows')]"
-                    },
-                    "adminPasswordDSAgentWindows": {
-                        "value": "[parameters('adminPasswordDSAgentWindows')]"
-                    },
-                    "publicIPDomainNameLabelDSAgentWindows": {
-                        "value": "[concat(parameters('publicIPDomainNameLabelDSAgentWindows'),variables('uniqueString'))]"
-                    },
-                    "windowsOSVersion": {
-                        "value": "[variables('windowsOSVersion')]"
-                    },
-                    "windowsvmcount": {
-                        "value": "[parameters('windowsvmcount')]"
-                    },
-                    "vmNameDSAgent": {
-                        "value": "[variables('vmNameDSAgent')]"
-                    },
-                    "vmSizeDSAgent": {
-                        "value": "[variables('vmSizeDSAgent')]"
-                    },
-                    "adminUsernameDSAgent": {
-                        "value": "[parameters('adminUsernameDSAgent')]"
-                    },
-                    "adminPasswordDSAgent": {
-                        "value": "[parameters('adminPasswordDSAgent')]"
-                    },
-                    "publicIPDomainNameLabelDSAgent": {
-                        "value": "[concat(parameters('publicIPDomainNameLabelDSAgent'),variables('uniqueString'))]"
-                    },
-                    "ubuntuOSVersion": {
-                        "value": "[variables('ubuntuOSVersion')]"
-                    },
-                    "linuxvmcount": {
-                        "value": "[parameters('linuxvmcount')]"
-                    },
-                    "ManagerAddress": {
-                        "value": "[variables('ManagerAddress')]"
-                    },
-                    "subnet4Ref": {
-                        "value": "[variables('subnet4Ref')]"
-                    },
-                    "imagePublisherWindows": {
-                        "value": "[variables('imagePublisherWindows')]"
-                    },
-                    "imageOfferWindows": {
-                        "value": "[variables('imageOfferWindows')]"
-                    },
-                    "imagePublisherLinux": {
-                        "value": "[variables('imagePublisherLinux')]"
-                    },
-                    "imageOfferLinux": {
-                        "value": "[variables('imageOfferLinux')]"
-                    },
-                    "storageAccountName": {
-                        "value": "[variables('storageAccountName')]"
-                    },
-                    "vmStorageAccountContainerName": {
-                        "value": "[variables('vmStorageAccountContainerName')]"
-                    },
-                    "ActivationPort": {
-                        "value": "[parameters('heartbeatPortTrendDSM')]"
-                    },
-                    "TenantIdentifier": {
-                        "value": "[variables('TenantIdentifier')]"
-                    },
-                    "TenantActivationPassword": {
-                        "value": "[variables('TenantActivationPassword')]"
-                    },
-                    "tagvalues": {
-                        "value": "[variables('tagvalues')]"
-                    },
-                    "chefprefix": {
-                        "value": "[variables('chefprefix')]"
-                    },
-                    "keyName": {
-                        "value": "[variables('keyName')]"
-                    },
-                    "kmServerUrl": {
-                        "value": "[variables('kmServerUrl')]"
-                    },
-                    "chef_node_name": {
-                        "value": "[variables('chef_node_name')]"
-                    },
-                    "chef_automate_url": {
-                        "value": "[variables('chef_automate_url')]"
-                    },
-                    "validation_client_name": {
-                        "value": "[variables('validation_client_name')]"
-                    },
-                    "validation_key_format": {
-                        "value": "[variables('validation_key_format')]"
-                    },
-                    "runlist": {
-                        "value": "[variables('runlist')]"
-                    },
-                    "resourcegroupName": {
-                        "value": "[variables('resourcegroupName')]"
-                    },
-                    "chefnodeCustomScripturl": {
-                        "value": "[variables('chefnodeCustomScripturl')]"
-                    },
-                    "trendmicroTags": {
-                        "value": "[variables('trendmicroTags')]"
-                    },
-                    "chefSoftwareTags": {
-                        "value": "[variables('chefSoftwareTags')]"
-                    },
-                    "splunkTags": {
-                        "value": "[variables('splunkTags')]"
-                    },
-                    "quickstartTags": {
-                        "value": "[variables('quickstartTags')]"
-                    },
-                    "chefAutoDNS": {
-                        "value": "[variables('networkSettings').chefAutoDns]"
-                    },
-                    "computeSettings": {
-                        "value": "[variables('computeSettings')]"
-                    }
-                }
-            }
-        }
-    ],
-    "outputs": {
-        "TrendAdminUserName":{
-            "type": "string",
-            "value": "[parameters('vmAdminNameTrendDSM')]"
-        },
-        "TrendAdminPassword":{
-            "type": "string",
-            "value": "[parameters('vmAdminPasswordTrendDSM')]"
-        },
-        "splunkAdminUserName":{
-            "type": "string",
-            "value": "admin"
-        },
-        "splunkAdminPassword":{
-            "type": "string",
-            "value":"[parameters('splunkAdminPassword')]"
-        },
-        "chefAutomateAdminUserName":{
-            "type": "string",
-            "value": "[parameters('vmAdminUsernameChefAutomate')]"
-        },
-        "chefAutomateAdminPassword":{
-            "type": "string",
-            "value": "[parameters('vmAdminPasswordChefAutomate')]"
-        },
-        "TrendMicro DSM URI": {
-            "type": "string",
-            "value": "[reference('trendmicrodsm').outputs.trendmicrodsmUri.value]"
-        },
-        "Chef Automate URI": {
-            "type": "string",
-            "value": "[concat('https://',reference('chefAutomate').outputs.chefAutomatefqdn.value)]"
-        },
-        "Splunk Server URI": {
-            "type": "string",
-            "value": "[reference('splunkstandalonedeployment').outputs.splunkenterpriseUri.value]"
-        }
+    "vmAdminPasswordTrendDSM": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager Virtual Machine admin password"
+      }
+    },
+    "vmSizeTrendDSM": {
+      "type": "string",
+      "defaultValue": "Standard_D2_v2",
+      "allowedValues": [
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2",
+        "Standard_D5_v2"
+      ],
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager Virtual Machine size"
+      }
+    },
+    "dsmAdminName": {
+      "type": "string",
+      "defaultValue": "trend",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager application username (To login to Trend DSM from browser)"
+      }
+    },
+    "dsmAdminPassword": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager application password (To login to Trend DSM from browser)"
+      }
+    },
+    "dbName": {
+      "type": "string",
+      "defaultValue": "dsm",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager database name"
+      }
+    },
+    "dbAdminName": {
+      "type": "string",
+      "defaultValue": "trend",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager database admin user"
+      }
+    },
+    "dbAdminPassword": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager database admin password"
+      }
+    },
+    "publicIPDomainNameLabelTrendDSM": {
+      "type": "string",
+      "defaultValue": "publicdnstrenddsm",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager unique public DNS prefix"
+      }
+    },
+    "managerPortTrendDSM": {
+      "type": "string",
+      "defaultValue": "443",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager management port"
+      }
+    },
+    "heartbeatPortTrendDSM": {
+      "type": "string",
+      "defaultValue": "4120",
+      "metadata": {
+        "description": "TrendMicro Deep Security Manager heartbeat port"
+      }
+    },
+    "vmAdminUsernameOrchServer": {
+      "defaultValue": "trend",
+      "type": "string",
+      "metadata": {
+        "description": "Orchestrator Server Virtual Machine admin username"
+      }
+    },
+    "vmAdminPasswordOrchServer": {
+      "defaultValue": "",
+      "type": "securestring",
+      "metadata": {
+        "description": "Orchestrator Server Virtual Machine admin password"
+      }
+    },
+    "publicIPDomainNameLabelOrchServer": {
+      "defaultValue": "publicdnsorcserver",
+      "type": "string",
+      "metadata": {
+        "description": "Orchestrator Server unique public DNS prefix"
+      }
+    },
+    "vmAdminUsernameChefAutomate": {
+      "defaultValue": "trend",
+      "type": "string",
+      "metadata": {
+        "description": "Chef Automate Virtual Machine admin username"
+      }
+    },
+    "vmAdminPasswordChefAutomate": {
+      "defaultValue": "",
+      "type": "SecureString",
+      "metadata": {
+        "description": "Chef Automate Virtual Machine admin password"
+      }
+    },
+    "vmSizeChefAutomate": {
+      "type": "string",
+      "defaultValue": "Standard_DS2_v2",
+      "metadata": {
+        "description": "Chef Automate Virtual Machine size"
+      }
+    },
+    "chefAutoDns": {
+      "type": "string",
+      "defaultValue": "chefautomate",
+      "metadata": {
+        "description": "Chef Automate unique public DNS prefix"
+      }
+    },
+    "chefUserFirstName": {
+      "type": "string",
+      "defaultValue": "chef",
+      "metadata": {
+        "description": "Chef user first name"
+      }
+    },
+    "chefUserLastName": {
+      "type": "string",
+      "defaultValue": "user",
+      "metadata": {
+        "description": "Chef user last name"
+      }
+    },
+    "chefUserEmail": {
+      "type": "string",
+      "defaultValue": "chef@noone.com",
+      "metadata": {
+        "description": "Chef user email"
+      }
+    },
+    "chefOrgShortName": {
+      "type": "string",
+      "defaultValue": "ct",
+      "metadata": {
+        "description": "Chef org short name"
+      }
+    },
+    "vmAdminUsernameSplunkEnterprise": {
+      "defaultValue": "trend",
+      "type": "string",
+      "metadata": {
+        "description": "Splunk Enterprise Virtual Machine admin username"
+      }
+    },
+    "vmAdminPasswordSplunkEnterprise": {
+      "defaultValue": "",
+      "type": "SecureString",
+      "metadata": {
+        "description": "Splunk Enterprise Virtual Machine admin password"
+      }
+    },
+    "splunkAdminPassword": {
+      "defaultValue": "",
+      "type": "SecureString",
+      "metadata": {
+        "description": "Splunk Enterprise Virtual Machine admin password"
+      }
+    },
+    "vmSizeSplunk": {
+      "type": "string",
+      "defaultValue": "Standard_D4_v2",
+      "allowedValues": [
+        "Standard_D4_v2"
+      ],
+      "metadata": {
+        "description": "Splunk Enterprise Virtual Machine size"
+      }
+    },
+    "publicIPDomainNameLabelSplunkEnterprise": {
+      "type": "string",
+      "defaultValue": "publicdnssplunkenterprise",
+      "metadata": {
+        "description": "Splunk Enterprise unique public DNS prefix"
+      }
+    },
+    "adminUsernameChefWorkstation": {
+      "type": "string",
+      "defaultValue": "trend",
+      "metadata": {
+        "description": "Chef Workstation Virtual Machine admin username"
+      }
+    },
+    "adminPasswordChefWorkstation": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Chef Workstation Virtual Machine admin password"
+      }
+    },
+    "vmSizeChefWorkstation": {
+      "type": "string",
+      "defaultValue": "Standard_D2_v2",
+      "allowedValues": [
+        "Standard_D2_v2",
+        "Standard_D3_v2",
+        "Standard_D4_v2"
+      ],
+      "metadata": {
+        "description": "Chef Workstation Virtual Machine size"
+      }
+    },
+    "publicIPDomainNameLabelChefWorkstation": {
+      "type": "string",
+      "defaultValue": "publicdnschefws",
+      "metadata": {
+        "description": "Chef Workstation unique public DNS prefix"
+      }
+    },
+    "adminUsernameDSAgentWindows": {
+      "type": "string",
+      "defaultValue": "trend",
+      "metadata": {
+        "description": "Windows Deep Security Agent Virtual Machine admin username"
+      }
+    },
+    "adminPasswordDSAgentWindows": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Windows Deep Security Agent Virtual Machine admin password"
+      }
+    },
+    "publicIPDomainNameLabelDSAgentWindows": {
+      "type": "string",
+      "defaultValue": "dnsdsagentwindow",
+      "metadata": {
+        "description": "Windows Deep Security Agent unique public DNS prefix"
+      }
+    },
+    "windowsvmcount": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "Count of Windows Deep Security Agents to deploy"
+      }
+    },
+    "adminUsernameDSAgent": {
+      "type": "string",
+      "defaultValue": "trend",
+      "metadata": {
+        "description": "Linux Deep Security Agent Virtual Machine admin username"
+      }
+    },
+    "adminPasswordDSAgent": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Linux Deep Security Agent Virtual Machine admin password"
+      }
+    },
+    "publicIPDomainNameLabelDSAgent": {
+      "type": "string",
+      "defaultValue": "dnsdsagentlinux",
+      "metadata": {
+        "description": "Linux Deep Security Agent unique public DNS prefix"
+      }
+    },
+    "linuxvmcount": {
+      "type": "int",
+      "defaultValue": 1,
+      "metadata": {
+        "description": "Count of Linux Deep Security Agents to deploy"
+      }
+    },
+    "baseUrl": {
+      "type": "string",
+      "metadata": {
+        "description": "The base URL for dependent deployment files",
+        "artifactsBaseUrl": ""
+      },
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/trend-chef-splunk-security"
     }
+  },
+  "variables": {
+    "computeSettings": {
+      "computeApiVersion": "2016-04-30-preview",
+      "location": "[variables('location')]",
+      "chefAutoVmName": "chefautomate",
+      "imagePublisher": "chef-software",
+      "imageOffer": "chef-automate",
+      "imageSKU": "byol",
+      "imageVersion": "latest",
+      "storageAccountType": "Standard_LRS",
+      "firstname": "[parameters('chefUserFirstName')]",
+      "lastname": "[parameters('chefUserLastName')]",
+      "orguser": "[parameters('chefOrgShortName')]",
+      "mailid": "[parameters('chefUserEmail')]",
+      "adminUsername": "[parameters('vmAdminUsernameChefAutomate')]",
+      "adminPassword": "[parameters('vmAdminPasswordChefAutomate')]",
+      "virtualMachineSize": "[parameters('vmSizeChefAutomate')]",
+      "chefAutoNic": "[variables('chefAutoNic')]",
+      "rubyPath": "/opt/chef-marketplace/embedded/bin/ruby",
+      "chefAutoScriptUrl1": "[concat(parameters('baseUrl'), '/scripts/automate_setup.rb')]",
+      "chefAutoScriptUrl2": "[concat(parameters('baseUrl'),'/scripts/chefautomate_setup.sh')]",
+      "automateLicenseUri": ""
+    },
+    "networkSettings": {
+      "networkApiVersion": "2015-06-15",
+      "location": "[variables('location')]",
+      "chefAutoPip": "chefauto-pip",
+      "chefAutoNsg": "chefauto-nsg",
+      "chefAutoNic": "[variables('chefAutoNic')]",
+      "publicIpAddressType": "Dynamic",
+      "chefAutoDns": "[concat(parameters('chefAutoDns'),substring(variables('prefix') ,0 ,5))]"
+    },
+    "prefix": "[uniqueString(resourceGroup().id)]",
+    "deploymentApiVersion": "2015-01-01",
+    "chefAutoNic": "chefauto-nic",
+    "location": "[parameters('location')]",
+    "vmNameTrendDSM": "trendMicroDSM",
+    "vmNameSplunkEnterprise": "splunkEnterprise",
+    "vmNameChefWorkstation": "chefWS",
+    "vmNameDSAWindows": "dsawindows",
+    "vmNameDSAgent": "dsalinux",
+    "vmNameOrchServer": "orchestratorServer",
+    "nicNameTrendDSM": "[concat(variables('vmNameTrendDSM'),'-nic')]",
+    "networkInterfaceNameSplunkEnterprise": "[concat(variables('vmNameSplunkEnterprise'),'-nic')]",
+    "networkInterfaceNameOrchServer": "[concat(variables('vmNameOrchServer'),'-nic')]",
+    "securityGroupNameTrendDSM": "[concat(variables('nicNameTrendDSM'),'-nsg')]",
+    "networkSecurityGroupNameSplunkEnterprise": "[concat(variables('networkInterfaceNameSplunkEnterprise'),'-nsg')]",
+    "networkSecurityGroupNameOrchServer": "[concat(variables('networkInterfaceNameOrchServer'),'-nsg')]",
+    "virtualNetworkName": "trendMicroP2PVnet",
+    "vnetAddressPrefix": "10.7.0.0/16",
+    "subnet1Name": "trendMicroDSMsubnet",
+    "subnet1Prefix": "10.7.0.0/24",
+    "subnet2Name": "chefAutomateSubnet",
+    "subnet2Prefix": "10.7.1.0/24",
+    "subnet3Name": "splunkEnterprisesubnet",
+    "subnet3Prefix": "10.7.2.0/24",
+    "subnet3StartAddress": "10.7.2.5",
+    "subnet4Name": "vmsubnet",
+    "subnet4Prefix": "10.7.3.0/24",
+    "publicIPAddressType": "Dynamic",
+    "publicIPAddressNameTrendDSM": "publicIPTrendDSM",
+    "publicIPAddressNameSplunkEnterprise": "publicIPSplunkEnterprise",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
+    "subnet2Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet2Name'))]",
+    "subnet3Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet3Name'))]",
+    "subnet4Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet4Name'))]",
+    "storageAccountName": "[tolower(concat(trim(substring(concat(variables('vmNameTrendDSM'),'       '),0,6)),uniquestring(resourceGroup().id)))]",
+    "storageAccountType": "Standard_LRS",
+    "vmStorageAccountContainerName": "vhds",
+    "newsqlServerName": "[tolower(concat(variables('vmNameTrendDSM'),uniquestring(resourceGroup().id),'-sql'))]",
+    "storage-api-version": "2015-06-15",
+    "deployment-api-version": "2015-11-01",
+    "deployment-api-version2": "2015-01-01",
+    "network-api-version": "2015-06-15",
+    "compute-api-version": "2015-06-15",
+    "publisherTrendDSM": "trendmicro",
+    "databaseOption": "new",
+    "offerChoosedTrendDSM": "[variables(concat('offer', parameters('vmSizeTrendDSM')))]",
+    "offerStandard_D2_v2": {
+      "vmSize": "Standard_D2_v2",
+      "vmSku": "dxxn25d2v2",
+      "product": "deep-security-vm"
+    },
+    "offerStandard_D3_v2": {
+      "vmSize": "Standard_D3_v2",
+      "vmSku": "dxxn50d3v2",
+      "product": "deep-security-vm"
+    },
+    "offerStandard_D4_v2": {
+      "vmSize": "Standard_D4_v2",
+      "vmSku": "dxxn100d4v2",
+      "product": "deep-security-vm"
+    },
+    "offerStandard_D5_v2": {
+      "vmSize": "Standard_D5_v2",
+      "vmSku": "dxxn200d5v2",
+      "product": "deep-security-vm"
+    },
+    "offerBYOL": {
+      "vmSize": "[parameters('vmSizeTrendDSM')]",
+      "vmSku": "dxxnbyol",
+      "product": "deep-security-vm-byol"
+    },
+    "offerStandard_DS2_v2": {
+      "vmSize": "Standard_DS2_v2",
+      "vmSku": "byol",
+      "product": "chef-automate"
+    },
+    "availabilitySetSettings": {
+      "name": "[concat(variables('virtualNetworkName'), '-aset')]",
+      "count": "[variables('tshirtSizeSplunk').availabilitySetCount]",
+      "fdCount": 3,
+      "udCount": 5
+    },
+    "sshFrom": "0.0.0.0/0",
+    "forwardedDataFrom": "0.0.0.0/0",
+    "deploymentSizeSplunk": "Standalone",
+    "emptyTemplateUrl": "[concat(parameters('baseUrl'),'/nested/empty-resources.json')]",
+    "tshirtSizeSplunk": "[variables(concat('tshirtSizeSplunk', variables('deploymentSizeSplunk')))]",
+    "tshirtSizeSplunkStandalone": {
+      "vmSize": "[parameters('vmSizeSplunk')]",
+      "vmSizeClusterMaster": "Standard_D3",
+      "diskSize": 1023,
+      "standaloneTemplateUrl": "[concat(parameters('baseUrl'), '/nested/trendp2p-splunkenterprise.json')]",
+      "clusterMasterTemplateUrl": "[variables('emptyTemplateUrl')]",
+      "clusterSearchheadTemplateUrl": "[variables('emptyTemplateUrl')]",
+      "clusterPeersTemplateUrl": "[variables('emptyTemplateUrl')]",
+      "clusterPeersCount": 0,
+      "availabilitySetCount": 1,
+      "publicIPAddress": {
+        "name": "[variables('publicIPAddressNameSplunkEnterprise')]",
+        "domainNamePrefix": "[concat(parameters('publicIPDomainNameLabelSplunkEnterprise'),variables('uniqueString'))]",
+        "count": 1,
+        "map": [
+          ""
+        ]
+      }
+    },
+    "osSettingsSplunk": {
+      "imageReference": {
+        "publisher": "splunk",
+        "offer": "splunk-enterprise-base-image",
+        "sku": "splunk-on-ubuntu-14-04-lts",
+        "version": "1.0.8"
+      },
+      "scripts": [
+        "[concat(parameters('baseUrl'), '/scripts/', 'vm-disk-utils-0.1.sh')]",
+        "[concat(parameters('baseUrl'), '/scripts/', 'node-setup.sh')]",
+        "[concat(parameters('baseUrl'), '/scripts/', 'splunkscript.sh')]"
+      ]
+    },
+    "networkSettingsSplunk": {
+      "virtualNetworkName": "[variables('virtualNetworkName')]",
+      "subnet": {
+        "sh": {
+          "name": "[variables('subnet1Name')]",
+          "prefix": "[variables('subnet1Prefix')]",
+          "vnet": "[variables('virtualNetworkName')]"
+        },
+        "idx": {
+          "name": "[variables('subnet2Name')]",
+          "prefix": "[variables('subnet2Prefix')]",
+          "vnet": "[variables('virtualNetworkName')]"
+        }
+      },
+      "statics": {
+        "standaloneIp": "[variables('subnet3StartAddress')]",
+        "clusterSearchheadIp": "[variables('subnet3StartAddress')]",
+        "clusterMasterIp": "[variables('subnet3StartAddress')]"
+      }
+    },
+    "linuxConfigurationChoosenTrendDSM": "[variables(concat('linuxConfiguration', variables('vmAuthTypeTrendDSM')))]",
+    "linuxConfigurationpassword": {
+      "disablePasswordAuthentication": "false"
+    },
+    "linuxConfigurationsshPublicKey": {
+      "disablePasswordAuthentication": "true",
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/',parameters('vmAdminNameTrendDSM'),'/.ssh/authorized_keys')]",
+            "keyData": "[variables('vmAdminSshPublicKeyTrendDSM')]"
+          }
+        ]
+      }
+    },
+    "imagePublisherWindows": "MicrosoftWindowsServer",
+    "imageOfferWindows": "WindowsServer",
+    "imagePublisherLinux": "Canonical",
+    "imageOfferLinux": "UbuntuServer",
+    "TenantIdentifier": "NA",
+    "TenantActivationPassword": "NA",
+    "tagvalues": {
+      "program": "p2p",
+      "project": "TrendMicro"
+    },
+    "vmAuthTypeTrendDSM": "password",
+    "vmAdminSshPublicKeyTrendDSM": "",
+    "existingSQLServerName": "",
+    "ManagerAddress": "[concat(parameters('publicIPDomainNameLabelTrendDSM'),variables('uniqueString'),'.',parameters('location'),'.cloudapp.azure.com')]",
+    "udpPort": "5005",
+    "chefprefix": "chef",
+    "vmSizeDSAWindows": "Standard_D1",
+    "windowsOSVersion": "2012-R2-Datacenter",
+    "vmSizeDSAgent": "Standard_D1",
+    "ubuntuOSVersion": "14.04.2-LTS",
+    "uniqueString": "[uniquestring(resourceGroup().id)]",
+    "keyName": "validatorkey",
+    "resourcegroupName": "[resourceGroup().name]",
+    "kmServerUrl": "[concat(parameters('publicIPDomainNameLabelOrchServer'),variables('uniqueString'),'.',variables('location'),'.cloudapp.azure.com')]",
+    "chef_node_name": "chefnodedsagent",
+    "chef_automate_url": "[concat('https://',variables('networkSettings').chefAutoDns,'.',parameters('location'),'.cloudapp.azure.com/organizations/',parameters('chefOrgShortName'))]",
+    "validation_client_name": "[concat(parameters('chefOrgShortName'),'-validator')]",
+    "validation_key_format": "base64encoded",
+    "runlist": "recipe[trendmicro]",
+    "vmSizeOrcServer": "Standard_D1",
+    "orcServerubuntuOSVersion": "14.04.2-LTS",
+    "installOrchTemplateurl": "[concat(parameters('baseUrl'),'/nested/orchestrator-server-setup-trend.json')]",
+    "chefnodeCustomScripturl": "[concat(parameters('baseUrl'),'/scripts/p2pchefnodebootstrap.sh')]",
+    "chefAutomateURL": "[concat(parameters('baseUrl'),'/nested/trendp2p-chefautomate.json')]",
+    "trendmicroTags": {
+      "type": "object",
+      "provider": "F0253A01-8156-4D41-BD91-E182158D4972"
+    },
+    "chefSoftwareTags": {
+      "type": "object",
+      "provider": "33194f91-eb5f-4110-827a-e95f640a9e46"
+    },
+    "splunkTags": {
+      "type": "object",
+      "provider": "7d69ff10-1a05-4353-b69d-0e87c3382e96"
+    },
+    "quickstartTags": {
+      "type": "object",
+      "name": "trend-chef-splunk-security"
+    }
+  },
+  "resources": [
+    {
+      "comments": "Gene",
+      "name": "vnetstorage",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-vnetstorage.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "storage-api-version": {
+            "value": "[variables('storage-api-version')]"
+          },
+          "storageAccountType": {
+            "value": "[variables('storageAccountType')]"
+          },
+          "location": {
+            "value": "[variables('location')]"
+          },
+          "network-api-version": {
+            "value": "[variables('network-api-version')]"
+          },
+          "virtualNetworkName": {
+            "value": "[variables('virtualNetworkName')]"
+          },
+          "vnetAddressPrefix": {
+            "value": "[variables('vnetAddressPrefix')]"
+          },
+          "subnet1Name": {
+            "value": "[variables('subnet1Name')]"
+          },
+          "subnet1Prefix": {
+            "value": "[variables('subnet1Prefix')]"
+          },
+          "subnet2Name": {
+            "value": "[variables('subnet2Name')]"
+          },
+          "subnet2Prefix": {
+            "value": "[variables('subnet2Prefix')]"
+          },
+          "subnet3Name": {
+            "value": "[variables('subnet3Name')]"
+          },
+          "subnet3Prefix": {
+            "value": "[variables('subnet3Prefix')]"
+          },
+          "subnet4Name": {
+            "value": "[variables('subnet4Name')]"
+          },
+          "subnet4Prefix": {
+            "value": "[variables('subnet4Prefix')]"
+          },
+          "tagvalues": {
+            "value": "[variables('tagvalues')]"
+          },
+          "availabilitySetSettings": {
+            "value": "[variables('availabilitySetSettings')]"
+          },
+          "trendmicroTags": {
+            "value": "[variables('trendmicroTags')]"
+          },
+          "chefSoftwareTags": {
+            "value": "[variables('chefSoftwareTags')]"
+          },
+          "splunkTags": {
+            "value": "[variables('splunkTags')]"
+          },
+          "quickstartTags": {
+            "value": "[variables('quickstartTags')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "trendmicrodsm",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "['Microsoft.Resources/deployments/vnetstorage']"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-trenddsm.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "vmStorageAccountContainerName": {
+            "value": "[variables('vmStorageAccountContainerName')]"
+          },
+          "location": {
+            "value": "[variables('location')]"
+          },
+          "network-api-version": {
+            "value": "[variables('network-api-version')]"
+          },
+          "compute-api-version": {
+            "value": "[variables('compute-api-version')]"
+          },
+          "tagvalues": {
+            "value": "[variables('tagvalues')]"
+          },
+          "publicIPDomainNameLabelTrendDSM": {
+            "value": "[concat(parameters('publicIPDomainNameLabelTrendDSM'),variables('uniqueString'))]"
+          },
+          "publicIPAddressType": {
+            "value": "[variables('publicIPAddressType')]"
+          },
+          "publicIPAddressNameTrendDSM": {
+            "value": "[variables('publicIPAddressNameTrendDSM')]"
+          },
+          "nicNameTrendDSM": {
+            "value": "[variables('nicNameTrendDSM')]"
+          },
+          "virtualNetworkName": {
+            "value": "[variables('virtualNetworkName')]"
+          },
+          "subnet1Ref": {
+            "value": "[variables('subnet1Ref')]"
+          },
+          "securityGroupNameTrendDSM": {
+            "value": "[variables('securityGroupNameTrendDSM')]"
+          },
+          "managerPortTrendDSM": {
+            "value": "[parameters('managerPortTrendDSM')]"
+          },
+          "heartbeatPortTrendDSM": {
+            "value": "[parameters('heartbeatPortTrendDSM')]"
+          },
+          "vmNameTrendDSM": {
+            "value": "[variables('vmNameTrendDSM')]"
+          },
+          "publisherTrendDSM": {
+            "value": "[variables('publisherTrendDSM')]"
+          },
+          "offerChoosedTrendDSM": {
+            "value": "[variables('offerChoosedTrendDSM')]"
+          },
+          "vmAdminNameTrendDSM": {
+            "value": "[parameters('vmAdminNameTrendDSM')]"
+          },
+          "vmAdminPasswordTrendDSM": {
+            "value": "[parameters('vmAdminPasswordTrendDSM')]"
+          },
+          "linuxConfigurationChoosenTrendDSM": {
+            "value": "[variables('linuxConfigurationChoosenTrendDSM')]"
+          },
+          "deployment-api-version": {
+            "value": "[variables('deployment-api-version')]"
+          },
+          "baseUrl": {
+            "value": "[parameters('baseUrl')]"
+          },
+          "databaseOption": {
+            "value": "[variables('databaseOption')]"
+          },
+          "newsqlServerName": {
+            "value": "[variables('newsqlServerName')]"
+          },
+          "existingSQLServerName": {
+            "value": "[variables('existingSQLServerName')]"
+          },
+          "dbAdminName": {
+            "value": "[parameters('dbAdminName')]"
+          },
+          "dbAdminPassword": {
+            "value": "[parameters('dbAdminPassword')]"
+          },
+          "dbName": {
+            "value": "[parameters('dbName')]"
+          },
+          "dsmAdminName": {
+            "value": "[parameters('dsmAdminName')]"
+          },
+          "dsmAdminPassword": {
+            "value": "[parameters('dsmAdminPassword')]"
+          },
+          "trendmicroTags": {
+            "value": "[variables('trendmicroTags')]"
+          },
+          "chefSoftwareTags": {
+            "value": "[variables('chefSoftwareTags')]"
+          },
+          "splunkTags": {
+            "value": "[variables('splunkTags')]"
+          },
+          "quickstartTags": {
+            "value": "[variables('quickstartTags')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "orchestrator",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "['Microsoft.Resources/deployments/vnetstorage']"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-orchestrator.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "location": {
+            "value": "[variables('location')]"
+          },
+          "network-api-version": {
+            "value": "[variables('network-api-version')]"
+          },
+          "compute-api-version": {
+            "value": "[variables('compute-api-version')]"
+          },
+          "deployment-api-version2": {
+            "value": "[variables('deployment-api-version2')]"
+          },
+          "tagvalues": {
+            "value": "[variables('tagvalues')]"
+          },
+          "publicIPDomainNameLabelOrchServer": {
+            "value": "[concat(parameters('publicIPDomainNameLabelOrchServer'),variables('uniqueString'))]"
+          },
+          "vmNameOrchServer": {
+            "value": "[variables('vmNameOrchServer')]"
+          },
+          "networkInterfaceNameOrchServer": {
+            "value": "[variables('networkInterfaceNameOrchServer')]"
+          },
+          "networkSecurityGroupNameOrchServer": {
+            "value": "[variables('networkSecurityGroupNameOrchServer')]"
+          },
+          "vmAdminUsernameOrchServer": {
+            "value": "[parameters('vmAdminUsernameOrchServer')]"
+          },
+          "vmAdminPasswordOrchServer": {
+            "value": "[parameters('vmAdminPasswordOrchServer')]"
+          },
+          "vmStorageAccountContainerName": {
+            "value": "[variables('vmStorageAccountContainerName')]"
+          },
+          "imagePublisherLinux": {
+            "value": "[variables('imagePublisherLinux')]"
+          },
+          "imageOfferLinux": {
+            "value": "[variables('imageOfferLinux')]"
+          },
+          "orcServerubuntuOSVersion": {
+            "value": "[variables('orcServerubuntuOSVersion')]"
+          },
+          "vmSizeOrcServer": {
+            "value": "[variables('vmSizeOrcServer')]"
+          },
+          "subnet2Ref": {
+            "value": "[variables('subnet2Ref')]"
+          },
+          "installOrchTemplateurl": {
+            "value": "[variables('installOrchTemplateurl')]"
+          },
+          "trendmicroTags": {
+            "value": "[variables('trendmicroTags')]"
+          },
+          "chefSoftwareTags": {
+            "value": "[variables('chefSoftwareTags')]"
+          },
+          "splunkTags": {
+            "value": "[variables('splunkTags')]"
+          },
+          "quickstartTags": {
+            "value": "[variables('quickstartTags')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "chefAutomate",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "['Microsoft.Resources/deployments/vnetstorage']",
+        "['Microsoft.Resources/deployments/trendmicrodsm']",
+        "['Microsoft.Resources/deployments/orchestrator']"
+      ],
+      "properties": {
+        "mode": "incremental",
+        "templateLink": {
+          "uri": "[variables('chefAutomateURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "computeSettings": {
+            "value": "[variables('computeSettings')]"
+          },
+          "networkSettings": {
+            "value": "[variables('networkSettings')]"
+          },
+          "subnet2Ref": {
+            "value": "[variables('subnet2Ref')]"
+          },
+          "publicIPDomainNameLabelOrchServer": {
+            "value": "[concat(parameters('publicIPDomainNameLabelOrchServer'),variables('uniqueString'))]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-01-01",
+      "type": "Microsoft.Resources/deployments",
+      "name": "splunkstandalonedeployment",
+      "dependsOn": [
+        "['Microsoft.Resources/deployments/vnetstorage']"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('tshirtSizeSplunk').standaloneTemplateUrl]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "location": {
+            "value": "[variables('location')]"
+          },
+          "network-api-version": {
+            "value": "[variables('network-api-version')]"
+          },
+          "compute-api-version": {
+            "value": "[variables('compute-api-version')]"
+          },
+          "vmNameSplunkEnterprise": {
+            "value": "[variables('vmNameSplunkEnterprise')]"
+          },
+          "vmAdminUsernameSplunkEnterprise": {
+            "value": "[parameters('vmAdminUsernameSplunkEnterprise')]"
+          },
+          "vmAdminPasswordSplunkEnterprise": {
+            "value": "[parameters('vmAdminPasswordSplunkEnterprise')]"
+          },
+          "splunkAdminPassword": {
+            "value": "[parameters('splunkAdminPassword')]"
+          },
+          "publicIPAddressSettingsSplunk": {
+            "value": "[variables('tshirtSizeSplunk').publicIPAddress]"
+          },
+          "networkSecurityGroupNameSplunkEnterprise": {
+            "value": "[variables('networkSecurityGroupNameSplunkEnterprise')]"
+          },
+          "networkInterfaceNameSplunkEnterprise": {
+            "value": "[variables('networkInterfaceNameSplunkEnterprise')]"
+          },
+          "machineSettings": {
+            "value": {
+              "vmSize": "[variables('tshirtSizeSplunk').vmSize]",
+              "diskSize": "[variables('tshirtSizeSplunk').diskSize]",
+              "staticIp": "[variables('networkSettingsSplunk').statics.standaloneIp]",
+              "clusterMasterIp": "NA",
+              "publicIPName": "[concat(variables('tshirtSizeSplunk').publicIPAddress.name, '')]",
+              "sshFrom": "[concat(variables('sshFrom'), '')]",
+              "forwardedDataFrom": "[concat(variables('forwardedDataFrom'), '')]",
+              "availabilitySet": "[concat(variables('availabilitySetSettings').name, '0')]"
+            }
+          },
+          "subnet3Ref": {
+            "value": "[variables('subnet3Ref')]"
+          },
+          "osSettingsSplunk": {
+            "value": "[variables('osSettingsSplunk')]"
+          },
+          "tagvalues": {
+            "value": "[variables('tagvalues')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "udpPort": {
+            "value": "[variables('udpPort')]"
+          },
+          "trendmicroTags": {
+            "value": "[variables('trendmicroTags')]"
+          },
+          "chefSoftwareTags": {
+            "value": "[variables('chefSoftwareTags')]"
+          },
+          "splunkTags": {
+            "value": "[variables('splunkTags')]"
+          },
+          "quickstartTags": {
+            "value": "[variables('quickstartTags')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-01-01",
+      "type": "Microsoft.Resources/deployments",
+      "name": "dsagents",
+      "dependsOn": [
+        "['Microsoft.Resources/deployments/vnetstorage']",
+        "['Microsoft.Resources/deployments/trendmicrodsm']",
+        "['Microsoft.Resources/deployments/chefAutomate']"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-dsagents.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "location": {
+            "value": "[variables('location')]"
+          },
+          "network-api-version": {
+            "value": "[variables('network-api-version')]"
+          },
+          "compute-api-version": {
+            "value": "[variables('compute-api-version')]"
+          },
+          "vmNameDSAWindows": {
+            "value": "[variables('vmNameDSAWindows')]"
+          },
+          "vmSizeDSAWindows": {
+            "value": "[variables('vmSizeDSAWindows')]"
+          },
+          "adminUsernameDSAgentWindows": {
+            "value": "[parameters('adminUsernameDSAgentWindows')]"
+          },
+          "adminPasswordDSAgentWindows": {
+            "value": "[parameters('adminPasswordDSAgentWindows')]"
+          },
+          "publicIPDomainNameLabelDSAgentWindows": {
+            "value": "[concat(parameters('publicIPDomainNameLabelDSAgentWindows'),variables('uniqueString'))]"
+          },
+          "windowsOSVersion": {
+            "value": "[variables('windowsOSVersion')]"
+          },
+          "windowsvmcount": {
+            "value": "[parameters('windowsvmcount')]"
+          },
+          "vmNameDSAgent": {
+            "value": "[variables('vmNameDSAgent')]"
+          },
+          "vmSizeDSAgent": {
+            "value": "[variables('vmSizeDSAgent')]"
+          },
+          "adminUsernameDSAgent": {
+            "value": "[parameters('adminUsernameDSAgent')]"
+          },
+          "adminPasswordDSAgent": {
+            "value": "[parameters('adminPasswordDSAgent')]"
+          },
+          "publicIPDomainNameLabelDSAgent": {
+            "value": "[concat(parameters('publicIPDomainNameLabelDSAgent'),variables('uniqueString'))]"
+          },
+          "ubuntuOSVersion": {
+            "value": "[variables('ubuntuOSVersion')]"
+          },
+          "linuxvmcount": {
+            "value": "[parameters('linuxvmcount')]"
+          },
+          "ManagerAddress": {
+            "value": "[variables('ManagerAddress')]"
+          },
+          "subnet4Ref": {
+            "value": "[variables('subnet4Ref')]"
+          },
+          "imagePublisherWindows": {
+            "value": "[variables('imagePublisherWindows')]"
+          },
+          "imageOfferWindows": {
+            "value": "[variables('imageOfferWindows')]"
+          },
+          "imagePublisherLinux": {
+            "value": "[variables('imagePublisherLinux')]"
+          },
+          "imageOfferLinux": {
+            "value": "[variables('imageOfferLinux')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "vmStorageAccountContainerName": {
+            "value": "[variables('vmStorageAccountContainerName')]"
+          },
+          "ActivationPort": {
+            "value": "[parameters('heartbeatPortTrendDSM')]"
+          },
+          "TenantIdentifier": {
+            "value": "[variables('TenantIdentifier')]"
+          },
+          "TenantActivationPassword": {
+            "value": "[variables('TenantActivationPassword')]"
+          },
+          "tagvalues": {
+            "value": "[variables('tagvalues')]"
+          },
+          "trendmicroTags": {
+            "value": "[variables('trendmicroTags')]"
+          },
+          "chefSoftwareTags": {
+            "value": "[variables('chefSoftwareTags')]"
+          },
+          "splunkTags": {
+            "value": "[variables('splunkTags')]"
+          },
+          "quickstartTags": {
+            "value": "[variables('quickstartTags')]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-01-01",
+      "type": "Microsoft.Resources/deployments",
+      "name": "chefnodes",
+      "dependsOn": [
+        "['Microsoft.Resources/deployments/vnetstorage']",
+        "['Microsoft.Resources/deployments/trendmicrodsm']",
+        "['Microsoft.Resources/deployments/chefAutomate']"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('baseUrl'), '/nested/trendp2p-chefnodes.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "location": {
+            "value": "[variables('location')]"
+          },
+          "network-api-version": {
+            "value": "[variables('network-api-version')]"
+          },
+          "compute-api-version": {
+            "value": "[variables('compute-api-version')]"
+          },
+          "deployment-api-version2": {
+            "value": "[variables('deployment-api-version2')]"
+          },
+          "vmNameChefWorkstation": {
+            "value": "[variables('vmNameChefWorkstation')]"
+          },
+          "vmSizeChefWorkstation": {
+            "value": "[parameters('vmSizeChefWorkstation')]"
+          },
+          "adminUsernameChefWorkstation": {
+            "value": "[parameters('adminUsernameChefWorkstation')]"
+          },
+          "adminPasswordChefWorkstation": {
+            "value": "[parameters('adminPasswordChefWorkstation')]"
+          },
+          "publicIPDomainNameLabelChefWorkstation": {
+            "value": "[concat(parameters('publicIPDomainNameLabelChefWorkstation'),variables('uniqueString'))]"
+          },
+          "vmNameDSAWindows": {
+            "value": "[variables('vmNameDSAWindows')]"
+          },
+          "vmSizeDSAWindows": {
+            "value": "[variables('vmSizeDSAWindows')]"
+          },
+          "adminUsernameDSAgentWindows": {
+            "value": "[parameters('adminUsernameDSAgentWindows')]"
+          },
+          "adminPasswordDSAgentWindows": {
+            "value": "[parameters('adminPasswordDSAgentWindows')]"
+          },
+          "publicIPDomainNameLabelDSAgentWindows": {
+            "value": "[concat(parameters('publicIPDomainNameLabelDSAgentWindows'),variables('uniqueString'))]"
+          },
+          "windowsOSVersion": {
+            "value": "[variables('windowsOSVersion')]"
+          },
+          "windowsvmcount": {
+            "value": "[parameters('windowsvmcount')]"
+          },
+          "vmNameDSAgent": {
+            "value": "[variables('vmNameDSAgent')]"
+          },
+          "vmSizeDSAgent": {
+            "value": "[variables('vmSizeDSAgent')]"
+          },
+          "adminUsernameDSAgent": {
+            "value": "[parameters('adminUsernameDSAgent')]"
+          },
+          "adminPasswordDSAgent": {
+            "value": "[parameters('adminPasswordDSAgent')]"
+          },
+          "publicIPDomainNameLabelDSAgent": {
+            "value": "[concat(parameters('publicIPDomainNameLabelDSAgent'),variables('uniqueString'))]"
+          },
+          "ubuntuOSVersion": {
+            "value": "[variables('ubuntuOSVersion')]"
+          },
+          "linuxvmcount": {
+            "value": "[parameters('linuxvmcount')]"
+          },
+          "ManagerAddress": {
+            "value": "[variables('ManagerAddress')]"
+          },
+          "subnet4Ref": {
+            "value": "[variables('subnet4Ref')]"
+          },
+          "imagePublisherWindows": {
+            "value": "[variables('imagePublisherWindows')]"
+          },
+          "imageOfferWindows": {
+            "value": "[variables('imageOfferWindows')]"
+          },
+          "imagePublisherLinux": {
+            "value": "[variables('imagePublisherLinux')]"
+          },
+          "imageOfferLinux": {
+            "value": "[variables('imageOfferLinux')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          },
+          "vmStorageAccountContainerName": {
+            "value": "[variables('vmStorageAccountContainerName')]"
+          },
+          "ActivationPort": {
+            "value": "[parameters('heartbeatPortTrendDSM')]"
+          },
+          "TenantIdentifier": {
+            "value": "[variables('TenantIdentifier')]"
+          },
+          "TenantActivationPassword": {
+            "value": "[variables('TenantActivationPassword')]"
+          },
+          "tagvalues": {
+            "value": "[variables('tagvalues')]"
+          },
+          "chefprefix": {
+            "value": "[variables('chefprefix')]"
+          },
+          "keyName": {
+            "value": "[variables('keyName')]"
+          },
+          "kmServerUrl": {
+            "value": "[variables('kmServerUrl')]"
+          },
+          "chef_node_name": {
+            "value": "[variables('chef_node_name')]"
+          },
+          "chef_automate_url": {
+            "value": "[variables('chef_automate_url')]"
+          },
+          "validation_client_name": {
+            "value": "[variables('validation_client_name')]"
+          },
+          "validation_key_format": {
+            "value": "[variables('validation_key_format')]"
+          },
+          "runlist": {
+            "value": "[variables('runlist')]"
+          },
+          "resourcegroupName": {
+            "value": "[variables('resourcegroupName')]"
+          },
+          "chefnodeCustomScripturl": {
+            "value": "[variables('chefnodeCustomScripturl')]"
+          },
+          "trendmicroTags": {
+            "value": "[variables('trendmicroTags')]"
+          },
+          "chefSoftwareTags": {
+            "value": "[variables('chefSoftwareTags')]"
+          },
+          "splunkTags": {
+            "value": "[variables('splunkTags')]"
+          },
+          "quickstartTags": {
+            "value": "[variables('quickstartTags')]"
+          },
+          "chefAutoDNS": {
+            "value": "[variables('networkSettings').chefAutoDns]"
+          },
+          "computeSettings": {
+            "value": "[variables('computeSettings')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "TrendAdminUserName": {
+      "type": "string",
+      "value": "[parameters('vmAdminNameTrendDSM')]"
+    },
+    "TrendAdminPassword": {
+      "type": "string",
+      "value": "[parameters('vmAdminPasswordTrendDSM')]"
+    },
+    "splunkAdminUserName": {
+      "type": "string",
+      "value": "admin"
+    },
+    "splunkAdminPassword": {
+      "type": "string",
+      "value": "[parameters('splunkAdminPassword')]"
+    },
+    "chefAutomateAdminUserName": {
+      "type": "string",
+      "value": "[parameters('vmAdminUsernameChefAutomate')]"
+    },
+    "chefAutomateAdminPassword": {
+      "type": "string",
+      "value": "[parameters('vmAdminPasswordChefAutomate')]"
+    },
+    "TrendMicro DSM URI": {
+      "type": "string",
+      "value": "[reference('trendmicrodsm').outputs.trendmicrodsmUri.value]"
+    },
+    "Chef Automate URI": {
+      "type": "string",
+      "value": "[concat('https://',reference('chefAutomate').outputs.chefAutomatefqdn.value)]"
+    },
+    "Splunk Server URI": {
+      "type": "string",
+      "value": "[reference('splunkstandalonedeployment').outputs.splunkenterpriseUri.value]"
+    }
+  }
 }

--- a/trend-chef-splunk-security/nested/database-new.json
+++ b/trend-chef-splunk-security/nested/database-new.json
@@ -1,94 +1,94 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string"
-        },
-        "newsqlServerName": {
-            "type": "string"
-        },
-        "existingSQLServerName": {
-            "type": "string"
-        },
-        "dbAdminName": {
-            "type": "string"
-        },
-        "dbAdminPassword": {
-            "type": "string"
-        },
-        "sqlDBName": {
-            "type": "string"
-        },
-        "trendmicroTags": {
-            "type": "object"
-        },
-        "chefSoftwareTags": {
-            "type": "object"
-        },
-        "splunkTags": {
-            "type": "object"
-        },
-        "quickstartTags": {
-            "type": "object"
-        }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string"
     },
-    "variables": {
-        "sql-api-version": "2014-04-01",
-        "sqldb-api-version": "2015-05-01-preview",
-        "sqlfirewallrules-api-version": "2014-04-01"
+    "newsqlServerName": {
+      "type": "string"
     },
-    "resources": [
-        {
-            "name": "[parameters('newsqlServerName')]",
-            "type": "Microsoft.Sql/servers",
-            "location": "[parameters('location')]",
-            "apiVersion": "[variables('sql-api-version')]",
-            "tags": {
-                "quickstartName": "[parameters('quickstartTags').name]",
-                "provider": "[parameters('trendmicroTags').provider]"
-            },
-            "properties": {
-                "administratorLogin": "[parameters('dbAdminName')]",
-                "administratorLoginPassword": "[parameters('dbAdminPassword')]",
-                "version": "12.0"
-            },
-            "resources": [
-                {
-                    "name": "[parameters('sqlDBName')]",
-                    "type": "databases",
-                    "location": "[parameters('location')]",
-                    "apiVersion": "[variables('sqldb-api-version')]",
-                    "dependsOn": [
-                        "[concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))]"
-                    ],
-                    "properties": {
-                        "edition": "Standard",
-                        "collation": "SQL_Latin1_General_CP1_CI_AS",
-                        "maxSizeBytes": "21474836480",
-                        "requestedServiceObjectiveName": "S3"
-                    }
-                },
-                {
-                    "apiVersion": "[variables('sqlfirewallrules-api-version')]",
-                    "dependsOn": [
-                        "[concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))]"
-                    ],
-                    "location": "[parameters('location')]",
-                    "name": "AllowAllAzureIps",
-                    "properties": {
-                        "endIpAddress": "0.0.0.0",
-                        "startIpAddress": "0.0.0.0"
-                    },
-                    "type": "firewallrules"
-                }
-            ]
-        }
-    ],
-    "outputs": {
-        "sqlServerFQDN": {
-            "type": "string",
-            "value": "[reference(concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))).fullyQualifiedDomainName]"
-        }
+    "existingSQLServerName": {
+      "type": "string"
+    },
+    "dbAdminName": {
+      "type": "string"
+    },
+    "dbAdminPassword": {
+      "type": "string"
+    },
+    "sqlDBName": {
+      "type": "string"
+    },
+    "trendmicroTags": {
+      "type": "object"
+    },
+    "chefSoftwareTags": {
+      "type": "object"
+    },
+    "splunkTags": {
+      "type": "object"
+    },
+    "quickstartTags": {
+      "type": "object"
     }
+  },
+  "variables": {
+    "sql-api-version": "2014-04-01",
+    "sqldb-api-version": "2015-05-01-preview",
+    "sqlfirewallrules-api-version": "2014-04-01"
+  },
+  "resources": [
+    {
+      "name": "[parameters('newsqlServerName')]",
+      "type": "Microsoft.Sql/servers",
+      "location": "[parameters('location')]",
+      "apiVersion": "2014-04-01",
+      "tags": {
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
+      },
+      "properties": {
+        "administratorLogin": "[parameters('dbAdminName')]",
+        "administratorLoginPassword": "[parameters('dbAdminPassword')]",
+        "version": "12.0"
+      },
+      "resources": [
+        {
+          "name": "[parameters('sqlDBName')]",
+          "type": "databases",
+          "location": "[parameters('location')]",
+          "apiVersion": "[variables('sqldb-api-version')]",
+          "dependsOn": [
+            "[concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))]"
+          ],
+          "properties": {
+            "edition": "Standard",
+            "collation": "SQL_Latin1_General_CP1_CI_AS",
+            "maxSizeBytes": "21474836480",
+            "requestedServiceObjectiveName": "S3"
+          }
+        },
+        {
+          "apiVersion": "[variables('sqlfirewallrules-api-version')]",
+          "dependsOn": [
+            "[concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))]"
+          ],
+          "location": "[parameters('location')]",
+          "name": "AllowAllAzureIps",
+          "properties": {
+            "endIpAddress": "0.0.0.0",
+            "startIpAddress": "0.0.0.0"
+          },
+          "type": "firewallrules"
+        }
+      ]
+    }
+  ],
+  "outputs": {
+    "sqlServerFQDN": {
+      "type": "string",
+      "value": "[reference(concat('Microsoft.Sql/servers/', parameters('newsqlServerName'))).fullyQualifiedDomainName]"
+    }
+  }
 }

--- a/trend-chef-splunk-security/nested/trendp2p-chefautomate.json
+++ b/trend-chef-splunk-security/nested/trendp2p-chefautomate.json
@@ -25,11 +25,11 @@
     "resources": [
         {
             "name": "[parameters('networkSettings').chefAutoPip]",
-            "type": "Microsoft.Network/publicIpAddresses",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
-                "publicIpAllocationMethod": "[parameters('networkSettings').publicIpAddressType]",
+                "publicIPAllocationMethod": "[parameters('networkSettings').publicIpAddressType]",
                 "dnsSettings": {
                     "domainNameLabel": "[parameters('networkSettings').chefAutoDns]"
                 }
@@ -38,7 +38,7 @@
          {
             "type": "Microsoft.Network/networkSecurityGroups",
             "name": "[parameters('networksettings').chefAutoNsg]",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "properties": {
                 "securityRules": [
@@ -47,7 +47,7 @@
                         "properties": {
                             "priority": 1010,
                             "sourceAddressPrefix": "*",
-                            "protocol": "TCP",
+                            "protocol": "Tcp",
                             "destinationPortRange": "22",
                             "access": "Allow",
                             "direction": "Inbound",
@@ -60,7 +60,7 @@
                         "properties": {
                             "priority": 1020,
                             "sourceAddressPrefix": "*",
-                            "protocol": "TCP",
+                            "protocol": "Tcp",
                             "destinationPortRange": "443",
                             "access": "Allow",
                             "direction": "Inbound",
@@ -73,7 +73,7 @@
                         "properties": {
                             "priority": 1030,
                             "sourceAddressPrefix": "*",
-                            "protocol": "TCP",
+                            "protocol": "Tcp",
                             "destinationPortRange": "80",
                             "access": "Allow",
                             "direction": "Inbound",
@@ -86,7 +86,7 @@
                         "properties": {
                             "priority": 1040,
                             "sourceAddressPrefix": "*",
-                            "protocol": "TCP",
+                            "protocol": "Tcp",
                             "destinationPortRange": "8989",
                             "access": "Allow",
                             "direction": "Inbound",
@@ -99,7 +99,7 @@
                         "properties": {
                             "priority": 1050,
                             "sourceAddressPrefix": "*",
-                            "protocol": "TCP",
+                            "protocol": "Tcp",
                             "destinationPortRange": "8443",
                             "access": "Allow",
                             "direction": "Inbound",
@@ -113,7 +113,7 @@
         {
             "name": "[parameters('networkSettings').chefAutoNic]",
             "type": "Microsoft.Network/networkInterfaces",
-            "apiVersion": "[parameters('networkSettings').networkApiVersion]",
+            "apiVersion": "2015-06-15",
             "location": "[parameters('networkSettings').location]",
             "dependsOn": [
                  "[concat('Microsoft.Network/publicIpAddresses/', parameters('networkSettings').chefAutoPip)]",
@@ -142,7 +142,7 @@
         {
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[parameters('computeSettings').chefAutoVmName]",
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "location": "[parameters('computeSettings').location]",
             "dependsOn": [
                 "[concat('Microsoft.Network/networkInterfaces/', parameters('computeSettings').chefAutoNic)]"
@@ -187,7 +187,7 @@
          {
             "type": "Microsoft.Compute/virtualMachines/extensions",
             "name": "[concat(parameters('computeSettings').chefAutoVmName,'/automate_setup')]",
-            "apiVersion": "[parameters('computeSettings').computeApiVersion]",
+            "apiVersion": "2016-04-30-preview",
             "location": "[parameters('computeSettings').location]",
             "properties": {
                 "publisher": "Microsoft.Azure.Extensions",

--- a/trend-chef-splunk-security/nested/trendp2p-chefnodes.json
+++ b/trend-chef-splunk-security/nested/trendp2p-chefnodes.json
@@ -217,7 +217,7 @@
   },
   "resources": [
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('chefprefix'),variables('publicIPAddressNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -235,7 +235,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('chefprefix'),variables('networkInterfaceNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -266,7 +266,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -314,7 +314,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('chefprefix'),variables('publicIPAddressNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -336,7 +336,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('chefprefix'),variables('networkInterfaceNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -371,7 +371,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -425,7 +425,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyIndex(),'/', variables('vmExtensionName'))]",
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -463,7 +463,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyIndex(),'/', variables('vmExtensionName2'))]",
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",

--- a/trend-chef-splunk-security/nested/trendp2p-chefnodes.json
+++ b/trend-chef-splunk-security/nested/trendp2p-chefnodes.json
@@ -194,10 +194,10 @@
     "quickstartTags": {
       "type": "object"
     },
-    "chefAutoDNS":{
+    "chefAutoDNS": {
       "type": "string"
     },
-    "computeSettings":{
+    "computeSettings": {
       "type": "secureObject"
     }
   },
@@ -217,7 +217,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('chefprefix'),variables('publicIPAddressNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -235,7 +235,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('chefprefix'),variables('networkInterfaceNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -266,7 +266,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameChefWorkstation'))]",
       "location": "[parameters('location')]",
@@ -314,7 +314,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('chefprefix'),variables('publicIPAddressNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -336,7 +336,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('chefprefix'),variables('networkInterfaceNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -371,7 +371,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -425,7 +425,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyIndex(),'/', variables('vmExtensionName'))]",
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -463,7 +463,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('chefprefix'),parameters('vmNameDSAgent'),copyIndex(),'/', variables('vmExtensionName2'))]",
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",

--- a/trend-chef-splunk-security/nested/trendp2p-dsagents.json
+++ b/trend-chef-splunk-security/nested/trendp2p-dsagents.json
@@ -139,7 +139,7 @@
   },
   "resources": [
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -161,7 +161,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('networkInterfaceNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -196,7 +196,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -248,7 +248,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameDSAWindows'), copyindex(),'/Installation')]",
       "location": "[parameters('location')]",
@@ -282,7 +282,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -304,7 +304,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('networkInterfaceNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -339,7 +339,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -391,7 +391,7 @@
       }
     },
     {
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameDSAgent'), copyindex(),'/Installation')]",
       "location": "[parameters('location')]",

--- a/trend-chef-splunk-security/nested/trendp2p-dsagents.json
+++ b/trend-chef-splunk-security/nested/trendp2p-dsagents.json
@@ -139,7 +139,7 @@
   },
   "resources": [
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -161,7 +161,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('networkInterfaceNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -196,7 +196,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNameDSAWindows'),copyindex())]",
       "location": "[parameters('location')]",
@@ -248,7 +248,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameDSAWindows'), copyindex(),'/Installation')]",
       "location": "[parameters('location')]",
@@ -282,7 +282,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(variables('publicIPAddressNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -304,7 +304,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(variables('networkInterfaceNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -339,7 +339,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('vmNameDSAgent'),copyindex())]",
       "location": "[parameters('location')]",
@@ -391,7 +391,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameDSAgent'), copyindex(),'/Installation')]",
       "location": "[parameters('location')]",

--- a/trend-chef-splunk-security/nested/trendp2p-orchestrator.json
+++ b/trend-chef-splunk-security/nested/trendp2p-orchestrator.json
@@ -98,7 +98,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmNameOrchServer')]",
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -151,7 +151,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameOrchServer'),'/','installdockerandcompose')]",
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -173,7 +173,7 @@
     {
       "name": "orchestratorapplication",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "",
+      "apiVersion": "2015-01-01",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameOrchServer'),'/extensions/installdockerandcompose')]"
       ],
@@ -208,7 +208,7 @@
     {
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressNameOrchServer')]",
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -228,7 +228,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceNameOrchServer')]",
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -267,7 +267,7 @@
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('networkSecurityGroupNameOrchServer')]",
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",

--- a/trend-chef-splunk-security/nested/trendp2p-orchestrator.json
+++ b/trend-chef-splunk-security/nested/trendp2p-orchestrator.json
@@ -98,7 +98,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmNameOrchServer')]",
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -151,7 +151,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameOrchServer'),'/','installdockerandcompose')]",
-      "apiVersion": "[parameters('compute-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -173,7 +173,7 @@
     {
       "name": "orchestratorapplication",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "[parameters('deployment-api-version2')]",
+      "apiVersion": "",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameOrchServer'),'/extensions/installdockerandcompose')]"
       ],
@@ -184,23 +184,23 @@
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
-          "location":{
+          "location": {
             "value": "[parameters('location')]"
           },
           "vmName": {
             "value": "[parameters('vmNameOrchServer')]"
           },
           "trendmicroTags": {
-              "value": "[parameters('trendmicroTags')]"
+            "value": "[parameters('trendmicroTags')]"
           },
           "chefSoftwareTags": {
-              "value": "[parameters('chefSoftwareTags')]"
+            "value": "[parameters('chefSoftwareTags')]"
           },
           "splunkTags": {
-              "value": "[parameters('splunkTags')]"
+            "value": "[parameters('splunkTags')]"
           },
           "quickstartTags": {
-              "value": "[parameters('quickstartTags')]"
+            "value": "[parameters('quickstartTags')]"
           }
         }
       }
@@ -208,7 +208,7 @@
     {
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressNameOrchServer')]",
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -228,7 +228,7 @@
     {
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceNameOrchServer')]",
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -267,7 +267,7 @@
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('networkSecurityGroupNameOrchServer')]",
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",

--- a/trend-chef-splunk-security/nested/trendp2p-splunkenterprise.json
+++ b/trend-chef-splunk-security/nested/trendp2p-splunkenterprise.json
@@ -88,7 +88,7 @@
   },
   "resources": [
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[concat(parameters('publicIPAddressSettingsSplunk').name, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]",
       "copy": {
@@ -110,7 +110,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('networkSecurityGroupNameSplunkEnterprise')]",
       "location": "[parameters('location')]",
@@ -224,7 +224,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('networkInterfaceNameSplunkEnterprise')]",
       "location": "[parameters('location')]",
@@ -260,7 +260,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmNameSplunkEnterprise')]",
       "location": "[parameters('location')]",
@@ -393,7 +393,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmNameSplunkEnterprise'), '/node-setup')]",
       "location": "[parameters('location')]",

--- a/trend-chef-splunk-security/nested/trendp2p-splunkenterprise.json
+++ b/trend-chef-splunk-security/nested/trendp2p-splunkenterprise.json
@@ -81,327 +81,350 @@
     }
   },
   "variables": {
-
     "publicIpName": "[parameters('machineSettings').publicIPName]",
     "splunkServerRole": "splunk_server",
     "singleQuote": "'",
     "clusterMasterIp": "[parameters('machineSettings').clusterMasterIp]"
-
   },
-  "resources": [{
-    "apiVersion": "[parameters('network-api-version')]",
-    "type": "Microsoft.Network/publicIPAddresses",
-    "name": "[concat(parameters('publicIPAddressSettingsSplunk').name, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]",
-    "copy": {
-      "name": "publicIPAddressLoop",
-      "count": "[parameters('publicIPAddressSettingsSplunk').count]"
-    },
-    "location": "[parameters('location')]",
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]",
-      "quickstartName": "[parameters('quickstartTags').name]",
-      "provider": "[parameters('splunkTags').provider]"
-    },
-    "properties": {
-      "publicIPAllocationMethod": "Dynamic",
-      "dnsSettings": {
-        "domainNameLabel": "[concat(parameters('publicIPAddressSettingsSplunk').domainNamePrefix, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]"
-      }
-    }
-  }, {
-    "apiVersion": "[parameters('network-api-version')]",
-    "type": "Microsoft.Network/networkSecurityGroups",
-    "name": "[parameters('networkSecurityGroupNameSplunkEnterprise')]",
-    "location": "[parameters('location')]",
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]",
-      "quickstartName": "[parameters('quickstartTags').name]",
-      "provider": "[parameters('splunkTags').provider]"
-    },
-    "properties": {
-      "securityRules": [{
-        "name": "Allow-SSH",
-        "properties": {
-          "description": "Allows SSH traffic",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "22",
-          "sourceAddressPrefix": "[parameters('machineSettings').sshFrom]",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 100,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-HTTP",
-        "properties": {
-          "description": "Allows HTTP traffic on port 8000",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "8000",
-          "sourceAddressPrefix": "*",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 110,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-HTTPS",
-        "properties": {
-          "description": "Allows HTTPS traffic on port 443",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "443",
-          "sourceAddressPrefix": "*",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 120,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-HTTP-Event-Collector",
-        "properties": {
-          "description": "Allows HTTP(S) Event Collector traffic on port 8088",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "8088",
-          "sourceAddressPrefix": "*",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 130,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-Receiver-TCP",
-        "properties": {
-          "description": "Allows receiver TCP traffic on port 9997",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "9997",
-          "sourceAddressPrefix": "[parameters('machineSettings').forwardedDataFrom]",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 140,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-Mgmt-From-VNET",
-        "properties": {
-          "description": "Allows mgmt on port 8089 from VNET only",
-          "protocol": "Tcp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "8089",
-          "sourceAddressPrefix": "VirtualNetwork",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 150,
-          "direction": "Inbound"
-        }
-      }, {
-        "name": "Allow-Custom-UDP",
-        "properties": {
-          "description": "Allows UDP port entered by user",
-          "protocol": "Udp",
-          "sourcePortRange": "*",
-          "destinationPortRange": "[parameters('udpPort')]",
-          "sourceAddressPrefix": "*",
-          "destinationAddressPrefix": "*",
-          "access": "Allow",
-          "priority": 160,
-          "direction": "Inbound"
-        }
-      }]
-    }
-  }, {
-    "apiVersion": "[parameters('network-api-version')]",
-    "type": "Microsoft.Network/networkInterfaces",
-    "name": "[parameters('networkInterfaceNameSplunkEnterprise')]",
-    "location": "[parameters('location')]",
-    "dependsOn": [
-      "[concat('Microsoft.Network/networkSecurityGroups/', parameters('networkSecurityGroupNameSplunkEnterprise'))]",
-      "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIpName'))]"
-    ],
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]",
-      "quickstartName": "[parameters('quickstartTags').name]",
-      "provider": "[parameters('splunkTags').provider]"
-    },
-    "properties": {
-      "networkSecurityGroup": {
-        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupNameSplunkEnterprise'))]"
+  "resources": [
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[concat(parameters('publicIPAddressSettingsSplunk').name, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]",
+      "copy": {
+        "name": "publicIPAddressLoop",
+        "count": "[parameters('publicIPAddressSettingsSplunk').count]"
       },
-      "ipConfigurations": [{
-        "name": "ipconfig1",
-        "properties": {
-          "privateIPAllocationMethod": "Static",
-          "privateIPAddress": "[parameters('machineSettings').staticIp]",
-          "publicIPAddress": {
-            "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('splunkTags').provider]"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic",
+        "dnsSettings": {
+          "domainNameLabel": "[concat(parameters('publicIPAddressSettingsSplunk').domainNamePrefix, parameters('publicIPAddressSettingsSplunk').map[copyindex()])]"
+        }
+      }
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('networkSecurityGroupNameSplunkEnterprise')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('splunkTags').provider]"
+      },
+      "properties": {
+        "securityRules": [
+          {
+            "name": "Allow-SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "[parameters('machineSettings').sshFrom]",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
           },
-          "subnet": {
-            "id": "[parameters('subnet3Ref')]"
+          {
+            "name": "Allow-HTTP",
+            "properties": {
+              "description": "Allows HTTP traffic on port 8000",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8000",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-HTTPS",
+            "properties": {
+              "description": "Allows HTTPS traffic on port 443",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-HTTP-Event-Collector",
+            "properties": {
+              "description": "Allows HTTP(S) Event Collector traffic on port 8088",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8088",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-Receiver-TCP",
+            "properties": {
+              "description": "Allows receiver TCP traffic on port 9997",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "9997",
+              "sourceAddressPrefix": "[parameters('machineSettings').forwardedDataFrom]",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 140,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-Mgmt-From-VNET",
+            "properties": {
+              "description": "Allows mgmt on port 8089 from VNET only",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8089",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 150,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "Allow-Custom-UDP",
+            "properties": {
+              "description": "Allows UDP port entered by user",
+              "protocol": "Udp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[parameters('udpPort')]",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 160,
+              "direction": "Inbound"
+            }
           }
-        }
-      }]
-    }
-  }, {
-    "apiVersion": "[parameters('compute-api-version')]",
-    "type": "Microsoft.Compute/virtualMachines",
-    "name": "[parameters('vmNameSplunkEnterprise')]",
-    "location": "[parameters('location')]",
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]",
-      "quickstartName": "[parameters('quickstartTags').name]",
-      "provider": "[parameters('splunkTags').provider]"
+        ]
+      }
     },
-    "plan": {
-      "name": "[parameters('osSettingsSplunk').imageReference.sku]",
-      "publisher": "[parameters('osSettingsSplunk').imageReference.publisher]",
-      "product": "[parameters('osSettingsSplunk').imageReference.offer]"
-    },
-    "dependsOn": [
-      "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceNameSplunkEnterprise'))]"
-    ],
-    "properties": {
-      "availabilitySet": {
-        "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('machineSettings').availabilitySet)]"
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[parameters('networkInterfaceNameSplunkEnterprise')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkSecurityGroups/', parameters('networkSecurityGroupNameSplunkEnterprise'))]",
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIpName'))]"
+      ],
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('splunkTags').provider]"
       },
-      "hardwareProfile": {
-        "vmSize": "[parameters('machineSettings').vmSize]"
-      },
-      "osProfile": {
-        "computername": "[parameters('vmNameSplunkEnterprise')]",
-        "adminUsername": "[parameters('vmAdminUsernameSplunkEnterprise')]",
-        "adminPassword": "[parameters('vmAdminPasswordSplunkEnterprise')]"
-      },
-      "storageProfile": {
-        "imageReference": "[parameters('osSettingsSplunk').imageReference]",
-        "osDisk": {
-          "name": "osdisk",
-          "vhd": {
-            "uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-osdisk.vhd')]"
-          },
-          "caching": "ReadWrite",
-          "createOption": "FromImage"
+      "properties": {
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('networkSecurityGroupNameSplunkEnterprise'))]"
         },
-        "dataDisks": [{
-          "name": "datadisk1",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 0,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk1.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk2",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 1,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk2.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk3",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 2,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk3.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk4",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 3,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk4.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk5",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 4,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk5.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk6",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 5,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk6.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk7",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 6,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk7.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }, {
-          "name": "datadisk8",
-          "diskSizeGB": "[parameters('machineSettings').diskSize]",
-          "lun": 7,
-          "vhd": {
-            "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk8.vhd')]"
-          },
-          "caching": "ReadOnly",
-          "createOption": "Empty"
-        }]
-      },
-      "networkProfile": {
-        "networkInterfaces": [{
-          "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceNameSplunkEnterprise'))]"
-        }]
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[parameters('machineSettings').staticIp]",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+              },
+              "subnet": {
+                "id": "[parameters('subnet3Ref')]"
+              }
+            }
+          }
+        ]
       }
-    }
-  }, {
-    "apiVersion": "[parameters('compute-api-version')]",
-    "type": "Microsoft.Compute/virtualMachines/extensions",
-    "name": "[concat(parameters('vmNameSplunkEnterprise'), '/node-setup')]",
-    "location": "[parameters('location')]",
-    "tags": {
-      "program": "[parameters('tagvalues').program]",
-      "project": "[parameters('tagvalues').project]",
-      "quickstartName": "[parameters('quickstartTags').name]",
-      "provider": "[parameters('splunkTags').provider]"
     },
-    "dependsOn": [
-      "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameSplunkEnterprise'))]",
-      "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceNameSplunkEnterprise'))]"
-    ],
-    "properties": {
-      "publisher": "Microsoft.Azure.Extensions",
-      "type": "CustomScript",
-      "typeHandlerVersion": "2.0",
-      "autoUpgradeMinorVersion": true,
-      "settings": {
-        "fileUris": "[parameters('osSettingsSplunk').scripts]"
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmNameSplunkEnterprise')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('splunkTags').provider]"
       },
-      "protectedSettings": {
-        "commandToExecute": "[concat('bash node-setup.sh', ' -r ', variables('splunkServerRole'), ' -c ', variables('clusterMasterIp'), ' -u ', parameters('udpPort'),  ' -p ', variables('singleQuote'), parameters('splunkAdminPassword'), variables('singleQuote'))]"
-
-
+      "plan": {
+        "name": "[parameters('osSettingsSplunk').imageReference.sku]",
+        "publisher": "[parameters('osSettingsSplunk').imageReference.publisher]",
+        "product": "[parameters('osSettingsSplunk').imageReference.offer]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceNameSplunkEnterprise'))]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', parameters('machineSettings').availabilitySet)]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('machineSettings').vmSize]"
+        },
+        "osProfile": {
+          "computername": "[parameters('vmNameSplunkEnterprise')]",
+          "adminUsername": "[parameters('vmAdminUsernameSplunkEnterprise')]",
+          "adminPassword": "[parameters('vmAdminPasswordSplunkEnterprise')]"
+        },
+        "storageProfile": {
+          "imageReference": "[parameters('osSettingsSplunk').imageReference]",
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          },
+          "dataDisks": [
+            {
+              "name": "datadisk1",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 0,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk1.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk2",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 1,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk2.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk3",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 2,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk3.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk4",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 3,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk4.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk5",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 4,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk5.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk6",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 5,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk6.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk7",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 6,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk7.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk8",
+              "diskSizeGB": "[parameters('machineSettings').diskSize]",
+              "lun": 7,
+              "vhd": {
+                "Uri": "[concat('http://', parameters('storageAccountName'), '.blob.core.windows.net','/vhds/', parameters('vmNameSplunkEnterprise'), '-datadisk8.vhd')]"
+              },
+              "caching": "ReadOnly",
+              "createOption": "Empty"
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('networkInterfaceNameSplunkEnterprise'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmNameSplunkEnterprise'), '/node-setup')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('splunkTags').provider]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmNameSplunkEnterprise'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('networkInterfaceNameSplunkEnterprise'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": "[parameters('osSettingsSplunk').scripts]"
+        },
+        "protectedSettings": {
+          "commandToExecute": "[concat('bash node-setup.sh', ' -r ', variables('splunkServerRole'), ' -c ', variables('clusterMasterIp'), ' -u ', parameters('udpPort'),  ' -p ', variables('singleQuote'), parameters('splunkAdminPassword'), variables('singleQuote'))]"
+        }
       }
     }
-  }],
-"outputs": {
-  "splunkenterpriseUri": {
+  ],
+  "outputs": {
+    "splunkenterpriseUri": {
       "type": "string",
       "value": "[concat('https://',reference(resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressSettingsSplunk').name)).dnsSettings.fqdn)]"
     }
-}
+  }
 }

--- a/trend-chef-splunk-security/nested/trendp2p-trenddsm.json
+++ b/trend-chef-splunk-security/nested/trendp2p-trenddsm.json
@@ -151,7 +151,7 @@
   },
   "resources": [
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[parameters('publicIPAddressNameTrendDSM')]",
       "location": "[parameters('location')]",
@@ -169,7 +169,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[parameters('nicNameTrendDSM')]",
       "location": "[parameters('location')]",
@@ -204,7 +204,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[parameters('securityGroupNameTrendDSM')]",
       "location": "[parameters('location')]",
@@ -298,7 +298,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2016-04-30-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmNameTrendDSM')]",
       "location": "[parameters('location')]",
@@ -353,7 +353,7 @@
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
-            "enabled": "true",
+            "enabled": true,
             "storageUri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/')]"
           }
         }
@@ -362,7 +362,7 @@
     {
       "name": "buildSQLServer",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "",
+      "apiVersion": "2015-01-01",
       "dependsOn": [],
       "properties": {
         "mode": "Incremental",

--- a/trend-chef-splunk-security/nested/trendp2p-trenddsm.json
+++ b/trend-chef-splunk-security/nested/trendp2p-trenddsm.json
@@ -1,403 +1,414 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  	"contentVersion": "1.0.0.0",
-  	"parameters": {
-
-      "storageAccountName": {
-        "type": "string",
-        "defaultValue": ""
-      },
-      "vmStorageAccountContainerName": {
-        "type": "string",
-        "defaultValue": ""
-      },      
-      "location": {
-        "type": "string",
-        "defaultValue": ""
-      },
-      "network-api-version": {
-        "type": "string",
-        "defaultValue": ""
-      },
-      "compute-api-version": {
-        "type": "string",
-        "defaultValue": ""
-      },
-      "tagvalues": {
-	      "type": "object",
-	      "defaultValue": {
-	        "program": "p2p",
-	        "project": "TrendMicro"
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "vmStorageAccountContainerName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "network-api-version": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "compute-api-version": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "tagvalues": {
+      "type": "object",
+      "defaultValue": {
+        "program": "p2p",
+        "project": "TrendMicro"
       }
     },
     "publicIPAddressNameTrendDSM": {
-        "type": "string",
-        "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "publicIPDomainNameLabelTrendDSM": {
-        "type": "string",
-        "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "publicIPAddressType": {
-        "type": "string",
-        "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "nicNameTrendDSM": {
-        "type": "string",
-        "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "virtualNetworkName": {
-        "type": "string",
-          "defaultValue": "dsmvnet"
+      "type": "string",
+      "defaultValue": "dsmvnet"
     },
     "subnet1Ref": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "securityGroupNameTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "managerPortTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "heartbeatPortTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "vmNameTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "publisherTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "offerChoosedTrendDSM": {
-        "type": "object",
-          "defaultValue": ""
+      "type": "object",
+      "defaultValue": ""
     },
     "vmAdminNameTrendDSM": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "vmAdminPasswordTrendDSM": {
-        "type": "securestring",
-          "defaultValue": ""
+      "type": "securestring",
+      "defaultValue": ""
     },
     "linuxConfigurationChoosenTrendDSM": {
-        "type": "object",
-          "defaultValue": ""
+      "type": "object",
+      "defaultValue": ""
     },
     "deployment-api-version": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "baseUrl": {
-        "type": "string",
-        "metadata": {
-            "description": "The base URL for dependent assets",
-            "artifactsBaseUrl": ""
-        },
-        "defaultValue": "https://deepsecurityazure.blob.core.windows.net/dsmtemplate"
+      "type": "string",
+      "metadata": {
+        "description": "The base URL for dependent assets",
+        "artifactsBaseUrl": ""
+      },
+      "defaultValue": "https://deepsecurityazure.blob.core.windows.net/dsmtemplate"
     },
     "dsmAdminName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
-      "dsmAdminPassword": {
-        "type": "securestring",
-          "defaultValue": ""
+    "dsmAdminPassword": {
+      "type": "securestring",
+      "defaultValue": ""
     },
     "databaseOption": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "newsqlServerName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "existingSQLServerName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "dbAdminName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "dbAdminPassword": {
-        "type": "securestring",
-          "defaultValue": ""
+      "type": "securestring",
+      "defaultValue": ""
     },
     "dbName": {
-        "type": "string",
-          "defaultValue": ""
+      "type": "string",
+      "defaultValue": ""
     },
     "trendmicroTags": {
-        "type": "object"
+      "type": "object"
     },
     "chefSoftwareTags": {
-        "type": "object"
+      "type": "object"
     },
     "splunkTags": {
-        "type": "object"
+      "type": "object"
     },
     "quickstartTags": {
-        "type": "object"
+      "type": "object"
     }
-  	},
-  	"variables": {
-  		"licenseMode": "10"
-  		},
-  	"resources": [
-  	{
-        "apiVersion": "[parameters('network-api-version')]",
-        "type": "Microsoft.Network/publicIPAddresses",
-        "name": "[parameters('publicIPAddressNameTrendDSM')]",
-        "location": "[parameters('location')]",
-        "tags": {
-          "program": "[parameters('tagvalues').program]",
-          "project": "[parameters('tagvalues').project]",
-          "quickstartName": "[parameters('quickstartTags').name]",
-          "provider": "[parameters('trendmicroTags').provider]"
-        },
-        "properties": {
-            "publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
-            "dnsSettings": {
-                "domainNameLabel": "[parameters('publicIPDomainNameLabelTrendDSM')]"
-            }
-        }
-     },
-  	{
-        "apiVersion": "[parameters('network-api-version')]",
-        "type": "Microsoft.Network/networkInterfaces",
-        "name": "[parameters('nicNameTrendDSM')]",
-        "location": "[parameters('location')]",
-        "tags": {
-          "program": "[parameters('tagvalues').program]",
-          "project": "[parameters('tagvalues').project]",
-          "quickstartName": "[parameters('quickstartTags').name]",
-          "provider": "[parameters('trendmicroTags').provider]"
-        },
-        "dependsOn": [
-            "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressNameTrendDSM'))]",
-           
-            "[concat('Microsoft.Network/networkSecurityGroups/', parameters('securityGroupNameTrendDSM'))]"
-        ],
-        "properties": {
-            "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('securityGroupNameTrendDSM'))]"
-            },
-            "ipConfigurations": [{
-                "name": "ipconfig1",
-                "properties": {
-                    "privateIPAllocationMethod": "Dynamic",
-                    "publicIPAddress": {
-                        "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM'))]"
-                    },
-                    "subnet": {
-                        "id": "[parameters('subnet1Ref')]"
-                    }
-                }
-            }]
-        }
+  },
+  "variables": {
+    "licenseMode": "10"
+  },
+  "resources": [
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[parameters('publicIPAddressNameTrendDSM')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
       },
-	 {
-        "apiVersion": "[parameters('network-api-version')]",
-        "type": "Microsoft.Network/networkSecurityGroups",
-        "name": "[parameters('securityGroupNameTrendDSM')]",
-        "location": "[parameters('location')]",
-        "tags": {
-          "program": "[parameters('tagvalues').program]",
-          "project": "[parameters('tagvalues').project]",
-          "quickstartName": "[parameters('quickstartTags').name]",
-          "provider": "[parameters('trendmicroTags').provider]"
-        },
-        "properties": {
-          "securityRules": [
-            {
-              "name": "allow-inbound-ssh",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "22",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1000,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmportal",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "[parameters('managerPortTrendDSM')]",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1100,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmagent",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "4118",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1200,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmheartbeat",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "[parameters('heartbeatPortTrendDSM')]",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1300,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmdownload",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "4122",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1400,
-                "direction": "Inbound"
-              }
-            },
-            {
-              "name": "allow-inbound-dsmwebinstaller",
-              "properties": {
-                "protocol": "Tcp",
-                "sourcePortRange": "*",
-                "destinationPortRange": "8443",
-                "sourceAddressPrefix": "*",
-                "destinationAddressPrefix": "*",
-                "access": "Allow",
-                "priority": 1500,
-                "direction": "Inbound"
-              }
-            }
-          ]
-        }
-      },
-	 {
-        "apiVersion": "[parameters('compute-api-version')]",
-        "type": "Microsoft.Compute/virtualMachines",
-        "name": "[parameters('vmNameTrendDSM')]",
-        "location": "[parameters('location')]",
-        "tags": {
-          "program": "[parameters('tagvalues').program]",
-          "project": "[parameters('tagvalues').project]",
-          "quickstartName": "[parameters('quickstartTags').name]",
-          "provider": "[parameters('trendmicroTags').provider]"
-        },
-        "dependsOn": [
-           
-            "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNameTrendDSM'))]",
-            "[concat('Microsoft.Resources/deployments/', 'buildSQLServer')]"
-        ],
-        "plan": {
-            "publisher": "[parameters('publisherTrendDSM')]",
-            "product": "[parameters('offerChoosedTrendDSM').product]",
-            "name": "[parameters('offerChoosedTrendDSM').vmSku]"            
-        },
-        "properties": {
-            "hardwareProfile": {
-                "vmSize": "[parameters('offerChoosedTrendDSM').vmSize]"
-            },
-            "osProfile": {
-                "computerName": "[parameters('vmNameTrendDSM')]",
-                "adminUsername": "[parameters('vmAdminNameTrendDSM')]",
-                "adminPassword": "[parameters('vmAdminPasswordTrendDSM')]",
-                "customData": "[base64(concat('vmName:',base64(parameters('vmNameTrendDSM')),',databaseServer:',reference('buildSQLServer').outputs.sqlServerFQDN.value,',databaseName:',base64(parameters('dbName')),',location:',parameters('location'),',managerPort:',parameters('managerPortTrendDSM'),',heartbeatPort:',parameters('heartbeatPortTrendDSM'),',vmFQDN:',reference(resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn,',publicIP:,adminUserName:',base64(parameters('dsmAdminName')),',adminPassword:',base64(parameters('dsmAdminPassword')),',databaseUserName:',base64(parameters('dbAdminName')),',databaseUserPassword:',base64(parameters('dbAdminPassword')),',subscriptionId:',subscription().subscriptionId,',databaseOption:',parameters('databaseOption'),',vmSize:',parameters('offerChoosedTrendDSM').vmSize,',licenseMode:',variables('licenseMode')))]",
-                "linuxConfiguration": "[parameters('linuxConfigurationChoosenTrendDSM')]"                
-            },
-            "storageProfile": {
-                "imageReference": {
-                    "publisher": "[parameters('publisherTrendDSM')]",
-                    "offer": "[parameters('offerChoosedTrendDSM').product]",
-                    "sku": "[parameters('offerChoosedTrendDSM').vmSku]",
-                    "version": "2.0.0"
-                },
-                "osDisk": {
-                    "name": "[concat(parameters('vmNameTrendDSM'),'-osDisk')]",
-                    "caching": "ReadWrite",
-                    "createOption": "FromImage",
-                    "vhd": {
-                        "uri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/',parameters('vmStorageAccountContainerName'),'/',parameters('vmNameTrendDSM'),'-osdisk.vhd')]"
-                    }
-                }
-            },
-            "networkProfile": {
-                "networkInterfaces": [{
-                    "id": "[resourceId('Microsoft.Network/networkInterfaces',parameters('nicNameTrendDSM'))]"
-                }]
-            },
-            "diagnosticsProfile": {
-                "bootDiagnostics": {
-                    "enabled": "true",
-                    "storageUri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/')]"
-                }
-            }
-        }
-      },
-      {
-        "name": "buildSQLServer",
-        "type": "Microsoft.Resources/deployments",
-        "apiVersion": "[parameters('deployment-api-version')]",
-        "dependsOn": [
-        ],
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-              "uri": "[concat(parameters('baseUrl'), '/nested/database-',parameters('databaseOption'),'.json')]",
-              "contentVersion": "1.0.0.0"
-            },
-            "parameters":{
-              "location": { "value": "[parameters('location')]" },
-              "newsqlServerName": { "value": "[parameters('newsqlServerName')]" },
-              "existingSQLServerName": { "value": "[parameters('existingSQLServerName')]"},
-              "dbAdminName": { "value": "[parameters('dbAdminName')]" },
-              "dbAdminPassword": { "value": "[parameters('dbAdminPassword')]" },
-              "sqlDBName": { "value": "[parameters('dbName')]" },
-              "trendmicroTags": {
-                 "value": "[parameters('trendmicroTags')]"
-              },
-              "chefSoftwareTags": {
-                 "value": "[parameters('chefSoftwareTags')]"
-              },
-              "splunkTags": {
-                 "value": "[parameters('splunkTags')]"
-              },
-              "quickstartTags": {
-                "value": "[parameters('quickstartTags')]"
-              }          
-            }
+      "properties": {
+        "publicIPAllocationMethod": "[parameters('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('publicIPDomainNameLabelTrendDSM')]"
         }
       }
-
-  	],
-"outputs": {
-  "trendmicrodsmUri": {
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[parameters('nicNameTrendDSM')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', parameters('publicIPAddressNameTrendDSM'))]",
+        "[concat('Microsoft.Network/networkSecurityGroups/', parameters('securityGroupNameTrendDSM'))]"
+      ],
+      "properties": {
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('securityGroupNameTrendDSM'))]"
+        },
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM'))]"
+              },
+              "subnet": {
+                "id": "[parameters('subnet1Ref')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('securityGroupNameTrendDSM')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
+      },
+      "properties": {
+        "securityRules": [
+          {
+            "name": "allow-inbound-ssh",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1000,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmportal",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[parameters('managerPortTrendDSM')]",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmagent",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "4118",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1200,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmheartbeat",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "[parameters('heartbeatPortTrendDSM')]",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1300,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmdownload",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "4122",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1400,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "allow-inbound-dsmwebinstaller",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "8443",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1500,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[parameters('vmNameTrendDSM')]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "program": "[parameters('tagvalues').program]",
+        "project": "[parameters('tagvalues').project]",
+        "quickstartName": "[parameters('quickstartTags').name]",
+        "provider": "[parameters('trendmicroTags').provider]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', parameters('nicNameTrendDSM'))]",
+        "[concat('Microsoft.Resources/deployments/', 'buildSQLServer')]"
+      ],
+      "plan": {
+        "publisher": "[parameters('publisherTrendDSM')]",
+        "product": "[parameters('offerChoosedTrendDSM').product]",
+        "name": "[parameters('offerChoosedTrendDSM').vmSku]"
+      },
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('offerChoosedTrendDSM').vmSize]"
+        },
+        "osProfile": {
+          "computerName": "[parameters('vmNameTrendDSM')]",
+          "adminUsername": "[parameters('vmAdminNameTrendDSM')]",
+          "adminPassword": "[parameters('vmAdminPasswordTrendDSM')]",
+          "customData": "[base64(concat('vmName:',base64(parameters('vmNameTrendDSM')),',databaseServer:',reference('buildSQLServer').outputs.sqlServerFQDN.value,',databaseName:',base64(parameters('dbName')),',location:',parameters('location'),',managerPort:',parameters('managerPortTrendDSM'),',heartbeatPort:',parameters('heartbeatPortTrendDSM'),',vmFQDN:',reference(resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn,',publicIP:,adminUserName:',base64(parameters('dsmAdminName')),',adminPassword:',base64(parameters('dsmAdminPassword')),',databaseUserName:',base64(parameters('dbAdminName')),',databaseUserPassword:',base64(parameters('dbAdminPassword')),',subscriptionId:',subscription().subscriptionId,',databaseOption:',parameters('databaseOption'),',vmSize:',parameters('offerChoosedTrendDSM').vmSize,',licenseMode:',variables('licenseMode')))]",
+          "linuxConfiguration": "[parameters('linuxConfigurationChoosenTrendDSM')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('publisherTrendDSM')]",
+            "offer": "[parameters('offerChoosedTrendDSM').product]",
+            "sku": "[parameters('offerChoosedTrendDSM').vmSku]",
+            "version": "2.0.0"
+          },
+          "osDisk": {
+            "name": "[concat(parameters('vmNameTrendDSM'),'-osDisk')]",
+            "caching": "ReadWrite",
+            "createOption": "FromImage",
+            "vhd": {
+              "uri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/',parameters('vmStorageAccountContainerName'),'/',parameters('vmNameTrendDSM'),'-osdisk.vhd')]"
+            }
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',parameters('nicNameTrendDSM'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": "true",
+            "storageUri": "[concat('https://',parameters('storageAccountName'),'.blob.core.windows.net/')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "buildSQLServer",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "",
+      "dependsOn": [],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(parameters('baseUrl'), '/nested/database-',parameters('databaseOption'),'.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "newsqlServerName": {
+            "value": "[parameters('newsqlServerName')]"
+          },
+          "existingSQLServerName": {
+            "value": "[parameters('existingSQLServerName')]"
+          },
+          "dbAdminName": {
+            "value": "[parameters('dbAdminName')]"
+          },
+          "dbAdminPassword": {
+            "value": "[parameters('dbAdminPassword')]"
+          },
+          "sqlDBName": {
+            "value": "[parameters('dbName')]"
+          },
+          "trendmicroTags": {
+            "value": "[parameters('trendmicroTags')]"
+          },
+          "chefSoftwareTags": {
+            "value": "[parameters('chefSoftwareTags')]"
+          },
+          "splunkTags": {
+            "value": "[parameters('splunkTags')]"
+          },
+          "quickstartTags": {
+            "value": "[parameters('quickstartTags')]"
+          }
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "trendmicrodsmUri": {
       "type": "string",
       "value": "[concat('https://',reference(resourceId('Microsoft.Network/publicIPAddresses',parameters('publicIPAddressNameTrendDSM'))).dnsSettings.fqdn)]"
     }
-}
+  }
 }

--- a/trend-chef-splunk-security/nested/trendp2p-vnetstorage.json
+++ b/trend-chef-splunk-security/nested/trendp2p-vnetstorage.json
@@ -93,7 +93,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "",
+      "apiVersion": "2016-01-01",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -106,7 +106,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
@@ -151,7 +151,7 @@
       }
     },
     {
-      "apiVersion": "",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('availabilitySetSettings').name, copyindex())]",
       "copy": {

--- a/trend-chef-splunk-security/nested/trendp2p-vnetstorage.json
+++ b/trend-chef-splunk-security/nested/trendp2p-vnetstorage.json
@@ -2,7 +2,6 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-
     "storageAccountName": {
       "type": "string",
       "defaultValue": ""
@@ -77,24 +76,24 @@
       }
     },
     "trendmicroTags": {
-       "type": "object"
+      "type": "object"
     },
     "chefSoftwareTags": {
-       "type": "object"
+      "type": "object"
     },
     "splunkTags": {
-       "type": "object"
+      "type": "object"
     },
-     "quickstartTags": {
-       "type": "object"
+    "quickstartTags": {
+      "type": "object"
     }
-
   },
   "variables": {},
-  "resources": [{
+  "resources": [
+    {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "[parameters('storage-api-version')]",
+      "apiVersion": "",
       "location": "[parameters('location')]",
       "tags": {
         "program": "[parameters('tagvalues').program]",
@@ -105,8 +104,9 @@
       "properties": {
         "accountType": "[parameters('storageAccountType')]"
       }
-    }, {
-      "apiVersion": "[parameters('network-api-version')]",
+    },
+    {
+      "apiVersion": "",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
@@ -122,32 +122,36 @@
             "[parameters('vnetAddressPrefix')]"
           ]
         },
-        "subnets": [{
-          "name": "[parameters('subnet1Name')]",
-          "properties": {
-            "addressPrefix": "[parameters('subnet1Prefix')]"
+        "subnets": [
+          {
+            "name": "[parameters('subnet1Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet1Prefix')]"
+            }
+          },
+          {
+            "name": "[parameters('subnet2Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet2Prefix')]"
+            }
+          },
+          {
+            "name": "[parameters('subnet3Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet3Prefix')]"
+            }
+          },
+          {
+            "name": "[parameters('subnet4Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet4Prefix')]"
+            }
           }
-        }, {
-          "name": "[parameters('subnet2Name')]",
-          "properties": {
-            "addressPrefix": "[parameters('subnet2Prefix')]"
-          }
-        }, {
-          "name": "[parameters('subnet3Name')]",
-          "properties": {
-            "addressPrefix": "[parameters('subnet3Prefix')]"
-          }
-        }, {
-          "name": "[parameters('subnet4Name')]",
-          "properties": {
-            "addressPrefix": "[parameters('subnet4Prefix')]"
-          }
-        }]
+        ]
       }
     },
-
     {
-      "apiVersion": "[parameters('network-api-version')]",
+      "apiVersion": "",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('availabilitySetSettings').name, copyindex())]",
       "copy": {
@@ -164,6 +168,5 @@
         "platformUpdateDomainCount": "[parameters('availabilitySetSettings').udCount]"
       }
     }
-
   ]
 }

--- a/ubuntu-desktop-xfce-rdp/azuredeploy.json
+++ b/ubuntu-desktop-xfce-rdp/azuredeploy.json
@@ -20,16 +20,16 @@
         "description": "DNS Name for the publicly accessible node. Must be lowercase. It should match with the following regular expression: ^[a-z][a-z0-9-]{1,61}[a-z0-9]$ or it will raise an error."
       }
     },
-	"vmSize": {
+    "vmSize": {
       "type": "string",
       "defaultValue": "Standard_A1",
       "allowedValues": [
-	    "Standard_A1",
-		"Standard_A2",
-		"Standard_A3",
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
         "Standard_D1",
         "Standard_D3",
-		"Standard_D4"
+        "Standard_D4"
       ],
       "metadata": {
         "description": "The size of the virtual machines used when provisioning"
@@ -56,8 +56,8 @@
     "addressPrefix": "10.0.0.0/16",
     "subnetName": "Subnet",
     "subnetPrefix": "10.0.0.0/24",
-	"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-	"apiVersion": "2015-06-15",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "apiVersion": "2015-06-15",
     "storageAccountType": "Standard_LRS",
     "publicIPAddressName": "myPublicIP",
     "publicIPAddressType": "Dynamic",
@@ -71,14 +71,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -90,7 +90,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -111,7 +111,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -137,7 +137,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[resourceGroup().location]",
@@ -182,7 +182,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
@@ -202,4 +202,3 @@
     }
   ]
 }
-

--- a/vertx-openjdk-apache-mysql-on-ubuntu/azuredeploy.json
+++ b/vertx-openjdk-apache-mysql-on-ubuntu/azuredeploy.json
@@ -62,14 +62,14 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[parameters('newStorageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {
         "accountType": "[variables('storageAccountType')]"
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -81,7 +81,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -102,7 +102,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -128,7 +128,7 @@
       }
     },
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",
@@ -173,7 +173,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(parameters('vmName'),'/newuserscript')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "dependsOn": [
         "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"

--- a/vod-aspera-wowza-azuremediaservices/ams/ams-with-automation.json
+++ b/vod-aspera-wowza-azuremediaservices/ams/ams-with-automation.json
@@ -1,234 +1,234 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "MediaServices_Name": {
-            "defaultValue": "media",
-            "type": "string"
-        },
-        "Input_StorageAccounts_Name": {
-            "defaultValue": "input",
-            "type": "string"
-        },
-        "Output_StorageAccounts_Name": {
-            "defaultValue": "output",
-            "type": "string"
-        },
-        "MediaService_StorageAccounts_Name": {
-            "defaultValue": "mediab",
-            "type": "string"
-        },
-        "storageApiVersion": {
-            "type": "string",
-            "defaultValue": "2015-06-15",
-            "allowedValues": [
-                "2015-05-01-preview",
-                "2015-06-15"
-            ],
-            "metadata": {
-                "description": "API Version for the Storage Account"
-            }
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": "West US",
-            "allowedValues": [
-                "Brazil South",
-                "East Asia",
-                "East US",
-                "Japan East",
-                "Japan West",
-                "North Central US",
-                "North Europe",
-                "South Central US",
-                "West Europe",
-                "West US",
-                "Southeast Asia",
-                "Central US",
-                "East US 2"
-            ],
-            "metadata": {
-                "description": "Storage Account Deployment Location"
-            }
-        },
-        "tag": {
-            "type": "object",
-            "defaultValue": {
-                "key1": "key",
-                "value1": "value"
-            },
-            "metadata": {
-                "description": "Tag Values"
-            }
-        },
-        "storageAccountType": {
-            "type": "string",
-            "defaultValue": "Standard_LRS",
-            "allowedValues": [
-                "Standard_LRS",
-                "Standard_ZRS",
-                "Standard_GRS",
-                "Standard_RAGRS",
-                "Premium_LRS"
-            ],
-            "metadata": {
-                "description": "Stoarge Account Type"
-            }
-        },
-        "jobId": {
-            "type": "string",
-            "defaultValue": "24b18f62-aa2c-4528-ac10-1e3602eb4053",
-            "metadata": {
-                "description": "Generate a Job ID (GUID) from https://www.guidgenerator.com/online-guid-generator.aspx "
-            }
-        },
-        "automationSku": {
-            "type": "string",
-            "defaultValue": "Basic",
-            "allowedValues": [
-                "Free",
-                "Basic"
-            ]
-        },
-        "automationLocation": {
-            "type": "string",
-            "defaultValue": "North Europe",
-            "allowedValues": [
-                "Japan East",
-                "North Europe",
-                "South Central US",
-                "West Europe",
-                "Southeast Asia",
-                "East US 2"
-            ]
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "MediaServices_Name": {
+      "defaultValue": "media",
+      "type": "string"
     },
-    "variables": {
-        "Input_StorageAccounts_Name": "[concat(parameters('Input_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
-        "Output_StorageAccounts_Name": "[concat(parameters('Output_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
-        "MediaService_StorageAccounts_Name": "[concat(parameters('MediaService_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
-        "MediaServices_Name": "[concat(parameters('MediaServices_Name'),uniqueString(resourceGroup().id))]",
-        "automationUrl": "https://raw.githubusercontent.com/ashwinse/azuremedia/master/azure-mediaservices-automation.json",
-        "automationAccountName": "azureMediaSrcAutoAcc",
-        "runbookUrl": " https://raw.githubusercontent.com/sysgain/azurequickstarts/master/VOD-Aspera-Wowza-AzureMediaServices/ams/MediaservicesRestapi1.ps1",
-        "runbookName": "myrunbook"
+    "Input_StorageAccounts_Name": {
+      "defaultValue": "input",
+      "type": "string"
     },
-    "resources": [
-        {
-            "comments": "Storage Account Resource",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('Input_StorageAccounts_Name')]",
-            "apiVersion": "[parameters('storageApiVersion')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "[parameters('tag').key1]": "[parameters('tag').value1]"
-            },
-            "properties": {
-                "accountType": "[parameters('storageAccountType')]"
-            }
+    "Output_StorageAccounts_Name": {
+      "defaultValue": "output",
+      "type": "string"
+    },
+    "MediaService_StorageAccounts_Name": {
+      "defaultValue": "mediab",
+      "type": "string"
+    },
+    "storageApiVersion": {
+      "type": "string",
+      "defaultValue": "2015-06-15",
+      "allowedValues": [
+        "2015-05-01-preview",
+        "2015-06-15"
+      ],
+      "metadata": {
+        "description": "API Version for the Storage Account"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "West US",
+      "allowedValues": [
+        "Brazil South",
+        "East Asia",
+        "East US",
+        "Japan East",
+        "Japan West",
+        "North Central US",
+        "North Europe",
+        "South Central US",
+        "West Europe",
+        "West US",
+        "Southeast Asia",
+        "Central US",
+        "East US 2"
+      ],
+      "metadata": {
+        "description": "Storage Account Deployment Location"
+      }
+    },
+    "tag": {
+      "type": "object",
+      "defaultValue": {
+        "key1": "key",
+        "value1": "value"
+      },
+      "metadata": {
+        "description": "Tag Values"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "allowedValues": [
+        "Standard_LRS",
+        "Standard_ZRS",
+        "Standard_GRS",
+        "Standard_RAGRS",
+        "Premium_LRS"
+      ],
+      "metadata": {
+        "description": "Stoarge Account Type"
+      }
+    },
+    "jobId": {
+      "type": "string",
+      "defaultValue": "24b18f62-aa2c-4528-ac10-1e3602eb4053",
+      "metadata": {
+        "description": "Generate a Job ID (GUID) from https://www.guidgenerator.com/online-guid-generator.aspx "
+      }
+    },
+    "automationSku": {
+      "type": "string",
+      "defaultValue": "Basic",
+      "allowedValues": [
+        "Free",
+        "Basic"
+      ]
+    },
+    "automationLocation": {
+      "type": "string",
+      "defaultValue": "North Europe",
+      "allowedValues": [
+        "Japan East",
+        "North Europe",
+        "South Central US",
+        "West Europe",
+        "Southeast Asia",
+        "East US 2"
+      ]
+    }
+  },
+  "variables": {
+    "Input_StorageAccounts_Name": "[concat(parameters('Input_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
+    "Output_StorageAccounts_Name": "[concat(parameters('Output_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
+    "MediaService_StorageAccounts_Name": "[concat(parameters('MediaService_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
+    "MediaServices_Name": "[concat(parameters('MediaServices_Name'),uniqueString(resourceGroup().id))]",
+    "automationUrl": "https://raw.githubusercontent.com/ashwinse/azuremedia/master/azure-mediaservices-automation.json",
+    "automationAccountName": "azureMediaSrcAutoAcc",
+    "runbookUrl": " https://raw.githubusercontent.com/sysgain/azurequickstarts/master/VOD-Aspera-Wowza-AzureMediaServices/ams/MediaservicesRestapi1.ps1",
+    "runbookName": "myrunbook"
+  },
+  "resources": [
+    {
+      "comments": "Storage Account Resource",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('Input_StorageAccounts_Name')]",
+      "apiVersion": "2015-06-15",
+      "location": "[parameters('location')]",
+      "tags": {
+        "[parameters('tag').key1]": "[parameters('tag').value1]"
+      },
+      "properties": {
+        "accountType": "[parameters('storageAccountType')]"
+      }
+    },
+    {
+      "comments": "Storage Account Resource",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('Output_StorageAccounts_Name')]",
+      "apiVersion": "2015-06-15",
+      "location": "[parameters('location')]",
+      "tags": {
+        "[parameters('tag').key1]": "[parameters('tag').value1]"
+      },
+      "properties": {
+        "accountType": "[parameters('storageAccountType')]"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('MediaService_StorageAccounts_Name')]",
+      "apiVersion": "2015-06-15",
+      "location": "[parameters('location')]",
+      "tags": {
+        "[parameters('tag').key1]": "[parameters('tag').value1]"
+      },
+      "properties": {
+        "accountType": "[parameters('storageAccountType')]"
+      }
+    },
+    {
+      "type": "Microsoft.Media/mediaServices",
+      "name": "[variables('MediaServices_Name')]",
+      "apiVersion": "2015-10-01",
+      "location": "East US",
+      "properties": {
+        "storageAccounts": [
+          {
+            "id": "[resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name'))]",
+            "isPrimary": true
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name'))]"
+      ]
+    },
+    {
+      "name": "automationJob",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Media/mediaServices', variables('MediaServices_Name'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('Output_StorageAccounts_Name'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('Input_StorageAccounts_Name'))]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('automationUrl')]",
+          "contentVersion": "1.0.0.0"
         },
-        {
-            "comments": "Storage Account Resource",
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('Output_StorageAccounts_Name')]",
-            "apiVersion": "[parameters('storageApiVersion')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "[parameters('tag').key1]": "[parameters('tag').value1]"
-            },
-            "properties": {
-                "accountType": "[parameters('storageAccountType')]"
-            }
-        },
-        {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('MediaService_StorageAccounts_Name')]",
-            "apiVersion": "[parameters('storageApiVersion')]",
-            "location": "[parameters('location')]",
-            "tags": {
-                "[parameters('tag').key1]": "[parameters('tag').value1]"
-            },
-            "properties": {
-                "accountType": "[parameters('storageAccountType')]"
-            }
-        },
-        {
-            "type": "Microsoft.Media/mediaServices",
-            "name": "[variables('MediaServices_Name')]",
-            "apiVersion": "2015-10-01",
-            "location": "East US",
-            "properties": {
-                "storageAccounts": [
-                    {
-                        "id": "[resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name'))]",
-                        "isPrimary": true
-                    }
-                ]
-            },
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name'))]"
-            ]
-        },
-        {
-            "name": "automationJob",
-            "type": "Microsoft.Resources/deployments",
-            "apiVersion": "2015-01-01",
-            "dependsOn": [
-                "[resourceId('Microsoft.Media/mediaServices', variables('MediaServices_Name'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('Output_StorageAccounts_Name'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('Input_StorageAccounts_Name'))]"
-            ],
-            "properties": {
-                "mode": "Incremental",
-                "templateLink": {
-                    "uri": "[variables('automationUrl')]",
-                    "contentVersion": "1.0.0.0"
-                },
-                "parameters": {
-                    "location": {
-                        "value": "[parameters('automationLocation')]"
-                    },
-                    "automationAccountName": {
-                        "value": "[variables('automationAccountName')]"
-                    },
-                    "sku": {
-                        "value": "[parameters('automationSku')]"
-                    },
-                    "runbookUrl": {
-                        "value": "[variables('runbookUrl')]"
-                    },
-                    "runbookName": {
-                        "value": "[variables('runbookName')]"
-                    },
-                    "MediaServices_Name": {
-                        "value": "[variables('MediaServices_Name')]"
-                    },
-                    "MediaServices_Keys": {
-                        "value": "[listKeys(resourceId('Microsoft.Media/mediaservices', variables('MediaServices_Name')), '2015-10-01').primaryKey]"
-                    },
-                    "Input_StorageAccounts_Name": {
-                        "value": "[variables('Input_StorageAccounts_Name')]"
-                    },
-                    "Input_StorageAccounts_Keys": {
-                        "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('Input_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-                    },
-                    "Ouput_StorageAccounts_Name": {
-                        "value": "[variables('Output_StorageAccounts_Name')]"
-                    },
-                    "Output_StorageAccounts_Keys": {
-                        "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('Output_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-                    },
-                    "MediaService_StorageAccounts_Name": {
-                        "value": "[variables('MediaService_StorageAccounts_Name')]"
-                    },
-                    "MediaService_StorageAccounts_Keys": {
-                        "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-                    },
-                    "jobId": {
-                        "value": "[parameters('jobId')]"
-                    }
-                }
-            }
+        "parameters": {
+          "location": {
+            "value": "[parameters('automationLocation')]"
+          },
+          "automationAccountName": {
+            "value": "[variables('automationAccountName')]"
+          },
+          "sku": {
+            "value": "[parameters('automationSku')]"
+          },
+          "runbookUrl": {
+            "value": "[variables('runbookUrl')]"
+          },
+          "runbookName": {
+            "value": "[variables('runbookName')]"
+          },
+          "MediaServices_Name": {
+            "value": "[variables('MediaServices_Name')]"
+          },
+          "MediaServices_Keys": {
+            "value": "[listKeys(resourceId('Microsoft.Media/mediaservices', variables('MediaServices_Name')), '2015-10-01').primaryKey]"
+          },
+          "Input_StorageAccounts_Name": {
+            "value": "[variables('Input_StorageAccounts_Name')]"
+          },
+          "Input_StorageAccounts_Keys": {
+            "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('Input_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+          },
+          "Ouput_StorageAccounts_Name": {
+            "value": "[variables('Output_StorageAccounts_Name')]"
+          },
+          "Output_StorageAccounts_Keys": {
+            "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('Output_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+          },
+          "MediaService_StorageAccounts_Name": {
+            "value": "[variables('MediaService_StorageAccounts_Name')]"
+          },
+          "MediaService_StorageAccounts_Keys": {
+            "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+          },
+          "jobId": {
+            "value": "[parameters('jobId')]"
+          }
         }
-    ]
+      }
+    }
+  ]
 }

--- a/vod-aspera-wowza-azuremediaservices/ams/ams.json
+++ b/vod-aspera-wowza-azuremediaservices/ams/ams.json
@@ -1,127 +1,133 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-		"MediaServices_Name": {
-			"defaultValue": "media",
-			"type": "String"
-		},
-		"Input_StorageAccounts_Name": {
-			"defaultValue": "input",
-			"type": "String"
-		},
-		"Output_StorageAccounts_Name": {
-			"defaultValue": "output",
-			"type": "String"
-		},
-		"MediaService_StorageAccounts_Name": {
-			"defaultValue": "mediab",
-			"type": "String"
-		},
-		"tag": {
-			"type": "object",
-			"defaultValue": {
-				"key1": "key",
-				"value1": "value"
-			},
-			"metadata": {
-				"description": "Tag Values"
-			}
-		}
-
-	},
-	"variables": {
-		"uniqueString": "[uniquestring(resourceGroup().id)]",
-		"Input_StorageAccounts_Name": "[concat(parameters('Input_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
-		"Output_StorageAccounts_Name": "[concat(parameters('Output_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
-		"MediaService_StorageAccounts_Name": "[concat(parameters('MediaService_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
-		"MediaServices_Name": "[concat(parameters('MediaServices_Name'),uniqueString(resourceGroup().id))]",
-		"storageApiVersion": "2015-06-15",
-		"storageAccountType": "Standard_LRS"
-	},
-	"resources": [{
-		"comments": "Storage Account Resource",
-		"type": "Microsoft.Storage/storageAccounts",
-		"name": "[variables('Input_StorageAccounts_Name')]",
-		"apiVersion": "[variables('storageApiVersion')]",
-		"location": "[resourceGroup().location]",
-		"tags": {
-			"[parameters('tag').key1]": "[parameters('tag').value1]"
-		},
-		"properties": {
-			"accountType": "[variables('storageAccountType')]"
-		}
-	}, {
-		"comments": "Storage Account Resource",
-		"type": "Microsoft.Storage/storageAccounts",
-		"name": "[variables('Output_StorageAccounts_Name')]",
-		"apiVersion": "[variables('storageApiVersion')]",
-		"location": "[resourceGroup().location]",
-		"tags": {
-			"[parameters('tag').key1]": "[parameters('tag').value1]"
-		},
-		"properties": {
-			"accountType": "[variables('storageAccountType')]"
-		}
-	}, {
-		"comments": "Storage Account Resource",
-		"type": "Microsoft.Storage/storageAccounts",
-		"name": "[variables('MediaService_StorageAccounts_Name')]",
-		"apiVersion": "[variables('storageApiVersion')]",
-		"location": "[resourceGroup().location]",
-		"tags": {
-			"[parameters('tag').key1]": "[parameters('tag').value1]"
-		},
-		"properties": {
-			"accountType": "[variables('storageAccountType')]"
-		}
-	}, {
-		"type": "Microsoft.Media/mediaservices",
-		"name": "[variables('MediaServices_Name')]",
-		"apiVersion": "2015-10-01",
-		"location": "[resourceGroup().location]",
-		"properties": {
-			"storageAccounts": [{
-				"id": "[resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name'))]",
-				"isPrimary": true
-			}]
-		},
-		"dependsOn": [
-			"[resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name'))]"
-		]
-	}],
-	"outputs": {
-		"Input_StorageAccounts_Name": {
-			"type": "string",
-			"value": "[variables('Input_StorageAccounts_Name')]"
-		},
-		"Input_StorageAccounts_Keys": {
-			"type": "string",
-			"value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('Input_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-		},
-		"Ouput_StorageAccounts_Name": {
-			"type": "string",
-			"value": "[variables('Output_StorageAccounts_Name')]"
-		},
-		"Output_StorageAccounts_Keys": {
-			"type": "string",
-			"value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('Output_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-		},
-		"MediaService_StorageAccounts_Name": {
-			"type": "string",
-			"value": "[variables('MediaService_StorageAccounts_Name')]"
-		},
-		"MediaService_StorageAccounts_Keys": {
-			"type": "string",
-			"value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
-		},
-		"MediaServices_Name": {
-			"type": "string",
-			"value": "[variables('MediaServices_Name')]"
-		},
-		"MediaServices_Keys": {
-			"type": "string",
-			"value": "[listKeys(resourceId('Microsoft.Media/mediaservices', variables('MediaServices_Name')), '2015-10-01').primaryKey]"
-		}
-	}
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "MediaServices_Name": {
+      "defaultValue": "media",
+      "type": "String"
+    },
+    "Input_StorageAccounts_Name": {
+      "defaultValue": "input",
+      "type": "String"
+    },
+    "Output_StorageAccounts_Name": {
+      "defaultValue": "output",
+      "type": "String"
+    },
+    "MediaService_StorageAccounts_Name": {
+      "defaultValue": "mediab",
+      "type": "String"
+    },
+    "tag": {
+      "type": "object",
+      "defaultValue": {
+        "key1": "key",
+        "value1": "value"
+      },
+      "metadata": {
+        "description": "Tag Values"
+      }
+    }
+  },
+  "variables": {
+    "uniqueString": "[uniquestring(resourceGroup().id)]",
+    "Input_StorageAccounts_Name": "[concat(parameters('Input_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
+    "Output_StorageAccounts_Name": "[concat(parameters('Output_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
+    "MediaService_StorageAccounts_Name": "[concat(parameters('MediaService_StorageAccounts_Name'),uniqueString(resourceGroup().id))]",
+    "MediaServices_Name": "[concat(parameters('MediaServices_Name'),uniqueString(resourceGroup().id))]",
+    "storageApiVersion": "2015-06-15",
+    "storageAccountType": "Standard_LRS"
+  },
+  "resources": [
+    {
+      "comments": "Storage Account Resource",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('Input_StorageAccounts_Name')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "[parameters('tag').key1]": "[parameters('tag').value1]"
+      },
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "comments": "Storage Account Resource",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('Output_StorageAccounts_Name')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "[parameters('tag').key1]": "[parameters('tag').value1]"
+      },
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "comments": "Storage Account Resource",
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('MediaService_StorageAccounts_Name')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "tags": {
+        "[parameters('tag').key1]": "[parameters('tag').value1]"
+      },
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "type": "Microsoft.Media/mediaservices",
+      "name": "[variables('MediaServices_Name')]",
+      "apiVersion": "2015-10-01",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "storageAccounts": [
+          {
+            "id": "[resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name'))]",
+            "isPrimary": true
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "Input_StorageAccounts_Name": {
+      "type": "string",
+      "value": "[variables('Input_StorageAccounts_Name')]"
+    },
+    "Input_StorageAccounts_Keys": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('Input_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+    },
+    "Ouput_StorageAccounts_Name": {
+      "type": "string",
+      "value": "[variables('Output_StorageAccounts_Name')]"
+    },
+    "Output_StorageAccounts_Keys": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('Output_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+    },
+    "MediaService_StorageAccounts_Name": {
+      "type": "string",
+      "value": "[variables('MediaService_StorageAccounts_Name')]"
+    },
+    "MediaService_StorageAccounts_Keys": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('MediaService_StorageAccounts_Name')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value]"
+    },
+    "MediaServices_Name": {
+      "type": "string",
+      "value": "[variables('MediaServices_Name')]"
+    },
+    "MediaServices_Keys": {
+      "type": "string",
+      "value": "[listKeys(resourceId('Microsoft.Media/mediaservices', variables('MediaServices_Name')), '2015-10-01').primaryKey]"
+    }
+  }
 }

--- a/vod-aspera-wowza-azuremediaservices/desktop/desktop.json
+++ b/vod-aspera-wowza-azuremediaservices/desktop/desktop.json
@@ -1,160 +1,166 @@
 {
-	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-	"contentVersion": "1.0.0.0",
-	"parameters": {
-
-		"deploymentName": {
-			"type": "string"
-		},
-		"storageAccountName": {
-			"type": "string"
-		},
-		"storageAccountKey": {
-			"type": "string"
-		},
-		"containerName": {
-			"type": "string"
-		},
-		"desktopUsername": {
-			"type": "string"
-		},
-		"desktopAdminPassword": {
-			"type": "string"
-		}
-
-
-	},
-	"variables": {
-		"vmName": "[concat(parameters('deploymentName'), 'desktop')]",
-		"vmSize": "Standard_DS2",
-		"dnsLabelPrefix": "[concat(parameters('deploymentName'), 'desktop')]",
-		"windowsOSVersion": "2012-R2-Datacenter",
-		"imagePublisher": "MicrosoftWindowsServer",
-		"imageOffer": "WindowsServer",
-		"OSDiskName": "osdiskforwindowssimple",
-		"nicName": "myVMNic",
-		"addressPrefix": "10.0.0.0/16",
-		"subnetName": "wow",
-		"subnetPrefix": "10.0.1.0/24",
-		"storageAccountType": "Standard_LRS",
-		"publicIPAddressName": "myPublicIP",
-		"publicIPAddressType": "Dynamic",
-		"vmStorageAccountContainerName": "vhds",
-		"virtualNetworkName": "MyVNET",
-		"vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
-		"subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
-		"storageAccountName": "[concat(uniqueString(resourceGroup().id),'winrmsa')]",
-		"apiVersion": "2015-06-15",
-		"FQDN": "[concat(variables('dnsLabelPrefix'),'.',resourceGroup().location,'.cloudapp.azure.com')]"
-
-	},
-	"resources": [{
-		"type": "Microsoft.Storage/storageAccounts",
-		"name": "[variables('storageAccountName')]",
-		"apiVersion": "[variables('apiVersion')]",
-		"location": "[resourceGroup().location]",
-		"properties": {
-			"accountType": "[variables('storageAccountType')]"
-		}
-	}, {
-		"apiVersion": "[variables('apiVersion')]",
-		"type": "Microsoft.Network/publicIPAddresses",
-		"name": "[variables('publicIPAddressName')]",
-		"location": "[resourceGroup().location]",
-		"properties": {
-			"publicIPAllocationMethod": "[variables('publicIPAddressType')]",
-			"dnsSettings": {
-				"domainNameLabel": "[variables('dnsLabelPrefix')]"
-			}
-		}
-	}, {
-		"apiVersion": "[variables('apiVersion')]",
-		"type": "Microsoft.Network/virtualNetworks",
-		"name": "[variables('virtualNetworkName')]",
-		"location": "[resourceGroup().location]",
-		"properties": {
-			"addressSpace": {
-				"addressPrefixes": [
-					"[variables('addressPrefix')]"
-				]
-			},
-			"subnets": [{
-				"name": "[variables('subnetName')]",
-				"properties": {
-					"addressPrefix": "[variables('subnetPrefix')]"
-				}
-			}]
-		}
-	}, {
-		"apiVersion": "[variables('apiVersion')]",
-		"type": "Microsoft.Network/networkInterfaces",
-		"name": "[variables('nicName')]",
-		"location": "[resourceGroup().location]",
-		"dependsOn": [
-			"[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-			"[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-		],
-		"properties": {
-			"ipConfigurations": [{
-				"name": "ipconfig1",
-				"properties": {
-					"privateIPAllocationMethod": "Dynamic",
-					"publicIPAddress": {
-						"id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
-					},
-					"subnet": {
-						"id": "[variables('subnetRef')]"
-					}
-				}
-			}]
-		}
-	}, {
-		"apiVersion": "[variables('apiVersion')]",
-		"type": "Microsoft.Compute/virtualMachines",
-		"name": "[variables('vmName')]",
-		"location": "[resourceGroup().location]",
-		"dependsOn": [
-			"[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
-			"[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
-		],
-		"properties": {
-			"hardwareProfile": {
-				"vmSize": "[variables('vmSize')]"
-			},
-			"osProfile": {
-				"computername": "[variables('vmName')]",
-				"adminUsername": "[parameters('desktopUsername')]",
-				"adminPassword": "[parameters('desktopAdminPassword')]"
-			},
-			"storageProfile": {
-				"imageReference": {
-					"publisher": "[variables('imagePublisher')]",
-					"offer": "[variables('imageOffer')]",
-					"sku": "[variables('windowsOSVersion')]",
-					"version": "latest"
-				},
-				"osDisk": {
-					"name": "osdisk",
-					"vhd": {
-						"uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-					},
-					"caching": "ReadWrite",
-					"createOption": "FromImage"
-				}
-			},
-			"networkProfile": {
-				"networkInterfaces": [{
-					"id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
-				}]
-			}
-		}
-
-	}],
-"outputs": {
-        "desktopURL": {
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "deploymentName": {
+      "type": "string"
+    },
+    "storageAccountName": {
+      "type": "string"
+    },
+    "storageAccountKey": {
+      "type": "string"
+    },
+    "containerName": {
+      "type": "string"
+    },
+    "desktopUsername": {
+      "type": "string"
+    },
+    "desktopAdminPassword": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "vmName": "[concat(parameters('deploymentName'), 'desktop')]",
+    "vmSize": "Standard_DS2",
+    "dnsLabelPrefix": "[concat(parameters('deploymentName'), 'desktop')]",
+    "windowsOSVersion": "2012-R2-Datacenter",
+    "imagePublisher": "MicrosoftWindowsServer",
+    "imageOffer": "WindowsServer",
+    "OSDiskName": "osdiskforwindowssimple",
+    "nicName": "myVMNic",
+    "addressPrefix": "10.0.0.0/16",
+    "subnetName": "wow",
+    "subnetPrefix": "10.0.1.0/24",
+    "storageAccountType": "Standard_LRS",
+    "publicIPAddressName": "myPublicIP",
+    "publicIPAddressType": "Dynamic",
+    "vmStorageAccountContainerName": "vhds",
+    "virtualNetworkName": "MyVNET",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]",
+    "storageAccountName": "[concat(uniqueString(resourceGroup().id),'winrmsa')]",
+    "apiVersion": "2015-06-15",
+    "FQDN": "[concat(variables('dnsLabelPrefix'),'.',resourceGroup().location,'.cloudapp.azure.com')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[variables('storageAccountType')]"
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[variables('dnsLabelPrefix')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[variables('vmSize')]"
+        },
+        "osProfile": {
+          "computername": "[variables('vmName')]",
+          "adminUsername": "[parameters('desktopUsername')]",
+          "adminPassword": "[parameters('desktopAdminPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('windowsOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "outputs": {
+    "desktopURL": {
       "type": "string",
       "value": "[ variables('FQDN')]"
-    
-        }
-}
+    }
+  }
 }

--- a/windows-server-containers-preview/azuredeploy.json
+++ b/windows-server-containers-preview/azuredeploy.json
@@ -2,35 +2,30 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-
     "VMName": {
       "type": "string",
       "metadata": {
         "description": "This name will also be used to prefix the network security group, storage, virtual network, network card, subnet and public IP address name."
       }
     },
-
     "adminUsername": {
       "type": "string",
       "metadata": {
         "description": "Username for the Virtual Machine."
       }
     },
-
     "adminPassword": {
       "type": "securestring",
       "metadata": {
         "description": "Password for the Virtual Machine."
       }
     },
-
     "dnsNameForPublicIP": {
       "type": "string",
       "metadata": {
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }
     },
-
     "vmSize": {
       "type": "string",
       "defaultValue": "Standard_D1",
@@ -39,7 +34,6 @@
       }
     }
   },
-
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id),'storage')]",
     "windowsOSVersion": "Windows-Server-Technical-Preview",
@@ -61,11 +55,10 @@
     "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
   },
   "resources": [
-
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('networkSecurityGroupName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "properties": {
         "securityRules": [
@@ -83,7 +76,6 @@
               "direction": "Inbound"
             }
           },
-
           {
             "name": "RDP",
             "properties": {
@@ -98,7 +90,6 @@
               "direction": "Inbound"
             }
           },
-
           {
             "name": "Docker",
             "properties": {
@@ -113,15 +104,13 @@
               "direction": "Inbound"
             }
           }
-
         ]
       }
     },
-
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "location": "[resourceGroup().location]",
       "tags": {
         "displayName": "StorageAccount"
@@ -130,9 +119,8 @@
         "accountType": "[variables('storageAccountType')]"
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[resourceGroup().location]",
@@ -146,9 +134,8 @@
         }
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
@@ -177,9 +164,8 @@
         ]
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[resourceGroup().location]",
@@ -207,9 +193,8 @@
         ]
       }
     },
-
     {
-      "apiVersion": "[variables('apiVersion')]",
+      "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('VMName')]",
       "location": "[resourceGroup().location]",

--- a/wordpress-mysql-replication/azuredeploy.json
+++ b/wordpress-mysql-replication/azuredeploy.json
@@ -1,369 +1,369 @@
-{  
-   "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
-   "contentVersion":"1.0.0.0",
-   "parameters":{  
-      "siteName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"wordpress site name"
-         }
-      },
-      "hostingPlanName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"website host plan"
-         }
-      },
-      "sku":{  
-         "type":"string",
-         "allowedValues":[  
-            "Basic",
-            "Standard",
-            "Premium"
-         ],
-         "defaultValue":"Standard",
-         "metadata":{  
-            "description":"website sku"
-         }
-      },
-      "workerSize":{  
-         "type":"string",
-         "allowedValues":[  
-            "0",
-            "1",
-            "2"
-         ],
-         "defaultValue":"1",
-         "metadata":{  
-            "description":"website worker size"
-         }
-      },
-      "dnsName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"Connect to your cluster using dnsName.location.cloudapp.azure.com"
-         }
-      },
-      "publicIPName":{  
-         "type":"string",
-         "defaultValue":"mysqlIP01",
-         "metadata":{  
-            "description":"public IP name for MySQL loadbalancer"
-         }
-      },      
-      "vmUserName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"user name to ssh to the VMs"
-         }
-      },
-      "vmPassword":{  
-         "type":"securestring",
-         "metadata":{  
-            "description":"password to ssh to the VMs"
-         }
-      },
-      "mysqlRootPassword":{  
-         "type":"securestring",
-         "metadata":{  
-            "description":"mysql root user password"
-         }
-      },
-      "mysqlReplicationPassword":{  
-         "type":"securestring",
-         "metadata":{  
-            "description":"mysql replication user password"
-         }
-      },
-      "mysqlProbePassword":{  
-         "type":"securestring",
-         "metadata":{  
-            "description":"mysql probe password"
-         }
-      },
-      "vmSize":{  
-         "type":"string",
-         "defaultValue":"Standard_D2",
-         "metadata":{  
-            "description":"size for the VMs"
-         }
-      },
-      "storageAccountType":{  
-         "type":"string",
-         "defaultValue":"Standard_LRS",
-         "metadata":{  
-            "description":"Storage account type for the cluster"
-         }
-      },
-      "virtualNetworkName":{  
-         "type":"string",
-         "defaultValue":"mysqlvnet",
-         "metadata":{  
-            "description":"New or Existing Virtual network name for the cluster"
-         }
-      },
-      "vnetNewOrExisting":{  
-         "type":"string",
-         "defaultValue":"new",
-         "allowedValues":[  
-            "new",
-            "existing"
-         ],
-         "metadata":{  
-            "description":"Identifies whether to use new or existing Virtual Network"
-         }
-      },
-      "vnetExistingResourceGroupName":{  
-         "type":"string",
-         "defaultValue":"",
-         "metadata":{  
-            "description":"If using existing VNet, specifies the resource group for the existing VNet"
-         }
-      },
-      "dbSubnetName":{  
-         "type":"string",
-         "defaultValue":"default",
-         "metadata":{  
-            "description":"subnet name for the MySQL nodes"
-         }
-      },
-      "vnetAddressPrefix":{  
-         "type":"string",
-         "defaultValue":"10.0.0.0/16",
-         "metadata":{  
-            "description":"IP address in CIDR for virtual network"
-         }
-      },
-      "dbSubnetAddressPrefix":{  
-         "type":"string",
-         "defaultValue":"10.0.1.0/24",
-         "metadata":{  
-            "description":"IP address in CIDR for db subnet"
-         }
-      },
-      "dbSubnetStartAddress":{  
-         "type":"string",
-         "defaultValue":"10.0.1.4",
-         "metadata":{  
-            "description":"Start IP address for the VMs in db subnet"
-         }
-      },
-      "imagePublisher":{  
-         "type":"string",
-         "defaultValue":"OpenLogic",
-         "allowedValues":[  
-            "OpenLogic"
-         ],
-         "metadata":{  
-            "description":"publisher for the VM OS image"
-         }
-      },
-      "imageOffer":{  
-         "type":"string",
-         "defaultValue":"CentOS",
-         "allowedValues":[  
-            "CentOS"
-         ],
-         "metadata":{  
-            "description":"VM OS name"
-         }
-      },
-      "imageSKU":{  
-         "type":"string",
-         "defaultValue":"6.6",
-         "allowedValues":[  
-            "6.5",
-            "6.6"
-         ],
-         "metadata":{  
-            "description":"VM OS version"
-         }
-      },
-      "mysqlFrontEndPort0":{  
-         "type":"int",
-         "defaultValue":3306,
-         "metadata":{  
-            "description":"MySQL public port"
-         }
-      },
-      "mysqlFrontEndPort1":{  
-         "type":"int",
-         "defaultValue":3307,
-         "metadata":{  
-            "description":"MySQL public port"
-         }
-      },
-      "sshNatRuleFrontEndPort0":{  
-         "type":"int",
-         "defaultValue":64001,
-         "metadata":{  
-            "description":"public ssh port for VM1"
-         }
-      },
-      "sshNatRuleFrontEndPort1":{  
-         "type":"int",
-         "defaultValue":64002,
-         "metadata":{  
-            "description":"public ssh port for VM2"
-         }
-      },
-      "mysqlProbePort0":{  
-         "type":"int",
-         "defaultValue":9200,
-         "metadata":{  
-            "description":"MySQL public port master"
-         }
-      },
-      "mysqlProbePort1":{  
-         "type":"int",
-         "defaultValue":9201,
-         "metadata":{  
-            "description":"MySQL public port slave"
-         }
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "siteName": {
+      "type": "string",
+      "metadata": {
+        "description": "wordpress site name"
       }
-   },
-   "variables":{  
-      "template":{  
-         "base":"https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/wordpress-mysql-replication"
-      },
-      "storageAccountName":"[concat(uniquestring(resourceGroup().id),'storagesa')]",
-      "templateAPIVersion":"2015-01-01",
-      "resourceAPIVersion":"2015-06-15",
-      "wpdbname":"[concat(uniquestring(resourceGroup().id),'wordpress')]"
-   },
-   "resources":[  
-      {  
-         "name":"mysql",
-         "type":"Microsoft.Resources/deployments",
-         "apiVersion":"[variables('templateAPIVersion')]",
-         "properties":{  
-            "mode":"Incremental",
-            "templateLink":{  
-               "uri":"[concat(variables('template').base, '/nested/mysql-replication.json')]",
-               "contentVersion":"1.0.0.0"
-            },
-            "parameters":{  
-               "dnsName":{  
-                  "value":"[parameters('dnsName')]"
-               },
-               "vmUserName":{  
-                  "value":"[parameters('vmUserName')]"
-               },
-               "vmPassword":{  
-                  "value":"[parameters('vmPassword')]"
-               },
-               "mysqlRootPassword":{  
-                  "value":"[parameters('mysqlRootPassword')]"
-               },
-               "mysqlReplicationPassword":{  
-                  "value":"[parameters('mysqlReplicationPassword')]"
-               },
-               "mysqlProbePassword":{  
-                  "value":"[parameters('mysqlProbePassword')]"
-               },
-               "vmSize":{  
-                  "value":"[parameters('vmSize')]"
-               },
-               "storageAccountType":{  
-                  "value":"[parameters('storageAccountType')]"
-               },
-               "virtualNetworkName":{  
-                  "value":"[parameters('virtualNetworkName')]"
-               },
-               "vnetNewOrExisting":{  
-                  "value":"[parameters('vnetNewOrExisting')]"
-               },
-               "vnetExistingResourceGroupName":{  
-                  "value":"[parameters('vnetExistingResourceGroupName')]"
-               },
-               "dbSubnetName":{  
-                  "value":"[parameters('dbSubnetName')]"
-               },
-               "vnetAddressPrefix":{  
-                  "value":"[parameters('vnetAddressPrefix')]"
-               },
-               "dbSubnetAddressPrefix":{  
-                  "value":"[parameters('dbSubnetAddressPrefix')]"
-               },
-               "dbSubnetStartAddress":{  
-                  "value":"[parameters('dbSubnetStartAddress')]"
-               },
-               "imagePublisher":{  
-                  "value":"[parameters('imagePublisher')]"
-               },
-               "imageOffer":{  
-                  "value":"[parameters('imageOffer')]"
-               },
-               "imageSKU":{  
-                  "value":"[parameters('imageSKU')]"
-               },
-               "mysqlFrontEndPort0":{  
-                  "value":"[parameters('mysqlFrontEndPort0')]"
-               },
-               "mysqlFrontEndPort1":{  
-                  "value":"[parameters('mysqlFrontEndPort1')]"
-               },
-               "sshNatRuleFrontEndPort0":{  
-                  "value":"[parameters('sshNatRuleFrontEndPort0')]"
-               },
-               "sshNatRuleFrontEndPort1":{  
-                  "value":"[parameters('sshNatRuleFrontEndPort1')]"
-               },
-               "mysqlProbePort0":{  
-                  "value":"[parameters('mysqlProbePort0')]"
-               },
-               "mysqlProbePort1":{  
-                  "value":"[parameters('mysqlProbePort1')]"
-               },
-               "artifactsPath":{  
-                  "value":"[variables('template').base]"
-               },
-               "publicIPName":{  
-                  "value":"[parameters('publicIPName')]"
-               },
-               "storageAccountName":{  
-                  "value":"[variables('storageAccountName')]"
-               }
-            }
-         }
-      },
-      {  
-         "name":"website",
-         "type":"Microsoft.Resources/deployments",
-         "apiVersion":"[variables('templateAPIVersion')]",
-         "dependsOn":[  
-            "Microsoft.Resources/deployments/mysql"
-         ],
-         "properties":{  
-            "mode":"Incremental",
-            "templateLink":{  
-               "uri":"[concat(variables('template').base, '/nested/website.json')]",
-               "contentVersion":"1.0.0.0"
-            },
-            "parameters":{  
-               "siteName":{  
-                  "value":"[parameters('siteName')]"
-               },
-               "hostingPlanName":{  
-                  "value":"[parameters('hostingPlanName')]"
-               },
-               "sku":{  
-                  "value":"[parameters('sku')]"
-               },
-               "workerSize":{  
-                  "value":"[parameters('workerSize')]"
-               },
-               "DbServer":{  
-                  "value":"[concat(parameters('dnsName'), '.', resourceGroup().location, '.cloudapp.azure.com:',parameters('mysqlFrontEndPort0'))]"
-               },
-               "DbName":{  
-                  "value":"[variables('wpdbname')]"
-               },
-               "DbAdminPassword":{  
-                  "value":"[parameters('mysqlRootPassword')]"
-               }
-            }
-         }
+    },
+    "hostingPlanName": {
+      "type": "string",
+      "metadata": {
+        "description": "website host plan"
       }
-   ]
+    },
+    "sku": {
+      "type": "string",
+      "allowedValues": [
+        "Basic",
+        "Standard",
+        "Premium"
+      ],
+      "defaultValue": "Standard",
+      "metadata": {
+        "description": "website sku"
+      }
+    },
+    "workerSize": {
+      "type": "string",
+      "allowedValues": [
+        "0",
+        "1",
+        "2"
+      ],
+      "defaultValue": "1",
+      "metadata": {
+        "description": "website worker size"
+      }
+    },
+    "dnsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Connect to your cluster using dnsName.location.cloudapp.azure.com"
+      }
+    },
+    "publicIPName": {
+      "type": "string",
+      "defaultValue": "mysqlIP01",
+      "metadata": {
+        "description": "public IP name for MySQL loadbalancer"
+      }
+    },
+    "vmUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "user name to ssh to the VMs"
+      }
+    },
+    "vmPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "password to ssh to the VMs"
+      }
+    },
+    "mysqlRootPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql root user password"
+      }
+    },
+    "mysqlReplicationPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql replication user password"
+      }
+    },
+    "mysqlProbePassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql probe password"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2",
+      "metadata": {
+        "description": "size for the VMs"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "metadata": {
+        "description": "Storage account type for the cluster"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "mysqlvnet",
+      "metadata": {
+        "description": "New or Existing Virtual network name for the cluster"
+      }
+    },
+    "vnetNewOrExisting": {
+      "type": "string",
+      "defaultValue": "new",
+      "allowedValues": [
+        "new",
+        "existing"
+      ],
+      "metadata": {
+        "description": "Identifies whether to use new or existing Virtual Network"
+      }
+    },
+    "vnetExistingResourceGroupName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "If using existing VNet, specifies the resource group for the existing VNet"
+      }
+    },
+    "dbSubnetName": {
+      "type": "string",
+      "defaultValue": "default",
+      "metadata": {
+        "description": "subnet name for the MySQL nodes"
+      }
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "IP address in CIDR for virtual network"
+      }
+    },
+    "dbSubnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.1.0/24",
+      "metadata": {
+        "description": "IP address in CIDR for db subnet"
+      }
+    },
+    "dbSubnetStartAddress": {
+      "type": "string",
+      "defaultValue": "10.0.1.4",
+      "metadata": {
+        "description": "Start IP address for the VMs in db subnet"
+      }
+    },
+    "imagePublisher": {
+      "type": "string",
+      "defaultValue": "OpenLogic",
+      "allowedValues": [
+        "OpenLogic"
+      ],
+      "metadata": {
+        "description": "publisher for the VM OS image"
+      }
+    },
+    "imageOffer": {
+      "type": "string",
+      "defaultValue": "CentOS",
+      "allowedValues": [
+        "CentOS"
+      ],
+      "metadata": {
+        "description": "VM OS name"
+      }
+    },
+    "imageSKU": {
+      "type": "string",
+      "defaultValue": "6.6",
+      "allowedValues": [
+        "6.5",
+        "6.6"
+      ],
+      "metadata": {
+        "description": "VM OS version"
+      }
+    },
+    "mysqlFrontEndPort0": {
+      "type": "int",
+      "defaultValue": 3306,
+      "metadata": {
+        "description": "MySQL public port"
+      }
+    },
+    "mysqlFrontEndPort1": {
+      "type": "int",
+      "defaultValue": 3307,
+      "metadata": {
+        "description": "MySQL public port"
+      }
+    },
+    "sshNatRuleFrontEndPort0": {
+      "type": "int",
+      "defaultValue": 64001,
+      "metadata": {
+        "description": "public ssh port for VM1"
+      }
+    },
+    "sshNatRuleFrontEndPort1": {
+      "type": "int",
+      "defaultValue": 64002,
+      "metadata": {
+        "description": "public ssh port for VM2"
+      }
+    },
+    "mysqlProbePort0": {
+      "type": "int",
+      "defaultValue": 9200,
+      "metadata": {
+        "description": "MySQL public port master"
+      }
+    },
+    "mysqlProbePort1": {
+      "type": "int",
+      "defaultValue": 9201,
+      "metadata": {
+        "description": "MySQL public port slave"
+      }
+    }
+  },
+  "variables": {
+    "template": {
+      "base": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/wordpress-mysql-replication"
+    },
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id),'storagesa')]",
+    "templateAPIVersion": "2015-01-01",
+    "resourceAPIVersion": "2015-06-15",
+    "wpdbname": "[concat(uniquestring(resourceGroup().id),'wordpress')]"
+  },
+  "resources": [
+    {
+      "name": "mysql",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('template').base, '/nested/mysql-replication.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "dnsName": {
+            "value": "[parameters('dnsName')]"
+          },
+          "vmUserName": {
+            "value": "[parameters('vmUserName')]"
+          },
+          "vmPassword": {
+            "value": "[parameters('vmPassword')]"
+          },
+          "mysqlRootPassword": {
+            "value": "[parameters('mysqlRootPassword')]"
+          },
+          "mysqlReplicationPassword": {
+            "value": "[parameters('mysqlReplicationPassword')]"
+          },
+          "mysqlProbePassword": {
+            "value": "[parameters('mysqlProbePassword')]"
+          },
+          "vmSize": {
+            "value": "[parameters('vmSize')]"
+          },
+          "storageAccountType": {
+            "value": "[parameters('storageAccountType')]"
+          },
+          "virtualNetworkName": {
+            "value": "[parameters('virtualNetworkName')]"
+          },
+          "vnetNewOrExisting": {
+            "value": "[parameters('vnetNewOrExisting')]"
+          },
+          "vnetExistingResourceGroupName": {
+            "value": "[parameters('vnetExistingResourceGroupName')]"
+          },
+          "dbSubnetName": {
+            "value": "[parameters('dbSubnetName')]"
+          },
+          "vnetAddressPrefix": {
+            "value": "[parameters('vnetAddressPrefix')]"
+          },
+          "dbSubnetAddressPrefix": {
+            "value": "[parameters('dbSubnetAddressPrefix')]"
+          },
+          "dbSubnetStartAddress": {
+            "value": "[parameters('dbSubnetStartAddress')]"
+          },
+          "imagePublisher": {
+            "value": "[parameters('imagePublisher')]"
+          },
+          "imageOffer": {
+            "value": "[parameters('imageOffer')]"
+          },
+          "imageSKU": {
+            "value": "[parameters('imageSKU')]"
+          },
+          "mysqlFrontEndPort0": {
+            "value": "[parameters('mysqlFrontEndPort0')]"
+          },
+          "mysqlFrontEndPort1": {
+            "value": "[parameters('mysqlFrontEndPort1')]"
+          },
+          "sshNatRuleFrontEndPort0": {
+            "value": "[parameters('sshNatRuleFrontEndPort0')]"
+          },
+          "sshNatRuleFrontEndPort1": {
+            "value": "[parameters('sshNatRuleFrontEndPort1')]"
+          },
+          "mysqlProbePort0": {
+            "value": "[parameters('mysqlProbePort0')]"
+          },
+          "mysqlProbePort1": {
+            "value": "[parameters('mysqlProbePort1')]"
+          },
+          "artifactsPath": {
+            "value": "[variables('template').base]"
+          },
+          "publicIPName": {
+            "value": "[parameters('publicIPName')]"
+          },
+          "storageAccountName": {
+            "value": "[variables('storageAccountName')]"
+          }
+        }
+      }
+    },
+    {
+      "name": "website",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "dependsOn": [
+        "Microsoft.Resources/deployments/mysql"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('template').base, '/nested/website.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "siteName": {
+            "value": "[parameters('siteName')]"
+          },
+          "hostingPlanName": {
+            "value": "[parameters('hostingPlanName')]"
+          },
+          "sku": {
+            "value": "[parameters('sku')]"
+          },
+          "workerSize": {
+            "value": "[parameters('workerSize')]"
+          },
+          "DbServer": {
+            "value": "[concat(parameters('dnsName'), '.', resourceGroup().location, '.cloudapp.azure.com:',parameters('mysqlFrontEndPort0'))]"
+          },
+          "DbName": {
+            "value": "[variables('wpdbname')]"
+          },
+          "DbAdminPassword": {
+            "value": "[parameters('mysqlRootPassword')]"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/wordpress-mysql-replication/nested/mysql-replication.json
+++ b/wordpress-mysql-replication/nested/mysql-replication.json
@@ -1,548 +1,546 @@
-{  
-   "$schema":"http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-   "contentVersion":"1.0.0.0",
-   "parameters":{  
-      "dnsName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"Connect to your cluster using dnsName.location.cloudapp.azure.com"
-         }
-      },
-      "vmUserName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"user name to ssh to the VMs"
-         }
-      },
-      "vmPassword":{  
-         "type":"securestring",
-         "metadata":{  
-            "description":"password to ssh to the VMs"
-         }
-      },
-      "mysqlRootPassword":{  
-         "type":"securestring",
-         "metadata":{  
-            "description":"mysql root user password single quote not allowed"
-         }
-      },
-      "mysqlReplicationPassword":{  
-         "type":"securestring",
-         "metadata":{  
-            "description":"mysql replication user password single quote not allowed"
-         }
-      },
-      "mysqlProbePassword":{  
-         "type":"securestring",
-         "metadata":{  
-            "description":"mysql probe password single quote not allowed"
-         }
-      },
-      "vmSize":{  
-         "type":"string",
-         "defaultValue":"Standard_D2",
-         "metadata":{  
-            "description":"size for the VMs"
-         }
-      },
-      "storageAccountType":{  
-         "type":"string",
-         "defaultValue":"Standard_LRS",
-         "metadata":{  
-            "description":"Storage account type for the cluster"
-         }
-      },
-      "vnetNewOrExisting":{  
-         "type":"string",
-         "defaultValue":"new",
-         "allowedValues":[  
-            "new",
-            "existing"
-         ],
-         "metadata":{  
-            "description":"Identifies whether to use a new or existing Virtual Network"
-         }
-      },
-      "virtualNetworkName":{  
-         "type":"string",
-         "defaultValue":"mysqlvnet",
-         "metadata":{  
-            "description":"New or existing Virtual network name"
-         }
-      },
-      "VNETExistingResourceGroupName":{  
-         "type":"string",
-         "defaultValue":"",
-         "metadata":{  
-            "description":"If using existing VNet, specifies the resource group for the existing VNet"
-         }
-      },
-      "dbSubnetName":{  
-         "type":"string",
-         "defaultValue":"default",
-         "metadata":{  
-            "description":"subnet name for the MySQL nodes"
-         }
-      },
-      "vnetAddressPrefix":{  
-         "type":"string",
-         "defaultValue":"10.0.0.0/16",
-         "metadata":{  
-            "description":"IP address in CIDR for virtual network"
-         }
-      },
-      "dbSubnetAddressPrefix":{  
-         "type":"string",
-         "defaultValue":"10.0.1.0/24",
-         "metadata":{  
-            "description":"IP address in CIDR for db subnet"
-         }
-      },
-      "dbSubnetStartAddress":{  
-         "type":"string",
-         "defaultValue":"10.0.1.4",
-         "metadata":{  
-            "description":"Start IP address in the subnet for the VMs"
-         }
-      },
-      "imagePublisher":{  
-         "type":"string",
-         "defaultValue":"OpenLogic",
-         "allowedValues":[  
-            "OpenLogic"
-         ],
-         "metadata":{  
-            "description":"publisher for the VM OS image"
-         }
-      },
-      "imageOffer":{  
-         "type":"string",
-         "defaultValue":"CentOS",
-         "allowedValues":[  
-            "CentOS"
-         ],
-         "metadata":{  
-            "description":"VM OS name"
-         }
-      },
-      "imageSKU":{  
-         "type":"string",
-         "defaultValue":"6.6",
-         "allowedValues":[  
-            "6.5",
-            "6.6"
-         ],
-         "metadata":{  
-            "description":"VM OS version"
-         }
-      },
-      "mysqlFrontEndPort0":{  
-         "type":"int",
-         "defaultValue":3306,
-         "metadata":{  
-            "description":"MySQL public port master"
-         }
-      },
-      "mysqlFrontEndPort1":{  
-         "type":"int",
-         "defaultValue":3307,
-         "metadata":{  
-            "description":"MySQL public port slave"
-         }
-      },
-      "sshNatRuleFrontEndPort0":{  
-         "type":"int",
-         "defaultValue":64001,
-         "metadata":{  
-            "description":"public ssh port for VM1"
-         }
-      },
-      "sshNatRuleFrontEndPort1":{  
-         "type":"int",
-         "defaultValue":64002,
-         "metadata":{  
-            "description":"public ssh port for VM2"
-         }
-      },
-      "mysqlProbePort0":{  
-         "type":"int",
-         "defaultValue":9200,
-         "metadata":{  
-            "description":"MySQL public port master"
-         }
-      },
-      "mysqlProbePort1":{  
-         "type":"int",
-         "defaultValue":9201,
-         "metadata":{  
-            "description":"MySQL public port slave"
-         }
-      },
-      "artifactsPath":{  
-         "type":"string",
-         "metadata":{  
-            "description":"template and script file location",
-            "artifactsBaseUrl":"Base URL of the Publisher Template gallery package"
-         }
-      },
-      "customScriptCommandToExecute":{  
-         "type":"string",
-         "defaultValue":"bash azuremysql.sh",
-         "metadata":{  
-            "description":"bash script command line"
-         }
-      },
-      "publicIPName":{  
-         "type":"string",
-         "defaultValue":"mysqlIP01",
-         "metadata":{  
-            "description":"public IP name for MySQL loadbalancer"
-         }
-      },
-      "storageAccountName":{  
-         "type":"string",
-         "metadata":{  
-            "description":"storage account name"
-         }
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dnsName": {
+      "type": "string",
+      "metadata": {
+        "description": "Connect to your cluster using dnsName.location.cloudapp.azure.com"
       }
-   },
-   "variables":{  
-      "templateAPIVersion":"2015-01-01",
-      "resourceAPIVersion":"2015-06-15",
-      "nodeCount":2,
-      "lbPublicIPName":"[parameters('publicIPName')]",
-      "lbPublicIPRef":"[resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName'))]",
-      "lbName":"[concat(parameters('dnsName'), '-lb')]",
-      "lbID":"[resourceId('Microsoft.Network/loadBalancers',variables('lbName'))]",
-      "ilbBackendAddressPoolName":"[concat(parameters('dnsName'), '-ilbBackendPool')]",
-      "ilbBackendAddressPoolID":"[concat(variables('lbID'),'/backendAddressPools/', variables('ilbBackendAddressPoolName'))]",
-      "ilbRuleName":"[concat(parameters('dnsName'), '-ilbRule')]",
-      "ilbRuleID":"[concat(variables('lbID'),'/loadBalancingRules/',variables('ilbRuleName'))]",
-      "sshIPConfigName":"[concat(parameters('dnsName'), '-sshIPCfg')]",
-      "sshIPConfig":"[concat(variables('lbID'),'/frontendIPConfigurations/',variables('sshIPConfigName'))]",
-      "nicName":"[concat(parameters('dnsName'), '-nic')]",
-      "availabilitySetName":"[concat(parameters('dnsName'), '-set')]",
-      "customScriptFilePath":"[concat(parameters('artifactsPath'), '/scripts/azuremysql.sh')]",
-      "mysqlConfigFilePath":"[concat(parameters('artifactsPath'), '/scripts/my.cnf.template')]",
-      "singleQuote":"",
-      "virtualNetworkSetupURL":"[concat(parameters('artifactsPath'),'/nested/vnet-',parameters('vnetNewOrExisting'),'.json')]",
-      "sa":"[parameters('dbSubnetStartAddress')]",
-      "ipOctet01":"[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
-      "ipOctet2":"[int(split(variables('sa'), '.')[2])]",
-      "ipOctet3":"[int(split(variables('sa'), '.')[3])]",
-      "DBName":"[concat(uniquestring(resourceGroup().id),'wordpress')]"
-   },
-   "resources":[  
-      {  
-         "name":"SettingUpVirtualNetwork",
-         "type":"Microsoft.Resources/deployments",
-         "apiVersion":"[variables('templateAPIVersion')]",
-         "properties":{  
-            "mode":"Incremental",
-            "templateLink":{  
-               "uri":"[variables('virtualNetworkSetupURL')]",
-               "contentVersion":"1.0.0.0"
-            },
-            "parameters":{  
-               "virtualNetworkName":{  
-                  "value":"[parameters('virtualNetworkName')]"
-               },
-               "virtualNetworkAddressPrefix":{  
-                  "value":"[parameters('vnetAddressPrefix')]"
-               },
-               "dbSubnetName":{  
-                  "value":"[parameters('dbSubnetName')]"
-               },
-               "dbSubnetAddressPrefix":{  
-                  "value":"[parameters('dbSubnetAddressPrefix')]"
-               },
-               "VNETExistingResourceGroupName":{  
-                  "value":"[parameters('VNETExistingResourceGroupName')]"
-               }
-            }
-         }
-      },
-      {  
-         "type":"Microsoft.Storage/storageAccounts",
-         "name":"[parameters('storageAccountName')]",
-         "apiVersion":"[variables('resourceAPIVersion')]",
-         "location":"[resourceGroup().location]",
-         "properties":{  
-            "accountType":"[parameters('storageAccountType')]"
-         }
-      },
-      {  
-         "apiVersion":"[variables('resourceAPIVersion')]",
-         "type":"Microsoft.Network/publicIPAddresses",
-         "name":"[variables('lbPublicIPName')]",
-         "location":"[resourceGroup().location]",
-         "properties":{  
-            "publicIPAllocationMethod":"Static",
-            "dnsSettings":{  
-               "domainNameLabel":"[parameters('dnsName')]"
-            }
-         }
-      },
-      {  
-         "type":"Microsoft.Compute/availabilitySets",
-         "name":"[variables('availabilitySetName')]",
-         "apiVersion":"[variables('resourceAPIVersion')]",
-         "location":"[resourceGroup().location]",
-         "properties":{  
-
-         }
-      },
-      {  
-         "apiVersion":"[variables('resourceAPIVersion')]",
-         "type":"Microsoft.Network/networkInterfaces",
-         "name":"[concat(variables('nicName'), copyIndex())]",
-         "location":"[resourceGroup().location]",
-         "copy":{  
-            "name":"nicLoop",
-            "count":"[variables('nodeCount')]"
-         },
-         "dependsOn":[  
-            "[concat('Microsoft.Resources/deployments/', 'SettingUpVirtualNetwork')]",
-            "[concat('Microsoft.Network/loadBalancers/', variables('lbName'))]"
-         ],
-         "properties":{  
-            "ipConfigurations":[  
-               {  
-                  "name":"[concat('ipconfig', copyIndex())]",
-                  "properties":{  
-                     "privateIPAllocationMethod":"Static",
-                     "privateIPAddress":"[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255))]",
-                     "subnet":{  
-                        "id":"[reference('Microsoft.Resources/deployments/SettingUpVirtualNetwork', variables('templateAPIVersion')).outputs.dbSubnetRef.value]"
-                     },
-                     "loadBalancerBackendAddressPools":[  
-                        {  
-                           "id":"[variables('ilbBackendAddressPoolID')]"
-                        }
-                     ],
-                     "loadBalancerInboundNatRules":[  
-                        {  
-                           "id":"[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'NatRule', copyIndex())]"
-                        },
-                        {  
-                           "id":"[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'ProbeNatRule', copyIndex())]"
-                        },
-                        {  
-                           "id":"[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'MySQLNatRule', copyIndex())]"
-                        }
-                     ]
-                  }
-               }
-            ]
-         }
-      },
-      {  
-         "name":"[concat(parameters('dnsName'), copyIndex())]",
-         "type":"Microsoft.Compute/virtualMachines",
-         "apiVersion":"[variables('resourceAPIVersion')]",
-         "location":"[resourceGroup().location]",
-         "copy":{  
-            "name":"vmLoop",
-            "count":"[variables('nodeCount')]"
-         },
-         "dependsOn":[  
-            "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]",
-            "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
-            "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex())]"
-         ],
-         "properties":{  
-            "availabilitySet":{  
-               "id":"[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
-            },
-            "hardwareProfile":{  
-               "vmSize":"[parameters('vmSize')]"
-            },
-            "osProfile":{  
-               "computerName":"[concat(parameters('dnsName'), copyIndex())]",
-               "adminUsername":"[parameters('vmUserName')]",
-               "adminPassword":"[parameters('vmPassword')]"
-            },
-            "storageProfile":{  
-               "imageReference":{  
-                  "publisher":"[parameters('imagePublisher')]",
-                  "offer":"[parameters('imageOffer')]",
-                  "sku":"[parameters('imageSKU')]",
-                  "version":"latest"
-               },
-               "osDisk":{  
-                  "name":"osdisk",
-                  "vhd":{  
-                     "uri":"[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'osdisk.vhd')]"
-                  },
-                  "caching":"ReadWrite",
-                  "createOption":"FromImage"
-               },
-               "dataDisks":[  
-                  {  
-                     "name":"datadisk1",
-                     "diskSizeGB":"1000",
-                     "lun":0,
-                     "vhd":{  
-                        "uri":"[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'dataDisk1.vhd')]"
-                     },
-                     "createOption":"Empty"
-                  },
-                  {  
-                     "name":"datadisk2",
-                     "diskSizeGB":"1000",
-                     "lun":1,
-                     "vhd":{  
-                        "uri":"[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'dataDisk2.vhd')]"
-                     },
-                     "createOption":"Empty"
-                  }
-               ]
-            },
-            "networkProfile":{  
-               "networkInterfaces":[  
-                  {  
-                     "id":"[concat(resourceId('Microsoft.Network/networkInterfaces',variables('nicName')), copyIndex())]"
-                  }
-               ]
-            }
-         }
-      },
-      {  
-         "type":"Microsoft.Compute/virtualMachines/extensions",
-         "name":"[concat(parameters('dnsName'), copyIndex(), '/setupMySQL')]",
-         "apiVersion":"[variables('resourceAPIVersion')]",
-         "location":"[resourceGroup().location]",
-         "copy":{  
-            "name":"extLoop",
-            "count":"[variables('nodeCount')]"
-         },
-         "dependsOn":[  
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('dnsName'), copyIndex())]"
-         ],
-         "properties":{  
-             "publisher": "Microsoft.Azure.Extensions",
-          "type": "CustomScript",
-          "typeHandlerVersion": "2.0",
-          "autoUpgradeMinorVersion": true,
-          "settings": {
-            "fileUris": [
-              "[variables('customScriptFilePath')]"
-            ]
+    },
+    "vmUserName": {
+      "type": "string",
+      "metadata": {
+        "description": "user name to ssh to the VMs"
+      }
+    },
+    "vmPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "password to ssh to the VMs"
+      }
+    },
+    "mysqlRootPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql root user password single quote not allowed"
+      }
+    },
+    "mysqlReplicationPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql replication user password single quote not allowed"
+      }
+    },
+    "mysqlProbePassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "mysql probe password single quote not allowed"
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2",
+      "metadata": {
+        "description": "size for the VMs"
+      }
+    },
+    "storageAccountType": {
+      "type": "string",
+      "defaultValue": "Standard_LRS",
+      "metadata": {
+        "description": "Storage account type for the cluster"
+      }
+    },
+    "vnetNewOrExisting": {
+      "type": "string",
+      "defaultValue": "new",
+      "allowedValues": [
+        "new",
+        "existing"
+      ],
+      "metadata": {
+        "description": "Identifies whether to use a new or existing Virtual Network"
+      }
+    },
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "mysqlvnet",
+      "metadata": {
+        "description": "New or existing Virtual network name"
+      }
+    },
+    "VNETExistingResourceGroupName": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "If using existing VNet, specifies the resource group for the existing VNet"
+      }
+    },
+    "dbSubnetName": {
+      "type": "string",
+      "defaultValue": "default",
+      "metadata": {
+        "description": "subnet name for the MySQL nodes"
+      }
+    },
+    "vnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.0.0/16",
+      "metadata": {
+        "description": "IP address in CIDR for virtual network"
+      }
+    },
+    "dbSubnetAddressPrefix": {
+      "type": "string",
+      "defaultValue": "10.0.1.0/24",
+      "metadata": {
+        "description": "IP address in CIDR for db subnet"
+      }
+    },
+    "dbSubnetStartAddress": {
+      "type": "string",
+      "defaultValue": "10.0.1.4",
+      "metadata": {
+        "description": "Start IP address in the subnet for the VMs"
+      }
+    },
+    "imagePublisher": {
+      "type": "string",
+      "defaultValue": "OpenLogic",
+      "allowedValues": [
+        "OpenLogic"
+      ],
+      "metadata": {
+        "description": "publisher for the VM OS image"
+      }
+    },
+    "imageOffer": {
+      "type": "string",
+      "defaultValue": "CentOS",
+      "allowedValues": [
+        "CentOS"
+      ],
+      "metadata": {
+        "description": "VM OS name"
+      }
+    },
+    "imageSKU": {
+      "type": "string",
+      "defaultValue": "6.6",
+      "allowedValues": [
+        "6.5",
+        "6.6"
+      ],
+      "metadata": {
+        "description": "VM OS version"
+      }
+    },
+    "mysqlFrontEndPort0": {
+      "type": "int",
+      "defaultValue": 3306,
+      "metadata": {
+        "description": "MySQL public port master"
+      }
+    },
+    "mysqlFrontEndPort1": {
+      "type": "int",
+      "defaultValue": 3307,
+      "metadata": {
+        "description": "MySQL public port slave"
+      }
+    },
+    "sshNatRuleFrontEndPort0": {
+      "type": "int",
+      "defaultValue": 64001,
+      "metadata": {
+        "description": "public ssh port for VM1"
+      }
+    },
+    "sshNatRuleFrontEndPort1": {
+      "type": "int",
+      "defaultValue": 64002,
+      "metadata": {
+        "description": "public ssh port for VM2"
+      }
+    },
+    "mysqlProbePort0": {
+      "type": "int",
+      "defaultValue": 9200,
+      "metadata": {
+        "description": "MySQL public port master"
+      }
+    },
+    "mysqlProbePort1": {
+      "type": "int",
+      "defaultValue": 9201,
+      "metadata": {
+        "description": "MySQL public port slave"
+      }
+    },
+    "artifactsPath": {
+      "type": "string",
+      "metadata": {
+        "description": "template and script file location",
+        "artifactsBaseUrl": "Base URL of the Publisher Template gallery package"
+      }
+    },
+    "customScriptCommandToExecute": {
+      "type": "string",
+      "defaultValue": "bash azuremysql.sh",
+      "metadata": {
+        "description": "bash script command line"
+      }
+    },
+    "publicIPName": {
+      "type": "string",
+      "defaultValue": "mysqlIP01",
+      "metadata": {
+        "description": "public IP name for MySQL loadbalancer"
+      }
+    },
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "storage account name"
+      }
+    }
+  },
+  "variables": {
+    "templateAPIVersion": "2015-01-01",
+    "resourceAPIVersion": "2015-06-15",
+    "nodeCount": 2,
+    "lbPublicIPName": "[parameters('publicIPName')]",
+    "lbPublicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName'))]",
+    "lbName": "[concat(parameters('dnsName'), '-lb')]",
+    "lbID": "[resourceId('Microsoft.Network/loadBalancers',variables('lbName'))]",
+    "ilbBackendAddressPoolName": "[concat(parameters('dnsName'), '-ilbBackendPool')]",
+    "ilbBackendAddressPoolID": "[concat(variables('lbID'),'/backendAddressPools/', variables('ilbBackendAddressPoolName'))]",
+    "ilbRuleName": "[concat(parameters('dnsName'), '-ilbRule')]",
+    "ilbRuleID": "[concat(variables('lbID'),'/loadBalancingRules/',variables('ilbRuleName'))]",
+    "sshIPConfigName": "[concat(parameters('dnsName'), '-sshIPCfg')]",
+    "sshIPConfig": "[concat(variables('lbID'),'/frontendIPConfigurations/',variables('sshIPConfigName'))]",
+    "nicName": "[concat(parameters('dnsName'), '-nic')]",
+    "availabilitySetName": "[concat(parameters('dnsName'), '-set')]",
+    "customScriptFilePath": "[concat(parameters('artifactsPath'), '/scripts/azuremysql.sh')]",
+    "mysqlConfigFilePath": "[concat(parameters('artifactsPath'), '/scripts/my.cnf.template')]",
+    "singleQuote": "",
+    "virtualNetworkSetupURL": "[concat(parameters('artifactsPath'),'/nested/vnet-',parameters('vnetNewOrExisting'),'.json')]",
+    "sa": "[parameters('dbSubnetStartAddress')]",
+    "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
+    "ipOctet2": "[int(split(variables('sa'), '.')[2])]",
+    "ipOctet3": "[int(split(variables('sa'), '.')[3])]",
+    "DBName": "[concat(uniquestring(resourceGroup().id),'wordpress')]"
+  },
+  "resources": [
+    {
+      "name": "SettingUpVirtualNetwork",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2015-01-01",
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[variables('virtualNetworkSetupURL')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "virtualNetworkName": {
+            "value": "[parameters('virtualNetworkName')]"
           },
-          "protectedSettings": {
-            "commandToExecute": "[concat(parameters('customScriptCommandToExecute'), ' ', copyIndex(1), ' ', variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255), ' ', variables('mysqlConfigFilePath'), ' ', variables('singleQuote'), parameters('mysqlReplicationPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlRootPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlProbePassword'), variables('singleQuote'), ' ', parameters('dbSubnetStartAddress'), ' ', variables('DBName'))]"
+          "virtualNetworkAddressPrefix": {
+            "value": "[parameters('vnetAddressPrefix')]"
+          },
+          "dbSubnetName": {
+            "value": "[parameters('dbSubnetName')]"
+          },
+          "dbSubnetAddressPrefix": {
+            "value": "[parameters('dbSubnetAddressPrefix')]"
+          },
+          "VNETExistingResourceGroupName": {
+            "value": "[parameters('VNETExistingResourceGroupName')]"
           }
-         }
-      },
-      {  
-         "apiVersion":"[variables('resourceAPIVersion')]",
-         "type":"Microsoft.Network/loadBalancers",
-         "name":"[variables('lbName')]",
-         "location":"[resourceGroup().location]",
-         "dependsOn":[  
-            "[concat('Microsoft.Network/publicIPAddresses/', variables('lbPublicIPName'))]"
-         ],
-         "properties":{  
-            "frontendIPConfigurations":[  
-               {  
-                  "name":"[variables('sshIPConfigName')]",
-                  "properties":{  
-                     "publicIPAddress":{  
-                        "id":"[variables('lbPublicIPRef')]"
-                     }
-                  }
-               }
-            ],
-            "backendAddressPools":[  
-               {  
-                  "name":"[variables('ilbBackendAddressPoolName')]"
-               }
-            ],
-            "inboundNatRules":[  
-               {  
-                  "name":"[concat(parameters('dnsName'),'NatRule0')]",
-                  "properties":{  
-                     "frontendIPConfiguration":{  
-                        "id":"[variables('sshIPConfig')]"
-                     },
-                     "protocol":"tcp",
-                     "frontendPort":"[parameters('sshNatRuleFrontEndPort0')]",
-                     "backendPort":22,
-                     "enableFloatingIP":false
-                  }
-               },
-               {  
-                  "name":"[concat(parameters('dnsName'),'NatRule1')]",
-                  "properties":{  
-                     "frontendIPConfiguration":{  
-                        "id":"[variables('sshIPConfig')]"
-                     },
-                     "protocol":"tcp",
-                     "frontendPort":"[parameters('sshNatRuleFrontEndPort1')]",
-                     "backendPort":22,
-                     "enableFloatingIP":false
-                  }
-               },
-               {  
-                  "name":"[concat(parameters('dnsName'),'MySQLNatRule0')]",
-                  "properties":{  
-                     "frontendIPConfiguration":{  
-                        "id":"[variables('sshIPConfig')]"
-                     },
-                     "protocol":"tcp",
-                     "frontendPort":"[parameters('mysqlFrontEndPort0')]",
-                     "backendPort":3306,
-                     "enableFloatingIP":false
-                  }
-               },
-               {  
-                  "name":"[concat(parameters('dnsName'),'MySQLNatRule1')]",
-                  "properties":{  
-                     "frontendIPConfiguration":{  
-                        "id":"[variables('sshIPConfig')]"
-                     },
-                     "protocol":"tcp",
-                     "frontendPort":"[parameters('mysqlFrontEndPort1')]",
-                     "backendPort":3306,
-                     "enableFloatingIP":false
-                  }
-               },
-               {  
-                  "name":"[concat(parameters('dnsName'),'ProbeNatRule0')]",
-                  "properties":{  
-                     "frontendIPConfiguration":{  
-                        "id":"[variables('sshIPConfig')]"
-                     },
-                     "protocol":"tcp",
-                     "frontendPort":"[parameters('mysqlProbePort0')]",
-                     "backendPort":9200,
-                     "enableFloatingIP":false
-                  }
-               },
-               {  
-                  "name":"[concat(parameters('dnsName'),'ProbeNatRule1')]",
-                  "properties":{  
-                     "frontendIPConfiguration":{  
-                        "id":"[variables('sshIPConfig')]"
-                     },
-                     "protocol":"tcp",
-                     "frontendPort":"[parameters('mysqlProbePort1')]",
-                     "backendPort":9200,
-                     "enableFloatingIP":false
-                  }
-               }
-            ]
-         }
+        }
       }
-   ],
-   "outputs":{  
-      "fqdn":{  
-         "value":"[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn]",
-         "type":"string"
-      },
-      "ipaddress":{  
-         "value":"[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).ipAddress]",
-         "type":"string"
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[parameters('storageAccountName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "accountType": "[parameters('storageAccountType')]"
       }
-   }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('lbPublicIPName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsName')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/availabilitySets",
+      "name": "[variables('availabilitySetName')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "properties": {}
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[concat(variables('nicName'), copyIndex())]",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "nicLoop",
+        "count": "[variables('nodeCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Resources/deployments/', 'SettingUpVirtualNetwork')]",
+        "[concat('Microsoft.Network/loadBalancers/', variables('lbName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "[concat('ipconfig', copyIndex())]",
+            "properties": {
+              "privateIPAllocationMethod": "Static",
+              "privateIPAddress": "[concat(variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255))]",
+              "subnet": {
+                "id": "[reference('Microsoft.Resources/deployments/SettingUpVirtualNetwork', variables('templateAPIVersion')).outputs.dbSubnetRef.value]"
+              },
+              "loadBalancerBackendAddressPools": [
+                {
+                  "id": "[variables('ilbBackendAddressPoolID')]"
+                }
+              ],
+              "loadBalancerInboundNatRules": [
+                {
+                  "id": "[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'NatRule', copyIndex())]"
+                },
+                {
+                  "id": "[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'ProbeNatRule', copyIndex())]"
+                },
+                {
+                  "id": "[concat(variables('lbID'),'/inboundNatRules/',parameters('dnsName'), 'MySQLNatRule', copyIndex())]"
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[concat(parameters('dnsName'), copyIndex())]",
+      "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "vmLoop",
+        "count": "[variables('nodeCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]",
+        "[concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]",
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'), copyIndex())]"
+      ],
+      "properties": {
+        "availabilitySet": {
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+        },
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[concat(parameters('dnsName'), copyIndex())]",
+          "adminUsername": "[parameters('vmUserName')]",
+          "adminPassword": "[parameters('vmPassword')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[parameters('imagePublisher')]",
+            "offer": "[parameters('imageOffer')]",
+            "sku": "[parameters('imageSKU')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "name": "osdisk",
+            "vhd": {
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'osdisk.vhd')]"
+            },
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          },
+          "dataDisks": [
+            {
+              "name": "datadisk1",
+              "diskSizeGB": "1000",
+              "lun": 0,
+              "vhd": {
+                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'dataDisk1.vhd')]"
+              },
+              "createOption": "Empty"
+            },
+            {
+              "name": "datadisk2",
+              "diskSizeGB": "1000",
+              "lun": 1,
+              "vhd": {
+                "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('storageAccountName')), variables('resourceAPIVersion')).primaryEndpoints.blob, 'vhds/', parameters('dnsName'), copyIndex(), 'dataDisk2.vhd')]"
+              },
+              "createOption": "Empty"
+            }
+          ]
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[concat(resourceId('Microsoft.Network/networkInterfaces',variables('nicName')), copyIndex())]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('dnsName'), copyIndex(), '/setupMySQL')]",
+      "apiVersion": "2015-06-15",
+      "location": "[resourceGroup().location]",
+      "copy": {
+        "name": "extLoop",
+        "count": "[variables('nodeCount')]"
+      },
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('dnsName'), copyIndex())]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": [
+            "[variables('customScriptFilePath')]"
+          ]
+        },
+        "protectedSettings": {
+          "commandToExecute": "[concat(parameters('customScriptCommandToExecute'), ' ', copyIndex(1), ' ', variables('ipOctet01'), add(variables('ipOctet2'), div(copyIndex(variables('ipOctet3')), 255)), '.', mod(copyIndex(variables('ipOctet3')), 255), ' ', variables('mysqlConfigFilePath'), ' ', variables('singleQuote'), parameters('mysqlReplicationPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlRootPassword'), variables('singleQuote'), ' ', variables('singleQuote'), parameters('mysqlProbePassword'), variables('singleQuote'), ' ', parameters('dbSubnetStartAddress'), ' ', variables('DBName'))]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/loadBalancers",
+      "name": "[variables('lbName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('lbPublicIPName'))]"
+      ],
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "[variables('sshIPConfigName')]",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[variables('lbPublicIPRef')]"
+              }
+            }
+          }
+        ],
+        "backendAddressPools": [
+          {
+            "name": "[variables('ilbBackendAddressPoolName')]"
+          }
+        ],
+        "inboundNatRules": [
+          {
+            "name": "[concat(parameters('dnsName'),'NatRule0')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('sshNatRuleFrontEndPort0')]",
+              "backendPort": 22,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'NatRule1')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('sshNatRuleFrontEndPort1')]",
+              "backendPort": 22,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'MySQLNatRule0')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('mysqlFrontEndPort0')]",
+              "backendPort": 3306,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'MySQLNatRule1')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('mysqlFrontEndPort1')]",
+              "backendPort": 3306,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'ProbeNatRule0')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('mysqlProbePort0')]",
+              "backendPort": 9200,
+              "enableFloatingIP": false
+            }
+          },
+          {
+            "name": "[concat(parameters('dnsName'),'ProbeNatRule1')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('sshIPConfig')]"
+              },
+              "protocol": "tcp",
+              "frontendPort": "[parameters('mysqlProbePort1')]",
+              "backendPort": 9200,
+              "enableFloatingIP": false
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "fqdn": {
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).dnsSettings.fqdn]",
+      "type": "string"
+    },
+    "ipaddress": {
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('lbPublicIPName')),providers('Microsoft.Network', 'publicIPAddresses').apiVersions[0]).ipAddress]",
+      "type": "string"
+    }
+  }
 }

--- a/wordpress-mysql-replication/nested/vnet-new.json
+++ b/wordpress-mysql-replication/nested/vnet-new.json
@@ -1,56 +1,56 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "virtualNetworkName": {
-            "type": "string"
-        },
-        "virtualNetworkAddressPrefix": {
-            "type": "string"
-        },
-        "dbSubnetName": {
-            "type": "string"
-        },
-        "dbSubnetAddressPrefix": {
-            "type": "string"
-        },
-        "vnetExistingResourceGroupName": {
-            "type": "string",
-            "defaultValue": ""
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "virtualNetworkName": {
+      "type": "string"
     },
-    "variables": {
-        "resourceAPIVersion": "2015-06-15",
-        "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
-        "dbSubnet": "[concat(variables('vnetID'),'/subnets/',parameters('dbSubnetName'))]"
+    "virtualNetworkAddressPrefix": {
+      "type": "string"
     },
-    "resources": [
-      {
-        "apiVersion": "[variables('resourceAPIVersion')]",
-        "type": "Microsoft.Network/virtualNetworks",
-        "name": "[parameters('virtualNetworkName')]",
-        "location": "[resourceGroup().location]",
-        "properties": {
-          "addressSpace": {
-            "addressPrefixes": [
-              "[parameters('virtualNetworkAddressPrefix')]"
-            ]
-          },
-          "subnets": [
-            {
-              "name": "[parameters('dbSubnetName')]",
-              "properties": {
-                "addressPrefix": "[parameters('dbSubnetAddressPrefix')]"
-              }
-            }
-          ]
-        }
-      }
-    ],
-    "outputs": {
-        "dbSubnetRef": {
-            "value": "[variables('dbSubnet')]",
-            "type": "string"
-        }
+    "dbSubnetName": {
+      "type": "string"
+    },
+    "dbSubnetAddressPrefix": {
+      "type": "string"
+    },
+    "vnetExistingResourceGroupName": {
+      "type": "string",
+      "defaultValue": ""
     }
+  },
+  "variables": {
+    "resourceAPIVersion": "2015-06-15",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
+    "dbSubnet": "[concat(variables('vnetID'),'/subnets/',parameters('dbSubnetName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[parameters('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('virtualNetworkAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[parameters('dbSubnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('dbSubnetAddressPrefix')]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "dbSubnetRef": {
+      "value": "[variables('dbSubnet')]",
+      "type": "string"
+    }
+  }
 }


### PR DESCRIPTION
### Remove API version as being one variable on all the templates

This check-in just removes some of the gross errors on the templates and basically remove the very bad practice of putting the API version of the resources as a variable. if you need to change the API version you needed to change the resource itself so including that as a variable cause many errors and since it was that way in many of the templates already here this would be recognized as something that it is encouraged. 

### Changelog

* Many files change due to the fact that this is common in many of the older templates.

