### PR TITLE
Fixing nestedtemplateUri capitalization

### DIFF
--- a/1-CONTRIBUTION-GUIDE/best-practices.md
+++ b/1-CONTRIBUTION-GUIDE/best-practices.md
@@ -284,7 +284,7 @@ After the parameters are added to the template all URIs can be created using the
 ```json
 "variables": {
         "scriptFileUri": "[uri(parameters('_artifactsLocation'), concat('scripts/configuration.sh', parameters('_artifactsLocationSasToken')))]",
-        "nestedTemplateUri": "[uri(parameters('_artifactsLocation'), concat('nestedTemplates/jumpbox.json', parameters('_artifactsLocationSasToken')))]"
+        "nestedtemplateUri": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/jumpbox.json', parameters('_artifactsLocationSasToken')))]"
     },
 ```
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog
nestedtemplateUri is given as nestedTemplateUri, whereas everywhere else in the document small T is used. Not sure which one is right, but this needs to be consistent.
*
*
*

