### PR TITLE
Template to create a TimeSeriesInsights environment with a child event source

### DIFF
--- a/201-timeseriesinsights-create-environment-with-eventsource/README.md
+++ b/201-timeseriesinsights-create-environment-with-eventsource/README.md
@@ -10,11 +10,3 @@
 This template creates a Time Series Insights environment and a child event source configured to consume events from an Event Hub. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/.
 
 The shared access key for the event hub must be stored as a secret in a Key Vault.
-
-## Temp - for testing template deployment from my fork
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https:%2F/github.com/sandshadow/azure-quickstart-templates/blob/master/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json" target="_blank">
-    <img src="http://azuredeploy.net/deploybutton.png"/>
-</a>
-<a href="http://armviz.io/#/?load=https:%2F/github.com/sandshadow/azure-quickstart-templates/blob/master/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json" target="_blank">
-    <img src="http://armviz.io/visualizebutton.png"/>
-</a>

--- a/201-timeseriesinsights-create-environment-with-eventsource/README.md
+++ b/201-timeseriesinsights-create-environment-with-eventsource/README.md
@@ -1,0 +1,12 @@
+# Create a Time Series Insights Environment and Event Source
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-timeseriesinsights-create-environment-with-eventsource%2azuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-timeseriesinsights-create-environment-with-eventsource%2azuredeploy.json" target="_blank">
+    <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+This template creates a Time Series Insights environment and a child event source configured to consume events from an Event Hub. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/.
+
+The shared access key for the event hub must be stored as a secret in a Key Vault.

--- a/201-timeseriesinsights-create-environment-with-eventsource/README.md
+++ b/201-timeseriesinsights-create-environment-with-eventsource/README.md
@@ -10,3 +10,11 @@
 This template creates a Time Series Insights environment and a child event source configured to consume events from an Event Hub. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/.
 
 The shared access key for the event hub must be stored as a secret in a Key Vault.
+
+## Temp - for testing template deployment from my fork
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https:%2F/github.com/sandshadow/azure-quickstart-templates/blob/master/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https:%2F/github.com/sandshadow/azure-quickstart-templates/blob/master/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json" target="_blank">
+    <img src="http://armviz.io/visualizebutton.png"/>
+</a>

--- a/201-timeseriesinsights-create-environment-with-eventsource/README.md
+++ b/201-timeseriesinsights-create-environment-with-eventsource/README.md
@@ -7,8 +7,6 @@
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-This template creates a Time Series Insights environment and a child event source configured to consume events from an Event Hub. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/.
-
-The shared access key for the event hub must be stored as a secret in a Key Vault.
+This template creates a Time Series Insights environment and a child event source configured to consume events from an Event Hub or an IoT Hub. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/.
 
 Before accessing data in your environment, you must create an Access Policy. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/time-series-insights-data-access

--- a/201-timeseriesinsights-create-environment-with-eventsource/README.md
+++ b/201-timeseriesinsights-create-environment-with-eventsource/README.md
@@ -10,3 +10,5 @@
 This template creates a Time Series Insights environment and a child event source configured to consume events from an Event Hub. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/.
 
 The shared access key for the event hub must be stored as a secret in a Key Vault.
+
+Before accessing data in your environment, you must create an Access Policy. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/time-series-insights-data-access

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -140,7 +140,8 @@
         {
           "condition": "[equals(parameters('eventSourceKind'),'Microsoft.EventHub')]",
           "type": "eventsources",
-          "name": "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'),parameters('eventSourceName'), 'usedToGetAroundValidationRestrictions')]",
+          "name": "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'),parameters('eventSourceName'), 'usedToGetAroundValidationRestrictionsWhenNotEventHub')]",
+          "comment": "NOTES: The 'if' conditional on the name property is a workaround for validation not recognizing that only one event source will be created, resulting in failures saying the same resource is being defined multiple times in the template. Likewise, the listKeys method will be invoked before the evaluation of the conditional which is why listkeys arguments for method and api-version are variables.",
           "apiVersion": "2017-11-15",
           "location": "[resourceGroup().location]",
           "kind": "[parameters('eventSourceKind')]",
@@ -161,7 +162,7 @@
         {
           "condition": "[equals(parameters('eventSourceKind'),'Microsoft.IoTHub')]",
           "type": "eventsources",
-          "name": "[if(equals(parameters('eventSourceKind'),'Microsoft.IoTHub'),parameters('eventSourceName'), 'usedToGetAroundValidationRestrictions')]",
+          "name": "[if(equals(parameters('eventSourceKind'),'Microsoft.IoTHub'),parameters('eventSourceName'), 'usedToGetAroundValidationRestrictionsWhenNotIoTHub')]",
           "apiVersion": "2017-11-15",
           "location": "[resourceGroup().location]",
           "kind": "[parameters('eventSourceKind')]",

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -70,31 +70,31 @@
     "hubResourceId": {
       "type": "string",
       "metadata": {
-        "description": "The resource id of the source event hub in ARM, e.g. '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventHubs/{hubName}'."
+        "description": "The resource id of the event hub or IoT hub from which the event source will read events. For IoT hubs, the format is \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{hubName}\". For event hubs, the format is \"/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.EventHub/namespaces/{{namespaceName}}/eventHubs/{{hubName}}\"."
       }
     },
     "hubName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the source event hub."
+        "description": "The name of the source event hub or IoT hub."
       }
     },
     "consumerGroupName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for the Time Series Insights service. This consumer group should not be shared with other services to avoid contention."
+        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub or IoT hub. NOTE: You should create a dedicated consumer group on the event hub for the Time Series Insights service. This consumer group should not be shared with other services to avoid contention."
       }
     },
     "keyName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the event hub's shared access key that the Time Series Insights service will use to connect to the event hub."
+        "description": "The name of the shared access key that the Time Series Insights service will use to connect to the event hub or IoT hub."
       }
     },
     "eventHubServiceBusNamespace": {
       "type": "string",
       "metadata": {
-        "description": "The service bus namespace of the source event hub."
+        "description": "The service bus namespace of the source event hub. This value is only required for event hub event sources, and will be ignored for IoT hub event sources."
       }
     }
   },

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -23,13 +23,19 @@
       "allowedValues": [
         "S1",
         "S2"
-      ]
+      ],
+      "metadata": {
+        "description": "The name of the sku. For more information, see https://azure.microsoft.com/pricing/details/time-series-insights/"
+      }
     },
     "environmentSkuCapacity": {
       "type": "int",
       "defaultValue": 1,
       "minValue": 1,
-      "maxValue": 10
+      "maxValue": 10,
+      "metadata": {
+        "description": "The unit capacity of the Sku. For more information, see https://azure.microsoft.com/pricing/details/time-series-insights/"
+      }
     },
     "environmentDataRetentionTime": {
       "type": "string",
@@ -113,8 +119,8 @@
       }
     ],
     "eventSourceTagsValue": "[variables('eventSourceTagsOptions')[length(take(parameters('eventSourceDisplayName'), 1))]]",
-    "listKeysApiVersion" : "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'), '2015-08-01', '2017-07-01')]",
-    "listKeysMethod" : "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'), '/authorizationRules/', '/Iothubkeys/')]"
+    "listKeysApiVersion": "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'), '2015-08-01', '2017-07-01')]",
+    "listKeysMethod": "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'), '/authorizationRules/', '/Iothubkeys/')]"
   },
   "resources": [
     {

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -96,29 +96,6 @@
       "metadata": {
         "description": "The shared access key value that the Time Series Insights service will use to connect to the event hub."
       }
-    },
-    "accessPolicyName": {
-      "type": "string",
-      "maxLength": 90,
-      "metadata": {
-        "description": "Name of the access policy child resource. The name cannot include:   '<', '>', '%', '&', ':', '\\', '?', '/' and any control characters. All other characters are allowed."
-      }
-    },
-    "accessPolicyPrincipalObjectId": {
-      "type": "string",
-      "metadata": {
-        "description": "Object Id of the AAD user or service principal that will have access to the environment. Available from the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets"
-      }
-    },
-     "accessPolicyRole": {
-      "type": "string",
-      "allowedValues": [
-        "Reader",
-        "Contributor"
-      ],
-      "metadata": {
-        "description": "The role that will be assigned to the AAD user or service principal that will have access to the environment."
-      }
     }
   },
   "variables": {
@@ -168,20 +145,6 @@
             "timestampPropertyName": "[parameters('eventSourceTimestampPropertyName')]"
           },
           "tags": "[variables('eventSourceTagsValue')]",
-          "dependsOn": [
-            "[concat('Microsoft.TimeSeriesInsights/environments/', parameters('environmentName'))]"
-          ]
-        },
-        {
-          "type": "accesspolicies",
-          "name": "[parameters('accessPolicyName')]",
-          "apiVersion": "2017-02-28-preview",
-          "properties": {
-            "principalObjectId": "[parameters('accessPolicyPrincipalObjectId')]",
-            "roles": [
-              "[parameters('accessPolicyRole')]"
-            ]
-          },
           "dependsOn": [
             "[concat('Microsoft.TimeSeriesInsights/environments/', parameters('environmentName'))]"
           ]

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -88,7 +88,7 @@
     "consumerGroupName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub or IoT hub. NOTE: You should create a dedicated consumer group on the event hub for the Time Series Insights service. This consumer group should not be shared with other services to avoid contention."
+        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub or IoT hub. NOTE: You should create a dedicated consumer group on the event hub or IoT hub for the Time Series Insights service. This consumer group should not be shared with other services to avoid contention."
       }
     },
     "keyName": {

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -1,0 +1,198 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "type": "string",
+      "maxLength": 90,
+      "metadata": {
+        "description": "Name of the environment. The name cannot include:   '<', '>', '%', '&', ':', '\\', '?', '/' and any control characters. All other characters are allowed."
+      }
+    },
+    "environmentDisplayName": {
+      "type": "string",
+      "defaultValue": "",
+      "maxLength": 90,
+      "metadata": {
+        "description": "An optional friendly name to show in tooling or user interfaces instead of the environment name."
+      }
+    },
+    "environmentSkuName": {
+      "type": "string",
+      "defaultValue": "S1",
+      "allowedValues": [
+        "S1",
+        "S2"
+      ]
+    },
+    "environmentSkuCapacity": {
+      "type": "int",
+      "defaultValue": 1,
+      "minValue": 1,
+      "maxValue": 10
+    },
+    "environmentDataRetentionTime": {
+      "type": "string",
+      "defaultValue": "P30D",
+      "metadata": {
+        "description": "The minimum timespan the environment’s events will be available for query. The value must be specified in the ISO 8601 format, e.g. \"P30D\" for a retention policy of 30 days."
+      }
+    },
+    "eventSourceName": {
+      "type": "string",
+      "maxLength": 90,
+      "metadata": {
+        "description": "Name of the event source child resource. The name cannot include:   '<', '>', '%', '&', ':', '\\', '?', '/' and any control characters. All other characters are allowed."
+      }
+    },
+    "eventSourceDisplayName": {
+      "type": "string",
+      "defaultValue": "",
+      "maxLength": 90,
+      "metadata": {
+        "description": "An optional friendly name to show in tooling or user interfaces instead of the event source name."
+      }
+    },
+    "eventSourceTimestampPropertyName": {
+      "type": "string",
+      "defaultValue": "",
+      "maxLength": 90,
+      "metadata": {
+        "description": "The event property that will be used as the event source's timestamp. If a value isn't specified for timestampPropertyName, or if null or empty-string is specified, the event creation time will be used."
+      }
+    },
+    "eventHubResourceId": {
+      "type": "string",
+      "metadata": {
+        "description": "The resource id of the source event hub or IoT Hub in ARM, e.g. '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{hubName}'."
+      }
+    },
+    "eventHubServiceBusNamespace": {
+      "type": "string",
+      "metadata": {
+        "description": "The service bus namespace of the source event hub."
+      }
+    },
+    "eventHubName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the source event hub."
+      }
+    },
+    "eventHubConsumerGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the consumer group that RDX will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for RDX. This consumer group should not be shared with other services to avoid contention."
+      }
+    },
+    "eventHubKeyName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the event hub's shared access key that RDX will use to connect to the event hub."
+      }
+    },
+    "eventHubSharedAccessKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The shared access key value that RDX will use to connect to the event hub."
+      }
+    },
+    "accessPolicyName": {
+      "type": "string",
+      "maxLength": 90,
+      "metadata": {
+        "description": "Name of the access policy child resource. The name cannot include:   '<', '>', '%', '&', ':', '\\', '?', '/' and any control characters. All other characters are allowed."
+      }
+    },
+    "accessPolicyPrincipalObjectId": {
+      "type": "string",
+      "metadata": {
+        "description": "Object Id of the AAD user or service principal that will have access to the environment. Available from the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets"
+      }
+    },
+     "accessPolicyRole": {
+      "type": "string",
+      "allowedValues": [
+        "Reader",
+        "Contributor"
+      ],
+      "metadata": {
+        "description": "The role that will be assigned to the AAD user or service principal that will have access to the environment."
+      }
+    }
+  },
+  "variables": {
+    "environmentTagsOptions": [
+      null,
+      {
+        "displayName": "[parameters('environmentDisplayName')]"
+      }
+    ],
+    "environmentTagsValue": "[variables('environmentTagsOptions')[length(take(parameters('environmentDisplayName'), 1))]]",
+    "eventSourceTagsOptions": [
+      null,
+      {
+        "displayName": "[parameters('eventSourceDisplayName')]"
+      }
+    ],
+    "eventSourceTagsValue": "[variables('eventSourceTagsOptions')[length(take(parameters('eventSourceDisplayName'), 1))]]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.TimeSeriesInsights/environments",
+      "name": "[parameters('environmentName')]",
+      "apiVersion": "2017-02-28-preview",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "dataRetentionTime": "[parameters('environmentDataRetentionTime')]"
+      },
+      "sku": {
+        "name": "[parameters('environmentSkuName')]",
+        "capacity": "[parameters('environmentSkuCapacity')]"
+      },
+      "tags": "[variables('environmentTagsValue')]",
+      "resources": [
+        {
+          "type": "eventsources",
+          "name": "[parameters('eventSourceName')]",
+          "apiVersion": "2017-02-28-preview",
+          "location": "[resourceGroup().location]",
+          "kind": "Microsoft.EventHub",
+          "properties": {
+            "eventSourceResourceId": "[parameters('eventHubResourceId')]",
+            "serviceBusNamespace": "[parameters('eventHubServiceBusNamespace')]",
+            "eventHubName": "[parameters('eventHubName')]",
+            "consumerGroupName": "[parameters('eventHubConsumerGroupName')]",
+            "keyName": "[parameters('eventHubKeyName')]",
+            "sharedAccessKey": "[parameters('eventHubSharedAccessKey')]",
+            "timestampPropertyName": "[parameters('eventSourceTimestampPropertyName')]"
+          },
+          "tags": "[variables('eventSourceTagsValue')]",
+          "dependsOn": [
+            "[concat('Microsoft.TimeSeriesInsights/environments/', parameters('environmentName'))]"
+          ]
+        },
+        {
+          "type": "accesspolicies",
+          "name": "[parameters('accessPolicyName')]",
+          "apiVersion": "2017-02-28-preview",
+          "properties": {
+            "principalObjectId": "[parameters('accessPolicyPrincipalObjectId')]",
+            "roles": [
+              "[parameters('accessPolicyRole')]"
+            ]
+          },
+          "dependsOn": [
+            "[concat('Microsoft.TimeSeriesInsights/environments/', parameters('environmentName'))]"
+          ]
+        }
+      ]
+    }
+  ],
+  "outputs": {
+    "dataAccessId" : {
+      "value" : "[reference(resourceId('Microsoft.TimeSeriesInsights/environments', parameters('environmentName'))).dataAccessId]",
+      "type": "string"
+      }
+  }
+}

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -82,19 +82,19 @@
     "eventHubConsumerGroupName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the consumer group that RDX will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for RDX. This consumer group should not be shared with other services to avoid contention."
+        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for the Time Series Insights service. This consumer group should not be shared with other services to avoid contention."
       }
     },
     "eventHubKeyName": {
       "type": "string",
       "metadata": {
-        "description": "The name of the event hub's shared access key that RDX will use to connect to the event hub."
+        "description": "The name of the event hub's shared access key that the Time Series Insights service will use to connect to the event hub."
       }
     },
     "eventHubSharedAccessKey": {
       "type": "securestring",
       "metadata": {
-        "description": "The shared access key value that RDX will use to connect to the event hub."
+        "description": "The shared access key value that the Time Series Insights service will use to connect to the event hub."
       }
     },
     "accessPolicyName": {

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -64,7 +64,7 @@
     "eventHubResourceId": {
       "type": "string",
       "metadata": {
-        "description": "The resource id of the source event hub or IoT Hub in ARM, e.g. '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{hubName}'."
+        "description": "The resource id of the source event hub in ARM, e.g. '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventHubs/{hubName}'."
       }
     },
     "eventHubServiceBusNamespace": {
@@ -90,12 +90,6 @@
       "metadata": {
         "description": "The name of the event hub's shared access key that the Time Series Insights service will use to connect to the event hub."
       }
-    },
-    "eventHubSharedAccessKey": {
-      "type": "securestring",
-      "metadata": {
-        "description": "The shared access key value that the Time Series Insights service will use to connect to the event hub."
-      }
     }
   },
   "variables": {
@@ -118,7 +112,7 @@
     {
       "type": "Microsoft.TimeSeriesInsights/environments",
       "name": "[parameters('environmentName')]",
-      "apiVersion": "2017-02-28-preview",
+      "apiVersion": "2017-11-15",
       "location": "[resourceGroup().location]",
       "properties": {
         "dataRetentionTime": "[parameters('environmentDataRetentionTime')]"
@@ -132,7 +126,7 @@
         {
           "type": "eventsources",
           "name": "[parameters('eventSourceName')]",
-          "apiVersion": "2017-02-28-preview",
+          "apiVersion": "2017-11-15",
           "location": "[resourceGroup().location]",
           "kind": "Microsoft.EventHub",
           "properties": {
@@ -141,7 +135,7 @@
             "eventHubName": "[parameters('eventHubName')]",
             "consumerGroupName": "[parameters('eventHubConsumerGroupName')]",
             "keyName": "[parameters('eventHubKeyName')]",
-            "sharedAccessKey": "[parameters('eventHubSharedAccessKey')]",
+            "sharedAccessKey": "[listkeys(concat(parameters('eventHubResourceId'),'/authorizationRules/', parameters('eventHubKeyName')),'2015-08-01').primaryKey]",
             "timestampPropertyName": "[parameters('eventSourceTimestampPropertyName')]"
           },
           "tags": "[variables('eventSourceTagsValue')]",

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -45,6 +45,12 @@
         "description": "Name of the event source child resource. The name cannot include:   '<', '>', '%', '&', ':', '\\', '?', '/' and any control characters. All other characters are allowed."
       }
     },
+    "eventSourceKind": {
+      "type": "string",
+      "metadata": {
+        "description": "Supported values are 'Microsoft.EventHub' and 'Microsoft.IoTHub'. "
+      }
+    },
     "eventSourceDisplayName": {
       "type": "string",
       "defaultValue": "",
@@ -61,34 +67,34 @@
         "description": "The event property that will be used as the event source's timestamp. If a value isn't specified for timestampPropertyName, or if null or empty-string is specified, the event creation time will be used."
       }
     },
-    "eventHubResourceId": {
+    "hubResourceId": {
       "type": "string",
       "metadata": {
         "description": "The resource id of the source event hub in ARM, e.g. '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.EventHub/namespaces/{namespaceName}/eventHubs/{hubName}'."
+      }
+    },
+    "hubName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the source event hub."
+      }
+    },
+    "consumerGroupName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for the Time Series Insights service. This consumer group should not be shared with other services to avoid contention."
+      }
+    },
+    "keyName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the event hub's shared access key that the Time Series Insights service will use to connect to the event hub."
       }
     },
     "eventHubServiceBusNamespace": {
       "type": "string",
       "metadata": {
         "description": "The service bus namespace of the source event hub."
-      }
-    },
-    "eventHubName": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the source event hub."
-      }
-    },
-    "eventHubConsumerGroupName": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for the Time Series Insights service. This consumer group should not be shared with other services to avoid contention."
-      }
-    },
-    "eventHubKeyName": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the event hub's shared access key that the Time Series Insights service will use to connect to the event hub."
       }
     }
   },
@@ -106,7 +112,9 @@
         "displayName": "[parameters('eventSourceDisplayName')]"
       }
     ],
-    "eventSourceTagsValue": "[variables('eventSourceTagsOptions')[length(take(parameters('eventSourceDisplayName'), 1))]]"
+    "eventSourceTagsValue": "[variables('eventSourceTagsOptions')[length(take(parameters('eventSourceDisplayName'), 1))]]",
+    "listKeysApiVersion" : "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'), '2015-08-01', '2017-07-01')]",
+    "listKeysMethod" : "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'), '/authorizationRules/', '/Iothubkeys/')]"
   },
   "resources": [
     {
@@ -124,18 +132,39 @@
       "tags": "[variables('environmentTagsValue')]",
       "resources": [
         {
+          "condition": "[equals(parameters('eventSourceKind'),'Microsoft.EventHub')]",
           "type": "eventsources",
-          "name": "[parameters('eventSourceName')]",
+          "name": "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'),parameters('eventSourceName'), 'usedToGetAroundValidationRestrictions')]",
           "apiVersion": "2017-11-15",
           "location": "[resourceGroup().location]",
-          "kind": "Microsoft.EventHub",
+          "kind": "[parameters('eventSourceKind')]",
           "properties": {
-            "eventSourceResourceId": "[parameters('eventHubResourceId')]",
+            "eventSourceResourceId": "[parameters('hubResourceId')]",
             "serviceBusNamespace": "[parameters('eventHubServiceBusNamespace')]",
-            "eventHubName": "[parameters('eventHubName')]",
-            "consumerGroupName": "[parameters('eventHubConsumerGroupName')]",
-            "keyName": "[parameters('eventHubKeyName')]",
-            "sharedAccessKey": "[listkeys(concat(parameters('eventHubResourceId'),'/authorizationRules/', parameters('eventHubKeyName')),'2015-08-01').primaryKey]",
+            "eventHubName": "[parameters('hubName')]",
+            "consumerGroupName": "[parameters('consumerGroupName')]",
+            "keyName": "[parameters('keyName')]",
+            "sharedAccessKey": "[listkeys(concat(parameters('hubResourceId'),variables('listKeysMethod'), parameters('keyName')), variables('listKeysApiVersion')).primaryKey]",
+            "timestampPropertyName": "[parameters('eventSourceTimestampPropertyName')]"
+          },
+          "tags": "[variables('eventSourceTagsValue')]",
+          "dependsOn": [
+            "[concat('Microsoft.TimeSeriesInsights/environments/', parameters('environmentName'))]"
+          ]
+        },
+        {
+          "condition": "[equals(parameters('eventSourceKind'),'Microsoft.IoTHub')]",
+          "type": "eventsources",
+          "name": "[if(equals(parameters('eventSourceKind'),'Microsoft.IoTHub'),parameters('eventSourceName'), 'usedToGetAroundValidationRestrictions')]",
+          "apiVersion": "2017-11-15",
+          "location": "[resourceGroup().location]",
+          "kind": "[parameters('eventSourceKind')]",
+          "properties": {
+            "eventSourceResourceId": "[parameters('hubResourceId')]",
+            "iotHubName": "[parameters('hubName')]",
+            "consumerGroupName": "[parameters('consumerGroupName')]",
+            "keyName": "[parameters('keyName')]",
+            "sharedAccessKey": "[listkeys(concat(parameters('hubResourceId'),variables('listKeysMethod'), parameters('keyName')),variables('listKeysApiVersion')).primaryKey]",
             "timestampPropertyName": "[parameters('eventSourceTimestampPropertyName')]"
           },
           "tags": "[variables('eventSourceTagsValue')]",
@@ -147,9 +176,9 @@
     }
   ],
   "outputs": {
-    "dataAccessId" : {
-      "value" : "[reference(resourceId('Microsoft.TimeSeriesInsights/environments', parameters('environmentName'))).dataAccessId]",
+    "dataAccessId": {
+      "value": "[reference(resourceId('Microsoft.TimeSeriesInsights/environments', parameters('environmentName'))).dataAccessId]",
       "type": "string"
-      }
+    }
   }
 }

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.json
@@ -141,7 +141,6 @@
           "condition": "[equals(parameters('eventSourceKind'),'Microsoft.EventHub')]",
           "type": "eventsources",
           "name": "[if(equals(parameters('eventSourceKind'),'Microsoft.EventHub'),parameters('eventSourceName'), 'usedToGetAroundValidationRestrictionsWhenNotEventHub')]",
-          "comment": "NOTES: The 'if' conditional on the name property is a workaround for validation not recognizing that only one event source will be created, resulting in failures saying the same resource is being defined multiple times in the template. Likewise, the listKeys method will be invoked before the evaluation of the conditional which is why listkeys arguments for method and api-version are variables.",
           "apiVersion": "2017-11-15",
           "location": "[resourceGroup().location]",
           "kind": "[parameters('eventSourceKind')]",

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
@@ -29,7 +29,7 @@
     "eventHubConsumerGroupName": {
       "value": "changeme",
       "metadata": {
-        "description": "The name of the consumer group that the Thime Series Insights service will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for Time Series Insights. This consumer group should not be shared with other services to avoid contention."
+        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for Time Series Insights. This consumer group should not be shared with other services to avoid contention."
       }
     },
     "eventHubKeyName": {

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
@@ -34,17 +34,6 @@
     },
     "eventHubKeyName": {
       "value": "changeme"
-    },
-    "eventHubSharedAccessKey": {
-      "reference": {
-        "keyVault": {
-          "id": "/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.KeyVault/vaults/{{keyVaultName}}"
-        },
-        "secretName": "changeMe"
-      },
-      "metadata": {
-        "description": "NOTE: This shared access key secret is used only when initially configuring the event source to read from the event hub. Changing the secret value will not be picked up by the event source. When you rotate your event hub's shared access key, you will need to update the event source with the new value."
-      }
     }
   }
 }

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
@@ -21,7 +21,7 @@
       "value": "changeme"
     },
     "hubResourceId": {
-      "value": "/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.EventHub/namespaces/{{namespaceName}}/eventHubs/{{eventHubName}}"
+      "value": "changeme"
     },
     "hubName": {
       "value": "changeme"

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "changeme"
+    },
+    "environmentSkuName": {
+      "value" : "S1"
+    },
+    "environmentSkuCapacity": {
+      "value": 1
+    },
+    "environmentDataRetentionTime" : {
+      "value": "P31D"
+    },
+    "eventSourceName": {
+      "value": "changeme"
+    },
+    "eventHubResourceId": {
+      "value": "/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.EventHub/namespaces/{{namespaceName}}/eventHubs/{{eventHubName}}"
+    },
+    "eventHubServiceBusNamespace": {
+      "value": "changeme"
+    },
+    "eventHubName": {
+      "value": "changeme"
+    },
+    "eventHubConsumerGroupName": {
+      "value": "changeme",
+      "metadata": {
+        "description": "The name of the consumer group that the Thime Series Insights service will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for Time Series Insights. This consumer group should not be shared with other services to avoid contention."
+      }
+    },
+    "eventHubKeyName": {
+      "value": "changeme"
+    },
+    "eventHubSharedAccessKey": {
+      "reference": {
+        "keyVault": {
+          "id": "/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.KeyVault/vaults/{{keyVaultName}}"
+        },
+        "secretName": "changeMe"
+      },
+      "metadata": {
+        "description": "NOTE: This shared access key secret is used only when initially configuring the event source to read from the event hub. Changing the secret value will not be picked up by the event source. When you rotate your event hub's shared access key, you will need to update the event source with the new value."
+      }
+    }
+  }
+}

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
@@ -18,34 +18,22 @@
       "value": "changeme"
     },
     "eventSourceKind": {
-      "value": "changeme",
-      "metadata": {
-        "description": "Supported values are 'Microsoft.EventHub' and 'Microsoft.IoTHub'. "
-      }
+      "value": "changeme"
     },
     "hubResourceId": {
-      "value": "/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.EventHub/namespaces/{{namespaceName}}/eventHubs/{{eventHubName}}",
-      "metadata": {
-        "description": "The resource id of the event hub or IoT hub from which the event source will read events. For IoT hubs, the format is \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{hubName}\". For event hubs, the format is \"/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.EventHub/namespaces/{{namespaceName}}/eventHubs/{{hubName}}\"."
-      }
+      "value": "/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.EventHub/namespaces/{{namespaceName}}/eventHubs/{{eventHubName}}"
     },
     "hubName": {
       "value": "changeme"
     },
     "consumerGroupName": {
-      "value": "changeme",
-      "metadata": {
-        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub or IoT hub. NOTE: You should create a dedicated consumer group on the event hub or IoT hub for Time Series Insights. This consumer group should not be shared with other services to avoid contention."
-      }
+      "value": "changeme"
     },
     "keyName": {
       "value": "changeme"
     },
     "eventHubServiceBusNamespace": {
-      "value": "changeme-eventHubOnly",
-      "metadata": {
-        "description": "This value is only required for event hub event sources, and will be ignored for IoT hub event sources."
-      }
+      "value": "changeme-eventHubOnly"
     }
   }
 }

--- a/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/azuredeploy.parameters.json
@@ -17,23 +17,35 @@
     "eventSourceName": {
       "value": "changeme"
     },
-    "eventHubResourceId": {
-      "value": "/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.EventHub/namespaces/{{namespaceName}}/eventHubs/{{eventHubName}}"
-    },
-    "eventHubServiceBusNamespace": {
-      "value": "changeme"
-    },
-    "eventHubName": {
-      "value": "changeme"
-    },
-    "eventHubConsumerGroupName": {
+    "eventSourceKind": {
       "value": "changeme",
       "metadata": {
-        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub. NOTE: You should create a dedicated consumer group on the event hub for Time Series Insights. This consumer group should not be shared with other services to avoid contention."
+        "description": "Supported values are 'Microsoft.EventHub' and 'Microsoft.IoTHub'. "
       }
     },
-    "eventHubKeyName": {
+    "hubResourceId": {
+      "value": "/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.EventHub/namespaces/{{namespaceName}}/eventHubs/{{eventHubName}}",
+      "metadata": {
+        "description": "The resource id of the event hub or IoT hub from which the event source will read events. For IoT hubs, the format is \"/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Devices/IotHubs/{hubName}\". For event hubs, the format is \"/subscriptions/{{subscriptionId}}/resourceGroups/{{resourcegroupName}}/providers/Microsoft.EventHub/namespaces/{{namespaceName}}/eventHubs/{{hubName}}\"."
+      }
+    },
+    "hubName": {
       "value": "changeme"
+    },
+    "consumerGroupName": {
+      "value": "changeme",
+      "metadata": {
+        "description": "The name of the consumer group that the Time Series Insights service will use to read the data from the event hub or IoT hub. NOTE: You should create a dedicated consumer group on the event hub or IoT hub for Time Series Insights. This consumer group should not be shared with other services to avoid contention."
+      }
+    },
+    "keyName": {
+      "value": "changeme"
+    },
+    "eventHubServiceBusNamespace": {
+      "value": "changeme-eventHubOnly",
+      "metadata": {
+        "description": "This value is only required for event hub event sources, and will be ignored for IoT hub event sources."
+      }
     }
   }
 }

--- a/201-timeseriesinsights-create-environment-with-eventsource/metadata.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Create a Time Series Insights Environment and Child Event Source",
+  "description": "This template enables you to deploy a Time Series Insights environment and a child event source that is configured to consume events from an Event Hub.",
+  "summary": "This template creates a Time Series Insights environment and child event source.",
+  "githubUsername": "sandshadow",
+  "dateUpdated": "2017-11-16"
+}

--- a/201-timeseriesinsights-create-environment-with-eventsource/metadata.json
+++ b/201-timeseriesinsights-create-environment-with-eventsource/metadata.json
@@ -1,5 +1,5 @@
 {
-  "itemDisplayName": "Create a Time Series Insights Environment and Child Event Source",
+  "itemDisplayName": "Create Time Series Insights Environment and Event Source",
   "description": "This template enables you to deploy a Time Series Insights environment and a child event source that is configured to consume events from an Event Hub.",
   "summary": "This template creates a Time Series Insights environment and child event source.",
   "githubUsername": "sandshadow",


### PR DESCRIPTION
Template to create a TimeSeriesInsights environment with a child event source.

The child event source can be hooked to either a IoT Hub or an Event Hub. This required some gymnastics with 'conditional' and 'if', as the 'listkeys' function is being evaluated in both event source resources, regardless of the conditional. 

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

