### PR TITLE
Using a version of ubuntuserver that will work

### DIFF
--- a/slurm/azuredeploy.json
+++ b/slurm/azuredeploy.json
@@ -47,7 +47,7 @@
     "dnsName": "[concat('slurm-', uniqueString(resourceGroup().id))]",
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
-    "ubuntuOSVersion": "16.10",
+    "ubuntuOSVersion": "16.04-LTS",
     "publicIPAddressName": "publicip",
     "vmNameMaster": "master",
     "vmNameWorker": "worker",


### PR DESCRIPTION
Ubuntu 16.10 not found when I'm trying to deploy the template. Used 16.04-LTS instead and it deployed fine.
Spoke on Twitter about it here, https://twitter.com/iStarr/status/921815630797516802

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ +] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

