### PR TITLE
Fix keyEncryptionKey URL parameter for Linux

### DIFF
--- a/201-encrypt-vmss-linux-jumpbox/azuredeploy.json
+++ b/201-encrypt-vmss-linux-jumpbox/azuredeploy.json
@@ -51,8 +51,9 @@
     },
     "keyEncryptionKeyURL": {
       "type": "string",
+      "defaultValue": "",
       "metadata": {
-        "description": "URL of the KeyEncryptionKey used to encrypt the volume encryption key. The Valut is assumed to be in keyVaultResourceGroup"
+        "description": "URL of the KeyEncryptionKey used to encrypt the volume encryption key. The Vault is assumed to be in keyVaultResourceGroup"
       }
     },
     "keyEncryptionAlgorithm": {

--- a/201-encrypt-vmss-linux-jumpbox/metadata.json
+++ b/201-encrypt-vmss-linux-jumpbox/metadata.json
@@ -5,7 +5,7 @@
   "summary": "This template deploys a new Linux VMSS and jumpbox and enables encryption on the data volumes of the Linux VMSS instances.", 
   "description": "This template deploys a Linux VMSS using the latest Linux image, adds data volumes, and then encrypts the data volumes of each Linux VMSS instance.  It also deploys a jumpbox with a public IP address in the same virtual network as the Linux VMSS instances with private IP addresses.  This allows connecting to the jumpbox via its public IP address, and then connecting to the Linux VMSS instances via private IP addresses.",
   "githubUsername": "azure",
-  "dateUpdated": "2017-10-19"
+  "dateUpdated": "2019-02-05"
 }
 
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added a default value "" to make Key Encryption Key optional. 
*  Fixed a typographical error. [vualt -> vault]
* Added current date to metadata.json

