### PR TITLE
updates to account for existing resourceGroups

### DIFF
--- a/Deploy-AzureResourceGroup.ps1
+++ b/Deploy-AzureResourceGroup.ps1
@@ -119,8 +119,10 @@ else {
 
 $TemplateArgs.Add('TemplateParameterFile', $TemplateParametersFile)
 
-# Create or update the resource group using the specified template file and template parameters file
-New-AzureRmResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation -Verbose -Force -ErrorAction Stop 
+# Create the resource group only when it doesn't already exist
+if ((Get-AzureRmresourcegroup -Name $ResourceGroupName -Location $ResourceGroupLocation -Verbose -Force -ErrorAction SilentlyContinue) -eq $null) {
+    New-AzureRmResourceGroup -Name $ResourceGroupName -Location $ResourceGroupLocation -Verbose -Force -ErrorAction Stop
+}
 
 if ($ValidateOnly) {
     $ErrorMessages = Format-ValidationOutput (Test-AzureRmResourceGroupDeployment -ResourceGroupName $ResourceGroupName `

--- a/az-group-deploy.sh
+++ b/az-group-deploy.sh
@@ -115,7 +115,12 @@ then
 
 fi
 
-az group create -n "$resourceGroupName" -l "$location"
+# Create the resource group only if it doesn't already exist
+targetResourceGroup=$( az group list -o json | jq -r '.[] | select(.name == '\"$resourceGroupName\"')'.name )
+if [[ -z $targetResourceGroup ]] 
+then
+    az group create -n "$resourceGroupName" -l "$location"
+fi   
 
 # Remove line endings from parameter JSON so it can be passed in to the CLI as a single line
 parameterJson=$( echo "$parameterJson" | jq -c '.' )


### PR DESCRIPTION
### Changelog

* When the resourceGroup already exists, the scripts will PUT on the resourceGroup which can remove tags if the tags aren't included in the PUT - so this will "PUT" only when the group does not already exist.


