### PR TITLE
Fix/duplicate values

### DIFF
--- a/101-backup-oms-monitoring/azuredeploy.json
+++ b/101-backup-oms-monitoring/azuredeploy.json
@@ -556,9 +556,8 @@
                             }
                         ],
                         "OverviewTile": {
-                            "Id": "SingleQueryDonutBuilderTileV1",
-                            "Type": "OverviewTile",
-                            "Version": 2,
+                           "Id": "SingleQueryDonutBuilderTileV1",
+                           "Type": "OverviewTile",
                            "Version": 2,
                             "Configuration": {
                                 "Donut": {

--- a/201-customscript-extension-azure-storage-on-ubuntu/azuredeploy.json
+++ b/201-customscript-extension-azure-storage-on-ubuntu/azuredeploy.json
@@ -166,10 +166,6 @@
           "adminPassword": "[parameters('password')]"
         },
         "storageProfile": {
-          "osDisk": {
-            "caching": "ReadWrite",
-            "createOption": "FromImage"
-         },
           "imageReference": {
             "publisher": "[variables('imagePublisher')]",
             "offer": "[variables('imageOffer')]",

--- a/intel-lustre-client-server/azuredeploy.json
+++ b/intel-lustre-client-server/azuredeploy.json
@@ -52,13 +52,6 @@
 				"description": "Admin password for the virtual machines"
 			}
 		},
-		"sshPublicKey": {
-			"type": "string",
-			"defaultValue": "",
-			"metadata": {
-				"description": "SSH public key that will be included on all nodes in the Lustre cluster. The OpenSSH public key can be generated with tools like ssh-keygen on Linux or OS X."
-			}
-		},
 		"dnsNamePrefix": {
 			"type": "string",
 			"metadata": {
@@ -503,13 +496,12 @@
 		"scriptUrlMonitoring": "[concat(variables('baseUrl'),'scripts/monitoring.sh')]",
 		"templateUrlVnet": "[concat(variables('baseUrl'),'vnet-',parameters('vnetNewOrExisting'),'.json')]",
 		"templateUrlMonitoring": "[concat(variables('baseUrl'),'monitoring.json')]",
-		"sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
 		"linuxConfiguration_sshPublicKey": {
 			"disablePasswordAuthentication": true,
 			"ssh": {
 				"publicKeys": [{
-					"path": "[variables('sshKeyPath')]",
-					"keyData": "[parameters('sshPublicKey')]"
+					"path": "[variables('sshKeyPathClient')]",
+					"keyData": "[parameters('sshPublicKeyForClient')]"
 				}]
 			}
 		},
@@ -558,15 +550,6 @@
 		"subnetClientsID1": "[concat(variables('vnetID1'), '/subnets/', parameters('existingSubnetClientsName'))]",
 		"scriptUrlLustreClient": "[concat(variables('baseUrl1'),'scripts/lustre_client.sh')]",
 		"sshKeyPathClient": "[concat('/home/',parameters('clientadminUsername'),'/.ssh/authorized_keys')]",
-		"linuxConfiguration_sshPublicKey": {
-			"disablePasswordAuthentication": true,
-			"ssh": {
-				"publicKeys": [{
-					"path": "[variables('sshKeyPathClient')]",
-					"keyData": "[parameters('sshPublicKeyForClient')]"
-				}]
-			}
-		},
 		"linuxConfiguration_password": {},
 		"linuxConfiguration": "[variables(concat('linuxConfiguration_',parameters('clientAuthenticationType')))]"
 	},

--- a/sap-3-tier-marketplace-image-multi-sid-db-md/azuredeploy.json
+++ b/sap-3-tier-marketplace-image-multi-sid-db-md/azuredeploy.json
@@ -93,13 +93,6 @@
         "description": "The id of the subnet you want to use."
       }
     },
-    "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]",
-      "metadata": {
-        "description": "Location for all resources."
-      }
-    },
     "_artifactsLocation": {
       "type": "string",
       "metadata": {


### PR DESCRIPTION
Strict JSON parsers don't admit duplicate keys. (JSON parsers in general shouldn't admit duplicate keys, since behaviour is undefined).

I've parsed all templates files with a strict parser, correcting duplicate keys. From what I've observed, it seems like the AzureARM JSON parser sticks to the value of last key parsed.

I'd be good to not accept JSON with duplicate keys, as this can make templates very difficult to understand.