### PR TITLE
Fixed Log Analytics Per GB SKU

### DIFF
--- a/oms-azure-storage-analytics-solution/azuredeploy.json
+++ b/oms-azure-storage-analytics-solution/azuredeploy.json
@@ -38,7 +38,7 @@
                 "free",
                 "standalone",
                 "pernode",
-                "Per GB"
+                "pergb2018"
             ],
             "metadata": {
                 "description": "Specify the Azure Region for your OMS Automation Account"
@@ -100,7 +100,7 @@
                     "free"
                 ],
                  [
-                    "Per GB",
+                    "pergb2018",
                     "OMS"
                 ]
             ],

--- a/oms-azure-storage-analytics-solution/nestedtemplates/deployToLinkedWorkspaceAnalyticsOnly.json
+++ b/oms-azure-storage-analytics-solution/nestedtemplates/deployToLinkedWorkspaceAnalyticsOnly.json
@@ -38,7 +38,8 @@
             "allowedValues": [
                 "free",
                 "standalone",
-                "pernode"
+                "pernode",
+                "pergb2018"
             ],
             "metadata": {
                 "description": "Specify the Azure Region for your OMS Automation Account"
@@ -89,6 +90,10 @@
                 [
                     "free",
                     "free"
+                ],
+                [
+                    "pergb2018",
+                    "OMS"
                 ]
             ]
         },

--- a/oms-azure-storage-analytics-solution/nestedtemplates/deployToLinkedWorkspaceWithAuditLogs.json
+++ b/oms-azure-storage-analytics-solution/nestedtemplates/deployToLinkedWorkspaceWithAuditLogs.json
@@ -38,7 +38,8 @@
             "allowedValues": [
                 "free",
                 "standalone",
-                "pernode"
+                "pernode",
+                "pergb2018"
             ],
             "metadata": {
                 "description": "Specify the Azure Region for your OMS Automation Account"
@@ -89,6 +90,10 @@
                 [
                     "free",
                     "free"
+                ],
+                [
+                    "pergb2018",
+                    "OMS"
                 ]
             ]
         },

--- a/oms-azure-storage-analytics-solution/nestedtemplates/deployToWorkspaceAnalyticsOnly.json
+++ b/oms-azure-storage-analytics-solution/nestedtemplates/deployToWorkspaceAnalyticsOnly.json
@@ -38,7 +38,8 @@
             "allowedValues": [
                 "free",
                 "standalone",
-                "pernode"
+                "pernode",
+                "pergb2018"
             ],
             "metadata": {
                 "description": "Specify the Azure Region for your OMS Automation Account"
@@ -89,6 +90,10 @@
                 [
                     "free",
                     "free"
+                ],
+                [
+                    "pergb2018",
+                    "OMS"
                 ]
             ]
         },

--- a/oms-azure-storage-analytics-solution/nestedtemplates/deployToWorkspaceWithAuditLogs.json
+++ b/oms-azure-storage-analytics-solution/nestedtemplates/deployToWorkspaceWithAuditLogs.json
@@ -38,7 +38,8 @@
             "allowedValues": [
                 "free",
                 "standalone",
-                "pernode"
+                "pernode",
+                "pergb2018"
             ],
             "metadata": {
                 "description": "Specify the Azure Region for your OMS Automation Account"
@@ -89,6 +90,10 @@
                 [
                     "free",
                     "free"
+                ],
+                [
+                    "pergb2018",
+                    "OMS"
                 ]
             ]
         },

--- a/oms-azure-storage-analytics-solution/nestedtemplates/omsDeployStorageAnalyticsOnly.json
+++ b/oms-azure-storage-analytics-solution/nestedtemplates/omsDeployStorageAnalyticsOnly.json
@@ -38,7 +38,8 @@
             "allowedValues": [
                 "free",
                 "standalone",
-                "pernode"
+                "pernode",
+                "pergb2018"
             ],
             "metadata": {
                 "description": "Specify the Azure Region for your OMS Automation Account"
@@ -99,6 +100,10 @@
                 [
                     "free",
                     "free"
+                ],
+                [
+                    "pergb2018",
+                    "OMS"
                 ]
             ],
             "metadata": {

--- a/oms-azure-storage-analytics-solution/nestedtemplates/omsDeployStorageAnalyticsWithAuditLogs.json
+++ b/oms-azure-storage-analytics-solution/nestedtemplates/omsDeployStorageAnalyticsWithAuditLogs.json
@@ -38,7 +38,8 @@
             "allowedValues": [
                 "free",
                 "standalone",
-                "pernode"
+                "pernode",
+                "pergb2018"
             ],
             "metadata": {
                 "description": "Specify the Azure Region for your OMS Automation Account"
@@ -99,6 +100,10 @@
                 [
                     "free",
                     "free"
+                ],
+                [
+                    "pergb2018",
+                    "OMS"
                 ]
             ],
             "metadata": {


### PR DESCRIPTION
Fixed SKU name (from "Per GB" to "pergb2018") for the Log Analytics and added "pergb2018" SKU to other files where it is necessary.

Without these changes, the service can not be deployed, because the Per GB SKU was not added everywhere where it is necessary, that when checking the template and parameters, it produced an error "Deployment template validation failed: 'The provided value 'Per GB' for the template parameter 'omsLogAnalyticsSku' at line '35' and column '31' is not valid. The parameter value is not part of the allowed value(s): '**free,standalone,pernode**'.'. (Code: InvalidTemplate)".