### PR TITLE
use exact match on filename tests

### DIFF
--- a/test/template-validation-tests/test/util.js
+++ b/test/template-validation-tests/test/util.js
@@ -19,7 +19,7 @@ exports.getFiles = function getFiles(folder, fileType, filelist, recursive) {
         if (fs.statSync(path.join(folder, file)).isDirectory() && recursive) {
             filelist = getFiles(path.join(folder, file), fileType, filelist, recursive);
         } else {
-            if (file.toLowerCase().endsWith(fileType)) {
+            if (file.toLowerCase() === fileType) {
                 filelist.push(path.join(folder, file));
             }
         }


### PR DESCRIPTION
use exact match on the filename to avoid confusing "createUIDefinition.json" with "._createUIDefinition.json" created by zip programs