### PR TITLE
Updating ADLS deployment template w/ KeyVault encryption

### DIFF
--- a/101-data-lake-store-encryption-key-vault/azuredeploy.json
+++ b/101-data-lake-store-encryption-key-vault/azuredeploy.json
@@ -1,65 +1,121 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "accountName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the Data Lake Store account to create."
-            }
-        },
-        "location": {
-            "type": "string",
-            "allowedValues": [
-                "East US 2",
-                "Central US",
-                "North Europe"
-            ],
-            "defaultValue": "East US 2",
-            "metadata": {
-                "description": "The location in which to create the Data Lake Store account."
-            }
-        },
-        "keyVaultResourceId": {
-            "type": "string",
-            "metadata": {
-                "description": "The Azure Key Vault resource ID."
-            }
-        },
-        "encryptionKeyName": {
-            "type": "string",
-            "metadata": {
-                "description": "The Azure Key Vault encryption key name."
-            }
-        },
-        "encryptionKeyVersion": {
-            "type": "string",
-            "metadata": {
-                "description": "The Azure Key Vault encryption key version."
-            }
-        }
+  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "0.9.0.0",
+  "parameters": {
+    "dataLakeStoreName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Data Lake Store account to create."
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "2016-11-01",
-            "name": "[parameters('accountName')]",
-            "location": "[parameters('location')]",
-            "type": "Microsoft.DataLakeStore/accounts",
-            "properties": {
-                "newTier": "Consumption",
-                "encryptionState": "Enabled",
-                "encryptionConfig": {
-                    "type": "UserManaged",
-                    "keyVaultMetaInfo": {
-                        "keyVaultResourceId": "[parameters('keyVaultResourceId')]",
-                        "encryptionKeyName": "[parameters('encryptionKeyName')]",
-                        "encryptionKeyVersion": "[parameters('encryptionKeyVersion')]"
-                    }
-                }
-            },
-            "identity": {
-                "type": "SystemAssigned"
-            }
+    "location": {
+      "type": "string",
+      "allowedValues": [
+        "East US 2",
+        "Central US",
+        "North Europe"
+      ],
+      "defaultValue": "East US 2",
+      "metadata": {
+        "description": "The location in which to create the Data Lake Store account."
+      }
+    },
+    "keyVaultName": {
+      "type": "string",
+      "metadata": {
+        "description": "The Azure Key Vault name."
+      }
+    },
+    "keyName": {
+      "type": "string",
+      "metadata": {
+        "description": "The Azure Key Vault encryption key name."
+      }
+    },
+    "keyVersion": {
+      "type": "string",
+      "metadata": {
+        "description": "The Azure Key Vault encryption key version."
+      }
+    }
+  },
+  "resources": [
+    {
+      "apiVersion": "2016-11-01",
+      "name": "[parameters('dataLakeStoreName')]",
+      "location": "[parameters('location')]",
+      "type": "Microsoft.DataLakeStore/accounts",
+      "properties": {
+        "encryptionState": "Enabled",
+        "encryptionConfig": {
+          "type": "UserManaged",
+          "keyVaultMetaInfo": {
+            "keyVaultResourceId": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
+            "encryptionKeyName": "[parameters('keyName')]",
+            "encryptionKeyVersion": "[parameters('keyVersion')]"
+          }
         }
-    ]
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      }
+    },
+    {
+      "type": "Microsoft.KeyVault/vaults/accessPolicies",
+      "name": "[concat(parameters('keyVaultName'), '/add')]",
+      "apiVersion": "2015-06-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.DataLakeStore/accounts', parameters('dataLakeStoreName'))]"
+      ],
+      "properties": {
+        "accessPolicies": [
+          {
+            "objectId": "[reference(resourceId('Microsoft.DataLakeStore/accounts', parameters('dataLakeStoreName')), '2016-11-01', 'Full').identity.principalId]",
+            "tenantId": "[reference(resourceId('Microsoft.DataLakeStore/accounts', parameters('dataLakeStoreName')), '2016-11-01', 'Full').identity.tenantId]",
+            "permissions": {
+              "keys": [
+                "encrypt",
+                "decrypt"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "name": "updateAdlsAccount",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults/accessPolicies', parameters('keyVaultName'), 'add')]"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "template": {
+          "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+          "contentVersion": "0.9.0.0",
+          "resources": [
+            {
+              "apiVersion": "2016-11-01",
+              "name": "[parameters('dataLakeStoreName')]",
+              "location": "[parameters('location')]",
+              "type": "Microsoft.DataLakeStore/accounts",
+              "properties": {
+                "encryptionConfig": {
+                  "keyVaultMetaInfo": {
+                    "keyVaultResourceId": "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]",
+                    "encryptionKeyName": "[parameters('keyName')]",
+                    "encryptionKeyVersion": "[parameters('keyVersion')]"
+                  }
+                }
+              },
+              "identity": {
+                "type": "SystemAssigned"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
 }

--- a/101-data-lake-store-encryption-key-vault/azuredeploy.parameters.json
+++ b/101-data-lake-store-encryption-key-vault/azuredeploy.parameters.json
@@ -2,16 +2,16 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-      "accountName": {
+      "dataLakeStoreName": {
         "value": "GEN-UNIQUE"
       },
-      "keyVaultResourceId": {
+      "keyVaultName": {
         "value": "/subscriptions/<SubscriptionID>/resourceGroups/<ResourceGroupName>/providers/Microsoft.KeyVault/vaults/<KeyVaultName>"
       },
-      "encryptionKeyName": {
+      "keyName": {
         "value": "<EncryptionKeyName>"
       },
-      "encryptionKeyVersion": {
+      "keyVersion": {
         "value": "<EncryptionKeyVersion>"
       }
     }

--- a/101-data-lake-store-encryption-key-vault/azuredeploy.parameters.json
+++ b/101-data-lake-store-encryption-key-vault/azuredeploy.parameters.json
@@ -6,7 +6,7 @@
         "value": "GEN-UNIQUE"
       },
       "keyVaultName": {
-        "value": "/subscriptions/<SubscriptionID>/resourceGroups/<ResourceGroupName>/providers/Microsoft.KeyVault/vaults/<KeyVaultName>"
+        "value": "<KeyVaultName>"
       },
       "keyName": {
         "value": "<EncryptionKeyName>"


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Updated 101-data-lake-store-encryption-key-vault to fully configure and enable KeyVault encryption on the Data Lake Store account that is created by the template.
* This change updates the RBAC permissions on the KeyVault key to allow the ADLS account's MSI to access the key to enable encryption. This change also notifies the ADLS account that the permissions have been updated, so that the encryption settings can be confirmed.

