### PR TITLE
Updated VM size and Ubuntu rev

### DIFF
--- a/zabbix-monitoring-cluster/nested/clusterNodes.json
+++ b/zabbix-monitoring-cluster/nested/clusterNodes.json
@@ -37,7 +37,7 @@
       {
         "publisher": "Canonical",
         "offer": "UbuntuServer",
-        "sku": "14.04.3-LTS",
+        "sku": "16.04-LTS",
         "version": "latest"
       },
       {
@@ -61,7 +61,7 @@
     "storageAccountName": "[concat(variables('prefix'),'sto')]",
     "vmStorageAccountContainerName": "vhds",
     "vmName": "[concat(variables('prefix'),'vm')]",
-    "vmSize": "Standard_D2",
+    "vmSize": "Standard_D2_v2",
     "storageAccountType": "Standard_LRS",
     "VMCount": "[parameters('vmCount')]",
     "VMStart": 1


### PR DESCRIPTION
standard_D2 no longer available in all regions; has been replaced with Standard_D2_v2