### PR TITLE
Updated to use Managed Disks - Removed Technical Preview

### DIFF
--- a/windows-server-containers-preview/README.md
+++ b/windows-server-containers-preview/README.md
@@ -1,4 +1,4 @@
-# Windows Server 2016 Technical Preview - Containers
+# Windows Server 2016 - Containers
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fwindows-server-containers-preview%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
@@ -7,17 +7,6 @@
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-The template will deploy a Windows Server 2016 Technical Preview virtual machine with Windows containers. 
+The template will deploy a Windows Server 2016 with Windows containers. 
 
-The following actions are completed:
-
-- Deploy the Windows Server 2016 Technical Preview system.
-- Enable the Windows containers role.
-- Download and install the Windows Server Core container base OS image.
-- Download and configure Docker.
-
-Once the template has been deployed, the virtual machine will be rebooted. At first logon, a second configuration script will be run to complete the process. Due to a large download, this configuration can take quite some time.
-
-Windows Server 2016 TP5 and Windows Containers are in an early preview release and are not production ready or supported.
-
-> Microsoft Azure does not support Hyper-V containers. To complete Hyper-V Container exercises, you need an on-premises container host.    
+> Microsoft Azure does not support Hyper-V containers. To complete Hyper-V Container exercises, you need an on-premises container host.

--- a/windows-server-containers-preview/azuredeploy.json
+++ b/windows-server-containers-preview/azuredeploy.json
@@ -42,11 +42,9 @@
     }
   },
   "variables": {
-    "storageAccountName": "[concat(uniquestring(resourceGroup().id),'storage')]",
-    "windowsOSVersion": "Windows-Server-Technical-Preview",
-    "imagePublisher": "MicrosoftWindowsServer",
+    "windowsOSVersion": "2016-Datacenter-with-Containers",
+    "imagePublisher": "MicrosoftWIndowsServer",
     "imageOffer": "WindowsServer",
-    "OSDiskName": "[concat(parameters('VMName'),'_osdisk')]",
     "nicName": "[concat(parameters('VMName'),'_nic')]",
     "addressPrefix": "10.0.0.0/16",
     "subnetName": "[concat(parameters('VMName'),'_subnet')]",
@@ -55,8 +53,6 @@
     "storageAccountType": "Standard_LRS",
     "publicIPAddressName": "[concat(parameters('VMName'),'_pubip')]",
     "publicIPAddressType": "Dynamic",
-    "vmStorageAccountContainerName": "vhds",
-    "apiVersion": "2015-05-01-preview",
     "virtualNetworkName": "[concat(parameters('VMName'),'_vnet')]",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
   },
@@ -111,18 +107,6 @@
             }
           }
         ]
-      }
-    },
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountName')]",
-      "apiVersion": "2015-05-01-preview",
-      "location": "[parameters('location')]",
-      "tags": {
-        "displayName": "StorageAccount"
-      },
-      "properties": {
-        "accountType": "[variables('storageAccountType')]"
       }
     },
     {
@@ -200,7 +184,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2017-03-30",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('VMName')]",
       "location": "[parameters('location')]",
@@ -208,7 +192,6 @@
         "displayName": "VirtualMachine"
       },
       "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('nicName'))]"
       ],
       "properties": {
@@ -228,12 +211,12 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "osdisk",
-            "vhd": {
-              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName')), variables('apiVersion')).primaryEndpoints.blob, variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-            },
+            "name": "[concat(parameters('VMName'), '_OSDisk')]",
             "caching": "ReadWrite",
-            "createOption": "FromImage"
+            "createOption": "FromImage",
+            "managedDisk": {
+              "storageAccountType": "[variables('storageAccountType')]"
+            }
           }
         },
         "networkProfile": {
@@ -243,33 +226,7 @@
             }
           ]
         }
-      },
-      "resources": [
-        {
-          "name": "containerConfiguration",
-          "type": "extensions",
-          "location": "[parameters('location')]",
-          "apiVersion": "2015-06-15",
-          "dependsOn": [
-            "[concat('Microsoft.Compute/virtualMachines/', parameters('VMName'))]"
-          ],
-          "tags": {
-            "displayName": "containerConfiguration"
-          },
-          "properties": {
-            "publisher": "Microsoft.Compute",
-            "type": "CustomScriptExtension",
-            "typeHandlerVersion": "1.2",
-            "autoUpgradeMinorVersion": true,
-            "settings": {
-              "fileUris": [
-                "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/windows-server-containers-preview/azure-containers.ps1"
-              ],
-              "commandToExecute": "[concat('powershell.exe -ExecutionPolicy Unrestricted -File azure-containers.ps1 -adminuser ',parameters('adminUsername'))]"
-            }
-          }
-        }
-      ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Updated template for Managed Disks
Windows Server 2016 is GA for Containers.  Removed the temporary scripts to enable containers and used the default gallery image.

Note: I think we should delete this template now that we have an image specifically for containers in the marketplace.  Windows Server 2016 is no longer in Technical Preview.