### PR TITLE
Update itemDisplayName and summary metadata typo

### DIFF
--- a/oms-azure-resource-usage-solution/metadata.json
+++ b/oms-azure-resource-usage-solution/metadata.json
@@ -1,7 +1,7 @@
 {
-  "itemDisplayName": "OMS - Azure Resouce Usage Solution",
+  "itemDisplayName": "OMS - Azure Resource Usage Solution",
   "description": "Solution brings billing infortmation about Azure Resources into OMS.  Cost of resources can be displayed in different currency and locale.",
-  "summary": "This template deploys  Azure Resouce Usage  solution with OMS workspace and Automation account.",
+  "summary": "This template deploys  Azure Resource Usage  solution with OMS workspace and Automation account.",
   "githubUsername": "volkanco",
   "dateUpdated": "2017-4-16"
 }


### PR DESCRIPTION
Update the typo error `resouce` to `resource` on itemDisplayName and summary in the metadata.json to display proper english spelling in Azure Quickstart Templates portal.