### PR TITLE
allow spaces around parameter names

### DIFF
--- a/test/template-validation-tests/test/mainTemplateTests.js
+++ b/test/template-validation-tests/test/mainTemplateTests.js
@@ -95,8 +95,8 @@ describe('template files - ', () => {
         /** Validate each parameter should be used in main template */
         var mainTemplateFileContent = JSON.stringify(mainTemplateFileJSONObject).toLowerCase();
         it.each(parametersInMainTemplate, 'parameter %s must be used in file mainTemplate.json', ['element'], function(element, next) {
-            var paramString = 'parameters(\'' + element.toLowerCase() + '\')';
-            assert(mainTemplateFileContent.includes(paramString) === true, 'unused parameter "' + element + '" in file mainTemplate.json');
+            var paramRegex = new RegExp( "parameters\\(\\\s?'" + element.toLowerCase() + "'\\\s?\\)" );
+            assert(mainTemplateFileContent.match(paramRegex) !== null, 'unused parameter "' + element + '" in file mainTemplate.json');
             next();
         });
     });


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use resourceGroup().location for resource locations
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* unused parameter test now allows spaces around parameter name in 
`parameters( 'parameterName' )` calls

