### PR TITLE
dependson casing changed to dependsOn

### DIFF
--- a/101-backup-oms-monitoring/azuredeploy.json
+++ b/101-backup-oms-monitoring/azuredeploy.json
@@ -41,7 +41,7 @@
                     "name": "Azure Backup Monitoring Solution",
                     "type": "views",
                     "location": "[parameters('workspaceLocation')]",
-                    "dependson": [
+                    "dependsOn": [
                         "[resourceId('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName'))]"
                     ],
                     "properties": {

--- a/101-webappazure-oms-monitoring/azuredeploy.json
+++ b/101-webappazure-oms-monitoring/azuredeploy.json
@@ -41,7 +41,7 @@
 					"name": "Azure Web Apps Analytics",
 					"type": "views",
 					"location": "[parameters('workspaceLocation')]",
-					"dependson": [
+					"dependsOn": [
 						"[resourceId('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName'))]"
 					],
 					"properties": {

--- a/oms-automation-solution/azuredeploy.json
+++ b/oms-automation-solution/azuredeploy.json
@@ -58,7 +58,7 @@
                     "name": "[variables('omsSolutions').customSolution.name]",
                     "type": "views",
                     "location": "[parameters('workspaceRegion')]",
-                    "dependson": [
+                    "dependsOn": [
                         "[resourceId('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName'))]"
                     ],
                     "properties": {

--- a/oms-azure-resource-usage-solution/azuredeploy.json
+++ b/oms-azure-resource-usage-solution/azuredeploy.json
@@ -502,7 +502,7 @@
           "name": "[variables('omsSolutions').customSolution.name]",
           "type": "views",
           "id": "[resourceId('Microsoft.OperationalInsights/workspaces/views/', parameters('omsLogAnalyticsWorkspaceName'), variables('omsSolutions').customSolution.name)]",
-          "dependson": [
+          "dependsOn": [
             "[Concat('Microsoft.OperationalInsights/workspaces/', parameters('omsLogAnalyticsWorkspaceName'))]"
           ],
           "properties": {

--- a/oms-azure-resource-usage-solution/azuredeployonlyloganalytics.json
+++ b/oms-azure-resource-usage-solution/azuredeployonlyloganalytics.json
@@ -133,7 +133,7 @@
                     "apiVersion": "2015-11-01-preview",
                     "name": "[variables('omsSolutions').customSolution.name]",
                     "type": "views",
-                    "dependson": [
+                    "dependsOn": [
                         "[Concat('Microsoft.OperationalInsights/workspaces/', parameters('omsLogAnalyticsWorkspaceName'))]"
                     ],
                     "properties": {

--- a/oms-azure-vminventory-solution/azuredeploy.json
+++ b/oms-azure-vminventory-solution/azuredeploy.json
@@ -180,7 +180,7 @@
           "name": "[variables('omsSolutions').customSolution.name]",
           "type": "views",
           "id": "[resourceId('Microsoft.OperationalInsights/workspaces/views/', parameters('omsLogAnalyticsWorkspaceName'), variables('omsSolutions').customSolution.name)]",
-          "dependson": [
+          "dependsOn": [
             "[Concat('Microsoft.OperationalInsights/workspaces/', parameters('omsLogAnalyticsWorkspaceName'))]"
           ],
           "properties": {

--- a/oms-azure-vminventory-solution/azuredeployonlyloganalytics.json
+++ b/oms-azure-vminventory-solution/azuredeployonlyloganalytics.json
@@ -133,7 +133,7 @@
           "name": "[variables('omsSolutions').customSolution.name]",
           "type": "views",
           "id": "[resourceId('Microsoft.OperationalInsights/workspaces/views/', parameters('omsLogAnalyticsWorkspaceName'), variables('omsSolutions').customSolution.name)]",
-          "dependson": [
+          "dependsOn": [
             "[Concat('Microsoft.OperationalInsights/workspaces/', parameters('omsLogAnalyticsWorkspaceName'))]"
           ],
           "properties": {

--- a/oms-azurensg-solution/azuredeploy.json
+++ b/oms-azurensg-solution/azuredeploy.json
@@ -39,7 +39,7 @@
 					"name": "Azure Network Security Group Analytics",
 					"type": "views",
 					"location": "[parameters('workspaceLocation')]",
-					"dependson": [
+					"dependsOn": [
 						"[resourceId('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName'))]"
 					],
 					"properties": {

--- a/oms-hyperv-replica-solution/azuredeploy.json
+++ b/oms-hyperv-replica-solution/azuredeploy.json
@@ -152,7 +152,7 @@
           "name": "[variables('solution').Name]",
           "type": "views",
           "location": "[parameters('workspaceRegion')]",
-          "dependson": [
+          "dependsOn": [
             "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
           ],
           "properties": {

--- a/oms-kemp-applicationdelivery-solution/azuredeploy.json
+++ b/oms-kemp-applicationdelivery-solution/azuredeploy.json
@@ -133,7 +133,7 @@
             "type": "Microsoft.OperationalInsights/workspaces/views",        
             "location": "[parameters('omsLogAnalyticsRegion')]",
             "id": "[resourceId('Microsoft.OperationalInsights/workspaces/views/', parameters('omsLogAnalyticsWorkspaceName'), variables('omsSolutions').customSolution.viewName)]",            
-            "dependson": [
+            "dependsOn": [
                 "[resourceId('Microsoft.OperationalInsights/workspaces/', parameters('omsLogAnalyticsWorkspaceName'))]"
             ],
             "properties": {

--- a/oms-scomacs-solution/azuredeploy.json
+++ b/oms-scomacs-solution/azuredeploy.json
@@ -86,7 +86,7 @@
                     "name": "[variables('omsSolutions').customSolution.name]",
                     "type": "views",
                     "id": "[resourceId('Microsoft.OperationalInsights/workspaces/views/', parameters('workspaceName'), variables('omsSolutions').customSolution.name)]",
-                    "dependson": [
+                    "dependsOn": [
                         "[Concat('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName'))]"
                     ],
                     "properties": {

--- a/oms-servicebus-solution/azuredeploy.json
+++ b/oms-servicebus-solution/azuredeploy.json
@@ -168,7 +168,7 @@
           "name": "[variables('omsSolutions').customSolution.name]",
           "type": "views",
           "id": "[resourceId('Microsoft.OperationalInsights/workspaces/views/', parameters('omsWorkspaceName'), variables('omsSolutions').customSolution.name)]",
-          "dependson": [
+          "dependsOn": [
             "[Concat('Microsoft.OperationalInsights/workspaces/', parameters('omsWorkspaceName'))]"
           ],
           "properties": {

--- a/oms-vmm-analytics/azuredeploy.json
+++ b/oms-vmm-analytics/azuredeploy.json
@@ -83,7 +83,7 @@
           "name": "[variables('omsSolutions').customSolution.name]",
           "type": "views",
           "location": "[parameters('workspaceRegion')]",
-          "dependson": [
+          "dependsOn": [
             "[resourceId('Microsoft.OperationalInsights/workspaces/', parameters('workspaceName'))]"
           ],
           "properties": {

--- a/s2d-oms-mgmt-solution/azuredeploy.json
+++ b/s2d-oms-mgmt-solution/azuredeploy.json
@@ -48,7 +48,7 @@
           "location": "[parameters('omsLogAnalyticsWorkspaceLocation')]",
           "id": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', parameters('omsLogAnalyticsWorkspaceName'),'/views/', variables('solutionId'))]",
           "apiVersion": "2015-11-01-preview",
-          "dependson": [
+          "dependsOn": [
             "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/Microsoft.OperationalInsights/workspaces/', parameters('omsLogAnalyticsWorkspaceName'))]"
           ],
           "properties": {


### PR DESCRIPTION
I've changed all instances of `dependson` to proper cased `dependsOn`, which is what is documented. in https://docs.microsoft.com/es-es/azure/azure-resource-manager/resource-group-define-dependencies#dependson

It looks like the ARM template service accepts templates case insensitively, but I haven't been able to a statement specifying that ARM templates are in fact case insensitive.

