### PR TITLE
Change type Microsoft.Backup to Microsoft.RecoveryServices

### DIFF
--- a/101-backup-vault-create/azuredeploy.json
+++ b/101-backup-vault-create/azuredeploy.json
@@ -28,7 +28,7 @@
   },
   "resources": [
     {
-      "type": "Microsoft.RecoveryServices/BackupVault",
+      "type": "Microsoft.RecoveryServices/vaults",
       "apiVersion": "2016-06-01",
       "name": "[parameters('vaultName')]",
       "location": "[parameters('location')]",

--- a/101-backup-vault-create/azuredeploy.json
+++ b/101-backup-vault-create/azuredeploy.json
@@ -28,8 +28,8 @@
   },
   "resources": [
     {
-      "type": "Microsoft.Backup/BackupVault",
-      "apiVersion": "2015-03-15",
+      "type": "Microsoft.RecoveryServices/BackupVault",
+      "apiVersion": "2016-06-01",
       "name": "[parameters('vaultName')]",
       "location": "[parameters('location')]",
       "properties": {

--- a/101-backup-vault-create/azuredeploy.json
+++ b/101-backup-vault-create/azuredeploy.json
@@ -32,10 +32,13 @@
       "apiVersion": "2016-06-01",
       "name": "[parameters('vaultName')]",
       "location": "[parameters('location')]",
+      "tags": {
+      },
       "properties": {
-        "sku": {
-          "name": "[parameters('skuName')]"
-        }
+        "upgradeDetails": {}
+      },
+      "sku": {
+        "name": "[parameters('skuName')]"
       }
     }
   ]


### PR DESCRIPTION
`"type": "Microsoft.Backup/BackupVault"` is not working anymore. Have to use `"type": "Microsoft.RecoveryServices/vaults" `and api version changed `"apiVersion": "2016-06-01"`,
