### PR TITLE
Fixes output fqdn in 101-aks deployments

### DIFF
--- a/101-aks/azuredeploy.json
+++ b/101-aks/azuredeploy.json
@@ -134,7 +134,7 @@
     "outputs": {
         "controlPlaneFQDN": {
             "type": "string",
-            "value": "reference(parameters('resourceName')).fqdn"
+            "value": "[reference(parameters('resourceName')).fqdn]"
         }
     }
 }


### PR DESCRIPTION
Currently the string is being stored as a literal rather than the calculated value of the fqdn