### PR TITLE
Delete duplicated keys in variables

### DIFF
--- a/intel-lustre-client-server/azuredeploy.json
+++ b/intel-lustre-client-server/azuredeploy.json
@@ -65,17 +65,6 @@
 				"description": "SSH public key that will be included on all nodes in the Lustre cluster. The OpenSSH public key can be generated with tools like ssh-keygen on Linux or OS X."
 			}
 		},
-		"authenticationType": {
-			"type": "string",
-			"defaultValue": "password",
-			"allowedValues": [
-				"password",
-				"sshPublicKey"
-			],
-			"metadata": {
-				"description": "Authentication type for the virtual machines"
-			}
-		},
 		"dnsNamePrefix": {
 			"type": "string",
 			"metadata": {
@@ -562,8 +551,6 @@
 		},
 		"storageAccountName": "[concat(uniquestring(resourceGroup().id), 'server')]",
 		"clientStorageAccountName": "[concat(uniquestring(resourceGroup().id), 'client')]",
-		"linuxConfiguration_password": {},
-		"linuxConfiguration": "[variables(concat('linuxConfiguration_',parameters('authenticationType')))]",
 		"vnetID": "[resourceId(parameters('existingVnetResourceGroup'), 'Microsoft.Network/virtualNetworks', parameters('existingVnetName'))]",
 		"subnetServersID": "[concat(variables('vnetID'), '/subnets/', parameters('subnetServersName'))]",
 		"subnetClientsID": "[concat(variables('vnetID'), '/subnets/', parameters('subnetClientsName'))]",


### PR DESCRIPTION
Deleting those keys leaves an unused parameter

I think I've deleted the appropiate keys, since the values of the duplicated variables were not the same.