### PR TITLE
Allow custom settings

### DIFF
--- a/101-aci-dynamicsnav/azuredeploy.json
+++ b/101-aci-dynamicsnav/azuredeploy.json
@@ -55,6 +55,20 @@
       },
       "defaultValue": "2.0"
     },
+    "customNavSettings": {
+      "type": "string",
+      "metadata": {
+        "description": "Custom settings for the NAV / BC NST"
+      },
+      "defaultValue": ""
+    },
+    "customWebSettings": {
+      "type": "string",
+      "metadata": {
+        "description": "Custom settings for the Web Client"
+      },
+      "defaultValue": ""
+    },
     "acceptEula": {
       "type": "string",
       "metadata": {
@@ -125,6 +139,14 @@
                 {
                   "name": "password",
                   "value": "[parameters('password')]"
+                },
+                {
+                  "name": "customNavSettings",
+                  "value": "[parameters('customNavSettings')]"
+                },
+                {
+                  "name": "customWebSettings",
+                  "value": "[parameters('customWebSettings')]"
                 },
                 { 
                   "name": "PublicDnsName",


### PR DESCRIPTION
The NAV / BC containers allows setup of custom settings through env variables and this should also be possible in the quickstart

### Best Practice Checklist
- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* add two new env params (customNavSettings and customWebSettings)
*
*

