### PR TITLE
AvailabilitySets failing as it needs sku name

### DIFF
--- a/301-storage-spaces-direct/nestedtemplates/deploy-s2d-cluster.json
+++ b/301-storage-spaces-direct/nestedtemplates/deploy-s2d-cluster.json
@@ -137,19 +137,15 @@
     {
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[variables('vmAvailabilitySetName')]",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2017-12-01",
       "location": "[parameters('location')]",
-      "properties": {}
-    },
-    {
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('witnessStorageName')]",
-      "apiVersion": "2016-01-01",
-      "location": "[parameters('location')]",
-      "sku": {
-        "name": "[variables('witnessStorageType')]"
+     "sku": {
+      "name": "Aligned"
       },
-      "kind": "Storage"
+      "properties": {
+        "platformUpdateDomainCount": "2",
+        "platformFaultDomainCount": "2"       
+      },
     },
     {
       "type": "Microsoft.Storage/storageAccounts",


### PR DESCRIPTION
Script fails as it needs the sku name set to aligned if managed disks are used. I also had to change teh apiVersion

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

