### PR TITLE
Add the ability to create multiple access policies with the template.

### DIFF
--- a/201-timeseriesinsights-environment-with-eventhub/README.md
+++ b/201-timeseriesinsights-environment-with-eventhub/README.md
@@ -7,6 +7,4 @@
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-This template creates an Event Hub, a Time Series Insights environment and a child event source configured to consume events from the Event Hub. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/.
-
-Before accessing data in your environment, you must create an Access Policy. For more information, go to: https://docs.microsoft.com/azure/time-series-insights/time-series-insights-data-access
+This template creates an Event Hub, a Time Series Insights environment, a child event source configured to consume events from the Event Hub, and access policies that grant access to the environment's data. For more information, go to: <https://docs.microsoft.com/azure/time-series-insights/>.

--- a/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
+++ b/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
@@ -91,6 +91,20 @@
       "metadata": {
         "description": "The name of the shared access key that the Time Series Insights service will use to connect to the event hub."
       }
+    },
+    "accessPolicyReaderObjectIds": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "A list of object ids of the users or applications in AAD that should have Reader access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for AAD groups is not yet supported."
+      }
+    },
+    "accessPolicyContributorObjectIds": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "A list of object ids of the users or applications in AAD that should have Contributor access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for AAD groups is not yet supported."
+      }
     }
   },
   "variables": {
@@ -194,16 +208,48 @@
           },
           "tags": "[variables('eventSourceTagsValue')]",
           "dependsOn": [
-            "[concat('Microsoft.TimeSeriesInsights/environments/',parameters('environmentName'))]",
+            "[concat('Microsoft.TimeSeriesInsights/environments/', parameters('environmentName'))]",
             "[concat('Microsoft.EventHub/namespaces/', parameters('eventHubNamespaceName'), '/eventHubs/', parameters('eventHubName'), '/consumerGroups/', parameters('consumerGroupname'))]"
           ]
         }
+      ]
+    },
+    {
+      "type": "Microsoft.TimeSeriesInsights/environments/accesspolicies",
+      "name": "[concat(parameters('environmentName'), '/', 'readerAccessPolicy', copyIndex())]",
+      "copy": { 
+        "name": "accessPolicyReaderCopy", 
+        "count": "[length(parameters('accessPolicyReaderObjectIds'))]"
+      },
+      "apiVersion": "2017-11-15",
+      "properties": {
+        "principalObjectId": "[parameters('accessPolicyReaderObjectIds')[copyIndex()]]",
+        "roles": ["Reader"]
+      },
+      "dependsOn": [
+        "[concat('Microsoft.TimeSeriesInsights/environments/', parameters('environmentName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.TimeSeriesInsights/environments/accesspolicies",
+      "name": "[concat(parameters('environmentName'), '/', 'contributorAccessPolicy', copyIndex())]",
+      "copy": { 
+        "name": "accessPolicyReaderCopy", 
+        "count": "[length(parameters('accessPolicyContributorObjectIds'))]"
+      },
+      "apiVersion": "2017-11-15",
+      "properties": {
+        "principalObjectId": "[parameters('accessPolicyContributorObjectIds')[copyIndex()]]",
+        "roles": ["Contributor"]
+      },
+      "dependsOn": [
+        "[concat('Microsoft.TimeSeriesInsights/environments/', parameters('environmentName'))]"
       ]
     }
   ],
   "outputs": {
     "dataAccessId": {
-      "value": "[reference(resourceId('Microsoft.TimeSeriesInsights/environments', parameters('environmentName'))).dataAccessId]",
+      "value": "[reference(resourceId('Microsoft.TimeSeriesInsights/environments', parameters('environmentName'))).dataAccessFQDN]",
       "type": "string"
     }
   }

--- a/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
+++ b/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
@@ -94,14 +94,14 @@
     },
     "accessPolicyReaderObjectIds": {
       "type": "array",
-      "defaultValue": ["thisArrayIsReallyEmpty"],
+      "defaultValue": [],
       "metadata": {
         "description": "A list of object ids of the users or applications in AAD that should have Reader access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for AAD groups is not yet supported."
       }
     },
     "accessPolicyContributorObjectIds": {
       "type": "array",
-      "defaultValue": ["thisArrayIsReallyEmpty"],
+      "defaultValue": [],
       "metadata": {
         "description": "A list of object ids of the users or applications in AAD that should have Contributor access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for AAD groups is not yet supported."
       }
@@ -215,12 +215,12 @@
       ]
     },
     {
-      "condition": "[if(equals(first(parameters('accessPolicyReaderObjectIds')), 'thisArrayIsReallyEmpty'), bool('false'), bool('true'))]",
+      "condition": "[not(empty(parameters('accessPolicyReaderObjectIds')))]",
       "type": "Microsoft.TimeSeriesInsights/environments/accesspolicies",
       "name": "[concat(parameters('environmentName'), '/', 'readerAccessPolicy', copyIndex())]",
       "copy": { 
         "name": "accessPolicyReaderCopy", 
-        "count": "[length(parameters('accessPolicyReaderObjectIds'))]"
+        "count": "[if(empty(parameters('accessPolicyReaderObjectIds')), 1, length(parameters('accessPolicyReaderObjectIds')))]"
       },
       "apiVersion": "2017-11-15",
       "properties": {
@@ -232,12 +232,12 @@
       ]
     },
     {
-      "condition": "[if(equals(first(parameters('accessPolicyContributorObjectIds')), 'thisArrayIsReallyEmpty'), bool('false'), bool('true'))]",
+      "condition": "[not(empty(parameters('accessPolicyContributorObjectIds')))]",
       "type": "Microsoft.TimeSeriesInsights/environments/accesspolicies",
       "name": "[concat(parameters('environmentName'), '/', 'contributorAccessPolicy', copyIndex())]",
       "copy": { 
         "name": "accessPolicyReaderCopy", 
-        "count": "[length(parameters('accessPolicyContributorObjectIds'))]"
+        "count": "[if(empty(parameters('accessPolicyContributorObjectIds')), 1, length(parameters('accessPolicyContributorObjectIds')))]"
       },
       "apiVersion": "2017-11-15",
       "properties": {

--- a/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
+++ b/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
@@ -94,14 +94,14 @@
     },
     "accessPolicyReaderObjectIds": {
       "type": "array",
-      "defaultValue": [],
+      "defaultValue": ["thisArrayIsReallyEmpty"],
       "metadata": {
         "description": "A list of object ids of the users or applications in AAD that should have Reader access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for AAD groups is not yet supported."
       }
     },
     "accessPolicyContributorObjectIds": {
       "type": "array",
-      "defaultValue": [],
+      "defaultValue": ["thisArrayIsReallyEmpty"],
       "metadata": {
         "description": "A list of object ids of the users or applications in AAD that should have Contributor access to the environment. The service principal objectId can be obtained by calling the Get-AzureRMADUser or the Get-AzureRMADServicePrincipal cmdlets. Creating an access policy for AAD groups is not yet supported."
       }
@@ -215,11 +215,12 @@
       ]
     },
     {
+      "condition": "[if(equals(first(parameters('accessPolicyReaderObjectIds')), 'thisArrayIsReallyEmpty'), bool('false'), bool('true'))]",
       "type": "Microsoft.TimeSeriesInsights/environments/accesspolicies",
       "name": "[concat(parameters('environmentName'), '/', 'readerAccessPolicy', copyIndex())]",
       "copy": { 
         "name": "accessPolicyReaderCopy", 
-        "count": "[length(parameters('accessPolicyReaderObjectIds'))]"
+        "count": "[if(equals(parameters('accessPolicyReaderObjectIds'), 0), 1, length(parameters('accessPolicyReaderObjectIds')))]"
       },
       "apiVersion": "2017-11-15",
       "properties": {
@@ -231,11 +232,12 @@
       ]
     },
     {
+      "condition": "[if(equals(first(parameters('accessPolicyContributorObjectIds')), 'thisArrayIsReallyEmpty'), bool('false'), bool('true'))]",
       "type": "Microsoft.TimeSeriesInsights/environments/accesspolicies",
       "name": "[concat(parameters('environmentName'), '/', 'contributorAccessPolicy', copyIndex())]",
       "copy": { 
         "name": "accessPolicyReaderCopy", 
-        "count": "[length(parameters('accessPolicyContributorObjectIds'))]"
+        "count": "[if(equals(parameters('accessPolicyContributorObjectIds'), 0), 1, length(parameters('accessPolicyContributorObjectIds')))]"
       },
       "apiVersion": "2017-11-15",
       "properties": {

--- a/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
+++ b/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
@@ -248,7 +248,7 @@
     }
   ],
   "outputs": {
-    "dataAccessId": {
+    "dataAccessFQDN": {
       "value": "[reference(resourceId('Microsoft.TimeSeriesInsights/environments', parameters('environmentName'))).dataAccessFQDN]",
       "type": "string"
     }

--- a/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
+++ b/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
@@ -220,7 +220,7 @@
       "name": "[concat(parameters('environmentName'), '/', 'readerAccessPolicy', copyIndex())]",
       "copy": { 
         "name": "accessPolicyReaderCopy", 
-        "count": "[if(equals(parameters('accessPolicyReaderObjectIds'), 0), 1, length(parameters('accessPolicyReaderObjectIds')))]"
+        "count": "[length(parameters('accessPolicyReaderObjectIds'))]"
       },
       "apiVersion": "2017-11-15",
       "properties": {

--- a/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
+++ b/201-timeseriesinsights-environment-with-eventhub/azuredeploy.json
@@ -237,7 +237,7 @@
       "name": "[concat(parameters('environmentName'), '/', 'contributorAccessPolicy', copyIndex())]",
       "copy": { 
         "name": "accessPolicyReaderCopy", 
-        "count": "[if(equals(parameters('accessPolicyContributorObjectIds'), 0), 1, length(parameters('accessPolicyContributorObjectIds')))]"
+        "count": "[length(parameters('accessPolicyContributorObjectIds'))]"
       },
       "apiVersion": "2017-11-15",
       "properties": {


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Add the ability to create multiple access policies with the template.
* Return the DataAccessFQDN instead of DataAccessId as output property, as it's more useful.