### PR TITLE
update authn condition to allow for copyIndex() in a vm

### DIFF
--- a/201-vm-new-or-existing-conditions/azuredeploy.json
+++ b/201-vm-new-or-existing-conditions/azuredeploy.json
@@ -155,24 +155,15 @@
   },
   "variables": {
     "nicName": "[concat(parameters('vmName'), '-nic')]",
-    "passwordAuth": {
-      "computerName": "[parameters('vmName')]",
-      "adminUsername": "[parameters('adminUsername')]",
-      "adminPassword": "[parameters('adminPassword')]"
-    },
-    "sshAuth": {
-      "computerName": "[parameters('vmName')]",
-      "adminUsername": "[parameters('adminUsername')]",
-      "linuxConfiguration": {
-        "disablePasswordAuthentication": true,
-        "ssh": {
-          "publicKeys": [
-            {
-              "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
-              "keyData": "[parameters('sshPublicKey')]"
-            }
-          ]
-        }
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('sshPublicKey')]"
+          }
+        ]
       }
     }
   },
@@ -262,7 +253,12 @@
         "hardwareProfile": {
           "vmSize": "[parameters('vmSize')]"
         },
-        "osProfile": "[if(equals(parameters('authenticationType'), 'password'), variables('passwordAuth'), variables('sshAuth'))]",
+        "osProfile": {
+          "computerName": "[parameters('vmName')]",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
+        },
         "storageProfile": {
           "imageReference": {
             "publisher": "Canonical",

--- a/Deploy-AzureResourceGroup.ps1
+++ b/Deploy-AzureResourceGroup.ps1
@@ -42,6 +42,8 @@ if ($Dev) {
     }
 }
 
+Write-Host "Using parameter file: $TemplateParametersFile"
+
 if (!$ValidateOnly) {
     $OptionalParameters.Add('DeploymentDebugLogLevel', $DebugOptions)
 }

--- a/az-group-deploy.sh
+++ b/az-group-deploy.sh
@@ -48,6 +48,8 @@ else
     fi
 fi
 
+echo "Using parameters file: "$parametersFile
+
 templateName="$( basename "${templateFile%.*}" )"
 templateDirectory="$( dirname "$templateFile")"
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* updated authn selection to make it easier to leverage for copy loops
* added some output to the scripts for parameter file in use
*

