### PR TITLE
Update Azure PostgreSQL REST apiversion in azuredeploy.json to latest as previous version is deprecated

### DIFF
--- a/101-webapp-linux-managed-postgresql/azuredeploy.json
+++ b/101-webapp-linux-managed-postgresql/azuredeploy.json
@@ -37,10 +37,22 @@
     "databaseSkuName": {
       "type": "string",
       "allowedValues": [
-        "PostgreSQLB100",
-        "PostgreSQLB50"
+        "GP_Gen5_2",
+        "GP_Gen5_4",
+        "GP_Gen5_8",
+        "GP_Gen5_16",
+        "GP_Gen5_32",
+        "B_Gen4_1",
+        "B_Gen4_2",
+        "B_Gen5_1",
+        "B_Gen5_2",
+        "GP_Gen4_2",
+        "GP_Gen4_4",
+        "GP_Gen4_8",
+        "GP_Gen4_16",
+        "GP_Gen4_32",
       ],
-      "defaultValue": "PostgreSQLB100",
+      "defaultValue": "GP_Gen5_2",
       "metadata": {
         "description": "Azure database for PostgreSQL sku name : PostgreSQLB100 (Basic 100 DTU tier) and PostgreSQLB50 (Basic 50 DTU tier)"
       }
@@ -59,9 +71,10 @@
     "databaseSkuTier": {
       "type": "string",
       "allowedValues": [
-        "Basic"
+        "Basic",
+        "GeneralPurpose"
       ],
-      "defaultValue": "Basic",
+      "defaultValue": "GeneralPurpose",
       "metadata": {
         "description": "Azure database for PostgreSQL pricing tier"
       }

--- a/101-webapp-linux-managed-postgresql/azuredeploy.json
+++ b/101-webapp-linux-managed-postgresql/azuredeploy.json
@@ -50,7 +50,7 @@
         "GP_Gen4_4",
         "GP_Gen4_8",
         "GP_Gen4_16",
-        "GP_Gen4_32",
+        "GP_Gen4_32"
       ],
       "defaultValue": "GP_Gen5_2",
       "metadata": {

--- a/101-webapp-linux-managed-postgresql/azuredeploy.json
+++ b/101-webapp-linux-managed-postgresql/azuredeploy.json
@@ -26,10 +26,13 @@
     "databaseDTU": {
       "type": "int",
       "allowedValues": [
-        50,
-        100
+        2,
+        4,
+        8,
+        16,
+        32
       ],
-      "defaultValue": 50,
+      "defaultValue": 2,
       "metadata": {
         "description": "Azure database for PostgreSQL pricing tier"
       }

--- a/101-webapp-linux-managed-postgresql/azuredeploy.json
+++ b/101-webapp-linux-managed-postgresql/azuredeploy.json
@@ -45,15 +45,8 @@
         "GP_Gen5_8",
         "GP_Gen5_16",
         "GP_Gen5_32",
-        "B_Gen4_1",
-        "B_Gen4_2",
         "B_Gen5_1",
-        "B_Gen5_2",
-        "GP_Gen4_2",
-        "GP_Gen4_4",
-        "GP_Gen4_8",
-        "GP_Gen4_16",
-        "GP_Gen4_32"
+        "B_Gen5_2"
       ],
       "defaultValue": "GP_Gen5_2",
       "metadata": {
@@ -165,7 +158,7 @@
         "tier": "[parameters('databaseSkuTier')]",
         "capacity": "[parameters('databaseDTU')]",
         "size": "[parameters('databaseSkuSizeMB')]",
-        "family": "SkuFamily"
+        "family": "Gen5"
       },
       "type": "Microsoft.DBforPostgreSQL/servers",
       "resources": [

--- a/101-webapp-linux-managed-postgresql/azuredeploy.json
+++ b/101-webapp-linux-managed-postgresql/azuredeploy.json
@@ -134,7 +134,7 @@
       "kind": "linux"
     },
     {
-      "apiVersion": "2016-02-01-privatepreview",
+      "apiVersion": "2017-12-01",
       "kind": "",
       "location": "[parameters('location')]",
       "name": "[variables('serverName')]",
@@ -155,7 +155,7 @@
       "resources": [
         {
           "type": "firewallrules",
-          "apiVersion": "2016-02-01-privatepreview",
+          "apiVersion": "2017-12-01",
           "dependsOn": [
             "[concat('Microsoft.DBforPostgreSQL/servers/', variables('serverName'))]"
           ],
@@ -169,7 +169,7 @@
         {
           "name": "[variables('databaseName')]",
           "type": "databases",
-          "apiVersion": "2016-02-01-privatepreview",
+          "apiVersion": "2017-12-01",
           "properties": {
             "charset": "utf8",
             "collation": "English_United States.1252"


### PR DESCRIPTION
Updating the apiversion to the latest since the privatepreview apiversion are now deprecated.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/bp-checklist.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

