### PR TITLE
azure-lb uses /usr/bin/nc, make a link so both cases work

### DIFF
--- a/nfs-ha-cluster-ubuntu/scripts/setup_nfs_ha.sh
+++ b/nfs-ha-cluster-ubuntu/scripts/setup_nfs_ha.sh
@@ -54,6 +54,7 @@ EOF
         curl -LO https://raw.githubusercontent.com/ClusterLabs/resource-agents/master/heartbeat/azure-lb
         chmod +x ./azure-lb
     fi
+    ln -s /bin/nc /usr/bin/nc
     popd
 }
 


### PR DESCRIPTION
### Changelog

Add a symlink to /usr/bin/nc.

Otherwise the commend ``OCF_ROOT=/usr/lib/ocf bash -x ./azure-lb monitor`` ends with:

```
+ fmt=%s
+ '[' -z '' ']'
+ cookie=ocf-exit-reason:
++ printf %s 'Setup problem: couldn'\''t find command: /usr/bin/nc'
+ msg='Setup problem: couldn'\''t find command: /usr/bin/nc'
+ printf '%s%s\n' ocf-exit-reason: 'Setup problem: couldn'\''t find command: /usr/bin/nc'
ocf-exit-reason:Setup problem: couldn't find command: /usr/bin/nc
+ __ha_log --ignore-stderr 'ERROR: Setup problem: couldn'\''t find command: /usr/bin/nc'
+ local ignore_stderr=false
+ local loglevel
+ '[' x--ignore-stderr = x--ignore-stderr ']'
+ ignore_stderr=true
+ shift
+ '[' none = '' ']'
+ tty
+ '[' x = x0 -a x = xdebug ']'
+ '[' true = true ']'
+ return 0
+ exit 5
```
This fixes the issue
