### PR TITLE
Fix msi permissions

### DIFF
--- a/201-vm-msi-linux-terraform/README.md
+++ b/201-vm-msi-linux-terraform/README.md
@@ -17,3 +17,13 @@ This template creates a Terraform workstation as follows:
 
 This template creates a new Linux VM with a MSI and deploys the MSI extension to the VM. The MSI associated with the VM is given owner permission on the resource group containing the VM. A shell script is then run on the VM using the customscript extension. This shell script installs Terraform and Azure CLI v2. It then creates a Terraform template folder that is preconfigured to use Terraform Remote State with the Azure backend. The Azure CLI also creates the storage container required by remote state.  Optionally, this template installs Ubuntu Mate Desktop environment for usage as develolpment environment. 
 
+
+### Steps to enable Remote State
+Copy remoteState.tf from home directory to the root of the Terraform scripts to enable remote state management
+
+### Steps to enable MSI
+Once the template is deployed, log into the vm and run the following command to enable MSI with terraform
+
+     `sh ~/tfEnv.sh`
+
+

--- a/201-vm-msi-linux-terraform/README.md
+++ b/201-vm-msi-linux-terraform/README.md
@@ -19,7 +19,7 @@ This template creates a new Linux VM with a MSI and deploys the MSI extension to
 
 
 ### Steps to enable Remote State
-Copy remoteState.tf from home directory to the root of the Terraform scripts to enable remote state management
+Copy ~/tfTemplate/remoteState.tf from home directory to the root of the Terraform scripts to enable remote state management
 
 ### Steps to enable MSI
 Once the template is deployed, log into the vm and run the following command to enable MSI with terraform

--- a/201-vm-msi-linux-terraform/scripts/install.sh
+++ b/201-vm-msi-linux-terraform/scripts/install.sh
@@ -87,7 +87,6 @@ done
 
 TEMPLATEFOLDER="/home/$USERNAME/tfTemplate"
 REMOTESTATEFILE="$TEMPLATEFOLDER/remoteState.tf"
-ACCESSKEYFILE="/home/$USERNAME/access_key"
 TFENVFILE="/home/$USERNAME/tfEnv.sh"
 CREDSFILE="$TEMPLATEFOLDER/azureProviderAndCreds.tf"
 
@@ -108,12 +107,6 @@ echo "}"                                                    >> $REMOTESTATEFILE
 chmod 666 $REMOTESTATEFILE
 
 chown -R $USERNAME:$USERNAME /home/$USERNAME/tfTemplate
-
-touch $ACCESSKEYFILE
-echo "access_key = \"$STORAGE_ACCOUNT_KEY\""                >> $ACCESSKEYFILE
-chmod 666 $ACCESSKEYFILE
-chown $USERNAME:$USERNAME $ACCESSKEYFILE
-
 
 touch $TFENVFILE
 echo "export ARM_SUBSCRIPTION_ID=\"$SUBSCRIPTION_ID\""     >> $TFENVFILE

--- a/201-vm-msi-linux-terraform/scripts/install.sh
+++ b/201-vm-msi-linux-terraform/scripts/install.sh
@@ -102,6 +102,7 @@ echo " backend \"azurerm\" {"                               >> $REMOTESTATEFILE
 echo "  storage_account_name = \"$STORAGE_ACCOUNT_NAME\""   >> $REMOTESTATEFILE
 echo "  container_name       = \"terraform-state\""         >> $REMOTESTATEFILE
 echo "  key                  = \"prod.terraform.tfstate\""  >> $REMOTESTATEFILE
+echo "  access_key           = \"$STORAGE_ACCOUNT_KEY\""    >> $REMOTESTATEFILE
 echo "  }"                                                  >> $REMOTESTATEFILE
 echo "}"                                                    >> $REMOTESTATEFILE
 chmod 666 $REMOTESTATEFILE
@@ -113,9 +114,12 @@ echo "access_key = \"$STORAGE_ACCOUNT_KEY\""                >> $ACCESSKEYFILE
 chmod 666 $ACCESSKEYFILE
 chown $USERNAME:$USERNAME $ACCESSKEYFILE
 
+
 touch $TFENVFILE
-echo "export ARM_SUBSCRIPTION_ID =\"$SUBSCRIPTION_ID\""     >> $TFENVFILE
-echo "export ARM_CLIENT_ID       =\"$MSI_PRINCIPAL_ID\""    >> $TFENVFILE
+echo "export ARM_SUBSCRIPTION_ID=\"$SUBSCRIPTION_ID\""     >> $TFENVFILE
+echo "export ARM_CLIENT_ID=\"$MSI_PRINCIPAL_ID\""          >> $TFENVFILE
+echo "az login"                                            >> $TFENVFILE
+echo "az role assignment create  --assignee \"$MSI_PRINCIPAL_ID\" --role 'b24988ac-6180-42a0-ab88-20f7382dd24c'  --scope /subscriptions/\"$SUBSCRIPTION_ID\""  >> $TFENVFILE
 chmod 755 $TFENVFILE
 chown $USERNAME:$USERNAME $TFENVFILE
 


### PR DESCRIPTION
Fixing MSI permissions issue where the VM identity required contributor permissions for entire subscription. We are now adding one script and that will make it easy. 

Also fixing remoteState.tf file to have access_key. 