### PR TITLE
Allowing the VM list to contain spaces

### DIFF
--- a/201-vm-domain-join-existing/azuredeploy.json
+++ b/201-vm-domain-join-existing/azuredeploy.json
@@ -50,7 +50,7 @@
             "comments": "Join domain - JsonADDomainExtension",
             "apiVersion": "2015-06-15",
             "type": "Microsoft.Compute/virtualMachines/extensions",
-            "name": "[concat(variables('vmListArray')[copyIndex()],'/joindomain')]",
+            "name": "[concat(trim(variables('vmListArray')[copyIndex()]),'/joindomain')]",
             "location": "[parameters('location')]",
             "copy": {
                 "name": "vmDomainJoinCopy",


### PR DESCRIPTION
Now users can have a VM list like: "vm1, vm2, vm3, vm4". Meaning, with spaces if they want, without this change, if they place a string like that, it will fail because of the trailing spaces.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

