### PR TITLE
replaced: invalid vmSizes for Ubuntu 14.04.5-LTS

### DIFF
--- a/101-container-registry-geo-replication/azuredeploy.json
+++ b/101-container-registry-geo-replication/azuredeploy.json
@@ -63,7 +63,7 @@
       "location": "[parameters('acrReplicaLocation')]",
       "properties": {},
       "dependsOn": [
-        "[concat('Microsoft.ContainerRegistry/registries/', parameters('acrName'))]"
+        "[resourceId('Microsoft.ContainerRegistry/registries/', parameters('acrName'))]"
       ]
     }
   ],

--- a/101-container-registry-geo-replication/azuredeploy.json
+++ b/101-container-registry-geo-replication/azuredeploy.json
@@ -5,8 +5,6 @@
     "acrName": {
       "type": "string",
       "defaultValue": "[concat('acr', uniqueString(resourceGroup().id))]",
-      "minLength": 5,
-      "maxLength": 50,
       "metadata": {
         "description": "Globally unique name of your Azure Container Registry"
       }

--- a/101-container-registry-geo-replication/azuredeploy.json
+++ b/101-container-registry-geo-replication/azuredeploy.json
@@ -28,10 +28,7 @@
       "metadata": {
         "description": "Tier of your Azure Container Registry.  Geo replicatoin requires Premium SKU."
       },
-      "defaultValue": "Premium",
-      "allowedValues": [
-        "Premium"
-      ]
+      "defaultValue": "Premium"
     },
     "acrReplicaLocation": {
       "type": "string",

--- a/101-container-registry-geo-replication/azuredeploy.json
+++ b/101-container-registry-geo-replication/azuredeploy.json
@@ -67,10 +67,5 @@
       ]
     }
   ],
-  "outputs": {
-    "acrLoginServer": {
-      "value": "[reference(resourceId('Microsoft.ContainerRegistry/registries',parameters('acrName')),'2017-10-01').loginServer]",
-      "type": "string"
-    }
-  }
+  "outputs": { }
 }

--- a/ubuntu-desktop-gnome/azuredeploy.json
+++ b/ubuntu-desktop-gnome/azuredeploy.json
@@ -4,7 +4,6 @@
   "parameters": {
     "newStorageAccountName": {
       "type": "string",
-      "defaultValue": "[concat(toLower(uniqueString(resourceGroup().id)), 'storage')]",
       "metadata": {
         "description": "Unique DNS Name Prefix for the Storage Account where the Virtual Machine's disks will be placed.  StorageAccounts may contain at most variables('vmsPerStorageAccount')"
       }
@@ -18,14 +17,12 @@
     },
     "adminPassword": {
       "type": "securestring",
-      "defaultValue": "[base64(concat(substring(uniqueString(deployment().name), 3, 9), uniqueString(resourceGroup().id)))]",
       "metadata": {
         "description": "Password for the Virtual Machine. Use a deployment name to increase complexity."
       }
     },
     "dnsNameForPublicIP": {
       "type": "string",
-      "defaultValue": "[concat('dns', substring(parameters('newStorageAccountName'), 0, 6))]",
       "metadata": {
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }

--- a/ubuntu-desktop-gnome/azuredeploy.json
+++ b/ubuntu-desktop-gnome/azuredeploy.json
@@ -4,6 +4,7 @@
   "parameters": {
     "newStorageAccountName": {
       "type": "string",
+      "defaultValue": "[concat(toLower(uniqueString(resourceGroup().id)), 'storage')]",
       "metadata": {
         "description": "Unique DNS Name Prefix for the Storage Account where the Virtual Machine's disks will be placed.  StorageAccounts may contain at most variables('vmsPerStorageAccount')"
       }
@@ -17,12 +18,14 @@
     },
     "adminPassword": {
       "type": "securestring",
+      "defaultValue": "[base64(concat(substring(uniqueString(deployment().name), 3, 9), uniqueString(resourceGroup().id)))]",
       "metadata": {
-        "description": "Password for the Virtual Machine."
+        "description": "Unique Password for the Virtual Machine. Use a deployment name to increase complexity."
       }
     },
     "dnsNameForPublicIP": {
       "type": "string",
+      "defaultValue": "[substring(parameters('newStorageAccountName'), 0, 6)]",
       "metadata": {
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }

--- a/ubuntu-desktop-gnome/azuredeploy.json
+++ b/ubuntu-desktop-gnome/azuredeploy.json
@@ -20,7 +20,7 @@
       "type": "securestring",
       "defaultValue": "[base64(concat(substring(uniqueString(deployment().name), 3, 9), uniqueString(resourceGroup().id)))]",
       "metadata": {
-        "description": "Unique Password for the Virtual Machine. Use a deployment name to increase complexity."
+        "description": "Password for the Virtual Machine. Use a deployment name to increase complexity."
       }
     },
     "dnsNameForPublicIP": {

--- a/ubuntu-desktop-gnome/azuredeploy.json
+++ b/ubuntu-desktop-gnome/azuredeploy.json
@@ -29,16 +29,17 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_D2",
+      "defaultValue": "Standard_D2s_v3",
       "allowedValues": [
-        "Standard_D1",
-        "Standard_D2",
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D11",
-        "Standard_D12",
-        "Standard_D13",
-        "Standard_D14"
+        "Standard_B1ms",
+        "Standard_B1s",
+        "Standard_B2ms",
+        "Standard_B4ms",
+        "Standard_D2s_v3",
+        "Standard_D4s_v3",
+        "Standard_DS1_v2",
+        "Standard_DS2_v2",
+        "Standard_DS3_v2"
       ],
       "metadata": {
         "description": "The VM role size of the jump box"

--- a/ubuntu-desktop-gnome/azuredeploy.json
+++ b/ubuntu-desktop-gnome/azuredeploy.json
@@ -25,7 +25,7 @@
     },
     "dnsNameForPublicIP": {
       "type": "string",
-      "defaultValue": "[substring(parameters('newStorageAccountName'), 0, 6)]",
+      "defaultValue": "[concat('dns', substring(parameters('newStorageAccountName'), 0, 6))]",
       "metadata": {
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }

--- a/ubuntu-desktop-gnome/azuredeploy.parameters.json
+++ b/ubuntu-desktop-gnome/azuredeploy.parameters.json
@@ -1,19 +1,5 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
-    "parameters": {
-
-        "newStorageAccountName": {
-            "value": "GEN-UNIQUE"
-        },
-        "adminUsername": {
-            "value": "GEN-UNIQUE-8"
-        },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "dnsNameForPublicIP": {
-            "value": "GEN-UNIQUE"
-        }
-    }
+    "parameters": { }
 }

--- a/ubuntu-desktop-gnome/azuredeploy.parameters.json
+++ b/ubuntu-desktop-gnome/azuredeploy.parameters.json
@@ -1,5 +1,19 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
-    "parameters": { }
+    "parameters": {
+
+        "newStorageAccountName": {
+            "value": "GEN-UNIQUE"
+        },
+        "adminUsername": {
+            "value": "GEN-UNIQUE-8"
+        },
+        "adminPassword": {
+            "value": "GEN-PASSWORD"
+        },
+        "dnsNameForPublicIP": {
+            "value": "GEN-UNIQUE"
+        }
+    }
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* added valid vmSizes
* removed failing special place holders
* updated parameters to generate unique strings

### Reason

* current syntax causes deployment to fail
