### PR TITLE
Bug fixes

### DIFF
--- a/oms-vmm-analytics/scripts/vmmanalytics.ps1
+++ b/oms-vmm-analytics/scripts/vmmanalytics.ps1
@@ -64,7 +64,7 @@ foreach ($server in $vmmServers)
         $lastRunTimestamp_r = $args[1]
         $currentTimestamp_r = $args[2]
 
-        $jobsData = Get-SCJob -All | where {$_.Status -ne 'Running' -and $_.EndTime -gt $lastRunTimestamp_r -and $_.EndTime -le $currentTimestamp_r}
+        $jobsData = Get-SCJob -All -VMMServer $server_r | where {$_.Status -ne 'Running' -and $_.EndTime -gt $lastRunTimestamp_r -and $_.EndTime -le $currentTimestamp_r}
       
         $vmmJobsDataForOMS = @();
         foreach ($job in $jobsData) {
@@ -77,7 +77,7 @@ foreach ($server in $vmmServers)
                 Duration = ($job.EndTime-$job.StartTime).TotalSeconds;     
                 Progress = $job.Progress.ToString();
                 Status = $job.Status;
-                ErrorInfo = $job.ErrorInfo;
+                ErrorInfo = $job.ErrorInfo.ToString();
                 Problem = $job.ErrorInfo.Problem;
                 CloudProblem = $job.ErrorInfo.CloudProblem;
                 RecommendedAction = $job.ErrorInfo.RecommendedAction;
@@ -85,7 +85,7 @@ foreach ($server in $vmmServers)
                 TargetObjectID = $job.TargetObjectID;
                 TargetObjectType = $job.TargetObjectType;
                 ID = $job.ID.ToString();
-                ServerConnection = $job.ServerConnection;
+                ServerConnection = $job.ServerConnection.ToString();
                 IsRestartable = $job.IsRestartable
                 IsCompleted = $job.IsCompleted
                 VMMServer = $server_r;


### PR DESCRIPTION
Adding server name parameter in get-scjob cmdlet
Fixing the values for parameters ErrorInfo and ServerConnection with .ToString() paramater

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

