### PR TITLE
Removed unnecessary "/"

### DIFF
--- a/101-hdinsight-linux-add-edge-node/azuredeploy.json
+++ b/101-hdinsight-linux-add-edge-node/azuredeploy.json
@@ -13,7 +13,7 @@
           "metadata": {
               "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
           },
-          "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-hdinsight-linux-add-edge-node/"
+          "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-hdinsight-linux-add-edge-node"
       },
     "_artifactsLocationSasToken": {
           "type": "securestring",

--- a/101-hdinsight-linux-add-edge-node/metadata.json
+++ b/101-hdinsight-linux-add-edge-node/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template allows you to create an empty edge node and add it to an existing HDInsight cluster. For more information, see https://docs.microsoft.com/azure/hdinsight/hdinsight-apps-use-edge-node",
   "summary": "Deploy an empty edge node and add it to an existing HDInsight cluster",
   "githubUsername": "mumian",
-  "dateUpdated": "2017-12-15"
+  "dateUpdated": "2018-03-14"
 }

--- a/101-hdinsight-linux-with-edge-node/azuredeploy.json
+++ b/101-hdinsight-linux-with-edge-node/azuredeploy.json
@@ -39,7 +39,7 @@
           "metadata": {
               "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
           },
-          "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-hdinsight-linux-with-edge-node/"
+          "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-hdinsight-linux-with-edge-node"
       },
     "_artifactsLocationSasToken": {
           "type": "securestring",

--- a/101-hdinsight-linux-with-edge-node/metadata.json
+++ b/101-hdinsight-linux-with-edge-node/metadata.json
@@ -3,5 +3,5 @@
   "description": "This template allows you to create an HDInsight cluster running Linux with an empty edge node. For more information, see https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-apps-use-edge-node",
   "summary": "Deploy a Linux-based HDInsight cluster with an empty edge node",
   "githubUsername": "mumian",
-  "dateUpdated": "2017-12-15"
+  "dateUpdated": "2018-03-14"
 }


### PR DESCRIPTION
Slashes are added appropriately in the concatenation of the URI in the
installScriptActions block. Leaving a trailing "/" at the end of the
_artifactsLocation parameter actually results in two consecutive slashes
in the URI, but it does not create an error because GitHub handles the
mistake elegantly. However, this creates a somewhat misleading example,
which can cause problems if this same pattern is used to refer to
websites which do not handle the redundant "/" automatically.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

