### PR TITLE
Adding template to create Ag listener on an always on setup.

### DIFF
--- a/101-sql-vm-ag-setup/nested/join-cluster.json
+++ b/101-sql-vm-ag-setup/nested/join-cluster.json
@@ -31,7 +31,7 @@
             "location": "[parameters('Location')]",
             "copy": {
                 "name": "vmToClusterLoop",
-                "count": "[length(parameters('virtualMachineNames'))]"
+                "count": "[length(parameters('existingVirtualMachineNames'))]"
             },
             "properties": {
                 "virtualMachineResourceId": "[resourceId(parameters('existingVmResourceGroup'),'Microsoft.Compute/virtualMachines', trim(parameters('existingVirtualMachineNames')[copyIndex()]))]",

--- a/101-sql-vm-aglistener-setup/.ci_skip
+++ b/101-sql-vm-aglistener-setup/.ci_skip
@@ -1,0 +1,2 @@
+Skip CI due to existing resource requirements
+

--- a/101-sql-vm-aglistener-setup/README.md
+++ b/101-sql-vm-aglistener-setup/README.md
@@ -1,0 +1,27 @@
+# Create SQL AvailabilityGroup listener on existing Always ON setup
+
+Before deploying the template you must have the following
+
+1. **AlwaysON setup** Always ON setup must exist as created by azure-quickstart-templates/101-sql-vm-ag-setup. This will include the VMs over which the setup was done.
+2. **SQL Availability Group** SQL Availability Group must have been created over the Always ON setup. No existing listener should be present for the SQL Availability Group.
+3. **LoadBalancer** Internal load balancer in same location as VMs.
+4. **CNO permissions** The CNO (COmputer object for Cluster name) should have Create Computer object permissions in the OU it is placed in.
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-sql-vm-aglistener-setup%2Fazuredeploy.json" target="_blank">
+    <img src="http://azuredeploy.net/deploybutton.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-sql-vm-aglistener-setup%2Fazuredeploy.json" target="_blank">
+    <img src="http://armviz.io/visualizebutton.png"/>
+</a>
+
+`Tags: Azure, SQL, VirtualMachine, AlwaysON, Listener`
+
+## Solution overview and deployed resources
+
+This deployment will create an AG listener for a SQL Availability Group. This will also setup Load balancer rules corresponding to the Listener.
+ Following resources will be created
+ - SQL Availability Group Listener for the provided AG.
+ - Load balancer rules that will enable Listner to work in Azure.
+ - Resource of type "AvailabilityGroupListener" in Microsoft.SqlVirtualMachine resource provider.
+ 
+

--- a/101-sql-vm-aglistener-setup/azuredeploy.json
+++ b/101-sql-vm-aglistener-setup/azuredeploy.json
@@ -1,0 +1,119 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "existingFailoverClusterName": {
+            "type": "String",
+            "metadata": {
+                "description": "Specify the name of the failover cluster"
+            }
+        },
+        "existingSqlAvailabilityGroup": {
+            "type": "String",
+            "metadata": {
+                "description": "Specify the name of SQL Availability Group for which listener is being created"
+            }
+        },
+        "existingVmList": {
+            "type": "String",
+            "metadata": {
+                "description": "Specify the Virtual machine list participating in SQL Availability Group e.g. VM1, VM2. Maximum number is 6."
+            }
+        },
+        "Listener": {
+            "type": "String",
+            "metadata": {
+                "description": "Specify a name for the listener for SQL Availability Group"
+            },
+            "defaultValue": "aglistener"
+        },
+        "ListenerPort": {
+            "type": "Int",
+            "metadata": {
+                "description": "Specify the port for listener"
+            },
+            "defaultValue": 1433
+        },
+        "ListenerIp": {
+            "type": "String",
+            "metadata": {
+                "description": "Specify the available private IP address for the listener from the subnet the existing Vms are part of."
+            },
+            "defaultValue": "10.0.0.7"
+        },
+        "existingVnetResourcegroup": {
+            "defaultValue": "[resourcegroup().name]",
+            "type": "String",
+            "metadata": {
+                "description": "Specify the resourcegroup for virtual network"
+            }
+        },
+        "existingVnet": {
+            "type": "String",
+            "metadata": {
+                "description": "Specify the virtual network for Listener IP Address"
+            }
+        },
+        "existingSubnet": {
+            "type": "String",
+            "metadata": {
+                "description": "Specify the subnet under Vnet for Listener IP address"
+            }
+        },
+        "existingInternalLoadBalancer": {
+            "type": "String",
+            "metadata": {
+                "description": "Name of existing internal load balancer for the AG listener. Choose Standard Sku if the VMs are not in an availability set."
+            }
+        },
+        "ProbePort": {
+            "type": "Int",
+            "metadata": {
+                "description": "Specify the load balancer port number (e.g. 59999)"
+            },
+            "defaultValue": 59999
+        },
+        "Location": {
+            "type": "string",
+            "metadata": {
+                "description": "Location for all resources."
+            },
+            "defaultValue": "[resourceGroup().location]"
+        }
+    },
+    "variables": {
+        "LoadBalancerResourceId": "[resourceId('Microsoft.Network/loadBalancers', parameters('existingInternalLoadBalancer'))]",
+        "SubnetResourceId": "[concat(resourceid(parameters('existingVnetResourcegroup'),'Microsoft.Network/virtualNetworks', parameters('existingVnet')), '/subnets/', parameters('existingSubnet'))]",
+        "VmArray": "[split(parameters('existingVmList'),',')]",
+        "VM0": "[if(less(0, length(variables('VmArray'))), createArray(resourceId('Microsoft.SqlVirtualMachine/sqlVirtualMachines', trim(variables('VmArray')[0]))), json('[]'))]",
+        "VM1": "[if(less(1, length(variables('VmArray'))), createArray(resourceId('Microsoft.SqlVirtualMachine/sqlVirtualMachines', trim(variables('VmArray')[1]))), json('[]'))]",
+        "VM2": "[if(less(2, length(variables('VmArray'))), createArray(resourceId('Microsoft.SqlVirtualMachine/sqlVirtualMachines', trim(variables('VmArray')[2]))), json('[]'))]",
+        "VM3": "[if(less(3, length(variables('VmArray'))), createArray(resourceId('Microsoft.SqlVirtualMachine/sqlVirtualMachines', trim(variables('VmArray')[3]))), json('[]'))]",
+        "VM4": "[if(less(4, length(variables('VmArray'))), createArray(resourceId('Microsoft.SqlVirtualMachine/sqlVirtualMachines', trim(variables('VmArray')[4]))), json('[]'))]",
+        "VM5": "[if(less(5, length(variables('VmArray'))), createArray(resourceId('Microsoft.SqlVirtualMachine/sqlVirtualMachines', trim(variables('VmArray')[5]))), json('[]'))]",
+        "SqlVmResourceIdList": "[union(variables('VM0'), variables('VM1'), variables('VM2'), variables('VM3'), variables('VM4'), variables('VM5'))]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.SqlVirtualMachine/SqlVirtualMachineGroups/availabilityGroupListeners",
+            "name": "[concat(parameters('existingFailoverClusterName'), '/', parameters('Listener'))]",
+            "apiVersion": "2017-03-01-preview",
+            "location": "[parameters('Location')]",
+            "properties": {
+                "AvailabilityGroupName": "[parameters('existingSqlAvailabilityGroup')]",
+                "LoadBalancerConfigurations": [
+                    {
+                        "privateIPAddress": {
+                            "IpAddress": "[parameters('ListenerIp')]",
+                            "SubnetResourceId": "[variables('SubnetResourceId')]"
+                        },
+                        "LoadBalancerResourceId": "[variables('LoadBalancerResourceId')]",
+                        "ProbePort": "[parameters('ProbePort')]",
+                        "SqlVirtualMachineInstances": "[variables('SqlVmResourceIdList')]"
+                    }
+                ],
+                "Port": "[parameters('ListenerPort')]"
+            }
+        }
+    ]
+}

--- a/101-sql-vm-aglistener-setup/metadata.json
+++ b/101-sql-vm-aglistener-setup/metadata.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
+  "type": "QuickStart",
+  "itemDisplayName": "Create SQL AvailabilityGroup listener on existing Always ON setup.",
+  "description": "Deploy SQL AvailabilityGroup listener on existing Always ON setup. This creates Listener on an existing SQL Availability Group, sets up corresponding load balancer rules and probe ports on Azure Load balancer to get the listener connections working.",
+  "summary": "Create SQL AvailabilityGroup listener on existing Always ON setup.",
+  "githubUsername": "pratraw",
+  "dateUpdated": "2018-11-16"
+}
+


### PR DESCRIPTION
Adding template to create Ag listener on an always on setup. Also fixed a bug in Always ON setup template

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

