### PR TITLE
Add GUID to identify chef-automate-ha deployments with the "open source" provider

### DIFF
--- a/chef-automate-ha/azuredeploy.json
+++ b/chef-automate-ha/azuredeploy.json
@@ -258,9 +258,26 @@
     "felbPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('networkSettings').felbPublicIPAddressName)]",
     "chefAutoPublicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses',variables('networkSettings').chefAutoPublicIPAddressName)]",
     "prefix": "[uniqueString(resourceGroup().id)]",
-    "provider": "[toUpper('33194f91-eb5f-4110-827a-e95f640a9e46')]"
+    "provider": "[toUpper('33194f91-eb5f-4110-827a-e95f640a9e46')]",
+    "tags": {
+      "provider": "18d63047-6cdf-4f34-beed-62f01fc73fc2"
+    }
   },
   "resources": [
+    {
+      "comments": "Resource to track Chef Automate installations using this template",
+      "type": "Microsoft.Resources/deployments",
+      "name": "[concat('pid-', variables('tags').provider)]",
+      "apiVersion": "2017-05-10",  
+      "properties": {
+          "mode": "Incremental",
+          "template": {
+              "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+              "contentVersion": "1.0.0.0",
+              "resources": []
+          }
+      }
+    },
     {
       "name": "keyvaultResource",
       "type": "Microsoft.Resources/deployments",


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added "open source" provider GUID to the chef-automat-ha deployment

Background for this change:  Chef needs to track chef automate deployments on azure, particularly whether the deployment is categorised into one of 3 provider groups either "open source", "commercial", or "partnerships".  To achieve this categorisation it was decided to (a) associate 3 unique GUIDs to each of the providers; and (b) create an empty resource group with a name that contains "pid-" plus the provider GUID.  This PR ensures that all chef-automate-ha quickstart deployments are tagged with the "open source" provider group

