### PR TITLE
List all template files in nested folders.

### DIFF
--- a/test/template-validation-tests/test/util.js
+++ b/test/template-validation-tests/test/util.js
@@ -8,41 +8,54 @@ var _this = this;
 var createUiDefFileName = "createuidefinition.json";
 var mainTemplateFileName = "maintemplate.json";
 
-exports.getFiles = function getFiles(folder, fileType) {
+// Get files in the root folder and in the nested folder if recursive is set true, otherwise only get files in the root folder
+exports.getFiles = function getFiles(folder, fileType, filelist, recursive) {
     if (folder == './') {
         folder = __dirname + '/../';
     }
-    if (fileType) {
-        return fs.readdirSync(folder).filter(function(file) {
-            return file.toLowerCase().endsWith(fileType);
-        });
-    } else {
-        return fs.readdirSync(folder);
-    }
+    var files = fs.readdirSync(folder);
+    filelist = filelist || [];
+    files.forEach(function(file) {
+        if (fs.statSync(path.join(folder, file)).isDirectory() && recursive) {
+            filelist = getFiles(path.join(folder, file), fileType, filelist, recursive);
+        } else {
+            if (file.toLowerCase().endsWith(fileType)) {
+                filelist.push(path.join(folder, file));
+            }
+        }
+    });
+    return filelist;
 };
 
 // Get create ui def file
 exports.getCreateUiDefFile = function getCreateUiDefFile(folder) {
-    var createUiDefFiles = _this.getFiles(folder, createUiDefFileName);
+    var createUiDefFiles = [];
+    createUiDefFiles = _this.getFiles(folder, createUiDefFileName, createUiDefFiles, true);
     createUiDefFiles.length.should.equals(1, 'Only one createUiDefinition.json file should exist, but found ' + createUiDefFiles.length + ' file(s) in path ' + folder);
-    var fileString = fs.readFileSync(path.resolve(folder, createUiDefFiles[0]), {
+    var fileString = fs.readFileSync(path.resolve(createUiDefFiles[0]), {
         encoding: 'utf8'
     }).trim();
     return {
-        file: path.resolve(folder, createUiDefFiles[0]),
+        file: path.resolve(createUiDefFiles[0]),
         jsonObject: JSON.parse(fileString)
     };
 };
 
 // Get main template file
 exports.getMainTemplateFile = function getMainTemplateFile(folder) {
-    var mainTemplateFiles = _this.getFiles(folder, mainTemplateFileName);
-    mainTemplateFiles.length.should.equals(1, 'Only one mainTemplate.json file should exist, but found ' + mainTemplateFiles.length + ' file(s)');
-    var fileString = fs.readFileSync(path.resolve(folder, mainTemplateFiles[0]), {
+    var mainTemplateFiles = [];
+    mainTemplateFiles = _this.getFiles(folder, mainTemplateFileName, mainTemplateFiles, true);
+    var rootMainTemplateFiles = [];
+    rootMainTemplateFiles = _this.getFiles(folder, mainTemplateFileName, rootMainTemplateFiles, false);
+    /** There must be one mainTemplate.json in the root folder. */
+    rootMainTemplateFiles.length.should.equals(1, 'Only one mainTemplate.json file should exist in the root folder, but found ' + mainTemplateFiles.length + ' file(s)');
+    /** There cannot be more than one mainTemplate.json in the root folder and nested folders. */
+    mainTemplateFiles.length.should.equals(1, 'Only one mainTemplate.json file should exist, but found ' + mainTemplateFiles.length + ' file(s) in path ' + path.resolve(folder));
+    var fileString = fs.readFileSync(path.resolve(mainTemplateFiles[0]), {
         encoding: 'utf8'
     }).trim();
     return {
-        file: path.resolve(folder, mainTemplateFiles[0]),
+        file: path.resolve(mainTemplateFiles[0]),
         jsonObject: JSON.parse(fileString)
     };
 };
@@ -64,21 +77,22 @@ exports.getObjects = function getObjects(obj, key, val) {
 
 // Get template files
 exports.getTemplateFiles = function getTemplateFiles(folder) {
-    var templateFiles = _this.getFiles(folder, '.json');
+    var templateFiles = [];
+    templateFiles = _this.getFiles(folder, '.json', templateFiles, true);
     var files = [];
     var fileJSONObjects = [];
     templateFiles.forEach(f => {
         if (f.toLowerCase().indexOf(createUiDefFileName) == -1) {
-            var fileString = fs.readFileSync(path.resolve(folder, f), {
+            var fileString = fs.readFileSync(path.resolve(f), {
                 encoding: 'utf8'
             }).trim();
             var jsonObject = JSON.parse(fileString);
             if (jsonObject.$schema && jsonObject.$schema.match('schema.management.azure.com/schemas/(.*)/deploymentTemplate.json')) {
-                files.push(path.resolve(folder, f));
+                files.push(path.resolve(f));
                 fileJSONObjects.push({
                     filename: f,
                     value: jsonObject,
-                    filepath: path.resolve(folder, f)
+                    filepath: path.resolve(f)
                 });
             }
         }

--- a/test/template-validation-tests/test/validateJsonTests.js
+++ b/test/template-validation-tests/test/validateJsonTests.js
@@ -16,7 +16,7 @@ var jsonFiles = util.getFiles(folder, '.json');
 describe('json files in folder - ', () => {
     // TODO: test ALL json files in subfolders are also returned here
     it.each(jsonFiles, '%s must be a valid json', ['element'], function(element, next) {
-        var fileString = fs.readFileSync(path.resolve(folder, element), {
+        var fileString = fs.readFileSync(path.resolve(element), {
             encoding: 'utf8'
         }).trim();
         try {


### PR DESCRIPTION
Items related with this PR
(1) https://msazure.visualstudio.com/One/_workitems/edit/2420279
(2) https://msazure.visualstudio.com/One/_workitems/edit/2440494

List all template files in nested folders, not only the template files in the root folder. This can solve the following problems
(1) Make sure there is only one maintemplate.json in the root folder, and also make sure there is no maintemplate.json in nested folders.
(2) Mark some not allowed value in all template files, such as resourcegroup().location should not occur in the nested folder template files.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

