### PR TITLE
Update deprecated values in Cloud-Config

### DIFF
--- a/guacamole-rdp-vnc-gateway-existing-vnet/scripts/cloud-config.yaml
+++ b/guacamole-rdp-vnc-gateway-existing-vnet/scripts/cloud-config.yaml
@@ -1,7 +1,7 @@
 #cloud-config
 coreos:
   update:
-    reboot-strategy: best-effort
+    reboot-strategy: etcd-lock
   units:
     - name: docker.service
       command: start


### PR DESCRIPTION
### Changelog

* 11/5/2018 Update deprecated values in Cloud-Config
The "reboot-strategy: best-effort" in Cloud-Config has been deprecated and removed from Locksmith begining Sep 14, 2017 ( reference - https://coreos.com/blog/locksmith-update-strategy-revision ) and is not available in current CoreOS Version 1855.5.0. This is causing Failed Units in Docker upon startup. Updating reboot-strategy: etcd-lock will fix the issue and make the work template to work as expected.

