### PR TITLE
service-fabric-cluster-ubuntu-5-node-1-nodetype: Updated azuredeploy.parameters.json to use GEN values

### DIFF
--- a/service-fabric-cluster-ubuntu-5-node-1-nodetype/azuredeploy.parameters.json
+++ b/service-fabric-cluster-ubuntu-5-node-1-nodetype/azuredeploy.parameters.json
@@ -1,63 +1,24 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "clusterLocation": {
-      "value": "eastus"
-    },
-    "clusterName": {
-      "value": "sfclust1"
-    },
-    "adminUserName": {
-      "value": "admuser"
-    },
-    "adminPassword": {
-      "value": "Pa$$word$1"
-    },
-    "vmImagePublisher": {
-      "value": "Microsoft.Azure.ServiceFabric"
-    },
-    "vmImageOffer": {
-      "value": "UbuntuServer"
-    },
-    "vmImageSku": {
-      "value": "16.04"
-    },
-    "vmImageVersion": {
-      "value": "6.0.11"
-    },
-    "loadBalancedAppPort1": {
-      "value": 80
-    },
-    "loadBalancedAppPort2": {
-      "value": 8081
-    },
-    "certificateStorevalue": {
-      "value": "My"
-    },
-    "certificateThumbprint": {
-      "value": "99912345o458045827c723047234"
-    },
-    "sourceVaultvalue": {
-      "value": "/subscriptions/<Sub ID>/resourceGroups/<Resource group name>/providers/Microsoft.KeyVault/vaults/<vault name>"
-    },
-    "certificateUrlvalue": {
-      "value": "https://<name of the vault>.vault.azure.net:443/secrets/<exact location>"
-    },
-    "clusterProtectionLevel": {
-      "value": "EncryptAndSign"
-    },
-    "storageAccountType": {
-      "value": "Standard_LRS"
-    },
-    "supportLogStorageAccountType": {
-      "value": "Standard_LRS"
-    },
-    "applicationDiagnosticsStorageAccountType": {
-      "value": "Standard_LRS"
-    },
-    "nt0InstanceCount": {
-      "value": 5
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "clusterLocation": {
+            "value": "westus"
+        },
+        "clusterName": {
+            "value": "GEN-UNIQUE"
+        },
+        "adminPassword": {
+            "value": "GEN-PASSWORD"
+        },
+        "certificateThumbprint": {
+            "value": "GEN-CUSTOM-DOMAIN-SSLCERT-THUMBPRINT"
+        },
+        "sourceVaultvalue": {
+            "value": "GEN-KEYVAULT-RESOURCE-ID"
+        },
+        "certificateUrlvalue": {
+            "value": "GEN-KEYVAULT-SSL-SECRET-URI"
+        }
     }
-  }
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

