### PR TITLE
fix typo in public certificate

### DIFF
--- a/201-application-gateway-2vms-iis-ssl/README.md
+++ b/201-application-gateway-2vms-iis-ssl/README.md
@@ -56,7 +56,7 @@ In order to use the certificates in the template, they need to be base-64 encode
 ```
 [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("C:\frontend.pfx")) > "C:\frontend.txt"
 [System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("C:\backend.pfx")) > "C:\backend.txt"
-[System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("C:\backend-public.pfx")) > "C:\backend-public.txt"
+[System.Convert]::ToBase64String([System.IO.File]::ReadAllBytes("C:\backend-public.cer")) > "C:\backend-public.txt"
 ```
 
 ## Deployment steps


### PR DESCRIPTION
the command to convert the backend public certificate to base-64 incorrectly listed the certificate name as "backend-public.pfx" instead of "backend-public.cer"

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

