### PR TITLE
Remove hyphens from ouput parameter names

### DIFF
--- a/moodle-scalable-cluster-ubuntu/azuredeploy.json
+++ b/moodle-scalable-cluster-ubuntu/azuredeploy.json
@@ -462,31 +462,31 @@
         "type": "string",
         "value": "[variables('moodleCommon').siteURL]"
       },
-      "controller-instance-ip": {
+      "controllerInstanceIP": {
         "type": "string",
         "value": "[reference('controllerTemplate').outputs.controllerIP.value]"
       },
-      "database-dns": {
+      "databaseDNS": {
         "type": "string",
         "value": "[concat(variables('moodleCommon').dbServerType, '-', variables('moodleCommon').resourcesPrefix, '.', variables('moodleCommon').dbServerType, '.database.azure.com')]"
       },
-      "database-admin-username": {
+      "databaseAdminUsername": {
         "type": "string",
         "value": "[variables('moodleCommon').dbUsername]"
       },
-      "database-admin-password": {
+      "databaseAdminPassword": {
         "type": "string",
         "value": "[variables('moodleCommon').dbLoginPassword]"
       },
-      "first-frontend-vm-ip": {
+      "firstFrontendVmIP": {
         "type": "string",
         "value": "[reference('scaleSetTemplate').outputs.webvm1IP.value]"
       },
-      "moodle-admin-password": {
+      "moodleAdminPassword": {
         "type": "string",
         "value": "[variables('moodleCommon').moodleAdminPass]"
       },
-      "load-balancer-dns": {
+      "loadBalancerDNS": {
         "type": "string",
         "value": "[variables('moodleCommon').lbDns]"
       }

--- a/moodle-scalable-cluster-ubuntu/azuredeploy.parameters.json
+++ b/moodle-scalable-cluster-ubuntu/azuredeploy.parameters.json
@@ -2,7 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
         "parameters": {
-                "applyScriptsSwitch":          { "value": 1 },
                 "autoscaleVmCount":            { "value": 10 },
                 "autoscaleVmSku":              { "value": "Standard_DS2_v2" },
                 "azureBackupSwitch":           { "value": 0 },


### PR DESCRIPTION

* Rename outputs becuase CLI fails with hyphenated output names


AZ CLI fails with hyphenated output names so de-hyphenate them

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.


  