### PR TITLE
201-vm-sql-full-autopatching: Updated azuredeploy.parameters.json to use GEN values

### DIFF
--- a/201-vm-sql-full-autopatching/azuredeploy.json
+++ b/201-vm-sql-full-autopatching/azuredeploy.json
@@ -242,7 +242,7 @@
         "storageProfile": {
           "imageReference": {
             "publisher": "MicrosoftSQLServer",
-            "offer": "SQL2014SP1-WS2012R2",
+            "offer": "SQL2016SP1-WS2016",
             "sku": "Enterprise",
             "version": "latest"
           },

--- a/201-vm-sql-full-autopatching/azuredeploy.parameters.json
+++ b/201-vm-sql-full-autopatching/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "adminUsername": {
-            "value": "GEN-UNIQUE"
+            "value": "GEN-UNIQUE-10"
         },
         "adminPassword": {
             "value": "GEN-PASSWORD"

--- a/201-vm-sql-full-autopatching/azuredeploy.parameters.json
+++ b/201-vm-sql-full-autopatching/azuredeploy.parameters.json
@@ -2,17 +2,11 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "virtualMachineName": {
-            "value": "vmName"
-        },
-        "virtualMachineSize": {
-            "value": "Standard_DS4"
-        },
         "adminUsername": {
-            "value": "myVmAdmin"
+            "value": "GEN-UNIQUE"
         },
-        "storageAccountType": {
-            "value": "Premium_LRS"
+        "adminPassword": {
+            "value": "GEN-PASSWORD"
         },
         "networkInterfaceName": {
             "value": "GEN-UNIQUE-13"
@@ -20,53 +14,17 @@
         "networkSecurityGroupName": {
             "value": "GEN-UNIQUE-13"
         },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        },
         "virtualNetworkName": {
             "value": "GEN-UNIQUE-13"
         },
-        "addressPrefix": {
-            "value": "10.0.0.0/16"
-        },
         "subnetName": {
-            "value": "default"
-        },
-        "subnetPrefix": {
-            "value": "10.0.0.0/24"
+            "value": "GEN-UNIQUE"
         },
         "publicIpAddressName": {
             "value": "GEN-UNIQUE-13"
         },
-        "publicIpAddressType": {
-            "value": "Dynamic"
-        },
-        "sqlConnectivityType": {
-            "value": "Public"
-        },
-        "sqlPortNumber": {
-            "value": 1579
-        },
-        "sqlStorageDisksCount": {
-            "value": 2
-        },
-        "sqlStorageWorkloadType": {
-            "value": "GENERAL"
-        },
-        "sqlAutopatchingDayOfWeek": {
-            "value": "Sunday"
-        },
-        "sqlAutopatchingStartHour": {
-            "value": "2"
-        },
-        "sqlAutopatchingWindowDuration": {
-            "value": "60"
-        },
-        "sqlAuthenticationLogin": {
-            "value": "mySqlAdmin"
-        },
         "sqlAuthenticationPassword": {
-            "value": "GEN-UNIQUE"
+            "value": "GEN-PASSWORD"
         }
     }
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

