### PR TITLE
Deploy HDInsight cluster in VNet

### DIFF
--- a/101-hdinsight-secure-vnet/azuredeploy.json
+++ b/101-hdinsight-secure-vnet/azuredeploy.json
@@ -47,7 +47,9 @@
       "name": "[concat(parameters('clusterName'),'-vnet')]",
       "addressSpacePrefix": "10.0.0.0/16",
       "subnetName": "subnet1",
-      "subnetPrefix": "10.0.0.0/24"
+      "subnetPrefix": "10.0.0.0/24",
+      "id": "[resourceId('Microsoft.Network/virtualNetworks', concat(parameters('clusterName'),'-vnet'))]",
+      "subnet": "[concat(resourceId('Microsoft.Network/virtualNetworks', concat(parameters('clusterName'),'-vnet')), '/subnets/subnet1')]"
     },
     "networkSecurityGroup": {
       "name": "[concat(parameters('clusterName'),'-nsg')]"
@@ -62,7 +64,7 @@
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[variables('networkSecurityGroup').name]",
       "location": "[parameters('location')]",
-      "apiVersion": "2016-03-30",
+      "apiVersion": "2017-06-01",
       "properties": {
         "securityRules": [
           {
@@ -135,14 +137,14 @@
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[variables('vnet').addressSpacePrefix]"
+            "[variables('vNet').addressSpacePrefix]"
           ]
         },
         "subnets": [
           {
-            "name": "[variables('vnet').subnetName]",
+            "name": "[variables('vNet').subnetName]",
             "properties": {
-              "addressPrefix": "[variables('vnet').subnetPrefix]",
+              "addressPrefix": "[variables('vNet').subnetPrefix]",
               "networkSecurityGroup": {
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroup').name)]"
               }
@@ -171,6 +173,7 @@
         "[concat('Microsoft.Storage/storageAccounts/',variables('defaultStorageAccount').name)]",
         "[concat('Microsoft.Network/virtualNetworks/',variables('vNet').name)]"
       ],
+      "tags": {},
       "properties": {
         "clusterVersion": "3.6",
         "osType": "Linux",
@@ -207,6 +210,10 @@
                   "username": "[parameters('sshUserName')]",
                   "password": "[parameters('sshPassword')]"
                 }
+              },
+             "virtualNetworkProfile": {
+                "id": "[variables('vNet').id]",
+                "subnet": "[variables('vNet').subnet]"
               }
             },
             {
@@ -220,11 +227,29 @@
                   "username": "[parameters('sshUserName')]",
                   "password": "[parameters('sshPassword')]"
                 }
+              },
+              "virtualNetworkProfile": {
+                "id": "[variables('vNet').id]",
+                "subnet": "[variables('vNet').subnet]"
               }
             }
           ]
         }
       }
     }
-  ]
+  ],
+  "outputs": {
+    "storage": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('defaultStorageAccount').name))]"
+    },
+    "vnet": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.Network/virtualNetworks',variables('vNet').name))]"
+    },
+    "cluster": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.HDInsight/clusters',parameters('clusterName')))]"
+    }
+  }
 }


### PR DESCRIPTION
HDInsight cluster was not being deployed in VNet, added necessary config

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

