### PR TITLE
added dev switch for easily swapping param files

### DIFF
--- a/Deploy-AzureResourceGroup.ps1
+++ b/Deploy-AzureResourceGroup.ps1
@@ -15,7 +15,8 @@ Param(
     [string] $TemplateParametersFile = $ArtifactStagingDirectory + '.\azuredeploy.parameters.json',
     [string] $DSCSourceFolder = $ArtifactStagingDirectory + '.\DSC',
     [switch] $ValidateOnly,
-    [string] $DebugOptions = "None"
+    [string] $DebugOptions = "None",
+    [switch] $Dev
 )
 
 try {
@@ -34,6 +35,9 @@ function Format-ValidationOutput {
 $OptionalParameters = New-Object -TypeName Hashtable
 $TemplateArgs = New-Object -TypeName Hashtable
 
+if ($Dev) {
+    $TemplateParametersFile.Replace('azuredeploy.parameters.json', 'azuredeploy.parameters.dev.json')
+}
 
 if (!$ValidateOnly) {
     $OptionalParameters.Add('DeploymentDebugLogLevel', $DebugOptions)

--- a/az-group-deploy.sh
+++ b/az-group-deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -e
-while getopts "a:l:g:s:f:e:uv" opt; do
+while getopts "a:l:g:s:f:e:uvd" opt; do
     case $opt in
         a)
             artifactsStagingDirectory=$OPTARG #the folder or sample to deploy
@@ -25,6 +25,9 @@ while getopts "a:l:g:s:f:e:uv" opt; do
         v)
             validateOnly='true'
         ;;
+        d)
+            devMode='true'
+        ;;
     esac
 done
     
@@ -34,9 +37,15 @@ if [[ -z $templateFile ]]
 then
     templateFile="$artifactsStagingDirectory/azuredeploy.json"
 fi
-if [[ -z $parametersFile ]]
+
+if [[ $devMode ]]
 then
-    parametersFile="$artifactsStagingDirectory/azuredeploy.parameters.json"
+    parametersFile="$artifactsStagingDirectory/azuredeploy.parameters.dev.json"
+else
+    if [[ -z $parametersFile ]]
+    then
+        parametersFile="$artifactsStagingDirectory/azuredeploy.parameters.json"
+    fi
 fi
 
 templateName="$( basename "${templateFile%.*}" )"


### PR DESCRIPTION
Updated scripts to include the use of a -Dev switch - this will then default to a param file named azuredeploy.parameters.dev.json which is .gitignore'd - you can use this param file for local testing without overriding with a long param value