### PR TITLE
[AUTO] for mysql-ha-pxc-zones

### DIFF
--- a/mysql-ha-pxc-zones/azuredeploy.json
+++ b/mysql-ha-pxc-zones/azuredeploy.json
@@ -285,7 +285,7 @@
               "count": 2,
               "input": {
                 "lun": "[copyIndex('dataDisks')]",
-                "createOption": "attach",
+                "createOption": "Attach",
                 "managedDisk": {
                   "id": "[resourceId('Microsoft.Compute/disks', concat('disk-', add(mul(copyIndex(), 2), add(copyIndex('dataDisks'), 1))))]"
                 }


### PR DESCRIPTION
Changes to comply to [schema](https://github.com/Azure/azure-resource-manager-schemas) and validations made with [validator](https://github.com/Nepomuceno/arm-validation) 
 Most of this changes were auto generated