### PR TITLE
Correct Type: rename secureObject parameter to secretsObject

### DIFF
--- a/201-key-vault-secret-create/azuredeploy.parameters.json
+++ b/201-key-vault-secret-create/azuredeploy.parameters.json
@@ -28,7 +28,7 @@
                     }
                 ]
             },
-            "secureObject": {
+            "secretsObject": {
                 "value": {
 					"secrets": [						
 						{

--- a/201-key-vault-secret-create/metadata.json
+++ b/201-key-vault-secret-create/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template creates a Key Vault and creates secrets within the vault as passed along with the parameters",
   "summary": "Creates a Key Vault with dynammic list of Secrets",
   "githubUsername": "rahulpnath",
-  "dateUpdated": "2016-06-04"
+  "dateUpdated": "2017-10-23"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Rename secureObject parameter to secretsObject for 201-key-vault-secret-create template

