### PR TITLE
fix location error for eventhub template

### DIFF
--- a/201-eventhubs-create-namespace-and-enable-capture-for-adls/azuredeploy.json
+++ b/201-eventhubs-create-namespace-and-enable-capture-for-adls/azuredeploy.json
@@ -107,6 +107,7 @@
       "apiVersion": "2017-04-01",
       "name": "[parameters('eventHubNamespaceName')]",
       "type": "Microsoft.EventHub/Namespaces",
+      "location": "[resourceGroup().location]",
       "sku": {
         "name": "Standard",
         "tier": "Standard"


### PR DESCRIPTION
The eventhub capturing to Azure data lake storage does not work, because of the following error:

```
t.guo@KI-3033 ~/workspace/ $ az group deployment create --name EventHubDeploy --resource-group data --template-file eventhub.json --parameters @eventhub-parameters.json
Deployment failed. Correlation ID: e7019dcd-7d2f-4f8c-81f7-b6e76f976905. {
  "error": {
    "code": "LocationRequired",
    "message": "The location property is required for this definition."
  }
}
```

Seems it's because the location parameter is missing from the eventhub namespace hence I add it according to other templates to use the location of the resource group by default.