### PR TITLE
added support to select the drive to use for data persistence on SF cluster nodes

### DIFF
--- a/service-fabric-cluster-ubuntu-5-node-1-nodetype/azuredeploy.json
+++ b/service-fabric-cluster-ubuntu-5-node-1-nodetype/azuredeploy.json
@@ -114,6 +114,16 @@
       "metadata": {
         "description": "Instance count for node type"
       }
+    },
+    "nodeDataDrive": {
+      "type": "string",
+      "defaultValue": "Temp",
+      "allowedValues": [
+        "OS", "Temp"
+      ],
+      "metadata": {
+        "description": "The drive to use to store data on a cluster node."
+      }
     }
   },
   "variables": {
@@ -388,6 +398,7 @@
                   "settings": {
                     "clusterEndpoint": "[reference(parameters('clusterDnsName')).clusterEndpoint]",
                     "nodeTypeRef": "[variables('vmNodeType0Name')]",
+                    "dataPath": "[concat(if(equals(parameters('nodeDataDrive'), 'OS'), '', '/mnt'), '/sfroot')]",
                     "durabilityLevel": "Bronze",
                     "certificate": {
                       "thumbprint": "[parameters('certificateThumbprint')]",

--- a/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
+++ b/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
@@ -115,6 +115,16 @@
       "metadata": {
         "description": "Instance count for node type"
       }
+    },
+    "nodeDataDrive": {
+      "type": "string",
+      "defaultValue": "Temp",
+      "allowedValues": [
+        "OS", "Temp"
+      ],
+      "metadata": {
+        "description": "The drive to use to store data on a cluster node."
+      }
     }
   },
   "variables": {
@@ -413,7 +423,7 @@
                   "settings": {
                     "clusterEndpoint": "[reference(parameters('clusterName')).clusterEndpoint]",
                     "nodeTypeRef": "[variables('vmNodeType0Name')]",
-                    "dataPath": "D:\\\\SvcFab",
+                    "dataPath": "[concat(if(equals(parameters('nodeDataDrive'), 'OS'), 'C', 'D'), ':\\\\SvcFab')]",
                     "durabilityLevel": "Bronze",
                     "nicPrefixOverride": "[variables('subnet0Prefix')]",
                     "certificate": {


### PR DESCRIPTION
This feature is needed to support SF cluster start/stop operations for cost saving.