### PR TITLE
update: replaced invalid VM in allowed list

### DIFF
--- a/101-vm-simple-linux/azuredeploy.json
+++ b/101-vm-simple-linux/azuredeploy.json
@@ -37,8 +37,8 @@
       "allowedValues": [
         "12.04.5-LTS",
         "14.04.5-LTS",
-        "15.10",
-        "16.04.0-LTS"
+        "16.04.0-LTS",
+        "18.04-LTS"
       ],
       "metadata": {
         "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."

--- a/101-vm-simple-linux/azuredeploy.json
+++ b/101-vm-simple-linux/azuredeploy.json
@@ -37,8 +37,8 @@
       "allowedValues": [
         "12.04.5-LTS",
         "14.04.5-LTS",
-        "16.04.0-LTS",
-        "18.04-LTS"
+        "15.10",
+        "16.04.0-LTS"
       ],
       "metadata": {
         "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."

--- a/201-encrypt-running-linux-vm/README.md
+++ b/201-encrypt-running-linux-vm/README.md
@@ -15,7 +15,7 @@ This template enables encryption on a running linux vm using AAD client secret. 
 ## Prerequisites:
 Azure Disk Encryption securely stores the encryption secrets in a specified Azure Key Vault.
 
-The [AzureDiskEncryptionPreRequisiteSetup.ps1](https://github.com/Azure/azure-powershell/blob/dev/src/ResourceManager/Compute/Commands.Compute/Extension/AzureDiskEncryption/Scripts/AzureDiskEncryptionPreRequisiteSetup.ps1) script can be used to create the Key Vault and assign appropriate access policies.
+The [AzureDiskEncryptionPreRequisiteSetup.ps1](https://raw.githubusercontent.com/Azure/azure-powershell/master/src/Compute/Compute/Extension/AzureDiskEncryption/Scripts/AzureDiskEncryptionPreRequisiteSetup.ps1) script can be used to create the Key Vault and assign appropriate access policies.
 
 Use the below PS cmdlet for getting the "keyVaultSecretUrl" and "keyVaultResourceId"
 

--- a/201-encrypt-running-linux-vm/README.md
+++ b/201-encrypt-running-linux-vm/README.md
@@ -15,7 +15,7 @@ This template enables encryption on a running linux vm using AAD client secret. 
 ## Prerequisites:
 Azure Disk Encryption securely stores the encryption secrets in a specified Azure Key Vault.
 
-The [AzureDiskEncryptionPreRequisiteSetup.ps1](https://raw.githubusercontent.com/Azure/azure-powershell/master/src/Compute/Compute/Extension/AzureDiskEncryption/Scripts/AzureDiskEncryptionPreRequisiteSetup.ps1) script can be used to create the Key Vault and assign appropriate access policies.
+The [AzureDiskEncryptionPreRequisiteSetup.ps1](https://github.com/Azure/azure-powershell/blob/dev/src/ResourceManager/Compute/Commands.Compute/Extension/AzureDiskEncryption/Scripts/AzureDiskEncryptionPreRequisiteSetup.ps1) script can be used to create the Key Vault and assign appropriate access policies.
 
 Use the below PS cmdlet for getting the "keyVaultSecretUrl" and "keyVaultResourceId"
 


### PR DESCRIPTION
1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* removed allowed VM "15.10" (No longer valid. If selected, deployment fails)
* added VM "18.04-LTS"
*