### PR TITLE
assetsURL was returning two rows. Need to match on architecture.

### DIFF
--- a/201-vm-vsts-agent/scripts/InstallVstsAgent.ps1
+++ b/201-vm-vsts-agent/scripts/InstallVstsAgent.ps1
@@ -37,7 +37,7 @@ $agentTempFolderName = Join-Path $env:temp ([System.IO.Path]::GetRandomFileName(
 New-Item -ItemType Directory -Force -Path $agentTempFolderName
 Write-Verbose "Temporary Agent download folder: $agentTempFolderName" -verbose
 
-$serverUrl = "https://$VSTSAccount.visualstudio.com"
+$serverUrl = "https://dev.azure.com/$VSTSAccount"
 Write-Verbose "Server URL: $serverUrl" -verbose
 
 $retryCount = 3

--- a/201-vm-vsts-agent/scripts/InstallVstsAgent.ps1
+++ b/201-vm-vsts-agent/scripts/InstallVstsAgent.ps1
@@ -52,7 +52,7 @@ do
     $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/Microsoft/vsts-agent/releases"
 	$latestRelease = $latestRelease | Where-Object assets -ne $null | Sort-Object created_at -Descending | Select-Object -First 1
     $assetsURL = ($latestRelease.assets).browser_download_url
-    $latestReleaseDownloadUrl = ((Invoke-RestMethod -Uri $assetsURL) -match 'win').downloadurl
+    $latestReleaseDownloadUrl = ((Invoke-RestMethod -Uri $assetsURL) -match 'win-x64').downloadurl
     Invoke-WebRequest -Uri $latestReleaseDownloadUrl -Method Get -OutFile "$agentTempFolderName\agent.zip"
     Write-Verbose "Downloaded agent successfully on attempt $retries" -verbose
     break


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

