### PR TITLE
update allowed vm images and alter hyperlink to dev.azure from vsts

### DIFF
--- a/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
+++ b/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
@@ -110,7 +110,7 @@ do
   try
   {
     Write-Verbose "Trying to get download URL for latest VSTS agent release..."
-    $latestReleaseDownloadUrl = "https://vstsagentpackage.azureedge.net/agent/2.126.0/vsts-agent-win-x64-2.126.0.zip"
+    $latestReleaseDownloadUrl = "https://vstsagentpackage.azureedge.net/agent/2.140.2/vsts-agent-win-x64-2.140.2.zip"
     Invoke-WebRequest -Uri $latestReleaseDownloadUrl -Method Get -OutFile "$agentTempFolderName\agent.zip"
     Write-Verbose "Downloaded agent successfully on attempt $retries" -verbose
     break

--- a/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
+++ b/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
@@ -99,7 +99,7 @@ $agentTempFolderName = Join-Path $env:temp ([System.IO.Path]::GetRandomFileName(
 New-Item -ItemType Directory -Force -Path $agentTempFolderName
 Write-Verbose "Temporary Agent download folder: $agentTempFolderName" -verbose
 
-$serverUrl = "https://$VSTSAccount.visualstudio.com"
+$serverUrl = "https://dev.azurevisualstudio.com/$VSTSAccount"
 Write-Verbose "Server URL: $serverUrl" -verbose
 
 $retryCount = 3

--- a/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
+++ b/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
@@ -4,29 +4,27 @@
 # Enable -Verbose option
 [CmdletBinding()]
 Param(
-[Parameter(Mandatory=$true)]$VSTSAccount,
-[Parameter(Mandatory=$true)]$PersonalAccessToken,
-[Parameter(Mandatory=$true)]$AgentName,
-[Parameter(Mandatory=$true)]$PoolName,
-[Parameter(Mandatory=$true)]$runAsAutoLogon,
-[Parameter(Mandatory=$false)]$vmAdminUserName,
-[Parameter(Mandatory=$false)]$vmAdminPassword
+    [Parameter(Mandatory = $true)]$VSTSAccount,
+    [Parameter(Mandatory = $true)]$PersonalAccessToken,
+    [Parameter(Mandatory = $true)]$AgentName,
+    [Parameter(Mandatory = $true)]$PoolName,
+    [Parameter(Mandatory = $true)]$runAsAutoLogon,
+    [Parameter(Mandatory = $false)]$vmAdminUserName,
+    [Parameter(Mandatory = $false)]$vmAdminPassword
 )
 
 function PrepMachineForAutologon () {
     # Create a PS session for the user to trigger the creation of the registry entries required for autologon
     $computerName = "localhost"
     $password = ConvertTo-SecureString $vmAdminPassword -AsPlainText -Force
-    if ($vmAdminUserName.Split("\").Count -eq 2)
-    {
-      $domain = $vmAdminUserName.Split("\")[0]
-      $userName = $vmAdminUserName.Split('\')[1]
+    if ($vmAdminUserName.Split("\").Count -eq 2) {
+        $domain = $vmAdminUserName.Split("\")[0]
+        $userName = $vmAdminUserName.Split('\')[1]
     }
-    else
-    {
-      $domain = $Env:ComputerName
-      $userName = $vmAdminUserName
-      Write-Verbose "Username constructed to use for creating a PSSession: $domain\\$userName"
+    else {
+        $domain = $Env:ComputerName
+        $userName = $vmAdminUserName
+        Write-Verbose "Username constructed to use for creating a PSSession: $domain\\$userName"
     }
    
     $credentials = New-Object System.Management.Automation.PSCredential("$domain\\$userName", $password)
@@ -35,57 +33,48 @@ function PrepMachineForAutologon () {
   
     $ErrorActionPreference = "stop"
   
-    try
-    {
-      # Check if the HKU drive already exists
-      Get-PSDrive -PSProvider Registry -Name HKU | Out-Null
-      $canCheckRegistry = $true
-    }
-    catch [System.Management.Automation.DriveNotFoundException]
-    {
-      try 
-      {
-        # Create the HKU drive
-        New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS | Out-Null
+    try {
+        # Check if the HKU drive already exists
+        Get-PSDrive -PSProvider Registry -Name HKU | Out-Null
         $canCheckRegistry = $true
-      }
-      catch 
-      {
-        # Ignore the failure to create the drive and go ahead with trying to set the agent up
-        Write-Warning "Moving ahead with agent setup as the script failed to create HKU drive necessary for checking if the registry entry for the user's SId exists.\n$_"
-      }
+    }
+    catch [System.Management.Automation.DriveNotFoundException] {
+        try {
+            # Create the HKU drive
+            New-PSDrive -PSProvider Registry -Name HKU -Root HKEY_USERS | Out-Null
+            $canCheckRegistry = $true
+        }
+        catch {
+            # Ignore the failure to create the drive and go ahead with trying to set the agent up
+            Write-Warning "Moving ahead with agent setup as the script failed to create HKU drive necessary for checking if the registry entry for the user's SId exists.\n$_"
+        }
     }
   
     # 120 seconds timeout
     $timeout = 120 
   
     # Check if the registry key required for enabling autologon is present on the machine, if not wait for 120 seconds in case the user profile is still getting created
-    while ($timeout -ge 0 -and $canCheckRegistry)
-    {
-      $objUser = New-Object System.Security.Principal.NTAccount($vmAdminUserName)
-      $securityId = $objUser.Translate([System.Security.Principal.SecurityIdentifier])
-      $securityId = $securityId.Value
+    while ($timeout -ge 0 -and $canCheckRegistry) {
+        $objUser = New-Object System.Security.Principal.NTAccount($vmAdminUserName)
+        $securityId = $objUser.Translate([System.Security.Principal.SecurityIdentifier])
+        $securityId = $securityId.Value
   
-      if (Test-Path "HKU:\\$securityId")
-      {
-        if (!(Test-Path "HKU:\\$securityId\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run"))
-        {
-          New-Item -Path "HKU:\\$securityId\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run" -Force
-          Write-Host "Created the registry entry path required to enable autologon."
-        }
+        if (Test-Path "HKU:\\$securityId") {
+            if (!(Test-Path "HKU:\\$securityId\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run")) {
+                New-Item -Path "HKU:\\$securityId\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run" -Force
+                Write-Host "Created the registry entry path required to enable autologon."
+            }
         
-        break
-      }
-      else
-      {
-        $timeout -= 10
-        Start-Sleep(10)
-      }
+            break
+        }
+        else {
+            $timeout -= 10
+            Start-Sleep(10)
+        }
     }
   
-    if ($timeout -lt 0)
-    {
-      Write-Warning "Failed to find the registry entry for the SId of the user, this is required to enable autologon. Trying to start the agent anyway."
+    if ($timeout -lt 0) {
+        Write-Warning "Failed to find the registry entry for the SId of the user, this is required to enable autologon. Trying to start the agent anyway."
     }
 }
 
@@ -105,23 +94,23 @@ Write-Verbose "Server URL: $serverUrl" -verbose
 $retryCount = 3
 $retries = 1
 Write-Verbose "Downloading Agent install files" -verbose
-do
-{
-  try
-  {
-    Write-Verbose "Trying to get download URL for latest VSTS agent release..."
-    $latestReleaseDownloadUrl = "https://vstsagentpackage.azureedge.net/agent/2.140.2/vsts-agent-win-x64-2.140.2.zip"
-    Invoke-WebRequest -Uri $latestReleaseDownloadUrl -Method Get -OutFile "$agentTempFolderName\agent.zip"
-    Write-Verbose "Downloaded agent successfully on attempt $retries" -verbose
-    break
-  }
-  catch
-  {
-    $exceptionText = ($_ | Out-String).Trim()
-    Write-Verbose "Exception occured downloading agent: $exceptionText in try number $retries" -verbose
-    $retries++
-    Start-Sleep -Seconds 30 
-  }
+do {
+    try {
+        Write-Verbose "Trying to get download URL for latest VSTS agent release..."
+        $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/Microsoft/vsts-agent/releases"
+        $latestRelease = $latestRelease | Where-Object assets -ne $null | Sort-Object created_at -Descending | Select-Object -First 1
+        $assetsURL = ($latestRelease.assets).browser_download_url
+        $latestReleaseDownloadUrl = ((Invoke-RestMethod -Uri $assetsURL) -match 'win-x64').downloadurl
+        Invoke-WebRequest -Uri $latestReleaseDownloadUrl -Method Get -OutFile "$agentTempFolderName\agent.zip"
+        Write-Verbose "Downloaded agent successfully on attempt $retries" -verbose
+        break
+    }
+    catch {
+        $exceptionText = ($_ | Out-String).Trim()
+        Write-Verbose "Exception occured downloading agent: $exceptionText in try number $retries" -verbose
+        $retries++
+        Start-Sleep -Seconds 30 
+    }
 } 
 while ($retries -le $retryCount)
 
@@ -135,7 +124,7 @@ New-Item -ItemType Directory -Force -Path (Join-Path $agentInstallationPath $Wor
 
 Write-Verbose "Extracting the zip file for the agent" -verbose
 $destShellFolder = (new-object -com shell.application).namespace("$agentInstallationPath")
-$destShellFolder.CopyHere((new-object -com shell.application).namespace("$agentTempFolderName\agent.zip").Items(),16)
+$destShellFolder.CopyHere((new-object -com shell.application).namespace("$agentTempFolderName\agent.zip").Items(), 16)
 
 # Removing the ZoneIdentifier from files downloaded from the internet so the plugins can be loaded
 # Don't recurse down _work or _diag, those files are not blocked and cause the process to take much longer
@@ -145,8 +134,7 @@ Get-ChildItem -Recurse -Path $agentInstallationPath | Unblock-File | out-null
 # Retrieve the path to the config.cmd file.
 $agentConfigPath = [System.IO.Path]::Combine($agentInstallationPath, 'config.cmd')
 Write-Verbose "Agent Location = $agentConfigPath" -Verbose
-if (![System.IO.File]::Exists($agentConfigPath))
-{
+if (![System.IO.File]::Exists($agentConfigPath)) {
     Write-Error "File not found: $agentConfigPath" -Verbose
     return
 }
@@ -159,17 +147,15 @@ Write-Verbose "Configuring agent" -Verbose
 # Set the current directory to the agent dedicated one previously created.
 Push-Location -Path $agentInstallationPath
 
-if ($runAsAutoLogon -ieq "true")
-{
-  PrepMachineForAutologon
+if ($runAsAutoLogon -ieq "true") {
+    PrepMachineForAutologon
 
-  # Setup the agent with autologon enabled
-  .\config.cmd --unattended --url $serverUrl --auth PAT --token $PersonalAccessToken --pool $PoolName --agent $AgentName --runAsAutoLogon --overwriteAutoLogon --windowslogonaccount $vmAdminUserName --windowslogonpassword $vmAdminPassword
+    # Setup the agent with autologon enabled
+    .\config.cmd --unattended --url $serverUrl --auth PAT --token $PersonalAccessToken --pool $PoolName --agent $AgentName --runAsAutoLogon --overwriteAutoLogon --windowslogonaccount $vmAdminUserName --windowslogonpassword $vmAdminPassword
 }
-else 
-{
-  # Setup the agent as a service
-  .\config.cmd --unattended --url $serverUrl --auth PAT --token $PersonalAccessToken --pool $PoolName --agent $AgentName --runasservice
+else {
+    # Setup the agent as a service
+    .\config.cmd --unattended --url $serverUrl --auth PAT --token $PersonalAccessToken --pool $PoolName --agent $AgentName --runasservice
 }
 
 Pop-Location

--- a/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
+++ b/visual-studio-vstsbuildagent-vm/InstallVSTSAgent.ps1
@@ -88,7 +88,7 @@ $agentTempFolderName = Join-Path $env:temp ([System.IO.Path]::GetRandomFileName(
 New-Item -ItemType Directory -Force -Path $agentTempFolderName
 Write-Verbose "Temporary Agent download folder: $agentTempFolderName" -verbose
 
-$serverUrl = "https://dev.azurevisualstudio.com/$VSTSAccount"
+$serverUrl = "https://dev.azure.com/$VSTSAccount"
 Write-Verbose "Server URL: $serverUrl" -verbose
 
 $retryCount = 3

--- a/visual-studio-vstsbuildagent-vm/azuredeploy.json
+++ b/visual-studio-vstsbuildagent-vm/azuredeploy.json
@@ -42,25 +42,15 @@
       "type": "string",
       "defaultValue": "VS-2017-Comm-WS2016",
       "allowedValues": [
-        "VS-2013-Comm-VSU5-AzureSDK-295-WS2012R2",
-        "VS-2013-Prem-VSU5-AzureSDK-295-WS2012R2",
-        "VS-2013-Ult-VSU5-AzureSDK-295-WS2012R2",
-        "VS-2015-Comm-AzureSDK-2.9-W10T-Win10-N",
-        "VS-2015-Comm-AzureSDK-2.9-WS2012R2",
-        "VS-2015-Comm-VSU3-AzureSDK-29-Win10-N",
-        "VS-2015-Comm-VSU3-AzureSDK-291-Win10-N",
+        "VS-2015-Comm-VSU3-AzureSDK-29-WS2012R2",
         "VS-2015-Comm-VSU3-AzureSDK-291-WS2012R2",
-        "VS-2015-Ent-AzureSDK-2.9-WS2012R2",
-        "VS-2015-Ent-AzureSDK-29-W10T-Win10-N",
-        "VS-2015-Ent-VSU3-AzureSDK-29-Win10-N",
-        "VS-2015-Ent-VSU3-AzureSDK-291-WS2012R2",
-        "VS-2017-RC1-Comm-Win10-N",
-        "VS-2017-RC1-Comm-WS2012R2",
-        "VS-2017-RC1-Ent-Win10-N",
-        "VS-2017-RC1-Ent-WS2012R2",
-        "VS-2017-Ent-v152-WS2016",
-        "VS-2017-Ent-v152-Win10-N",
-        "VS-2017-Comm-WS2016"
+        "VS-2015-Ent-VSU3-AzureSDK-29-WS2012R2",
+        "VS-2017-Comm-Latest-Preview-WS2016",
+        "VS-2017-Comm-Latest-WS2016",
+        "VS-2017-Comm-WS2016",
+        "VS-2017-Ent-Latest-Preview-WS2016",
+        "VS-2017-Ent-Latest-WS2016",
+        "VS-2017-Ent-WS2016"        
       ],
       "metadata": {
         "description": "Which version of Visual Studio you would like to deploy"


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* updated allowed values for VM Image as some are out of date and a few were not included
* altered url to use dev.azure.com instead of .visualstudio.com

