### PR TITLE
Made 201-vsts-cloudloadtest-rig-existing-vnet more flexible

### DIFF
--- a/201-vsts-cloudloadtest-rig-existing-vnet/README.md
+++ b/201-vsts-cloudloadtest-rig-existing-vnet/README.md
@@ -22,10 +22,11 @@ To learn about how to view and manage registered load agents for your VSTS accou
     "VSTSPersonalAccessToken": "<Get PAT token for VSTS account>",
     "AgentCount": "<number of desired VMs>",
     "AdminUsername":"<Admin user name>",
-    "AdminPassword":"<password>" 
-	"ExistingVNetResourceGroupName": "<Resource group name where the Vnet exists"
-	"ExistingVNetName":"<VNet name>"
-	"SubnetName":"<Subnet under VNet where you want to deployment load agents>"
+    "AdminPassword":"<password>",
+    "ExistingVNetResourceGroupName": "<Resource group name where the Vnet exists",
+    "ExistingVNetName":"<VNet name>",
+    "SubnetName":"<Subnet under VNet where you want to deployment load agents>",
+    "VmSize": "Virtual Machine Size, e.g. Standard_D4_v2"
 }
 ```
 

--- a/201-vsts-cloudloadtest-rig-existing-vnet/README.md
+++ b/201-vsts-cloudloadtest-rig-existing-vnet/README.md
@@ -26,6 +26,7 @@ To learn about how to view and manage registered load agents for your VSTS accou
     "ExistingVNetResourceGroupName": "<Resource group name where the Vnet exists",
     "ExistingVNetName":"<VNet name>",
     "SubnetName":"<Subnet under VNet where you want to deployment load agents>",
+    "SubnetPrefix": "<Subnet prefix in the virtual network you want to use, e.g. 10.1.2.0/28; make sure it is valid for existing virtual network>",
     "VmSize": "Virtual Machine Size, e.g. Standard_D4_v2"
 }
 ```

--- a/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.json
+++ b/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.json
@@ -62,6 +62,12 @@
                 "description": "Name of the subnet in the virtual network you want to use"
             }
         },
+        "subnetPrefix": {
+            "type": "String",
+            "metadata": {
+                "description": "Subnet prefix in the virtual network you want to use, make sure it is valid for existing virtual network"
+            }
+        },
         "vmSize": {
             "type": "String",
             "defaultValue": "Standard_D4_v2",
@@ -74,10 +80,9 @@
         "sizeOfDiskInGB": "100",
         "imagePublisher": "MicrosoftWindowsServer",
         "imageOffer": "WindowsServer",
-        "addressPrefix": "10.0.0.0/16",
         "sequenceVersion": "[uniqueString(resourceGroup().id)]",
         "uniqueStringValue": "[substring(variables('sequenceVersion'), 3, 7)]",
-        "subnetPrefix": "10.0.0.0/24",
+        "subnetPrefix": "[parameters('subnetPrefix')]",
         "storageAccountType": "Standard_LRS",
         "vmName": "[concat('vm', variables('uniqueStringValue'))]",
         "vmSize": "[parameters('vmSize')]",
@@ -90,6 +95,7 @@
         "windowsOSVersion": "2012-R2-Datacenter",
         "OSDiskName": "osdisk",
         "vnetID": "[resourceId(parameters('existingVNetResourceGroupName'), 'Microsoft.Network/virtualNetworks', parameters('existingVNetName'))]",
+        "existingVNetLocation": "[resourceGroup().location]",
         "subnetRef": "[concat(variables('vnetID'),'/subnets/', parameters('subnetName'))]",
         "apiVersion": "2015-06-15",
 		"agentGroupName":"[resourceGroup().name]"
@@ -118,6 +124,33 @@
             }
         },
         {
+            "apiVersion": "2017-05-10",
+            "name": "nestedTemplate",
+            "type": "Microsoft.Resources/deployments",
+            "resourceGroup": "[parameters('existingVNetResourceGroupName')]",
+            "properties": {
+                "mode": "Incremental",
+                "template": {
+                    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+                    "contentVersion": "1.0.0.0",
+                    "parameters": {},
+                    "variables": {},
+                    "resources": [
+                        {
+                            "type": "Microsoft.Network/virtualNetworks/subnets",
+                            "name": "[concat(parameters('existingVNetName'), '/', parameters('subnetName'))]",
+                            "apiVersion": "2017-10-01",
+                            "location": "[variables( 'existingVNetLocation' )]",
+                            "properties": {
+                              "addressPrefix": "[variables('subnetPrefix')]"
+                            }
+                        }
+                    ]
+                },
+                "parameters": {}
+            }
+        },        
+        {
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('nicName'), 'i', copyIndex())]",
             "apiVersion": "2015-06-15",
@@ -143,7 +176,8 @@
                 ]
             },
             "dependsOn": [
-                "[concat('Microsoft.Network/publicIPAddresses/', concat(variables('publicIPAddressName'),'i', copyIndex()))]"
+                "[concat('Microsoft.Network/publicIPAddresses/', concat(variables('publicIPAddressName'),'i', copyIndex()))]",
+                "Microsoft.Resources/deployments/nestedTemplate"
             ]
         },
         {

--- a/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.json
+++ b/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.json
@@ -61,6 +61,13 @@
             "metadata": {
                 "description": "Name of the subnet in the virtual network you want to use"
             }
+        },
+        "vmSize": {
+            "type": "String",
+            "defaultValue": "Standard_D4_v2",
+            "metadata": {
+                "description": "Virtual Machines Size"
+            }
         }
     },
     "variables": {
@@ -73,7 +80,7 @@
         "subnetPrefix": "10.0.0.0/24",
         "storageAccountType": "Standard_LRS",
         "vmName": "[concat('vm', variables('uniqueStringValue'))]",
-        "vmSize": "Standard_D4_v2",
+        "vmSize": "[parameters('vmSize')]",
         "storageAccountName": "[concat('storage', variables('uniqueStringValue'))]",
         "vmStorageAccountContainerName": "vhd",
         "publicIPAddressName": "[concat('publicip', variables('uniqueStringValue'))]",

--- a/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.parameters.json
+++ b/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.parameters.json
@@ -26,6 +26,9 @@
         "subnetName": {
             "value":"GEN-UNIQUE"
         },
+        "subnetPrefix": {
+            "value": "10.0.0.0/24"
+        },
         "vmSize": {
             "value": "Standard_D4_v2"
         }

--- a/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.parameters.json
+++ b/201-vsts-cloudloadtest-rig-existing-vnet/azuredeploy.parameters.json
@@ -25,6 +25,9 @@
         },
         "subnetName": {
             "value":"GEN-UNIQUE"
+        },
+        "vmSize": {
+            "value": "Standard_D4_v2"
         }
     }
 }

--- a/201-vsts-cloudloadtest-rig-existing-vnet/metadata.json
+++ b/201-vsts-cloudloadtest-rig-existing-vnet/metadata.json
@@ -3,5 +3,5 @@
   "description": "Using this template, you can create your own load test rig on Azure IaaS virtual machines in order to test applications that do not have a public end-point. The load generating agent machines will be created in the specified VNet. This VNet should have line of sight to the application you want to test. The test rig will be configured for your Visual Studio Team Services (VSTS) account and can be used to run cloud-based load tests using Visual Studio.",
   "summary": "Yet to come",
   "githubUsername": "dpksinghal",
-  "dateUpdated": "2016-07-21"
+  "dateUpdated": "2018-02-15"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

Changes to 201-vsts-cloudloadtest-rig-existing-vnet
* Parametric VM size
* Automatic creation of subnet if it does not exist in target virtual network

