### PR TITLE
Update azuredeploy.json

### DIFF
--- a/201-site-to-site-vpn/azuredeploy.json
+++ b/201-site-to-site-vpn/azuredeploy.json
@@ -112,6 +112,13 @@
         "description": "Name of the sample VM to create"
       }
     },
+    "vmImageSKU":{
+      "type": "string",
+      "defaultValue": "14.04.5-LTS",
+      "metadata": {
+        "description": "VM Image SKU"
+      }
+    },
     "vmSize": {
       "type": "string",
       "defaultValue": "Standard_A1",
@@ -172,13 +179,13 @@
   "variables": {
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
-    "imageSKU": "14.04.2-LTS",
+    "imageSKU": "[parameters('vmImageSKU')]",
     "gatewaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), 'GatewaySubnet')]",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnetName'))]",
     "nicName": "[concat(parameters('vmName'), '-nic')]",
-    "vmStorageAccountContainerName": "vhds",
-    "OSDiskName": "osDisk",
-    "vmPublicIPName": "[concat(parameters('vmName'), '-publicIP')]"
+    "vmPublicIPName": "[concat(parameters('vmName'), '-publicIP')]",
+    "OSDiskName": "osdisk",
+    "vmStorageAccountContainerName":"vhds"
   },
   "resources": [
     {
@@ -262,7 +269,7 @@
       }
     },
     {
-      "apiVersion": "2015-05-01-preview",
+      "apiVersion": "2015-06-15",
       "name": "[parameters('newStorageAccountName')]",
       "location": "[resourceGroup().location]",
       "type": "Microsoft.Storage/storageAccounts",
@@ -356,12 +363,11 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "osdisk1",
+            "createOption": "FromImage",
+            "name": "osdisk",
             "vhd": {
-              "uri": "[concat('http://',parameters('newStorageAccountName'),'.blob.core.windows.net/',variables('vmStorageAccountContainerName'),'/',variables('OSDiskName'),'.vhd')]"
-            },
-            "caching": "ReadWrite",
-            "createOption": "FromImage"
+              "uri": "[concat(reference(concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob, variables('vmStorageAccountContainerName'),'/', variables('OSDiskName'), '.vhd')]"
+            }
           }
         },
         "networkProfile": {


### PR DESCRIPTION
added vmImageSKU as a parameter; 14.04.2-LTS is outdated; changed the default value to 14.04.5-LTS; removed unnecessary stuff from image deployment and updated api version to 2015-06-15; tested the changes on azure stack development kit and in public azure

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

