### PR TITLE
Remove WEBSITE_CONTENTSHARE

### DIFF
--- a/101-function-app-create-dynamic/azuredeploy.json
+++ b/101-function-app-create-dynamic/azuredeploy.json
@@ -76,10 +76,6 @@
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
                         },
                         {
-                            "name": "WEBSITE_CONTENTSHARE",
-                            "value": "[toLower(variables('functionAppName'))]"
-                        },
-                        {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
                             "value": "~1"
                         },


### PR DESCRIPTION
This setting is no longer needed, and not having it here will help reduce confusion.