### PR TITLE
Added scale set dependency on load balancer

### DIFF
--- a/201-vmss-internal-loadbalancer/azuredeploy.json
+++ b/201-vmss-internal-loadbalancer/azuredeploy.json
@@ -247,7 +247,8 @@
       "location": "[resourceGroup().location]",
       "apiVersion": "2017-03-30",
       "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[concat('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]"
       ],
       "sku": {
         "name": "[parameters('vmSku')]",

--- a/201-vmss-internal-loadbalancer/metadata.json
+++ b/201-vmss-internal-loadbalancer/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template allows you to deploy a VM Scale Set of Linux VMs using the latest patched version of Ubuntu Linux 15.10 or 14.04.4-LTS. These VMs are behind an internal load balancer with NAT rules for ssh connections.",
   "summary": "This template deploys a VM Scale Set of Linux VMs behind an internal load balancer with NAT rules for ssh connections.",
   "githubUsername": "gatneil",
-  "dateUpdated": "2016-12-19"
+  "dateUpdated": "2017-10-12"
 }


### PR DESCRIPTION
In most cases load balancer spins up faster than the scale set but a strict dependency should be better.

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added scale set dependency on load balancer

