### PR TITLE
201-application-gateway-2vms-iis-ssl VMs not a part of availability set

### DIFF
--- a/201-application-gateway-2vms-iis-ssl/README.md
+++ b/201-application-gateway-2vms-iis-ssl/README.md
@@ -1,9 +1,9 @@
 ## Application Gateway with WAF, end to end SSL, two IIS servers and HTTP to HTTPS redirection ##
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmurrahjm%2Fazure-quickstart-templates%2Fmaster%2F201-application-gateway-2vms-iis-ssl%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-application-gateway-2vms-iis-ssl%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fmurrahjm%2Fazure-quickstart-templates%2Fmaster%2F201-application-gateway-2vms-iis-ssl%2Fazuredeploy.json" target="_blank">
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-application-gateway-2vms-iis-ssl%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 

--- a/201-application-gateway-2vms-iis-ssl/README.md
+++ b/201-application-gateway-2vms-iis-ssl/README.md
@@ -1,9 +1,9 @@
 ## Application Gateway with WAF, end to end SSL, two IIS servers and HTTP to HTTPS redirection ##
 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-application-gateway-2vms-iis-ssl%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmurrahjm%2Fazure-quickstart-templates%2Fmaster%2F201-application-gateway-2vms-iis-ssl%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-application-gateway-2vms-iis-ssl%2Fazuredeploy.json" target="_blank">
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fmurrahjm%2Fazure-quickstart-templates%2Fmaster%2F201-application-gateway-2vms-iis-ssl%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 

--- a/201-application-gateway-2vms-iis-ssl/azuredeploy.json
+++ b/201-application-gateway-2vms-iis-ssl/azuredeploy.json
@@ -65,7 +65,8 @@
           8,
           9,
           10
-        ]        "defaultValue": 2,
+        ],
+        "defaultValue": 2,
         "metadata": {
           "description": "Number of instances"
         }
@@ -122,7 +123,7 @@
         "metadata": {
           "description": "The base URI where artifacts required by this template are located. For example, if stored on a public GitHub repo, you'd use the following URI: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vmss-windows-webapp-dsc-autoscale."
         },
-        "defaultValue": "https://raw.githubusercontent.com/murrahjm/azure-quickstart-templates/master/201-application-gateway-2vms-iis-ssl"
+        "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-application-gateway-2vms-iis-ssl"
       },
       "_artifactsLocationSasToken": {
         "type": "securestring",
@@ -184,14 +185,6 @@
         "properties": {
           "platformUpdateDomainCount": 5,
           "platformFaultDomainCount": 2,
-          "virtualMachines": [
-            {
-              "id": "[resourceId('Microsoft.Compute/virtualMachines', variables('vm1Name'))]"
-            },
-            {
-              "id": "[resourceId('Microsoft.Compute/virtualMachines', variables('vm2Name'))]"
-            }
-          ]
         },
         "dependsOn": []
       },

--- a/201-application-gateway-2vms-iis-ssl/azuredeploy.json
+++ b/201-application-gateway-2vms-iis-ssl/azuredeploy.json
@@ -460,6 +460,9 @@
               "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vm1NicName'))]"
             }
           ]
+        },
+        "availabilitySet": {
+            "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('webAvailabilitySetName'))]"
         }
       },
       "resources": [
@@ -538,6 +541,9 @@
               "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vm2NicName'))]"
             }
           ]
+        },
+        "availabilitySet": {
+            "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('webAvailabilitySetName'))]"
         }
       },
       "resources": [

--- a/201-application-gateway-2vms-iis-ssl/azuredeploy.json
+++ b/201-application-gateway-2vms-iis-ssl/azuredeploy.json
@@ -1,764 +1,763 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "adminUsername": {
-      "type": "string",
-      "minLength": 1,
-      "metadata": {
-        "description": "Username for the Virtual Machine."
-      }
-    },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for the Virtual Machine."
-      }
-    },
-    "windowsOSVersion": {
-      "type": "string",
-      "defaultValue": "2016-Datacenter",
-      "allowedValues": [
-        "2012-R2-Datacenter",
-        "2016-Datacenter"
-      ],
-      "metadata": {
-        "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2012-R2-Datacenter, 2016-Datacenter."
-      }
-    },
-    "virtualMachineSize": {
-      "type": "string",
-      "defaultValue": "Standard_D2_v2",
-      "allowedValues": [
-        "Standard_A1",
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_D1_v2",
-        "Standard_D2_v2",
-        "Standard_D3_v2"
-      ],
-      "metadata": {
-        "description": "The virtual machine size. Allowed values: Standard_A1, Standard_A2, Standard_A3."
-      }
-    },
-    "applicationGatewaySize": {
-      "type": "string",
-      "allowedValues": [
-        "WAF_Medium",
-        "WAF_Large"
-      ],
-      "defaultValue": "WAF_Medium",
-      "metadata": {
-        "description": "Application Gateway size"
-      }
-    },
-    "capacity": {
-      "type": "int",
-      "allowedValues": [
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10
-      ],
-      "defaultValue": 2,
-      "metadata": {
-        "description": "Number of instances"
-      }
-    },
-    "wafMode": {
-      "type": "string",
-      "allowedValues": [
-        "Detection",
-        "Prevention"
-      ],
-      "defaultValue": "Prevention",
-      "metadata": {
-        "description": "WAF Mode"
-      }
-    },
-    "frontendCertData": {
-      "type": "string",
-      "metadata": {
-        "description": "Base-64 encoded form of the .pfx file. This is the cert terminating on the Application Gateway."
-      }
-    },
-    "frontendCertPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for .pfx certificate"
-      }
-    },
-    "backendCertData": {
-      "type": "string",
-      "metadata": {
-        "description": "Base-64 encoded form of the .pfx file. This is the cert installed on the web servers."
-      }
-    },
-    "backendCertPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for .pfx certificate"
-      }
-    },
-    "backendPublicKeyData": {
-      "type": "string",
-      "metadata": {
-        "description": "Base-64 encoded form of the .cer file. This is the public key for the cert on the web servers."
-      }
-    },
-    "backendCertDnsName": {
-      "type": "string",
-      "metadata": {
-        "description": "DNS name of the backend cert"
-      }
-    },
-    "_artifactsLocation": {
-      "type": "string",
-      "metadata": {
-        "description": "The base URI where artifacts required by this template are located. For example, if stored on a public GitHub repo, you'd use the following URI: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vmss-windows-webapp-dsc-autoscale."
-      },
-      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-application-gateway-2vms-iis-ssl"
-    },
-    "_artifactsLocationSasToken": {
-      "type": "securestring",
-      "defaultValue": "",
-      "metadata": {
-        "description": "The sasToken required to access _artifactsLocation.  If your artifacts are stored on a public repo or public storage account you can leave this blank."
-      }
-    }
-  },
-  "variables": {
-    "imagePublisher": "MicrosoftWindowsServer",
-    "imageOffer": "WindowsServer",
-    "vm1NicName": "vm1Nic",
-    "vm2NicName": "vm2Nic",
-    "addressPrefix": "10.0.0.0/16",
-    "webSubnetName": "WebSubnet",
-    "webSubnetPrefix": "10.0.0.0/24",
-    "appGatewaySubnetName": "AppGatewaySubnet",
-    "appGatewaySubnetPrefix": "10.0.1.0/24",
-    "vm1PublicIPAddressName": "vm1PublicIP",
-    "vm1PublicIPAddressType": "Dynamic",
-    "vm2PublicIPAddressName": "vm2PublicIP",
-    "vm2PublicIPAddressType": "Dynamic",
-    "vm1IpAddress": "10.0.0.4",
-    "vm2IpAddress": "10.0.0.5",
-    "vm1Name": "iisvm1",
-    "vm2Name": "iisvm2",
-    "vmSize": "[parameters('virtualMachineSize')]",
-    "virtualNetworkName": "MyVNet",
-    "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
-    "webSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('webSubnetName'))]",
-    "webAvailabilitySetName": "IISAvailabilitySet",
-    "webNsgName": "WebNSG",
-    "appGwNsgName": "AppGwNSG",
-    "applicationGatewayName": "ApplicationGateway",
-    "appGwPublicIpName": "ApplicationGatewayPublicIp",
-    "appGatewaySubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('appGatewaySubnetName'))]",
-    "appGwPublicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('appGwPublicIpName'))]",
-    "wafEnabled": true,
-    "wafMode": "[parameters('wafMode')]",
-    "wafRuleSetType": "OWASP",
-    "wafRuleSetVersion": "3.0",
-    "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
-    "dscZipFullPath": "[concat(parameters('_artifactsLocation'), '/DSC/iisInstall.ps1.zip', parameters('_artifactsLocationSasToken'))]",
-    "webConfigFullPath": "[concat(parameters('_artifactsLocation'), '/artifacts/web.config', parameters('_artifactsLocationSasToken'))]",
-    "vm1DefaultHtmFullPath": "[concat(parameters('_artifactsLocation'), '/artifacts/vm1.default.htm', parameters('_artifactsLocationSasToken'))]",
-    "vm2DefaultHtmFullPath": "[concat(parameters('_artifactsLocation'), '/artifacts/vm2.default.htm', parameters('_artifactsLocationSasToken'))]"
-  },
-  "resources": [
-    {
-      "comments": "Availability set for the web servers",
-      "type": "Microsoft.Compute/availabilitySets",
-      "sku": {
-        "name": "Aligned"
-      },
-      "name": "[variables('webAvailabilitySetName')]",
-      "apiVersion": "2016-04-30-preview",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "platformUpdateDomainCount": 5,
-        "platformFaultDomainCount": 2,
-        "virtualMachines": [
-          {
-            "id": "[resourceId('Microsoft.Compute/virtualMachines', variables('vm1Name'))]"
-          },
-          {
-            "id": "[resourceId('Microsoft.Compute/virtualMachines', variables('vm2Name'))]"
-          }
-        ]
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', variables('vm1Name'))]",
-        "[resourceId('Microsoft.Compute/virtualMachines', variables('vm2Name'))]"
-      ]
-    },
-    {
-      "apiVersion": "2016-03-30",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[variables('vm1PublicIPAddressName')]",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "publicIPAllocationMethod": "[variables('vm1PublicIPAddressType')]"
-      }
-    },
-    {
-      "apiVersion": "2016-03-30",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[variables('vm2PublicIPAddressName')]",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "publicIPAllocationMethod": "[variables('vm2PublicIPAddressType')]"
-      }
-    },
-    {
-      "apiVersion": "2017-03-01",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[variables('appGwPublicIpName')]",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "publicIPAllocationMethod": "Dynamic"
-      }
-    },
-    {
-      "apiVersion": "2016-03-30",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('webNsgName')]",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "Allow80",
-            "properties": {
-              "description": "Allow 80 from local VNet",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "80",
-              "sourceAddressPrefix": "VirtualNetwork",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 100,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "Allow443",
-            "properties": {
-              "description": "Allow 443 from local VNet",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "443",
-              "sourceAddressPrefix": "VirtualNetwork",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 101,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "AllowRDP",
-            "properties": {
-              "description": "Allow RDP from everywhere",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "3389",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 102,
-              "direction": "Inbound"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2016-03-30",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('appGwNsgName')]",
-      "location": "[resourceGroup().location]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "Allow80",
-            "properties": {
-              "description": "Allow 80 from Internet",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "80",
-              "sourceAddressPrefix": "Internet",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 100,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "Allow443",
-            "properties": {
-              "description": "Allow 443 from Internet",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "443",
-              "sourceAddressPrefix": "Internet",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 102,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "AllowAppGwProbes",
-            "properties": {
-              "description": "Allow ports for App Gw probes",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "65503-65534 ",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 103,
-              "direction": "Inbound"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2016-03-30",
-      "type": "Microsoft.Network/virtualNetworks",
-      "name": "[variables('virtualNetworkName')]",
-      "location": "[resourceGroup().location]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('webNsgName'))]",
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('appGwNsgName'))]"
-      ],
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('addressPrefix')]"
-          ]
-        },
-        "subnets": [
-          {
-            "name": "[variables('webSubnetName')]",
-            "properties": {
-              "addressPrefix": "[variables('webSubnetPrefix')]",
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('webNsgName'))]"
-              }
-            }
-          },
-          {
-            "name": "[variables('appGatewaySubnetName')]",
-            "properties": {
-              "addressPrefix": "[variables('appGatewaySubnetPrefix')]",
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('appGwNsgName'))]"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2016-03-30",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('vm1NicName')]",
-      "location": "[resourceGroup().location]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/publicIPAddresses/', variables('vm1PublicIPAddressName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-      ],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfigVm1",
-            "properties": {
-              "privateIPAddress": "[variables('vm1IpAddress')]",
-              "privateIPAllocationMethod": "Static",
-              "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('vm1PublicIPAddressName'))]"
-              },
-              "subnet": {
-                "id": "[variables('webSubnetRef')]"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2016-03-30",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('vm2NicName')]",
-      "location": "[resourceGroup().location]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/publicIPAddresses/', variables('vm2PublicIPAddressName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-      ],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfigVm2",
-            "properties": {
-              "privateIPAddress": "[variables('vm2IpAddress')]",
-              "privateIPAllocationMethod": "Static",
-              "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('vm2PublicIPAddressName'))]"
-              },
-              "subnet": {
-                "id": "[variables('webSubnetRef')]"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2016-04-30-preview",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[variables('vm1Name')]",
-      "location": "[resourceGroup().location]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkInterfaces/', variables('vm1NicName'))]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
-        },
-        "osProfile": {
-          "computerName": "[variables('vm1Name')]",
-          "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "publisher": "[variables('imagePublisher')]",
-            "offer": "[variables('imageOffer')]",
-            "sku": "[parameters('windowsOSVersion')]",
-            "version": "latest"
-          },
-          "osDisk": {
-            "name": "[variables('vm1Name')]",
-            "caching": "ReadWrite",
-            "createOption": "FromImage",
-            "managedDisk": {
-              "storageAccountType": "Standard_LRS"
-            }
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vm1NicName'))]"
-            }
-          ]
-        },
-        "availabilitySet": {
-            "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('webAvailabilitySetName'))]"
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "adminUsername": {
+        "type": "string",
+        "minLength": 1,
+        "metadata": {
+          "description": "Username for the Virtual Machine."
         }
       },
-      "resources": [
-        {
-          "name": "Microsoft.Powershell.DSC",
-          "type": "extensions",
-          "location": "[resourceGroup().location]",
-          "apiVersion": "2016-04-30-preview",
-          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines', variables('vm1Name'))]"
-          ],
-          "properties": {
-            "publisher": "Microsoft.Powershell",
-            "type": "DSC",
-            "typeHandlerVersion": "2.9",
-            "autoUpgradeMinorVersion": true,
-            "forceUpdateTag": "1.0",
-            "settings": {
-              "configuration": {
-                "url": "[variables('dscZipFullPath')]",
-                "script": "iisInstall.ps1",
-                "function": "InstallIIS"
-              },
-              "configurationArguments": {
-                "nodeName": "[variables('vm1Name')]",
-                "vmNumber": "vm1",
-                "backendCert": "[parameters('backendCertData')]",
-                "backendCertPw": "[parameters('backendCertPassword')]",
-                "backendCertDnsName": "[parameters('backendCertDnsName')]",
-                "webConfigPath": "[variables('webConfigFullPath')]",
-                "defaultHtmPath": "[variables('vm1DefaultHtmFullPath')]"
-              }
-            },
-            "protectedSettings": {
-            }
-          }
-        }
-      ]
-    },
-    {
-      "apiVersion": "2016-04-30-preview",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[variables('vm2Name')]",
-      "location": "[resourceGroup().location]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkInterfaces/', variables('vm2NicName'))]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
-        },
-        "osProfile": {
-          "computerName": "[variables('vm2Name')]",
-          "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "publisher": "[variables('imagePublisher')]",
-            "offer": "[variables('imageOffer')]",
-            "sku": "[parameters('windowsOSVersion')]",
-            "version": "latest"
-          },
-          "osDisk": {
-            "name": "[variables('vm2Name')]",
-            "caching": "ReadWrite",
-            "createOption": "FromImage",
-            "managedDisk": {
-              "storageAccountType": "Standard_LRS"
-            }
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vm2NicName'))]"
-            }
-          ]
-        },
-        "availabilitySet": {
-            "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('webAvailabilitySetName'))]"
+      "adminPassword": {
+        "type": "securestring",
+        "metadata": {
+          "description": "Password for the Virtual Machine."
         }
       },
-      "resources": [
-        {
-          "name": "Microsoft.Powershell.DSC",
-          "type": "extensions",
-          "location": "[resourceGroup().location]",
-          "apiVersion": "2016-04-30-preview",
-          "dependsOn": [
-            "[resourceId('Microsoft.Compute/virtualMachines', variables('vm2Name'))]"
-          ],
-          "properties": {
-            "publisher": "Microsoft.Powershell",
-            "type": "DSC",
-            "typeHandlerVersion": "2.9",
-            "autoUpgradeMinorVersion": true,
-            "forceUpdateTag": "1.0",
-            "settings": {
-              "configuration": {
-                "url": "[variables('dscZipFullPath')]",
-                "script": "iisInstall.ps1",
-                "function": "InstallIIS"
-              },
-              "configurationArguments": {
-                "nodeName": "[variables('vm2Name')]",
-                "vmNumber": "vm2",
-                "backendCert": "[parameters('backendCertData')]",
-                "backendCertPw": "[parameters('backendCertPassword')]",
-                "backendCertDnsName": "[parameters('backendCertDnsName')]",
-                "webConfigPath": "[variables('webConfigFullPath')]",
-                "defaultHtmPath": "[variables('vm2DefaultHtmFullPath')]"
-
-              }
-            },
-            "protectedSettings": {
-            }
-          }
+      "windowsOSVersion": {
+        "type": "string",
+        "defaultValue": "2016-Datacenter",
+        "allowedValues": [
+          "2012-R2-Datacenter",
+          "2016-Datacenter"
+        ],
+        "metadata": {
+          "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2012-R2-Datacenter, 2016-Datacenter."
         }
-      ]
+      },
+      "virtualMachineSize": {
+        "type": "string",
+        "defaultValue": "Standard_D2_v2",
+        "allowedValues": [
+          "Standard_A1",
+          "Standard_A2",
+          "Standard_A3",
+          "Standard_D1_v2",
+          "Standard_D2_v2",
+          "Standard_D3_v2"
+        ],
+        "metadata": {
+          "description": "The virtual machine size. Allowed values: Standard_A1, Standard_A2, Standard_A3."
+        }
+      },
+      "applicationGatewaySize": {
+        "type": "string",
+        "allowedValues": [
+          "WAF_Medium",
+          "WAF_Large"
+        ],
+        "defaultValue": "WAF_Medium",
+        "metadata": {
+          "description": "Application Gateway size"
+        }
+      },
+      "capacity": {
+        "type": "int",
+        "allowedValues": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10
+        ],
+        "defaultValue": 2,
+        "metadata": {
+          "description": "Number of instances"
+        }
+      },
+      "wafMode": {
+        "type": "string",
+        "allowedValues": [
+          "Detection",
+          "Prevention"
+        ],
+        "defaultValue": "Prevention",
+        "metadata": {
+          "description": "WAF Mode"
+        }
+      },
+      "frontendCertData": {
+        "type": "string",
+        "metadata": {
+          "description": "Base-64 encoded form of the .pfx file. This is the cert terminating on the Application Gateway."
+        }
+      },
+      "frontendCertPassword": {
+        "type": "securestring",
+        "metadata": {
+          "description": "Password for .pfx certificate"
+        }
+      },
+      "backendCertData": {
+        "type": "string",
+        "metadata": {
+          "description": "Base-64 encoded form of the .pfx file. This is the cert installed on the web servers."
+        }
+      },
+      "backendCertPassword": {
+        "type": "securestring",
+        "metadata": {
+          "description": "Password for .pfx certificate"
+        }
+      },
+      "backendPublicKeyData": {
+        "type": "string",
+        "metadata": {
+          "description": "Base-64 encoded form of the .cer file. This is the public key for the cert on the web servers."
+        }
+      },
+      "backendCertDnsName": {
+        "type": "string",
+        "metadata": {
+          "description": "DNS name of the backend cert"
+        }
+      },
+      "_artifactsLocation": {
+        "type": "string",
+        "metadata": {
+          "description": "The base URI where artifacts required by this template are located. For example, if stored on a public GitHub repo, you'd use the following URI: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vmss-windows-webapp-dsc-autoscale."
+        },
+        "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-application-gateway-2vms-iis-ssl"
+      },
+      "_artifactsLocationSasToken": {
+        "type": "securestring",
+        "defaultValue": "",
+        "metadata": {
+          "description": "The sasToken required to access _artifactsLocation.  If your artifacts are stored on a public repo or public storage account you can leave this blank."
+        }
+      }
     },
-    {
-      "apiVersion": "2017-06-01",
-      "name": "[variables('applicationGatewayName')]",
-      "type": "Microsoft.Network/applicationGateways",
-      "location": "[resourceGroup().location]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
-        "[resourceId('Microsoft.Network/publicIPAddresses/', variables('appGwPublicIpName'))]"
-      ],
-      "properties": {
+    "variables": {
+      "imagePublisher": "MicrosoftWindowsServer",
+      "imageOffer": "WindowsServer",
+      "vm1NicName": "vm1Nic",
+      "vm2NicName": "vm2Nic",
+      "addressPrefix": "10.0.0.0/16",
+      "webSubnetName": "WebSubnet",
+      "webSubnetPrefix": "10.0.0.0/24",
+      "appGatewaySubnetName": "AppGatewaySubnet",
+      "appGatewaySubnetPrefix": "10.0.1.0/24",
+      "vm1PublicIPAddressName": "vm1PublicIP",
+      "vm1PublicIPAddressType": "Dynamic",
+      "vm2PublicIPAddressName": "vm2PublicIP",
+      "vm2PublicIPAddressType": "Dynamic",
+      "vm1IpAddress": "10.0.0.4",
+      "vm2IpAddress": "10.0.0.5",
+      "vm1Name": "iisvm1",
+      "vm2Name": "iisvm2",
+      "vmSize": "[parameters('virtualMachineSize')]",
+      "virtualNetworkName": "MyVNet",
+      "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
+      "webSubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('webSubnetName'))]",
+      "webAvailabilitySetName": "IISAvailabilitySet",
+      "webNsgName": "WebNSG",
+      "appGwNsgName": "AppGwNSG",
+      "applicationGatewayName": "ApplicationGateway",
+      "appGwPublicIpName": "ApplicationGatewayPublicIp",
+      "appGatewaySubnetRef": "[concat(variables('vnetId'), '/subnets/', variables('appGatewaySubnetName'))]",
+      "appGwPublicIPRef": "[resourceId('Microsoft.Network/publicIPAddresses',variables('appGwPublicIpName'))]",
+      "wafEnabled": true,
+      "wafMode": "[parameters('wafMode')]",
+      "wafRuleSetType": "OWASP",
+      "wafRuleSetVersion": "3.0",
+      "applicationGatewayID": "[resourceId('Microsoft.Network/applicationGateways',variables('applicationGatewayName'))]",
+      "dscZipFullPath": "[concat(parameters('_artifactsLocation'), '/DSC/iisInstall.ps1.zip', parameters('_artifactsLocationSasToken'))]",
+      "webConfigFullPath": "[concat(parameters('_artifactsLocation'), '/artifacts/web.config', parameters('_artifactsLocationSasToken'))]",
+      "vm1DefaultHtmFullPath": "[concat(parameters('_artifactsLocation'), '/artifacts/vm1.default.htm', parameters('_artifactsLocationSasToken'))]",
+      "vm2DefaultHtmFullPath": "[concat(parameters('_artifactsLocation'), '/artifacts/vm2.default.htm', parameters('_artifactsLocationSasToken'))]"
+    },
+    "resources": [
+      {
+        "comments": "Availability set for the web servers",
+        "type": "Microsoft.Compute/availabilitySets",
         "sku": {
-          "name": "[parameters('applicationGatewaySize')]",
-          "tier": "WAF",
-          "capacity": "[parameters('capacity')]"
+          "name": "Aligned"
         },
-        "sslCertificates": [
-          {
-            "name": "appGatewayFrontEndSslCert",
-            "properties": {
-              "data": "[parameters('frontendCertData')]",
-              "password": "[parameters('frontendCertPassword')]"
-            }
-          }
-        ],
-        "gatewayIPConfigurations": [
-          {
-            "name": "appGatewayIpConfig",
-            "properties": {
-              "subnet": {
-                "id": "[variables('appGatewaySubnetRef')]"
-              }
-            }
-          }
-        ],
-        "authenticationCertificates": [
-          {
-            "properties": {
-              "data": "[parameters('backendPublicKeyData')]"
+        "name": "[variables('webAvailabilitySetName')]",
+        "apiVersion": "2016-04-30-preview",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "platformUpdateDomainCount": 5,
+          "platformFaultDomainCount": 2,
+          "virtualMachines": [
+            {
+              "id": "[resourceId('Microsoft.Compute/virtualMachines', variables('vm1Name'))]"
             },
-            "name": "appGatewayBackendCert"
-          }
-        ],
-        "frontendIPConfigurations": [
-          {
-            "name": "appGatewayFrontendIP",
-            "properties": {
-              "PublicIPAddress": {
-                "id": "[variables('appGwPublicIPRef')]"
+            {
+              "id": "[resourceId('Microsoft.Compute/virtualMachines', variables('vm2Name'))]"
+            }
+          ]
+        },
+        "dependsOn": []
+      },
+      {
+        "apiVersion": "2016-03-30",
+        "type": "Microsoft.Network/publicIPAddresses",
+        "name": "[variables('vm1PublicIPAddressName')]",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "publicIPAllocationMethod": "[variables('vm1PublicIPAddressType')]"
+        }
+      },
+      {
+        "apiVersion": "2016-03-30",
+        "type": "Microsoft.Network/publicIPAddresses",
+        "name": "[variables('vm2PublicIPAddressName')]",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "publicIPAllocationMethod": "[variables('vm2PublicIPAddressType')]"
+        }
+      },
+      {
+        "apiVersion": "2017-03-01",
+        "type": "Microsoft.Network/publicIPAddresses",
+        "name": "[variables('appGwPublicIpName')]",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "publicIPAllocationMethod": "Dynamic"
+        }
+      },
+      {
+        "apiVersion": "2016-03-30",
+        "type": "Microsoft.Network/networkSecurityGroups",
+        "name": "[variables('webNsgName')]",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "securityRules": [
+            {
+              "name": "Allow80",
+              "properties": {
+                "description": "Allow 80 from local VNet",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "80",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 100,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "Allow443",
+              "properties": {
+                "description": "Allow 443 from local VNet",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "443",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 101,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "AllowRDP",
+              "properties": {
+                "description": "Allow RDP from everywhere",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "3389",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 102,
+                "direction": "Inbound"
               }
             }
-          }
-        ],
-        "frontendPorts": [
-          {
-            "name": "appGatewayFrontendPort80",
-            "properties": {
-              "Port": 80
+          ]
+        }
+      },
+      {
+        "apiVersion": "2016-03-30",
+        "type": "Microsoft.Network/networkSecurityGroups",
+        "name": "[variables('appGwNsgName')]",
+        "location": "[resourceGroup().location]",
+        "properties": {
+          "securityRules": [
+            {
+              "name": "Allow80",
+              "properties": {
+                "description": "Allow 80 from Internet",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "80",
+                "sourceAddressPrefix": "Internet",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 100,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "Allow443",
+              "properties": {
+                "description": "Allow 443 from Internet",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "443",
+                "sourceAddressPrefix": "Internet",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 102,
+                "direction": "Inbound"
+              }
+            },
+            {
+              "name": "AllowAppGwProbes",
+              "properties": {
+                "description": "Allow ports for App Gw probes",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "65503-65534 ",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 103,
+                "direction": "Inbound"
+              }
             }
+          ]
+        }
+      },
+      {
+        "apiVersion": "2016-03-30",
+        "type": "Microsoft.Network/virtualNetworks",
+        "name": "[variables('virtualNetworkName')]",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+          "[concat('Microsoft.Network/networkSecurityGroups/', variables('webNsgName'))]",
+          "[concat('Microsoft.Network/networkSecurityGroups/', variables('appGwNsgName'))]"
+        ],
+        "properties": {
+          "addressSpace": {
+            "addressPrefixes": [
+              "[variables('addressPrefix')]"
+            ]
           },
-          {
-            "name": "appGatewayFrontendPort443",
-            "properties": {
-              "Port": 443
+          "subnets": [
+            {
+              "name": "[variables('webSubnetName')]",
+              "properties": {
+                "addressPrefix": "[variables('webSubnetPrefix')]",
+                "networkSecurityGroup": {
+                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('webNsgName'))]"
+                }
+              }
+            },
+            {
+              "name": "[variables('appGatewaySubnetName')]",
+              "properties": {
+                "addressPrefix": "[variables('appGatewaySubnetPrefix')]",
+                "networkSecurityGroup": {
+                  "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('appGwNsgName'))]"
+                }
+              }
             }
-          }
+          ]
+        }
+      },
+      {
+        "apiVersion": "2016-03-30",
+        "type": "Microsoft.Network/networkInterfaces",
+        "name": "[variables('vm1NicName')]",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+          "[resourceId('Microsoft.Network/publicIPAddresses/', variables('vm1PublicIPAddressName'))]",
+          "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
         ],
-        "backendAddressPools": [
-          {
-            "name": "appGatewayBackendPool",
-            "properties": {
-              "BackendAddresses": [
-                {
-                  "IpAddress": "[variables('vm1IpAddress')]"
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfigVm1",
+              "properties": {
+                "privateIPAddress": "[variables('vm1IpAddress')]",
+                "privateIPAllocationMethod": "Static",
+                "publicIPAddress": {
+                  "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('vm1PublicIPAddressName'))]"
                 },
-                {
-                  "IpAddress": "[variables('vm2IpAddress')]"
+                "subnet": {
+                  "id": "[variables('webSubnetRef')]"
                 }
-              ]
+              }
             }
-          }
+          ]
+        }
+      },
+      {
+        "apiVersion": "2016-03-30",
+        "type": "Microsoft.Network/networkInterfaces",
+        "name": "[variables('vm2NicName')]",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+          "[resourceId('Microsoft.Network/publicIPAddresses/', variables('vm2PublicIPAddressName'))]",
+          "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
         ],
-        "backendHttpSettingsCollection": [
-          {
-            "name": "appGatewayBackendHttpSettings",
-            "properties": {
-              "Port": 80,
-              "Protocol": "Http",
-              "CookieBasedAffinity": "Disabled"
-            }
-          },
-          {
-            "name": "appGatewayBackendHttpsSettings",
-            "properties": {
-              "Port": 443,
-              "Protocol": "Https",
-              "CookieBasedAffinity": "Disabled",
-              "AuthenticationCertificates": [
-                {
-                  "Id": "[concat(variables('applicationGatewayID'), '/authenticationCertificates/appGatewayBackendCert')]"
+        "properties": {
+          "ipConfigurations": [
+            {
+              "name": "ipconfigVm2",
+              "properties": {
+                "privateIPAddress": "[variables('vm2IpAddress')]",
+                "privateIPAllocationMethod": "Static",
+                "publicIPAddress": {
+                  "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('vm2PublicIPAddressName'))]"
+                },
+                "subnet": {
+                  "id": "[variables('webSubnetRef')]"
                 }
-              ]
-            }
-          }
-        ],
-        "httpListeners": [
-          {
-            "name": "appGatewayHttpListener",
-            "properties": {
-              "FrontendIPConfiguration": {
-                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-              },
-              "FrontendPort": {
-                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort80')]"
-              },
-              "Protocol": "Http",
-              "SslCertificate": null
-            }
-          },
-          {
-            "name": "appGatewayHttpsListener",
-            "properties": {
-              "FrontendIPConfiguration": {
-                "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
-              },
-              "FrontendPort": {
-                "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort443')]"
-              },
-              "Protocol": "Https",
-              "SslCertificate": {
-                "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewayFrontEndSslCert')]"
               }
             }
-          }
+          ]
+        }
+      },
+      {
+        "apiVersion": "2016-04-30-preview",
+        "type": "Microsoft.Compute/virtualMachines",
+        "name": "[variables('vm1Name')]",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+          "[resourceId('Microsoft.Network/networkInterfaces/', variables('vm1NicName'))]",
+          "[resourceId('Microsoft.Compute/availabilitySets', variables('webAvailabilitySetName'))]"
         ],
-        "requestRoutingRules": [
-          {
-            "Name": "HTTPRule",
-            "properties": {
-              "RuleType": "Basic",
-              "httpListener": {
-                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener')]"
-              },
-              "backendAddressPool": {
-                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
-              },
-              "backendHttpSettings": {
-                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "[variables('vmSize')]"
+          },
+          "osProfile": {
+            "computerName": "[variables('vm1Name')]",
+            "adminUsername": "[parameters('adminUsername')]",
+            "adminPassword": "[parameters('adminPassword')]"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "[variables('imagePublisher')]",
+              "offer": "[variables('imageOffer')]",
+              "sku": "[parameters('windowsOSVersion')]",
+              "version": "latest"
+            },
+            "osDisk": {
+              "name": "[variables('vm1Name')]",
+              "caching": "ReadWrite",
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS"
               }
             }
           },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vm1NicName'))]"
+              }
+            ]
+          },
+          "availabilitySet": {
+              "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('webAvailabilitySetName'))]"
+          }
+        },
+        "resources": [
           {
-            "Name": "HTTPSRule",
+            "name": "Microsoft.Powershell.DSC",
+            "type": "extensions",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2016-04-30-preview",
+            "dependsOn": [
+              "[resourceId('Microsoft.Compute/virtualMachines', variables('vm1Name'))]"
+            ],
             "properties": {
-              "RuleType": "Basic",
-              "httpListener": {
-                "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpsListener')]"
+              "publisher": "Microsoft.Powershell",
+              "type": "DSC",
+              "typeHandlerVersion": "2.9",
+              "autoUpgradeMinorVersion": true,
+              "forceUpdateTag": "1.0",
+              "settings": {
+                "configuration": {
+                  "url": "[variables('dscZipFullPath')]",
+                  "script": "iisInstall.ps1",
+                  "function": "InstallIIS"
+                },
+                "configurationArguments": {
+                  "nodeName": "[variables('vm1Name')]",
+                  "vmNumber": "vm1",
+                  "backendCert": "[parameters('backendCertData')]",
+                  "backendCertPw": "[parameters('backendCertPassword')]",
+                  "backendCertDnsName": "[parameters('backendCertDnsName')]",
+                  "webConfigPath": "[variables('webConfigFullPath')]",
+                  "defaultHtmPath": "[variables('vm1DefaultHtmFullPath')]"
+                }
               },
-              "backendAddressPool": {
-                "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
-              },
-              "backendHttpSettings": {
-                "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpsSettings')]"
+              "protectedSettings": {
               }
             }
           }
+        ]
+      },
+      {
+        "apiVersion": "2016-04-30-preview",
+        "type": "Microsoft.Compute/virtualMachines",
+        "name": "[variables('vm2Name')]",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+          "[resourceId('Microsoft.Network/networkInterfaces/', variables('vm2NicName'))]",
+          "[resourceId('Microsoft.Compute/availabilitySets', variables('webAvailabilitySetName'))]"
         ],
-        "webApplicationFirewallConfiguration": {
-          "enabled": "[variables('wafEnabled')]",
-          "firewallMode": "[variables('wafMode')]",
-          "ruleSetType": "[variables('wafRuleSetType')]",
-          "ruleSetVersion": "[variables('wafRuleSetVersion')]",
-          "disabledRuleGroups": []
+        "properties": {
+          "hardwareProfile": {
+            "vmSize": "[variables('vmSize')]"
+          },
+          "osProfile": {
+            "computerName": "[variables('vm2Name')]",
+            "adminUsername": "[parameters('adminUsername')]",
+            "adminPassword": "[parameters('adminPassword')]"
+          },
+          "storageProfile": {
+            "imageReference": {
+              "publisher": "[variables('imagePublisher')]",
+              "offer": "[variables('imageOffer')]",
+              "sku": "[parameters('windowsOSVersion')]",
+              "version": "latest"
+            },
+            "osDisk": {
+              "name": "[variables('vm2Name')]",
+              "caching": "ReadWrite",
+              "createOption": "FromImage",
+              "managedDisk": {
+                "storageAccountType": "Standard_LRS"
+              }
+            }
+          },
+          "networkProfile": {
+            "networkInterfaces": [
+              {
+                "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vm2NicName'))]"
+              }
+            ]
+          },
+          "availabilitySet": {
+              "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('webAvailabilitySetName'))]"
+          }
+        },
+        "resources": [
+          {
+            "name": "Microsoft.Powershell.DSC",
+            "type": "extensions",
+            "location": "[resourceGroup().location]",
+            "apiVersion": "2016-04-30-preview",
+            "dependsOn": [
+              "[resourceId('Microsoft.Compute/virtualMachines', variables('vm2Name'))]"
+            ],
+            "properties": {
+              "publisher": "Microsoft.Powershell",
+              "type": "DSC",
+              "typeHandlerVersion": "2.9",
+              "autoUpgradeMinorVersion": true,
+              "forceUpdateTag": "1.0",
+              "settings": {
+                "configuration": {
+                  "url": "[variables('dscZipFullPath')]",
+                  "script": "iisInstall.ps1",
+                  "function": "InstallIIS"
+                },
+                "configurationArguments": {
+                  "nodeName": "[variables('vm2Name')]",
+                  "vmNumber": "vm2",
+                  "backendCert": "[parameters('backendCertData')]",
+                  "backendCertPw": "[parameters('backendCertPassword')]",
+                  "backendCertDnsName": "[parameters('backendCertDnsName')]",
+                  "webConfigPath": "[variables('webConfigFullPath')]",
+                  "defaultHtmPath": "[variables('vm2DefaultHtmFullPath')]"
+  
+                }
+              },
+              "protectedSettings": {
+              }
+            }
+          }
+        ]
+      },
+      {
+        "apiVersion": "2017-06-01",
+        "name": "[variables('applicationGatewayName')]",
+        "type": "Microsoft.Network/applicationGateways",
+        "location": "[resourceGroup().location]",
+        "dependsOn": [
+          "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+          "[resourceId('Microsoft.Network/publicIPAddresses/', variables('appGwPublicIpName'))]"
+        ],
+        "properties": {
+          "sku": {
+            "name": "[parameters('applicationGatewaySize')]",
+            "tier": "WAF",
+            "capacity": "[parameters('capacity')]"
+          },
+          "sslCertificates": [
+            {
+              "name": "appGatewayFrontEndSslCert",
+              "properties": {
+                "data": "[parameters('frontendCertData')]",
+                "password": "[parameters('frontendCertPassword')]"
+              }
+            }
+          ],
+          "gatewayIPConfigurations": [
+            {
+              "name": "appGatewayIpConfig",
+              "properties": {
+                "subnet": {
+                  "id": "[variables('appGatewaySubnetRef')]"
+                }
+              }
+            }
+          ],
+          "authenticationCertificates": [
+            {
+              "properties": {
+                "data": "[parameters('backendPublicKeyData')]"
+              },
+              "name": "appGatewayBackendCert"
+            }
+          ],
+          "frontendIPConfigurations": [
+            {
+              "name": "appGatewayFrontendIP",
+              "properties": {
+                "PublicIPAddress": {
+                  "id": "[variables('appGwPublicIPRef')]"
+                }
+              }
+            }
+          ],
+          "frontendPorts": [
+            {
+              "name": "appGatewayFrontendPort80",
+              "properties": {
+                "Port": 80
+              }
+            },
+            {
+              "name": "appGatewayFrontendPort443",
+              "properties": {
+                "Port": 443
+              }
+            }
+          ],
+          "backendAddressPools": [
+            {
+              "name": "appGatewayBackendPool",
+              "properties": {
+                "BackendAddresses": [
+                  {
+                    "IpAddress": "[variables('vm1IpAddress')]"
+                  },
+                  {
+                    "IpAddress": "[variables('vm2IpAddress')]"
+                  }
+                ]
+              }
+            }
+          ],
+          "backendHttpSettingsCollection": [
+            {
+              "name": "appGatewayBackendHttpSettings",
+              "properties": {
+                "Port": 80,
+                "Protocol": "Http",
+                "CookieBasedAffinity": "Disabled"
+              }
+            },
+            {
+              "name": "appGatewayBackendHttpsSettings",
+              "properties": {
+                "Port": 443,
+                "Protocol": "Https",
+                "CookieBasedAffinity": "Disabled",
+                "AuthenticationCertificates": [
+                  {
+                    "Id": "[concat(variables('applicationGatewayID'), '/authenticationCertificates/appGatewayBackendCert')]"
+                  }
+                ]
+              }
+            }
+          ],
+          "httpListeners": [
+            {
+              "name": "appGatewayHttpListener",
+              "properties": {
+                "FrontendIPConfiguration": {
+                  "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+                },
+                "FrontendPort": {
+                  "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort80')]"
+                },
+                "Protocol": "Http",
+                "SslCertificate": null
+              }
+            },
+            {
+              "name": "appGatewayHttpsListener",
+              "properties": {
+                "FrontendIPConfiguration": {
+                  "Id": "[concat(variables('applicationGatewayID'), '/frontendIPConfigurations/appGatewayFrontendIP')]"
+                },
+                "FrontendPort": {
+                  "Id": "[concat(variables('applicationGatewayID'), '/frontendPorts/appGatewayFrontendPort443')]"
+                },
+                "Protocol": "Https",
+                "SslCertificate": {
+                  "Id": "[concat(variables('applicationGatewayID'), '/sslCertificates/appGatewayFrontEndSslCert')]"
+                }
+              }
+            }
+          ],
+          "requestRoutingRules": [
+            {
+              "Name": "HTTPRule",
+              "properties": {
+                "RuleType": "Basic",
+                "httpListener": {
+                  "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpListener')]"
+                },
+                "backendAddressPool": {
+                  "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
+                },
+                "backendHttpSettings": {
+                  "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpSettings')]"
+                }
+              }
+            },
+            {
+              "Name": "HTTPSRule",
+              "properties": {
+                "RuleType": "Basic",
+                "httpListener": {
+                  "id": "[concat(variables('applicationGatewayID'), '/httpListeners/appGatewayHttpsListener')]"
+                },
+                "backendAddressPool": {
+                  "id": "[concat(variables('applicationGatewayID'), '/backendAddressPools/appGatewayBackendPool')]"
+                },
+                "backendHttpSettings": {
+                  "id": "[concat(variables('applicationGatewayID'), '/backendHttpSettingsCollection/appGatewayBackendHttpsSettings')]"
+                }
+              }
+            }
+          ],
+          "webApplicationFirewallConfiguration": {
+            "enabled": "[variables('wafEnabled')]",
+            "firewallMode": "[variables('wafMode')]",
+            "ruleSetType": "[variables('wafRuleSetType')]",
+            "ruleSetVersion": "[variables('wafRuleSetVersion')]",
+            "disabledRuleGroups": []
+          }
         }
       }
-    }
-  ],
-  "outputs": {}
-}
+    ],
+    "outputs": {}
+  }

--- a/201-application-gateway-2vms-iis-ssl/azuredeploy.json
+++ b/201-application-gateway-2vms-iis-ssl/azuredeploy.json
@@ -65,8 +65,7 @@
           8,
           9,
           10
-        ],
-        "defaultValue": 2,
+        ]        "defaultValue": 2,
         "metadata": {
           "description": "Number of instances"
         }
@@ -123,7 +122,7 @@
         "metadata": {
           "description": "The base URI where artifacts required by this template are located. For example, if stored on a public GitHub repo, you'd use the following URI: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vmss-windows-webapp-dsc-autoscale."
         },
-        "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-application-gateway-2vms-iis-ssl"
+        "defaultValue": "https://raw.githubusercontent.com/murrahjm/azure-quickstart-templates/master/201-application-gateway-2vms-iis-ssl"
       },
       "_artifactsLocationSasToken": {
         "type": "securestring",

--- a/201-application-gateway-2vms-iis-ssl/azuredeploy.json
+++ b/201-application-gateway-2vms-iis-ssl/azuredeploy.json
@@ -184,7 +184,7 @@
         "location": "[resourceGroup().location]",
         "properties": {
           "platformUpdateDomainCount": 5,
-          "platformFaultDomainCount": 2,
+          "platformFaultDomainCount": 2
         },
         "dependsOn": []
       },


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* fix issue where VMs were not a part of the availability set upon template deployment
