### PR TITLE
Add resource types to allowed types for solution-template-validation-tests

### DIFF
--- a/test/solution-template-validation-tests/test/mainTemplateTests.js
+++ b/test/solution-template-validation-tests/test/mainTemplateTests.js
@@ -129,7 +129,7 @@ describe('mainTemplate.json file - ', () => {
             });
         });
 
-        it('template must contain only approved resources (Compute/Network/Storage)', () => {
+        it('template must contain only approved resources', () => {
             // Add allowed types here
             // NOTE that the property name is the lower case resource provider portion of the type
             // and the array can either be a single entry of '*' for all types for that provider
@@ -145,7 +145,7 @@ describe('mainTemplate.json file - ', () => {
             templateFileJSONObjects.forEach(templateJSONObject => {
                 var templateObject = templateJSONObject.value;
                 templateObject.should.have.property('resources');
-                var message = 'in file:' + templateJSONObject.filename + ' is NOT a compute, network or a storage resource type';
+                var message = 'in file:' + templateJSONObject.filename + ' is NOT an approved resource type (' + JSON.stringify(allowedResourceTypes) + ')';
                 Object.keys(templateObject.resources).forEach(resource => {
                     var val = templateObject.resources[resource];
                     if (val.type) {

--- a/test/solution-template-validation-tests/test/mainTemplateTests.js
+++ b/test/solution-template-validation-tests/test/mainTemplateTests.js
@@ -153,7 +153,7 @@ describe('mainTemplate.json file - ', () => {
                         var providerLower = rType[0];
                         var typeLower = rType[1];
                         var condition = allowedResourceTypes[providerLower] &&
-                                    (allowedResourceTypes[providerLower][0] == '*' || allowedResourceTypes[providerLower].indexOf(typeLower) > -1);
+                                    (allowedResourceTypes[providerLower][0] == '*' || (typeLower && allowedResourceTypes[providerLower].indexOf(typeLower) > -1));
                         expect(condition, getErrorMessage(val, templateJSONObject.filepath, message + '. The resource object: ' + JSON.stringify(val))).to.be.true;
                     }
                 });

--- a/test/solution-template-validation-tests/test/mainTemplateTests.js
+++ b/test/solution-template-validation-tests/test/mainTemplateTests.js
@@ -130,6 +130,18 @@ describe('mainTemplate.json file - ', () => {
         });
 
         it('template must contain only approved resources (Compute/Network/Storage)', () => {
+            // Add allowed types here
+            // NOTE that the property name is the lower case resource provider portion of the type
+            // and the array can either be a single entry of '*' for all types for that provider
+            // or it can be one or more elements which are the resource type names to allow
+            var allowedResourceTypes = {
+                'microsoft.compute' : ['*'],
+                'microsoft.storage' : ['*'],
+                'microsoft.network' : ['*'],
+                'microsoft.resources' : ['*'],
+                'microsoft.insights' : ['autoscalesettings'],
+                'microsoft.authorization' : ['roleassignments']
+            };
             templateFileJSONObjects.forEach(templateJSONObject => {
                 var templateObject = templateJSONObject.value;
                 templateObject.should.have.property('resources');
@@ -137,15 +149,12 @@ describe('mainTemplate.json file - ', () => {
                 Object.keys(templateObject.resources).forEach(resource => {
                     var val = templateObject.resources[resource];
                     if (val.type) {
-                        var rType = val.type.split('/');
-                        var lowerType = val.type.toLowerCase();
-                        var cond = rType[0].toLowerCase() == 'microsoft.compute' ||
-                            rType[0].toLowerCase() == 'microsoft.storage' ||
-                            rType[0].toLowerCase() == 'microsoft.network' ||
-                            rType[0].toLowerCase() == 'microsoft.resources' ||
-                            lowerType == 'microsoft.insights/autoscalesettings' || 
-                            lowerType == 'microsoft.authorization/roleassignments';
-                        expect(cond, getErrorMessage(val, templateJSONObject.filepath, message + '. The resource object: ' + JSON.stringify(val))).to.be.true;
+                        var rType = val.type.toLowerCase().split('/');
+                        var providerLower = rType[0];
+                        var typeLower = rType[1];
+                        var condition = allowedResourceTypes[providerLower] &&
+                                    (allowedResourceTypes[providerLower][0] == '*' || allowedResourceTypes[providerLower].indexOf(typeLower) > -1);
+                        expect(condition, getErrorMessage(val, templateJSONObject.filepath, message + '. The resource object: ' + JSON.stringify(val))).to.be.true;
                     }
                 });
             });

--- a/test/solution-template-validation-tests/test/mainTemplateTests.js
+++ b/test/solution-template-validation-tests/test/mainTemplateTests.js
@@ -138,10 +138,13 @@ describe('mainTemplate.json file - ', () => {
                     var val = templateObject.resources[resource];
                     if (val.type) {
                         var rType = val.type.split('/');
+                        var lowerType = val.type.toLowerCase();
                         var cond = rType[0].toLowerCase() == 'microsoft.compute' ||
                             rType[0].toLowerCase() == 'microsoft.storage' ||
                             rType[0].toLowerCase() == 'microsoft.network' ||
-                            rType[0].toLowerCase() == 'microsoft.resources';
+                            rType[0].toLowerCase() == 'microsoft.resources' ||
+                            lowerType == 'microsoft.insights/autoscalesettings' || 
+                            lowerType == 'microsoft.authorization/roleassignments';
                         expect(cond, getErrorMessage(val, templateJSONObject.filepath, message + '. The resource object: ' + JSON.stringify(val))).to.be.true;
                     }
                 });


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Add Microsoft.Insights/autoscaleSettings and Microsoft.Authorization/roleAssignments to the allowed resource types in solution-template-validation-tests

