### PR TITLE
password bug in simple vm

### DIFF
--- a/101-vm-simple-linux/azuredeploy.json
+++ b/101-vm-simple-linux/azuredeploy.json
@@ -19,10 +19,16 @@
         "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
       }
     },
-    "adminPasswordOrKey": {
+    "adminPassword": {
       "type": "securestring",
       "metadata": {
-        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+        "description": "Password for the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPublicKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key for the Virtual Machine. This is recommended."
       }
     },
     "dnsLabelPrefix": {
@@ -66,17 +72,6 @@
     "vmName": "MyUbuntuVM",
     "vmSize": "Standard_A1",
     "virtualNetworkName": "MyVNET",
-    "linuxConfiguration": {
-      "disablePasswordAuthentication": true,
-      "ssh": {
-        "publicKeys": [
-          {
-            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
-            "keyData": "[parameters('adminPasswordOrKey')]"
-          }
-        ]
-      }
-    },
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
   },
   "resources": [
@@ -166,8 +161,18 @@
         "osProfile": {
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPasswordOrKey')]",
-          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), parameters('adminPasswordOrKey'))]"
+          "adminPassword": "[parameters('adminPassword')]",
+          "linuxConfiguration": {
+            "disablePasswordAuthentication": true,
+            "ssh": {
+              "publicKeys": [
+                {
+                  "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                  "keyData": "[parameters('adminPublicKey')]"
+                }
+              ]
+            }
+          }
         },
         "storageProfile": {
           "imageReference": {

--- a/101-vm-simple-linux/azuredeploy.json
+++ b/101-vm-simple-linux/azuredeploy.json
@@ -19,16 +19,10 @@
         "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
       }
     },
-    "adminPassword": {
+    "adminPasswordOrKey": {
       "type": "securestring",
       "metadata": {
-        "description": "Password for the Virtual Machine. SSH key is recommended."
-      }
-    },
-    "adminPublicKey": {
-      "type": "securestring",
-      "metadata": {
-        "description": "SSH Key for the Virtual Machine. This is recommended."
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
     },
     "dnsLabelPrefix": {
@@ -72,6 +66,17 @@
     "vmName": "MyUbuntuVM",
     "vmSize": "Standard_A1",
     "virtualNetworkName": "MyVNET",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    },
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
   },
   "resources": [
@@ -161,18 +166,8 @@
         "osProfile": {
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]",
-          "linuxConfiguration": {
-            "disablePasswordAuthentication": true,
-            "ssh": {
-              "publicKeys": [
-                {
-                  "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
-                  "keyData": "[parameters('adminPublicKey')]"
-                }
-              ]
-            }
-          }
+          "adminPassword": "[if(equals(parameters('authenticationType'), 'password'), json('null'), json('null'))]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {
@@ -219,3 +214,4 @@
     }
   }
 }
+

--- a/101-vm-simple-linux/azuredeploy.json
+++ b/101-vm-simple-linux/azuredeploy.json
@@ -166,7 +166,7 @@
         "osProfile": {
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[if(equals(parameters('authenticationType'), 'password'), json('null'), json('null'))]",
+          "adminPassword": "[if(equals(parameters('authenticationType'), 'sshPublicKey'), json('null'), json('null'))]",
           "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {

--- a/101-vm-simple-linux/azuredeploy.json
+++ b/101-vm-simple-linux/azuredeploy.json
@@ -167,7 +167,7 @@
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPasswordOrKey')]",
-          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), parameters('adminPasswordOrKey'))]"
         },
         "storageProfile": {
           "imageReference": {

--- a/101-vm-simple-linux/azuredeploy.parameters.json
+++ b/101-vm-simple-linux/azuredeploy.parameters.json
@@ -5,7 +5,10 @@
     "adminUsername": {
       "value": "GEN-UNIQUE"
     },
-    "adminPasswordOrKey": {
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "adminPublicKey": {
       "value": "GEN-SSH-PUB-KEY"
     },
     "dnsLabelPrefix": {

--- a/101-vm-simple-linux/azuredeploy.parameters.json
+++ b/101-vm-simple-linux/azuredeploy.parameters.json
@@ -5,10 +5,7 @@
     "adminUsername": {
       "value": "GEN-UNIQUE"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
-    },
-    "adminPublicKey": {
+    "adminPasswordOrKey": {
       "value": "GEN-SSH-PUB-KEY"
     },
     "dnsLabelPrefix": {


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* forced adminPassword variable to be null when authn is sshPublicKey

### Reason

* current logic makes sshPublicKey null when authn is password but the reverse is not true...con't
* when authn is sshPublicKey, adminPassword is also assigned the sshPublicKey string (bug)

