### PR TITLE
Fix the MSI breaking change and Azure CLI signing certificate change

### DIFF
--- a/201-vm-msi-linux-terraform/scripts/infra.sh
+++ b/201-vm-msi-linux-terraform/scripts/infra.sh
@@ -25,7 +25,7 @@ unset TF_VERSION
 
 echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ wheezy main" | sudo tee /etc/apt/sources.list.d/azure-cli.list
 
-apt-key adv --keyserver packages.microsoft.com --recv-keys 52E16F86FEE04B979B07E28DB02C46DF417A0893
+sudo curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
 
 apt-get install apt-transport-https
 

--- a/201-vm-msi-linux-terraform/scripts/install.sh
+++ b/201-vm-msi-linux-terraform/scripts/install.sh
@@ -113,10 +113,11 @@ chmod 666 $REMOTESTATEFILE
 chown -R $USERNAME:$USERNAME /home/$USERNAME/tfTemplate
 
 # Set these variables in the profile
-echo "export ARM_SUBSCRIPTION_ID=\"$SUBSCRIPTION_ID\""      >> $PROFILEFILE
-echo "export ARM_USE_MSI=true"                              >> $PROFILEFILE
-echo "export ARM_MSI_ENDPOINT=\"http://localhost:50342\""   >> $PROFILEFILE
-echo "export ARM_TENANT_ID=\"$TENANT_ID\""                  >> $PROFILEFILE
+echo "export ARM_SUBSCRIPTION_ID=\"$SUBSCRIPTION_ID\""                                     >> $PROFILEFILE
+echo "export ARM_CLIENT_ID=\"$MSI_PRINCIPAL_ID\""                                          >> $PROFILEFILE
+echo "export ARM_USE_MSI=true"                                                             >> $PROFILEFILE
+echo "export ARM_MSI_ENDPOINT=\"http://169.254.169.254/metadata/identity/oauth2/token\""   >> $PROFILEFILE
+echo "export ARM_TENANT_ID=\"$TENANT_ID\""                                                 >> $PROFILEFILE
 
 # Add contributor permissions to the MSI for entire subscription
 touch $TFENVFILE
@@ -128,7 +129,7 @@ chown $USERNAME:$USERNAME $TFENVFILE
 
 # create the container for remote state
 logger -t devvm "Creating the container for remote state"
-az login --msi
+az login --identity
 az storage container create -n terraform-state --account-name $STORAGE_ACCOUNT_NAME --account-key $STORAGE_ACCOUNT_KEY
 logger -t devvm "Container for remote state created: $?"
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

