### PR TITLE
mongodb-sharding-centos actualization

### DIFF
--- a/mongodb-sharding-centos/azuredeploy.json
+++ b/mongodb-sharding-centos/azuredeploy.json
@@ -41,7 +41,11 @@
         "6.7",
         "7.0",
         "7.1",
-        "7.2"
+        "7.2",
+        "7.3",
+        "7.4",
+        "7.5",
+        "7.6"
       ],
       "metadata": {
         "description": "The CentOS version for the VM. This will pick a fully patched image of this given CentOS version."
@@ -109,7 +113,13 @@
         "Standard_D4_v2",
         "Standard_DS2_v2",
         "Standard_DS3_v2",
-        "Standard_DS4_v2"
+        "Standard_DS4_v2",
+        "Standard_D2s_v3",
+        "Standard_D4s_v3",
+        "Standard_D8s_v3",
+        "Standard_D16s_v3",
+        "Standard_D32s_v3",
+        "Standard_D64s_v3"
       ],
       "metadata": {
         "description": "The size of the virtual machines used when provisioning the router nodes"
@@ -133,7 +143,13 @@
         "Standard_D4_v2",
         "Standard_DS2_v2",
         "Standard_DS3_v2",
-        "Standard_DS4_v2"
+        "Standard_DS4_v2",
+        "Standard_D2s_v3",
+        "Standard_D4s_v3",
+        "Standard_D8s_v3",
+        "Standard_D16s_v3",
+        "Standard_D32s_v3",
+        "Standard_D64s_v3"
       ],
       "metadata": {
         "description": "The size of the virtual machines used when provisioning config nodes"
@@ -157,7 +173,13 @@
         "Standard_D4_v2",
         "Standard_DS2_v2",
         "Standard_DS3_v2",
-        "Standard_DS4_v2"
+        "Standard_DS4_v2",
+        "Standard_D2s_v3",
+        "Standard_D4s_v3",
+        "Standard_D8s_v3",
+        "Standard_D16s_v3",
+        "Standard_D32s_v3",
+        "Standard_D64s_v3"
       ],
       "metadata": {
         "description": "The size of the virtual machines used when provisioning replica set nodes"
@@ -168,13 +190,6 @@
       "defaultValue": "",
       "metadata": {
         "description": "The zabbix server IP which will monitor the mongodb nodes' mongodb status. Null means no zabbix server."
-      }
-    },
-    "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]",
-      "metadata": {
-        "description": "Location for all resources."
       }
     }
   },
@@ -212,7 +227,6 @@
     "replicaSecondaryTemplateUrl": "[concat(variables('templateBaseUrl'), 'replica-secondary-resources.json')]",
     "namespace": "mongodb-",
     "virtualNetworkName": "myVNET",
-    "apiVersion": "2015-01-01",
     "networkSettings": {
       "virtualNetworkName": "[variables('virtualNetworkName')]",
       "addressPrefix": "10.0.0.0/16",
@@ -321,6 +335,9 @@
           },
           "namespace": {
             "value": "[variables('namespace')]"
+          },
+          "zabbixServerIPAddress": {
+            "value": "[parameters('zabbixServerIPAddress')]"
           }
         }
       }
@@ -494,9 +511,6 @@
           "vmbasename": {
             "value": "[concat('aReplicaSecondary', '0')]"
           },
-          "storageAccountBasename": {
-            "value": "[concat('aresecond', '0')]"
-          },
           "sizeOfDataDiskInGB": {
             "value": "[parameters('sizeOfDataDiskInGB')]"
           },
@@ -550,9 +564,6 @@
           },
           "vmbasename": {
             "value": "[concat('aReplicaSecondary', '1')]"
-          },
-          "storageAccountBasename": {
-            "value": "[concat('aresecond', '1')]"
           },
           "sizeOfDataDiskInGB": {
             "value": "[parameters('sizeOfDataDiskInGB')]"
@@ -620,9 +631,6 @@
           "vmSize": {
             "value": "[parameters('replicaNodeVmSize')]"
           },
-          "storageAccountBasename": {
-            "value": "areprimary"
-          },
           "sizeOfDataDiskInGB": {
             "value": "[parameters('sizeOfDataDiskInGB')]"
           },
@@ -673,9 +681,6 @@
           },
           "vmbasename": {
             "value": "[concat('bReplicaSecondary', '0')]"
-          },
-          "storageAccountBasename": {
-            "value": "[concat('bresecond', '0')]"
           },
           "sizeOfDataDiskInGB": {
             "value": "[parameters('sizeOfDataDiskInGB')]"
@@ -730,9 +735,6 @@
           },
           "vmbasename": {
             "value": "[concat('bReplicaSecondary', '1')]"
-          },
-          "storageAccountBasename": {
-            "value": "[concat('bresecond', '1')]"
           },
           "sizeOfDataDiskInGB": {
             "value": "[parameters('sizeOfDataDiskInGB')]"
@@ -793,9 +795,6 @@
           },
           "vmbasename": {
             "value": "bReplicaPrimary"
-          },
-          "storageAccountBasename": {
-            "value": "breprimary"
           },
           "sizeOfDataDiskInGB": {
             "value": "[parameters('sizeOfDataDiskInGB')]"

--- a/mongodb-sharding-centos/azuredeploy.json
+++ b/mongodb-sharding-centos/azuredeploy.json
@@ -98,29 +98,6 @@
     "routerNodeVmSize": {
       "type": "string",
       "defaultValue": "Standard_DS3_v2",
-      "allowedValues": [
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_A4",
-        "Standard_A5",
-        "Standard_A6",
-        "Standard_A7",
-        "Standard_D2",
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D2_v2",
-        "Standard_D3_v2",
-        "Standard_D4_v2",
-        "Standard_DS2_v2",
-        "Standard_DS3_v2",
-        "Standard_DS4_v2",
-        "Standard_D2s_v3",
-        "Standard_D4s_v3",
-        "Standard_D8s_v3",
-        "Standard_D16s_v3",
-        "Standard_D32s_v3",
-        "Standard_D64s_v3"
-      ],
       "metadata": {
         "description": "The size of the virtual machines used when provisioning the router nodes"
       }
@@ -128,29 +105,6 @@
     "configNodeVmSize": {
       "type": "string",
       "defaultValue": "Standard_DS3_v2",
-      "allowedValues": [
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_A4",
-        "Standard_A5",
-        "Standard_A6",
-        "Standard_A7",
-        "Standard_D2",
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D2_v2",
-        "Standard_D3_v2",
-        "Standard_D4_v2",
-        "Standard_DS2_v2",
-        "Standard_DS3_v2",
-        "Standard_DS4_v2",
-        "Standard_D2s_v3",
-        "Standard_D4s_v3",
-        "Standard_D8s_v3",
-        "Standard_D16s_v3",
-        "Standard_D32s_v3",
-        "Standard_D64s_v3"
-      ],
       "metadata": {
         "description": "The size of the virtual machines used when provisioning config nodes"
       }

--- a/mongodb-sharding-centos/azuredeploy.json
+++ b/mongodb-sharding-centos/azuredeploy.json
@@ -158,29 +158,6 @@
     "replicaNodeVmSize": {
       "type": "string",
       "defaultValue": "Standard_DS3_v2",
-      "allowedValues": [
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_A4",
-        "Standard_A5",
-        "Standard_A6",
-        "Standard_A7",
-        "Standard_D2",
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D2_v2",
-        "Standard_D3_v2",
-        "Standard_D4_v2",
-        "Standard_DS2_v2",
-        "Standard_DS3_v2",
-        "Standard_DS4_v2",
-        "Standard_D2s_v3",
-        "Standard_D4s_v3",
-        "Standard_D8s_v3",
-        "Standard_D16s_v3",
-        "Standard_D32s_v3",
-        "Standard_D64s_v3"
-      ],
       "metadata": {
         "description": "The size of the virtual machines used when provisioning replica set nodes"
       }

--- a/mongodb-sharding-centos/azuredeploy.parameters.json
+++ b/mongodb-sharding-centos/azuredeploy.parameters.json
@@ -39,7 +39,7 @@
       "value": "Standard_DS3_v2"
     },
     "zabbixServerIPAddress": {
-	  "value": "Null"
-	}
+	    "value": "Null"
+	  }
   }
 }

--- a/mongodb-sharding-centos/nested/config-primary-resources.json
+++ b/mongodb-sharding-centos/nested/config-primary-resources.json
@@ -44,76 +44,9 @@
     }
   },
   "variables": {
-    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]", 
-    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]"
   },
   "resources": [
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('securityGroupName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "SSH",
-            "properties": {
-              "description": "Allows SSH traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "22",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 100,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "MongoDB",
-            "properties": {
-              "description": "Allows MongoDB traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "27019",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 110,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10050",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 120,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent1",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10051",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 130,
-              "direction": "Inbound"
-            }
-          }
-        ]
-      }
-    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
@@ -128,9 +61,6 @@
               "privateIPAddress": "[parameters('staticIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
-              },
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
               }
             }
           }
@@ -168,6 +98,9 @@
               "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
             }
           ]
+        },
+        "availabilitySet":{
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), 'set'))]"
         }
       }
     },

--- a/mongodb-sharding-centos/nested/config-secondary-resources.json
+++ b/mongodb-sharding-centos/nested/config-secondary-resources.json
@@ -38,76 +38,9 @@
     }
   },
   "variables": {
-    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]", 
-    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]"
   },
   "resources": [
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('securityGroupName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "SSH",
-            "properties": {
-              "description": "Allows SSH traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "22",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 100,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "MongoDB",
-            "properties": {
-              "description": "Allows MongoDB traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "27019",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 110,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10050",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 120,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent1",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10051",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 130,
-              "direction": "Inbound"
-            }
-          }
-        ]
-      }
-    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
@@ -122,9 +55,6 @@
               "privateIPAddress": "[parameters('staticIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
-              },
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
               }
             }
           }
@@ -162,6 +92,9 @@
               "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), parameters('vmbasename'), 'nic'))]"
             }
           ]
+        },
+        "availabilitySet":{
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), 'set'))]"
         }
       }
     },

--- a/mongodb-sharding-centos/nested/replica-primary-resources.json
+++ b/mongodb-sharding-centos/nested/replica-primary-resources.json
@@ -29,9 +29,6 @@
     "vmSize": {
       "type": "string"
     },
-    "storageAccountBasename": {
-      "type": "string"
-    },
     "numDataDisks": {
       "type": "string"
     },
@@ -59,8 +56,7 @@
     }
   },
   "variables": {
-    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]", 
-    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]"
   },
   "resources": [
      {
@@ -91,72 +87,6 @@
     },
     {
       "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('securityGroupName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "SSH",
-            "properties": {
-              "description": "Allows SSH traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "22",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 100,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "MongoDB",
-            "properties": {
-              "description": "Allows MongoDB traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "27017",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 110,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10050",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 120,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent1",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10051",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 130,
-              "direction": "Inbound"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[parameters('location')]",
@@ -169,9 +99,6 @@
               "privateIPAddress": "[parameters('staticIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
-              },
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
               }
             }
           }
@@ -211,6 +138,9 @@
               "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
             }
           ]
+        },
+        "availabilitySet":{
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), 'set'))]"
         }
       }
     },

--- a/mongodb-sharding-centos/nested/replica-secondary-resources.json
+++ b/mongodb-sharding-centos/nested/replica-secondary-resources.json
@@ -17,9 +17,6 @@
     "vmbasename": {
       "type": "string"
     },
-    "storageAccountBasename": {
-      "type": "string"
-    },
     "osSettings": {
       "type": "object"
     },
@@ -50,8 +47,7 @@
     }
   },
   "variables": {
-    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]", 
-    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]"
   },
   "resources": [
     {
@@ -82,72 +78,6 @@
     },
     {
       "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('securityGroupName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "SSH",
-            "properties": {
-              "description": "Allows SSH traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "22",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 100,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "MongoDB",
-            "properties": {
-              "description": "Allows MongoDB traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "27017",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 110,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10050",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 120,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent1",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10051",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 130,
-              "direction": "Inbound"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic'))]",
       "location": "[parameters('location')]",
@@ -159,9 +89,6 @@
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
                 "id": "[variables('subnetRef')]"
-              },
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
               }
             }
           }
@@ -201,6 +128,9 @@
               "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), parameters('vmbasename'), 'nic'))]"
             }
           ]
+        },
+        "availabilitySet":{
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), 'set'))]"
         }
       }
     },

--- a/mongodb-sharding-centos/nested/router1-resources.json
+++ b/mongodb-sharding-centos/nested/router1-resources.json
@@ -47,76 +47,9 @@
     }
   },
   "variables": {
-    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]", 
-    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]"
   },
   "resources": [
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('securityGroupName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "SSH",
-            "properties": {
-              "description": "Allows SSH traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "22",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 100,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "MongoDB",
-            "properties": {
-              "description": "Allows MongoDB traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "27017",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 110,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10050",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 120,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent1",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10051",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 130,
-              "direction": "Inbound"
-            }
-          }
-        ]
-      }
-    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
@@ -149,9 +82,6 @@
               "privateIPAddress": "[parameters('staticIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
-              },
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
               }
             }
           }
@@ -189,6 +119,9 @@
               "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
             }
           ]
+        },
+        "availabilitySet":{
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), 'set'))]"
         }
       }
     },

--- a/mongodb-sharding-centos/nested/router2-resources.json
+++ b/mongodb-sharding-centos/nested/router2-resources.json
@@ -41,76 +41,9 @@
     }
   },
   "variables": {
-    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]", 
-    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+    "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]"
   },
   "resources": [
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('securityGroupName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "SSH",
-            "properties": {
-              "description": "Allows SSH traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "22",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 100,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "MongoDB",
-            "properties": {
-              "description": "Allows MongoDB traffic",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "27017",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 110,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10050",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 120,
-              "direction": "Inbound"
-            }
-          },
-          {
-            "name": "zabbixAgent1",
-            "properties": {
-              "description": "Allows zabbix monitoring",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "10051",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 130,
-              "direction": "Inbound"
-            }
-          }
-        ]
-      }
-    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/publicIPAddresses",
@@ -143,9 +76,6 @@
               "privateIPAddress": "[parameters('staticIp')]",
               "subnet": {
                 "id": "[variables('subnetRef')]"
-              },
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('securityGroupName'))]"
               }
             }
           }
@@ -183,6 +113,9 @@
               "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(parameters('namespace'), concat(parameters('vmbasename'), 'nic')))]"
             }
           ]
+        },
+        "availabilitySet":{
+          "id": "[resourceId('Microsoft.Compute/availabilitySets', concat(parameters('namespace'), 'set'))]"
         }
       }
     },

--- a/mongodb-sharding-centos/nested/shared-resources.json
+++ b/mongodb-sharding-centos/nested/shared-resources.json
@@ -45,7 +45,7 @@
     },
     {
       "condition": "[not(equals(parameters('zabbixServerIPAddress'),'Null'))]",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2018-10-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(variables('securityGroupName'),'withZabbix')]",
       "location": "[parameters('location')]",
@@ -112,7 +112,7 @@
     },
     {
       "condition": "[equals(parameters('zabbixServerIPAddress'),'Null')]",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2018-10-01",
       "type": "Microsoft.Network/networkSecurityGroups",
       "name": "[concat(variables('securityGroupName'),'withoutZabbix')]",
       "location": "[parameters('location')]",

--- a/mongodb-sharding-centos/nested/shared-resources.json
+++ b/mongodb-sharding-centos/nested/shared-resources.json
@@ -20,9 +20,14 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "zabbixServerIPAddress": {
+      "type": "string"
     }
   },
   "variables": {
+    "securityGroupName": "[concat(parameters('namespace'), 'nsg')]",
+    "nsgName": "[if(equals(parameters('zabbixServerIPAddress'),'Null'),concat(variables('securityGroupName'),'withoutZabbix'),concat(variables('securityGroupName'),'withZabbix'))]"
   },
   "resources": [
     {
@@ -34,15 +39,124 @@
         "name": "Aligned"
         },
         "properties": { 
-        "platformFaultDomainCount": 2,
-        "platformUpdateDomainCount": 5
+          "platformFaultDomainCount": 2,
+          "platformUpdateDomainCount": 5
         }
+    },
+    {
+      "condition": "[not(equals(parameters('zabbixServerIPAddress'),'Null'))]",
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[concat(variables('securityGroupName'),'withZabbix')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "MongoDB",
+            "properties": {
+              "description": "Allows MongoDB traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "27017",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "zabbixAgent",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10050",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 120,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "zabbixAgent1",
+            "properties": {
+              "description": "Allows zabbix monitoring",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "10051",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 130,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "condition": "[equals(parameters('zabbixServerIPAddress'),'Null')]",
+      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[concat(variables('securityGroupName'),'withoutZabbix')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "SSH",
+            "properties": {
+              "description": "Allows SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "MongoDB",
+            "properties": {
+              "description": "Allows MongoDB traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "27017",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 110,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
     },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('networkSettings').virtualNetworkName]",
       "location": "[parameters('location')]",
+	  "dependsOn": [
+        "[concat(resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName')))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -53,7 +167,10 @@
           {
             "name": "[parameters('networkSettings').subnet.dse.name]",
             "properties": {
-              "addressPrefix": "[parameters('networkSettings').subnet.dse.prefix]"
+              "addressPrefix": "[parameters('networkSettings').subnet.dse.prefix]",
+              "networkSecurityGroup": { 
+                "id": "[concat(resourceId('Microsoft.Network/networkSecurityGroups',variables('nsgName')))]"
+              }
             }
           }
         ]


### PR DESCRIPTION
### Changelog
NSG moved to shared-resources.json from primary-resources.json and secondary-resources.json
zabbix rules now optional
added current VM Sizes like d*_v3
fresh version of centos added
deleted parameters without references from primary-resources.json and secondary-resources.json
dropped storage account as it was rudiment from unmanaged disks age.
all vms now inside avset. I don't know how high avaliable installation can be outside of avset.

to test this PR
we need to replace baseUrl in a azuredeploy.json with a version with fixed tempaltes
   "baseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mongodb-sharding-centos/",
    "baseUrl": "https://raw.githubusercontent.com/SychevIgor/azure-quickstart-templates/mongodb-sharding-centos-fix/mongodb-sharding-centos/",

https://github.com/Azure/azure-quickstart-templates/issues/5791