### PR TITLE
Fixes integer comparison error in `vm-disk-utils-0.1.sh`

### DIFF
--- a/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
+++ b/shared_scripts/ubuntu/vm-disk-utils-0.1.sh
@@ -10,10 +10,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -33,9 +33,9 @@
 # Parameters :
 #  1 - b: The base directory for mount points (default: /datadisks)
 #  2 - s  Create a striped RAID0 Array (No redundancy)
-#  3 - h  Help 
+#  3 - h  Help
 #  4 - o  Mount options for mount points
-# Note : 
+# Note :
 # This script has only been tested on Ubuntu 12.04 LTS and must be root
 
 help()
@@ -67,6 +67,8 @@ fi
 DATA_BASE="/datadisks"
 # Mount options for data disk
 MOUNT_OPTIONS="noatime,nodiratime,nodev,noexec,nosuid,nofail"
+# Determines wheter partition and format data disks as raid set or not
+RAID_CONFIGURATION=0
 
 while getopts b:sho: optname; do
     log "Option $optname set with value ${OPTARG}"
@@ -111,7 +113,7 @@ is_partitioned() {
         return 1
     else
         return 0
-    fi    
+    fi
 }
 
 has_filesystem() {
@@ -279,11 +281,11 @@ create_striped_volume()
 	    PARTITIONS+=("${PARTITION}")
 	done
 
-    MDDEVICE=$(get_next_md_device)    
+    MDDEVICE=$(get_next_md_device)
 	udevadm control --stop-exec-queue
 	mdadm --create ${MDDEVICE} --level 0 -c 64 --raid-devices ${#PARTITIONS[@]} ${PARTITIONS[*]}
 	udevadm control --start-exec-queue
-	
+
 	MOUNTPOINT=$(get_next_mountpoint)
 	echo "Next mount point appears to be ${MOUNTPOINT}"
 	[ -d "${MOUNTPOINT}" ] || mkdir -p "${MOUNTPOINT}"


### PR DESCRIPTION
Fixes integer comparison error by setting default value for RAID_CONFIGURATION

`vm-disk-utils-0.1.sh: line 316: [: :…integer expression expected`

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Fixes integer comparison error  in `vm-disk-utils-0.1.sh: line 316: [: :…integer expression expected`

