### PR TITLE
location value of each resource should be an expression

### DIFF
--- a/test/template-validation-tests/test/mainTemplateTests.js
+++ b/test/template-validation-tests/test/mainTemplateTests.js
@@ -108,11 +108,11 @@ describe('template files - ', () => {
             var resources = Object.keys(templateObject.resources).map(function(key) {
                 return templateObject.resources[key];
             });
-            /** Each resource location should be "location": "[parameters('*')]" or ""[variables('*')]"" */
-            it.each(resources, 'location value of resource %s should be either [parameters(\'*\')] or [variables(\'*\')]', ['name'], function(element, next) {
-                var message = 'in file:' + templateJSONObject.filename + ' should have location set to [parameters(\'location\')] or [variables(\'location\')]';
+            /** Each resource location should be "location": "[*]" */
+            it.each(resources, 'location value of resource %s should be an expression', ['name'], function(element, next) {
+                var message = 'in file:' + templateJSONObject.filename + ' should have location set to an expression';
                 if (element.location) {
-                    element.location.should.withMessage(getErrorMessage(element, templateJSONObject.filepath, message)).match(/\[parameters\('.+'\)\]|\[variables\('.+'\)\]/);
+                    element.location.should.withMessage(getErrorMessage(element, templateJSONObject.filepath, message)).match(/\[.+\]/);
                 }
                 next();
             });


### PR DESCRIPTION
Let's check to ensure that:
1) the location property value must be an expression (starts with "[" and ends with "]" (fixed in this PR)
AND
2) does not contain "resourceGroup().location" in the property value (Already checked for resourceGroup().location)

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

