### PR TITLE
Bring DB Refs into conformance with Contribution Guidelines

### DIFF
--- a/101-webapp-linux-managed-mysql/azuredeploy.json
+++ b/101-webapp-linux-managed-mysql/azuredeploy.json
@@ -84,7 +84,7 @@
           "connectionStrings": [
             {
               "name": "defaultConnection",
-              "ConnectionString": "[concat('Database=', variables('databaseName'), ';Data Source=', variables('serverName') ,'.mysql.database.azure.com;User Id=',parameters('administratorLogin'),'@',variables('serverName') ,';Password=',parameters('administratorLoginPassword'))]",
+              "ConnectionString": "[concat('Database=', variables('databaseName'), ';Data Source=', reference(resourceId('Microsoft.DBforMySQL/servers',variables('serverName'))).fullyQualifiedDomainName,';User Id=',parameters('administratorLogin'),'@',variables('serverName') ,';Password=',parameters('administratorLoginPassword'))]",
               "type": "MySql"
             }
           ]

--- a/101-webapp-linux-managed-postgresql/azuredeploy.json
+++ b/101-webapp-linux-managed-postgresql/azuredeploy.json
@@ -103,7 +103,7 @@
           "connectionStrings": [
             {
               "name": "defaultConnection",
-              "ConnectionString": "[concat('Database=', variables('databaseName'), ';Server=', variables('serverName') ,'.postgres.database.azure.com;User Id=',parameters('administratorLogin'),'@',variables('serverName') ,';Password=',parameters('administratorLoginPassword'))]",
+              "ConnectionString": "[concat('Database=', variables('databaseName'), ';Server=', reference(resourceId('Microsoft.DBforPostgreSQL/servers',variables('serverName'))).fullyQualifiedDomainName, ';User Id=',parameters('administratorLogin'),'@',variables('serverName') ,';Password=',parameters('administratorLoginPassword'))]",
               "type": "PostgreSQL"
             }
           ]

--- a/101-webapp-managed-mysql/azuredeploy.json
+++ b/101-webapp-managed-mysql/azuredeploy.json
@@ -122,7 +122,7 @@
           ],
           "properties": {
             "defaultConnection": {
-              "value": "[concat('Database=', variables('databaseName'), ';Data Source=', variables('serverName'), '.mysql.database.azure.com;User Id=', parameters('administratorLogin'),'@', variables('serverName'),';Password=', parameters('administratorLoginPassword'))]",
+              "value": "[concat('Database=', variables('databaseName'), ';Data Source=', reference(resourceId('Microsoft.DBforMySQL/servers',variables('serverName'))).fullyQualifiedDomainName, ';User Id=', parameters('administratorLogin'),'@', variables('serverName'),';Password=', parameters('administratorLoginPassword'))]",
               "type": "MySql"
             }
           }

--- a/101-webapp-managed-postgresql/azuredeploy.json
+++ b/101-webapp-managed-postgresql/azuredeploy.json
@@ -130,7 +130,7 @@
           ],
           "properties": {
             "defaultConnection": {
-              "value": "[concat('Database=', variables('databaseName'), ';Server=', variables('serverName'), '.postgres.database.azure.com;User Id=', parameters('administratorLogin'),'@', variables('serverName'),';Password=', parameters('administratorLoginPassword'))]",
+              "value": "[concat('Database=', variables('databaseName'), ';Server=', reference(resourceId('Microsoft.DBforPostgreSQL/servers',variables('serverName'))).fullyQualifiedDomainName, ';User Id=', parameters('administratorLogin'),'@', variables('serverName'),';Password=', parameters('administratorLoginPassword'))]",
               "type": "PostgreSQL"
             }
           }

--- a/201-application-gateway-webapp-iprestriction/azuredeploy.json
+++ b/201-application-gateway-webapp-iprestriction/azuredeploy.json
@@ -333,7 +333,7 @@
           ],
           "properties": {
             "DefaultConnection": {
-              "value": "[concat('Database=', variables('databaseName'), ';Data Source=', variables('serverName'), '.mysql.database.azure.com;User Id=', parameters('administratorLogin'),'@', variables('serverName'),';Password=', parameters('administratorLoginPassword'))]",
+              "value": "[concat('Database=', variables('databaseName'), ';Data Source=', reference(resourceId('Microsoft.DBforMySQL/servers',variables('serverName'))).fullyQualifiedDomainName, ';User Id=', parameters('administratorLogin'),'@', variables('serverName'),';Password=', parameters('administratorLoginPassword'))]",
               "type": "MySql"
             }
           }

--- a/jenkins-cicd-webapp/azuredeploy.json
+++ b/jenkins-cicd-webapp/azuredeploy.json
@@ -169,7 +169,7 @@
           ],
           "properties": {
             "defaultConnection": {
-              "value": "[concat('Database=', variables('mySqlDbName'), ';Data Source=', variables('mySqlServerName'), '.mysql.database.azure.com;User Id=', parameters('mySqlAdminLogin'),'@', variables('mySqlServerName'),';Password=', parameters('mySqlAdminPassword'))]",
+              "value": "[concat('Database=', variables('mySqlDbName'), ';Data Source=', reference(resourceId('Microsoft.DBforMySQL/servers',variables('mySqlServerName'))).fullyQualifiedDomainName, ';User Id=', parameters('mySqlAdminLogin'),'@', variables('mySqlServerName'),';Password=', parameters('mySqlAdminPassword'))]",
               "type": "MySql"
             }
           }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Fixing all instances of MySQL hard-coded domain names.
* Fixing all instances of Postgres hard-coded domain names.
