### PR TITLE
Fix vm extension names in sf templates

### DIFF
--- a/service-fabric-oms/azuredeploy.json
+++ b/service-fabric-oms/azuredeploy.json
@@ -392,7 +392,7 @@
                 }
               },
               {
-                "name": "[concat('VMDiagnosticsVmExt','_vmNodeType0Name')]",
+                "name": "[concat('VMDiagnosticsVmExt','_',parameters('vmNodeType0Name'))]",
                 "properties": {
                   "type": "IaaSDiagnostics",
                   "autoUpgradeMinorVersion": true,

--- a/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
+++ b/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
@@ -418,7 +418,7 @@
           "extensionProfile": {
             "extensions": [
               {
-                "name": "[concat('ServiceFabricNodeVmExt','_',parameters('vmNodeType0Name'))]",
+                "name": "[concat('ServiceFabricNodeVmExt','_',variables('vmNodeType0Name'))]",
                 "properties": {
                   "type": "ServiceFabricNode",
                   "autoUpgradeMinorVersion": true,

--- a/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
+++ b/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
@@ -418,7 +418,7 @@
           "extensionProfile": {
             "extensions": [
               {
-                "name": "[concat('ServiceFabricNodeVmExt','_vmNodeType0Name')]",
+                "name": "[concat('ServiceFabricNodeVmExt','_',parameters('vmNodeType0Name'))]",
                 "properties": {
                   "type": "ServiceFabricNode",
                   "autoUpgradeMinorVersion": true,
@@ -442,7 +442,7 @@
                 }
               },
               {
-                "name": "[concat('VMDiagnosticsVmExt','_vmNodeType0Name')]",
+                "name": "[concat('VMDiagnosticsVmExt','_',parameters('vmNodeType0Name'))]",
                 "properties": {
                   "type": "IaaSDiagnostics",
                   "autoUpgradeMinorVersion": true,

--- a/service-fabric-secure-nsg-cluster-65-node-3-nodetype/azuredeploy.json
+++ b/service-fabric-secure-nsg-cluster-65-node-3-nodetype/azuredeploy.json
@@ -696,7 +696,7 @@
           "extensionProfile": {
             "extensions": [
               {
-                "name": "[concat('ServiceFabricNodeVmExt','_vmNodeType0Name')]",
+                "name": "[concat('ServiceFabricNodeVmExt','_',parameters('vmNodeType0Name'))]",
                 "properties": {
                   "type": "ServiceFabricNode",
                   "autoUpgradeMinorVersion": true,

--- a/service-fabric-secure-nsg-cluster-65-node-3-nodetype/azuredeploy.json
+++ b/service-fabric-secure-nsg-cluster-65-node-3-nodetype/azuredeploy.json
@@ -696,7 +696,7 @@
           "extensionProfile": {
             "extensions": [
               {
-                "name": "[concat('ServiceFabricNodeVmExt','_',parameters('vmNodeType0Name'))]",
+                "name": "[concat('ServiceFabricNodeVmExt','_',variables('vmNodeType0Name'))]",
                 "properties": {
                   "type": "ServiceFabricNode",
                   "autoUpgradeMinorVersion": true,
@@ -1176,7 +1176,7 @@
           "extensionProfile": {
             "extensions": [
               {
-                "name": "[concat('ServiceFabricNodeVmExt','_vmNodeType1Name')]",
+                "name": "[concat('ServiceFabricNodeVmExt','_',variables('vmNodeType1Name'))]",
                 "properties": {
                   "type": "ServiceFabricNode",
                   "autoUpgradeMinorVersion": true,
@@ -1656,7 +1656,7 @@
           "extensionProfile": {
             "extensions": [
               {
-                "name": "[concat('ServiceFabricNodeVmExt','_vmNodeType2Name')]",
+                "name": "[concat('ServiceFabricNodeVmExt','_',variables('vmNodeType2Name'))]",
                 "properties": {
                   "type": "ServiceFabricNode",
                   "autoUpgradeMinorVersion": true,

--- a/service-fabric-vmss-oms/azuredeploy.json
+++ b/service-fabric-vmss-oms/azuredeploy.json
@@ -409,7 +409,7 @@
                 }
               },
               {
-                "name": "[concat('VMDiagnosticsVmExt','_vmNodeType0Name')]",
+                "name": "[concat('VMDiagnosticsVmExt','_',parameters('vmNodeType0Name'))]",
                 "properties": {
                   "type": "IaaSDiagnostics",
                   "autoUpgradeMinorVersion": true,


### PR DESCRIPTION
Several template have extensions with names like 'ServiceFabricNodeVmExt_vmNodeType0Name' instead of using the variable/parameter name.