### PR TITLE
fixes #4323 artificats location is fork repo until PR passes

### DIFF
--- a/ubuntu-tensorflow-cocoapi/README.md
+++ b/ubuntu-tensorflow-cocoapi/README.md
@@ -1,0 +1,25 @@
+# A sample to run scripts in public storage using CustomScript Extension
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fubuntu-tensorflow-cocoapi%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fubuntu-tensorflow-cocoapi%2Fazuredeploy.json" target="_blank">
+    <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+[CustomScript Extension](https://github.com/Azure/azure-linux-extensions/tree/master/CustomScript) allows the owner of the Azure Virtual Machines to run customized scripts in the VM.
+
+This template shows a simple example to run scripts which are stored in public storage(e.g. Github).
+
+## Deploy
+
+1. Using Azure CLI
+
+  https://azure.microsoft.com/en-us/documentation/articles/xplat-cli-azure-resource-manager/
+
+2. Using Powershell
+
+  https://azure.microsoft.com/en-us/documentation/articles/powershell-azure-resource-manager/
+
+3. Using Azure Portal
+  Click the "Deploy to Azure" button.

--- a/ubuntu-tensorflow-cocoapi/azuredeploy.json
+++ b/ubuntu-tensorflow-cocoapi/azuredeploy.json
@@ -1,0 +1,201 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmSize": {
+      "type": "string",
+      "allowedValues": [
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_D1",
+        "Standard_D2",
+        "Standard_D3",
+        "Standard_D4"
+      ],
+      "metadata": {
+        "description": "Size of vm"
+      }
+    },
+    "username": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
+    },
+    "password": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Password for the Virtual Machine."
+      }
+    },
+    "dnsNameForPublicIP": {
+      "type": "string",
+      "metadata": {
+        "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
+      }
+    },
+    "_artifactsLocation": {
+      "defaultValue": "https://github.com/JayDevOps/azure-quickstart-templates/blob/vm-ubuntu-tensorflow-cocoapi/ubuntu-tensorflow-cocoapi/",
+      "type": "string",
+      "metadata": {
+        "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+      }
+    },
+    "_artifactsLocationSasToken": {
+      "defaultValue": "",
+      "type": "securestring",
+      "metadata": {
+        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+      }
+    },
+    "commandToExecute": {
+      "type": "string",
+      "metadata": {
+        "description": "The command to execute."
+      }
+    }
+  },
+  "variables": {
+    "extensionName": "CustomScript",
+    "scenarioPrefix": "customscriptLinux",
+    "apiVersion": "2015-05-01-preview",
+    "imagePublisher": "Canonical",
+    "imageOffer": "UbuntuServer",
+    "ubuntuOSVersion": "17.10",
+    "OSDiskName": "[concat(variables('scenarioPrefix'),'OSDisk')]",
+    "nicName": "[concat(variables('scenarioPrefix'),'Nic')]",
+    "vnetAddressPrefix": "10.0.0.0/16",
+    "subnetName": "[concat(variables('scenarioPrefix'),'Subnet')]",
+    "subnetPrefix": "10.0.0.0/24",
+    "storageAccountType": "Standard_LRS",
+    "publicIPAddressName": "[concat(variables('scenarioPrefix'),'PublicIp')]",
+    "publicIPAddressType": "Dynamic",
+    "vmStorageAccountContainerName": "vhds",
+    "vmName": "[concat(variables('scenarioPrefix'),'VM')]",
+    "virtualNetworkName": "[concat(variables('scenarioPrefix'),'Vnet')]",
+    "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
+    "subnetRef": "[concat(variables('vnetID'),'/subnets/',variables('subnetName'))]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
+        }
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/virtualNetworks",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('subnetPrefix')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2015-05-01-preview",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('nicName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
+        "[concat('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('subnetRef')]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2016-04-30-preview",
+      "type": "Microsoft.Compute/virtualMachines",
+      "name": "[variables('vmName')]",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "osProfile": {
+          "computerName": "[variables('vmName')]",
+          "adminUsername": "[parameters('username')]",
+          "adminPassword": "[parameters('password')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "[variables('imagePublisher')]",
+            "offer": "[variables('imageOffer')]",
+            "sku": "[variables('ubuntuOSVersion')]",
+            "version": "latest"
+          },
+          "osDisk": {
+            "caching": "ReadWrite",
+            "createOption": "FromImage"
+          }
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicName'))]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(variables('vmName'),'/installcustomscript')]",
+      "apiVersion": "2015-05-01-preview",
+      "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
+      ],
+      "properties": {
+        "publisher": "Microsoft.Azure.Extensions",
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.0",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "fileUris": [
+            "[concat(parameters('_artifactsLocation'), '/scripts/installtensor.sh')]"
+          ],
+          "commandToExecute": "[parameters('commandToExecute')]"
+        }
+      }
+    }
+  ]
+}

--- a/ubuntu-tensorflow-cocoapi/azuredeploy.parameters.json
+++ b/ubuntu-tensorflow-cocoapi/azuredeploy.parameters.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "username": {
+      "value": "azureuser"
+    },
+    "password": {
+      "value": "GEN-PASSWORD"
+    },
+    "vmSize": {
+      "value": "Standard_D1"
+    },
+    "dnsNameForPublicIP": {
+      "value": "GEN-UNIQUE"
+    },
+    "commandToExecute": {
+      "value": "sudo sh installtensorflow.sh"
+    }
+  }
+}

--- a/ubuntu-tensorflow-cocoapi/metadata.json
+++ b/ubuntu-tensorflow-cocoapi/metadata.json
@@ -1,0 +1,7 @@
+{
+  "itemDisplayName": "Ubuntu VM with TensorFlow and CocoAPI installed",
+  "description": "This template creates a Ubuntu VM and installs TensorFlow and CocoAPI",
+  "summary": "This template creates a Ubuntu VM and installs TensorFlow and CocoAPI",
+  "githubUsername": "jaydevops",
+  "dateUpdated": "2018-02-25"
+}

--- a/ubuntu-tensorflow-cocoapi/scripts/installtensorflow.sh
+++ b/ubuntu-tensorflow-cocoapi/scripts/installtensorflow.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# print commands and arguments as they are executed
+set -x
+
+echo 'hello'
+
+echo "starting ubuntu tensorflow install on pid $$"
+date
+ps axjf
+
+#############
+# Parameters
+#############
+
+AZUREUSER=$1
+HOMEDIR="/home/$AZUREUSER"
+VMNAME=`hostname`
+echo "User: $AZUREUSER"
+echo "User home dir: $HOMEDIR"
+echo "vmname: $VMNAME"
+
+###################
+# Common Functions
+###################
+
+ensureAzureNetwork()
+{
+  # ensure the host name is resolvable
+  hostResolveHealthy=1
+  for i in {1..120}; do
+    host $VMNAME
+    if [ $? -eq 0 ]
+    then
+      # hostname has been found continue
+      hostResolveHealthy=0
+      echo "the host name resolves"
+      break
+    fi
+    sleep 1
+  done
+  if [ $hostResolveHealthy -ne 0 ]
+  then
+    echo "host name does not resolve, aborting install"
+    exit 1
+  fi
+
+  # ensure the network works
+  networkHealthy=1
+  for i in {1..12}; do
+    wget -O/dev/null http://bing.com
+    if [ $? -eq 0 ]
+    then
+      # hostname has been found continue
+      networkHealthy=0
+      echo "the network is healthy"
+      break
+    fi
+    sleep 10
+  done
+  if [ $networkHealthy -ne 0 ]
+  then
+    echo "the network is not healthy, aborting install"
+    ifconfig
+    ip a
+    exit 2
+  fi
+}
+ensureAzureNetwork
+
+time  apt-get -y update
+
+echo 'system updated'
+
+pip3Install() {
+    time  apt install -y python3-pip 
+}
+pip3Install
+
+echo 'pip3 installed'
+
+tensorflowInstall() {
+    time pip3 install tensorflow
+    time  apt-get install -y protobuf-compiler python-pil python-lxml python-tk
+    time  pip3 install pillow
+    time  pip3 install lxml
+    time  pip3 install jupyter
+    time  apt-get install -y openjdk-8-jdk
+    time  apt-get install -y python3-numpy python3-dev python3-pip python3-wheel
+    time pip3 install --no-binary --no-cache-dir Cython
+}
+
+echo 'tensorflow installed'
+
+tensorFlow="$HOMEDIR/.local/lib/python3.6/site-packages/tensorflow"
+
+copyModels() {
+    time git clone https://github.com/tensorflow/models.git
+    time  cp -r models $tensorFlow/
+}
+
+copyModels
+
+echo 'models copied'
+
+echo 'using forked branch of cocoapi to support python3'
+
+installCocoAPI() {
+    cd $HOMEDIR
+    git clone https://github.com/JayDevOps/cocoapi.git
+    cd cocoapi/PythonAPI/
+    time  git checkout python3X-compat
+    time  make -w
+    time  make install -w
+    cd $HOMEDIR/cocoapi/PythonAPI/
+    cp -r pycocotools $tensorFlow/models/research/
+    cd $tensorFlow/models/research/
+    protoc object_detection/protos/*.proto --python_out=.
+    ls $HOMEDIR/.bashrc | while read file; do
+        (echo 'export PYTHONPATH=$PYTHONPATH':`pwd`:`pwd`/slim; cat ${file} ) > ${file}.new && mv ${file}.new ${file};
+        done
+     source $HOMEDIR/.bashrc
+}
+installCocoAPI
+echo 'cocoAPI install completed'


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* added a ubuntu vm tensor flow template. 
* a forked cocoapi is used at this time to support python3. A separate fix is submitted to that repo. Until that is accepted, this fork will work and maintained for new updates in cocoapi upstream
* Also many other linux templates have issues to be used since sh to update fails as it requires sudo and the script is "sh script.sh" Creating a separate ticket for this issue

