### PR TITLE
Use proper casing for maxLength and minLength properties

### DIFF
--- a/301-create-ad-forest-with-subdomain/azuredeploy.json
+++ b/301-create-ad-forest-with-subdomain/azuredeploy.json
@@ -22,7 +22,7 @@
         "description": "Full FQDN name for the forest root domain."
       },
       "defaultValue": "contoso.com",
-      "minlength": 4
+      "minLength": 4
     },
     "ChildDomainName": {
       "type": "string",
@@ -30,22 +30,22 @@
         "description": "SHORT name for the child domain. New AD trees are not allowed."
       },
       "defaultValue": "child",
-      "minlength": 2,
-      "maxlength": 15
+      "minLength": 2,
+      "maxLength": 15
     },
     "adminUsername": {
       "type": "string",
       "metadata": {
         "description": "The name of the admin account for the Domain(s)"
       },
-      "minlength": 6
+      "minLength": 6
     },
     "adminPassword": {
       "type": "securestring",
       "metadata": {
         "description": "The (complex!) password for the Administrator account of the new VMs and Domain(s)"
       },
-      "minlength": 8
+      "minLength": 8
     },
     "VMSize": {
       "type": "string",
@@ -103,8 +103,8 @@
         "description": "The name of the new VNET for the DC(s)."
       },
       "defaultValue": "adVNET",
-      "minlength": 2,
-      "maxlength": 16
+      "minLength": 2,
+      "maxLength": 16
     },
     "virtualNetworkAddressRange": {
       "type": "string",
@@ -126,8 +126,8 @@
         "description": "The name of the VM subnet created in the new VNET."
       },
       "defaultValue": "adSubnet",
-      "minlength": 2,
-      "maxlength": 16
+      "minLength": 2,
+      "maxLength": 16
     },
     "adSubnet": {
       "type": "string",
@@ -142,8 +142,8 @@
         "description": "The computer name of the first DC of the root domain."
       },
       "defaultValue": "rootdc1",
-      "minlength": 2,
-      "maxlength": 15
+      "minLength": 2,
+      "maxLength": 15
     },
     "RootDC1IPAddress": {
       "type": "string",
@@ -158,8 +158,8 @@
         "description": "The computer name of the second DC of the root domain."
       },
       "defaultValue": "rootdc2",
-      "minlength": 2,
-      "maxlength": 15
+      "minLength": 2,
+      "maxLength": 15
     },
     "RootDC2IPAddress": {
       "type": "string",
@@ -174,8 +174,8 @@
         "description": "The computer name of the first DC of the CHILD domain."
       },
       "defaultValue": "childdc3",
-      "minlength": 2,
-      "maxlength": 15
+      "minLength": 2,
+      "maxLength": 15
     },
     "ChildDC3IPAddress": {
       "type": "string",
@@ -190,8 +190,8 @@
         "description": "The computer name of the second DC of the CHILD domain."
       },
       "defaultValue": "childdc4",
-      "minlength": 2,
-      "maxlength": 15
+      "minLength": 2,
+      "maxLength": 15
     },
     "ChildDC4IPAddress": {
       "type": "string",


### PR DESCRIPTION
Change files to use the documented casing for the maxLength and minLength properties of parameters