### PR TITLE
Update Elasticsearch VM ScaleSet to current versions

### DIFF
--- a/elasticsearch-vmss/azuredeploy.json
+++ b/elasticsearch-vmss/azuredeploy.json
@@ -21,7 +21,7 @@
             "metadata": {
                 "description": "Number of VM instances (200 or less)."
             },
-            "defaultValue": 5,
+            "defaultValue": 2,
             "maxValue": 200
         },
         "adminUsername": {
@@ -80,12 +80,12 @@
         "loadBalancerProbeId": "[concat(variables('loadBalancerId'),'/probes/tcpProbe')]",
         "sshProbeId": "[concat(variables('loadBalancerId'),'/probes/sshProbe')]",
         "subnetName": "[concat(variables('namingInfix'), '-subnet')]",
-        "masterSize": "Standard_DS3_v2",
-        "vmSku": "Standard_DS4_v2",
+        "masterSize": "Standard_DS2_v2",
+        "vmSku": "Standard_DS2_v2",
         "imageReference": {
             "publisher": "Canonical",
             "offer": "UbuntuServer",
-            "sku": "16.04-LTS",
+            "sku": "18.04-LTS",
             "version": "latest"
         },
         "elasticSetupScriptUrl": "[concat(parameters('_artifactsLocation'), '/elasticsearch-vmss/install-elasticsearch.sh', parameters('_artifactsLocationSasToken'))]",
@@ -256,8 +256,10 @@
             "apiVersion": "2018-06-01",
             "properties": {
                 "platformUpdateDomainCount": 3,
-                "platformFaultDomainCount": 3,
-                "managed": true
+                "platformFaultDomainCount": 3
+            },
+            "sku": {
+              "name": "Aligned"
             }
         },
         {

--- a/elasticsearch-vmss/azuredeploy.json
+++ b/elasticsearch-vmss/azuredeploy.json
@@ -104,7 +104,7 @@
                         "properties": {
                             "description": "Allows inbound ssh traffic",
                             "protocol": "Tcp",
-                            "sourcePortRange": "22",
+                            "sourcePortRange": "*",
                             "destinationPortRange": "22",
                             "sourceAddressPrefix": "*",
                             "destinationAddressPrefix": "*",
@@ -118,7 +118,7 @@
                         "properties": {
                             "description": "Allows inbound HTTP traffic from anyone",
                             "protocol": "Tcp",
-                            "sourcePortRange": "5601",
+                            "sourcePortRange": "*",
                             "destinationPortRange": "5601",
                             "sourceAddressPrefix": "*",
                             "destinationAddressPrefix": "*",

--- a/elasticsearch-vmss/install-elasticsearch.sh
+++ b/elasticsearch-vmss/install-elasticsearch.sh
@@ -90,7 +90,7 @@ done
 # Install Oracle Java
 install_java()
 {
-    if [ -f "jdk-8u151-linux-x64.tar.gz" ];
+    if [ -f "jdk-8u201-linux-x64.tar.gz" ];
     then
         log "Java already downloaded"
         return
@@ -100,8 +100,8 @@ install_java()
     RETRY=0
     MAX_RETRY=5
     while [ $RETRY -lt $MAX_RETRY ]; do
-        log "Retry $RETRY: downloading jdk-8u151-linux-x64.tar.gz"
-        wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/8u151-b12/e758a0de34e24606bca991d704f6dcbf/jdk-8u151-linux-x64.tar.gz
+        log "Retry $RETRY: downloading jdk-8u201-linux-x64.tar.gz"
+        wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" https://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/jdk-8u201-linux-x64.tar.gz
         if [ $? -ne 0 ]; then
             let RETRY=RETRY+1
         else
@@ -109,12 +109,12 @@ install_java()
         fi
     done
     if [ $RETRY -eq $MAX_RETRY ]; then
-        log "Failed to download jdk-8u151-linux-x64.tar.gz"
+        log "Failed to download jdk-8u201-linux-x64.tar.gz"
         exit 1
     fi
     
-    tar xzf jdk-8u151-linux-x64.tar.gz -C /var/lib
-    export JAVA_HOME=/var/lib/jdk1.8.0_151
+    tar xzf jdk-8u201-linux-x64.tar.gz -C /var/lib
+    export JAVA_HOME=/var/lib/jdk1.8.0_201
     export PATH=$PATH:$JAVA_HOME/bin
     log "JAVA_HOME: $JAVA_HOME"
     log "PATH: $PATH"

--- a/elasticsearch-vmss/install-elasticsearch.sh
+++ b/elasticsearch-vmss/install-elasticsearch.sh
@@ -189,9 +189,8 @@ configure_system()
     if [ ${IS_DATA_NODE} -eq 0 ]; 
     then
         # Kibana    
-        IPADDRESS=$(ip route get 8.8.8.8 | awk 'NR==1 {print $NF}')
-        echo "server.host: \"$IPADDRESS\"" >> /etc/kibana/kibana.yml
-        echo "elasticsearch.url: \"http://$IPADDRESS:9200\"" >> /etc/kibana/kibana.yml
+        echo "server.host: \"$HOSTNAME\"" >> /etc/kibana/kibana.yml
+        echo "elasticsearch.url: \"http://localhost:9200\"" >> /etc/kibana/kibana.yml
         echo "xpack.security.enabled: false" >> /etc/kibana/kibana.yml
         chown -R kibana:kibana /usr/share/kibana
     else

--- a/elasticsearch-vmss/install-elasticsearch.sh
+++ b/elasticsearch-vmss/install-elasticsearch.sh
@@ -189,8 +189,9 @@ configure_system()
     if [ ${IS_DATA_NODE} -eq 0 ]; 
     then
         # Kibana    
-        echo "server.host: \"$HOSTNAME\"" >> /etc/kibana/kibana.yml
-        echo "elasticsearch.url: \"http://localhost:9200\"" >> /etc/kibana/kibana.yml
+        IP_ADDRESS=$(ip route get 8.8.8.8 | awk -F"src " 'NR==1{split($2,a," ");print a[1]}')
+        echo "server.host: \"$IP_ADDRESS\"" >> /etc/kibana/kibana.yml
+        echo "elasticsearch.url: \"http://$IP_ADDRESS:9200\"" >> /etc/kibana/kibana.yml
         echo "xpack.security.enabled: false" >> /etc/kibana/kibana.yml
         chown -R kibana:kibana /usr/share/kibana
     else

--- a/elasticsearch-vmss/metadata.json
+++ b/elasticsearch-vmss/metadata.json
@@ -5,6 +5,6 @@
   "description": "This template deploys an Elasticsearch cluster on a Virtual Machine scale set. The template provisions 3 dedicated master nodes, with an optional number of data nodes, which run on managed disks.",
   "summary": "Provision an Elasticsearch cluster on a Virtual Machine Scale Set",
   "githubUsername": "hglkrijger",
-  "dateUpdated": "2017-02-02"
+  "dateUpdated": "2019-02-26"
 }
 


### PR DESCRIPTION
The current ElasticSearch VM ScaleSet example doesn't work, mostly due to an outdated JDK version. In updating the necessary I found a few other things to fix, too...

- [x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Update JDK version to current, since the old one is no longer available
* Update base image to Ubuntu 18.04 LTS
* Fix Availability Set managed disk configuration to one that actually works - I can't find the schema used before in any documentation, not sure if it worked at all before. 
* Reduce starting number of data VMs to 2, and the SKUs for default master/data VMs, to help fit within default core quotas
* Fix Network Security Group "source port range" settings. I don't think this ever worked...
* Fix host IP address detection used in configuring Kibana
