### PR TITLE
fix: removed "." from workflow syntax "Send_message."

### DIFF
--- a/201-alert-to-queue-with-logic-app/azuredeploy.json
+++ b/201-alert-to-queue-with-logic-app/azuredeploy.json
@@ -81,7 +81,7 @@
             }
           },
           "actions": {
-            "Send_message.": {
+            "Send_message": {
               "type": "ApiConnection",
               "inputs": {
                 "body": {

--- a/201-alert-to-queue-with-logic-app/azuredeploy.parameters.json
+++ b/201-alert-to-queue-with-logic-app/azuredeploy.parameters.json
@@ -5,13 +5,13 @@
         "logicAppName": {
             "value":"AlertToQueue"
         },
-        "servicebusconnectionString": {
+        "serviceBusConnectionString": {
             "value":"GEN-PASSWORD"
         },
-        "servicebusConnectionName": {
+        "serviceBusConnectionName": {
             "value":"AlertQueue"
         },
-        "servicebusQueueName": {
+        "serviceBusQueueName": {
             "value":"myQueue"
         }
     }


### PR DESCRIPTION
removed "." from work flow definition "Send_message." which causes this deployment to fail. Successfully tested deployment. However, initial CI test failed due to non-matching letter case of parameters in deployment and parameter files. Updated letter case in azuredeploy.parameters.json, the CI test passed. 

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* removed "." from logic app action "Send_message"
* updated parameter letter case after failed CI build
*

### Reason

* current syntax "Send_message." causes deployment to fail
