### PR TITLE
Add template for emptyDir volume

### DIFF
--- a/201-aci-linuxcontainer-volume-emptydir/README.md
+++ b/201-aci-linuxcontainer-volume-emptydir/README.md
@@ -1,0 +1,3 @@
+# Azure Container Instances
+
+This template demonstrates a simple use case for emptyDir volume of [Azure Container Instances](https://docs.microsoft.com/en-us/azure/container-instances/).

--- a/201-aci-linuxcontainer-volume-emptydir/azuredeploy.json
+++ b/201-aci-linuxcontainer-volume-emptydir/azuredeploy.json
@@ -1,0 +1,186 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "containergroupname": {
+      "type": "string",
+      "metadata": {
+        "description": "Name for the container group"
+      },
+      "defaultValue": "acilinuxcontainergroup"
+    },
+    "containername1": {
+      "type": "string",
+      "metadata": {
+        "description": "Name for the container 1"
+      },
+      "defaultValue": "acilinuxcontainer1"
+    },
+    "containername2": {
+      "type": "string",
+      "metadata": {
+        "description": "Name for the container 2"
+      },
+      "defaultValue": "acilinuxcontainer2"
+    },
+    "volumename1": {
+      "type": "string",
+      "metadata": {
+        "description": "Name for the volume 1"
+      },
+      "defaultValue": "sharedvolume"
+    },
+    "volumename2": {
+      "type": "string",
+      "metadata": {
+        "description": "Name for the volume 2"
+      },
+      "defaultValue": "azurefile"
+    },
+    "image": {
+      "type": "string",
+      "metadata": {
+        "description": "Container image to deploy. Should be of the form accountName/imagename[:tag] for images stored in Docker Hub or a fully qualified URI for a private registry like the Azure Container Registry."
+      },
+      "defaultValue": "centos:latest"
+    },
+    "port": {
+      "type": "string",
+      "metadata": {
+        "description": "Port to open on the container and the public IP address."
+      },
+      "defaultValue": "80"
+    },
+    "cpuCores": {
+      "type": "string",
+      "metadata": {
+        "description": "The number of CPU cores to allocate to the container."
+      },
+      "defaultValue": "1.0"
+    },
+    "memoryInGb": {
+      "type": "string",
+      "metadata": {
+        "description": "The amount of memory to allocate to the container in gigabytes."
+      },
+      "defaultValue": "1.5"
+    },
+    "shareName": {
+      "type": "string",
+      "metadata": {
+        "description": "The Azure file share name."
+      }
+    },
+    "shareStorageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "The Azure storage account name for the share."
+      }
+    },
+    "shareResourceGroup": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource group of the storage account containing the Azure file share."
+      }
+    }
+  },
+  "variables": {
+    "accountid": "[concat('/subscriptions/',subscription().subscriptionId,'/resourceGroups/',parameters('shareResourceGroup'),'/providers/','Microsoft.Storage/storageAccounts/', parameters('shareStorageAccountName'))]"
+  },
+  "resources": [
+    {
+      "name": "[parameters('containergroupname')]",
+      "type": "Microsoft.ContainerInstance/containerGroups",
+      "apiVersion": "2017-10-01-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "containers": [
+          {
+            "name": "[parameters('containername1')]",
+            "properties": {
+              "command": [],
+              "image": "nginx",
+              "ports": [
+                {
+                  "port": "[parameters('port')]"
+                }
+              ],
+              "resources": {
+                "requests": {
+                  "cpu": "[parameters('cpuCores')]",
+                  "memoryInGb": "[parameters('memoryInGb')]"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "name": "[parameters('volumename1')]",
+                  "mountPath": "/var/log/nginx",
+                  "readOnly": false
+                }
+              ]
+            }
+          },
+          {
+            "name": "[parameters('containername2')]",
+            "properties": {
+              "command": [
+                "bin/bash",
+                "-c",
+                "while sleep 5; do cat /mnt/input/access.log > /mnt/azurefile/test.txt; done"
+              ],
+              "image": "[parameters('image')]",
+              "resources": {
+                "requests": {
+                  "cpu": "[parameters('cpuCores')]",
+                  "memoryInGb": "[parameters('memoryInGb')]"
+                }
+              },
+              "volumeMounts": [
+                {
+                  "name": "[parameters('volumename1')]",
+                  "mountPath": "/mnt/input",
+                  "readOnly": true
+                },
+                {
+                  "name": "[parameters('volumename2')]",
+                  "mountPath": "/mnt/azurefile",
+                  "readOnly": false
+                }
+              ]
+            }
+          }
+        ],
+        "osType": "Linux",
+        "ipAddress": {
+          "type": "Public",
+          "ports": [
+            {
+              "protocol": "tcp",
+              "port": "[parameters('port')]"
+            }
+          ]
+        },
+        "volumes": [
+          {
+            "name": "[parameters('volumename1')]",
+            "emptyDir": {}
+          },
+          {
+            "name": "[parameters('volumename2')]",
+            "azureFile": {
+              "shareName": "[parameters('shareName')]",
+              "storageAccountName": "[parameters('shareStorageAccountName')]",
+              "storageAccountKey": "[listKeys(variables('accountid'),'2015-05-01-preview').key1]"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "outputs": {
+    "containerIPv4Address": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups/', parameters('containergroupname'))).ipAddress.ip]"
+    }
+  }
+}

--- a/201-aci-linuxcontainer-volume-emptydir/azuredeploy.parameters.json
+++ b/201-aci-linuxcontainer-volume-emptydir/azuredeploy.parameters.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "containergroupname": {
+      "value": "acilinuxcontainergroup"
+    },
+    "containername1": {
+      "value": "acilinuxcontainer1"
+    },
+    "containername2": {
+      "value": "acilinuxcontainer2"
+    },
+    "volumename1": {
+      "value": "sharedvolume"
+    },
+    "volumename2": {
+      "value": "azurefile"
+    },
+    "image": {
+      "value": "centos:latest"
+    },
+    "port": {
+      "value": "80"
+    },
+    "cpuCores": {
+      "value": "1.0"
+    },
+    "memoryInGb": {
+      "value": "1.5"
+    }
+  }
+}

--- a/201-aci-linuxcontainer-volume-emptydir/azuredeploy.parameters.json
+++ b/201-aci-linuxcontainer-volume-emptydir/azuredeploy.parameters.json
@@ -28,6 +28,15 @@
     },
     "memoryInGb": {
       "value": "1.5"
+    },
+    "shareName": {
+      "value": "yourShareName"
+    },
+    "shareStorageAccountName": {
+      "value": "yourStorageAccountName"
+    },
+    "shareResourceGroup": {
+      "value": "yourResourceGroup"
     }
   }
 }

--- a/201-aci-linuxcontainer-volume-emptydir/metadata.json
+++ b/201-aci-linuxcontainer-volume-emptydir/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Azure Container Instances - Linux container with emptyDir",
+  "description": "Deploy two Linux containers that share an emptyDir volume using Azure Container Instances.",
+  "summary": "This template demonstrates how to create a container group with two Linux containers that share an emptyDir volume using Azure Container Instances.",
+  "githubUsername": "zhedahht",
+  "dateUpdated": "2017-11-09"
+}


### PR DESCRIPTION
Add quick-start templates for emptyDir volumes in Azure Container Instance.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

