### PR TITLE
Switch to Postgresql10 from 9.3 in install script

### DIFF
--- a/postgresql-on-ubuntu/README.md
+++ b/postgresql-on-ubuntu/README.md
@@ -1,4 +1,4 @@
-# Create PostgreSQL 9.3 master-slave streaming replication on multiple Ubuntu 14.04 VMs and one jumpbox VM with a public IP
+# Create PostgreSQL 10 master-slave streaming replication on multiple Ubuntu 18.04 VMs and one jumpbox VM with a public IP
 
 <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fpostgresql-on-ubuntu%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
@@ -7,7 +7,7 @@
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 
-This template creates one master PostgreSQL 9.3 server with streaming-replication to multiple (based on the T-Shirt size parameter) slave servers. Each database server is configured with multiple data disks that are striped into RAID-0 configuration using mdadm. The template also optionally creates one externally accessible VM to serve as a jumpbox for ssh into the backend database servers.
+This template creates one master PostgreSQL 10 server with streaming-replication to multiple (based on the T-Shirt size parameter) slave servers. Each database server is configured with multiple data disks that are striped into RAID-0 configuration using mdadm. The template also optionally creates one externally accessible VM to serve as a jumpbox for ssh into the backend database servers.
 
 The template creates the following deployment resources:
 * Virtual Network with two subnets: "dmz 10.0.0.0/24" for the jumpbox VM and "data 10.0.1.0/24" for the PostgreSQL master and slave VMs

--- a/postgresql-on-ubuntu/azuredeploy.json
+++ b/postgresql-on-ubuntu/azuredeploy.json
@@ -148,7 +148,7 @@
       "imageReference": {
         "publisher": "Canonical",
         "offer": "UbuntuServer",
-        "sku": "14.04.5-LTS",
+        "sku": "18.04-LTS",
         "version": "latest"
       }
     },

--- a/postgresql-on-ubuntu/install_postgresql.sh
+++ b/postgresql-on-ubuntu/install_postgresql.sh
@@ -10,10 +10,10 @@
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in all
 # copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -50,7 +50,7 @@ fi
 
 # Get today's date into YYYYMMDD format
 now=$(date +"%Y%m%d")
- 
+
 # Get passed in parameters $1, $2, $3, $4, and others...
 MASTERIP=""
 SUBNETADDRESS=""
@@ -90,17 +90,17 @@ export PGPASSWORD=$REPLICATORPASSWORD
 logger "NOW=$now MASTERIP=$MASTERIP SUBNETADDRESS=$SUBNETADDRESS NODETYPE=$NODETYPE"
 
 install_postgresql_service() {
-	logger "Start installing PostgreSQL..."
+	logger "Start installing PostgreSQL 10..."
 	# Re-synchronize the package index files from their sources. An update should always be performed before an upgrade.
 	apt-get -y update
 
 	# Install PostgreSQL if it is not yet installed
 	if [ $(dpkg-query -W -f='${Status}' postgresql 2>/dev/null | grep -c "ok installed") -eq 0 ];
 	then
-	  apt-get -y install postgresql=9.3* postgresql-contrib=9.3* postgresql-client=9.3*
+	  apt-get -y install postgresql-10 postgresql-contrib-10 postgresql-client-10
 	fi
-	
-	logger "Done installing PostgreSQL..."
+
+	logger "Start installing PostgreSQL 10..."
 }
 
 setup_datadisks() {
@@ -130,7 +130,7 @@ setup_datadisks() {
 
 configure_streaming_replication() {
 	logger "Starting configuring PostgreSQL streaming replication..."
-	
+
 	# Configure the MASTER node
 	if [ "$NODETYPE" == "MASTER" ];
 	then
@@ -156,7 +156,7 @@ configure_streaming_replication() {
 		echo "host replication replicator $SUBNETADDRESS md5" >> pg_hba.conf
 		echo "hostssl replication replicator $SUBNETADDRESS md5" >> pg_hba.conf
 		echo "" >> pg_hba.conf
-			
+
 		logger "Updated pg_hba.conf"
 		echo "Updated pg_hba.conf"
 	fi
@@ -173,12 +173,11 @@ configure_streaming_replication() {
 		echo "wal_level = hot_standby" >> postgresql.conf
 		echo "max_wal_senders = 10" >> postgresql.conf
 		echo "wal_keep_segments = 500" >> postgresql.conf
-		echo "checkpoint_segments = 8" >> postgresql.conf
 		echo "archive_mode = on" >> postgresql.conf
 		echo "archive_command = 'cd .'" >> postgresql.conf
 		echo "hot_standby = on" >> postgresql.conf
 		echo "" >> postgresql.conf
-		
+
 		logger "Updated postgresql.conf"
 		echo "Updated postgresql.conf"
 	fi
@@ -192,17 +191,17 @@ configure_streaming_replication() {
 
 		# Make a binary copy of the database cluster files while making sure the system is put in and out of backup mode automatically
 		logger "Make binary copy of the data directory from master"
-		sudo PGPASSWORD=$PGPASSWORD -u postgres pg_basebackup -h $MASTERIP -D /datadisks/disk1/main -U replicator -x
-		 
+		sudo PGPASSWORD=$PGPASSWORD -u postgres pg_basebackup -h $MASTERIP -D /datadisks/disk1/main -U replicator
+
 		# Create recovery file
 		logger "Create recovery.conf file"
 		cd /var/lib/postgresql/9.3/main/
-		
+
 		sudo -u postgres echo "standby_mode = 'on'" > recovery.conf
 		sudo -u postgres echo "primary_conninfo = 'host=$MASTERIP port=5432 user=replicator password=$PGPASSWORD'" >> recovery.conf
 		sudo -u postgres echo "trigger_file = '/var/lib/postgresql/9.3/main/failover'" >> recovery.conf
 	fi
-	
+
 	logger "Done configuring PostgreSQL streaming replication"
 }
 

--- a/postgresql-on-ubuntu/metadata.json
+++ b/postgresql-on-ubuntu/metadata.json
@@ -1,11 +1,9 @@
 {
   "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
   "type": "QuickStart",
-  "itemDisplayName": "PostgreSQL 9.3 on Ubuntu VMs",
+  "itemDisplayName": "PostgreSQL 10 on Ubuntu VMs",
   "description": "This template creates PostgreSQL streaming replication from one master to one or more slaves each configured with multiple striped data disks. The database servers are deployed into a private subnet with an optional externally accessible jumpbox.",
   "summary": "PostgreSQL stream-replication with multiple slave servers and a publicly accessible jumpbox VM",
   "githubUsername": "trentmswanson",
   "dateUpdated": "2018-09-06"
 }
-
-


### PR DESCRIPTION
- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Modify `install_postgresql.sh` script to install and configure Postgresql-10.
* Modify README to emphasize Postgresql 10 instead of 9.3.
* Modify `metadata.json` to state Postgresql 10.
* Modify `azuredeploy.json` so that it deploys Ubuntu **18.04-LTS**

### Notes

- I have run this install script multiple times over the past couple of weeks on Ubuntu 18.04. 
- I have not run it on previous Ubuntu versions (I checked, though, and by default Postgresql 9.5 is what's available on 16.04...).
- Wasn't sure if this should be a separate template or perhaps a parameter that gets passed via a template parameter or something?

cc @bmoore-msft 
