### PR TITLE
UseBasicParsing when invoking webrequest

### DIFF
--- a/test/solution-template-validation-tests/DownloadTestScriptFiles.ps1
+++ b/test/solution-template-validation-tests/DownloadTestScriptFiles.ps1
@@ -17,7 +17,7 @@ if(!$githubBuildFilesFolderUri) {
 }
 
 Write-Host "Getting contents from $githubTestFilesFolderUri"
-$folderContents = Invoke-WebRequest $githubTestFilesFolderUri | Select-Object -ExpandProperty Content | ConvertFrom-Json
+$folderContents = Invoke-WebRequest $githubTestFilesFolderUri -UseBasicParsing | Select-Object -ExpandProperty Content | ConvertFrom-Json
 
 Write-Host "Creating test directory if one doesn't exist already"
 $path = (Get-Item -Path ".\" -Verbose).FullName + "\test"
@@ -31,7 +31,7 @@ cd $path
 foreach($file in $folderContents) 
 {
     Write-Host "Downloading file $file.name"
-    Invoke-WebRequest $file.download_url -OutFile $file.name
+    Invoke-WebRequest $file.download_url -UseBasicParsing -OutFile $file.name
 }
 
 Write-Host "Listing files downloaded"
@@ -41,17 +41,17 @@ dir
 cd ..
 
 Write-Host "Getting contents from $githubBuildFilesFolderUri"
-$folderContents = Invoke-WebRequest $githubBuildFilesFolderUri | Select-Object -ExpandProperty Content | ConvertFrom-Json
+$folderContents = Invoke-WebRequest $githubBuildFilesFolderUri -UseBasicParsing | Select-Object -ExpandProperty Content | ConvertFrom-Json
 
 foreach($file in $folderContents) 
 {
     Write-Host "Downloading file $file.name"
-    Invoke-WebRequest $file.download_url -OutFile $file.name
+    Invoke-WebRequest $file.download_url -UseBasicParsing -OutFile $file.name
 }
 
 $packageJsonFile = "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/test/solution-template-validation-tests/package.json"
 Write-Host "Downloading package.json file from $packageJsonFile"
-Invoke-WebRequest $packageJsonFile -OutFile "package.json"
+Invoke-WebRequest $packageJsonFile -OutFile -UseBasicParsing "package.json"
 
 Write-Host "Listing files downloaded"
 dir


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

