### PR TITLE
Revert "Updated Schema and removed hard coded region parameter for ASE"

### DIFF
--- a/201-web-app-asev2-create/README.md
+++ b/201-web-app-asev2-create/README.md
@@ -7,6 +7,4 @@
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-Template creates an App Service Environment v2 in your existing virtual network.
-
 For more details on App Service Environments, see the [Introduction to App Service Environments](https://docs.microsoft.com/en-us/azure/app-service/app-service-environment/intro).

--- a/201-web-app-asev2-create/azuredeploy.json
+++ b/201-web-app-asev2-create/azuredeploy.json
@@ -12,7 +12,7 @@
             "type": "string",
             "defaultValue": "South Central US",
             "metadata": { 
-                "description": "Location of the App Service Environment, must be the same region as virtual network" 
+                "description": "Location of the App Service Environment" 
             } 
          }, 
         "existingVnetResourceId": {
@@ -30,7 +30,7 @@
     },
     "resources": [
       {
-        "apiVersion": "2016-09-01",
+        "apiVersion": "2015-08-01",
         "type": "Microsoft.Web/hostingEnvironments",
         "name": "[parameters('aseName')]",
         "kind": "ASEV2",

--- a/201-web-app-asev2-create/metadata.json
+++ b/201-web-app-asev2-create/metadata.json
@@ -3,5 +3,5 @@
   "description": "Creates an App Service Environment v2 in your virtual network",
   "summary": "Create an App Service Environment v2",
   "githubUsername": "stefsch",
-  "dateUpdated": "2018-03-27"
+  "dateUpdated": "2017-06-15"
 }

--- a/201-web-app-asev2-ilb-create/azuredeploy.json
+++ b/201-web-app-asev2-ilb-create/azuredeploy.json
@@ -12,7 +12,7 @@
             "type": "string",
             "defaultValue": "South Central US",
             "metadata": { 
-                "description": "Location of the App Service Environment, must be the same region of the existing virtual network" 
+                "description": "Location of the App Service Environment" 
             } 
          },
         "existingVnetResourceId": {
@@ -28,27 +28,23 @@
             }
         },
         "internalLoadBalancingMode": {
-            "type": "string",
-            "defaultValue": "Web",
-            "allowedValues": [
-                "None",
-                "Publishing",
-                "Web"
-            ],
+            "type": "int",
+            "defaultValue": 3,
+            "allowedValues": [0,1,2,3],
             "metadata": {
-                "description": "None = public VIP only, Publishing = only FTP ports are mapped to ILB VIP, Web = only ports 80/443 are mapped to ILB VIP."
+                "description": "0 = public VIP only, 1 = only ports 80/443 are mapped to ILB VIP, 2 = only FTP ports are mapped to ILB VIP, 3 = both ports 80/443 and FTP ports are mapped to an ILB VIP."
             }
         },
         "dnsSuffix": {
             "type": "string",
             "metadata": {
-                "description": "Used *only* when deploying an ILB enabled ASE in Web mode.  Set this to the root domain associated with the ASE.  For example: contoso.com"
+                "description": "Used *only* when deploying an ILB enabled ASE.  Set this to the root domain associated with the ASE.  For example: contoso.com"
             }
         }
     },
     "resources": [
       {
-        "apiVersion": "2016-09-01",
+        "apiVersion": "2015-08-01",
         "type": "Microsoft.Web/hostingEnvironments",
         "name": "[parameters('aseName')]",
         "kind": "ASEV2",

--- a/201-web-app-asev2-ilb-create/azuredeploy.parameters.json
+++ b/201-web-app-asev2-ilb-create/azuredeploy.parameters.json
@@ -15,7 +15,7 @@
             "value": "changeme"
         },
         "internalLoadBalancingMode": {
-            "value": "Web"
+            "value": 3
         },
         "dnsSuffix": {
             "value": "changeme"

--- a/201-web-app-asev2-ilb-create/metadata.json
+++ b/201-web-app-asev2-ilb-create/metadata.json
@@ -3,5 +3,5 @@
   "description": "Creates an App Service Environment v2 in your virtual network with a private internal load balancer address",
   "summary": "Create an App Service Environment v2 with an ILB Address",
   "githubUsername": "stefsch",
-  "dateUpdated": "2018-03-27"
+  "dateUpdated": "2017-06-15"
 }


### PR DESCRIPTION
Reverts Azure/azure-quickstart-templates#4480

@bmoore-msft - Inconsistency found between schema versions that can limit the options for ILB mode when deploying with ARM template versus deploying in Azure Portal. Revert will bring template to schema version that does not have issue, until further investigation can be done. 