### PR TITLE
Fix gist-url in 201-vm-push-certificate-windows/README.md

### DIFF
--- a/201-vm-push-certificate-windows/README.md
+++ b/201-vm-push-certificate-windows/README.md
@@ -9,6 +9,6 @@
 
 Push a certificate onto a VM. Pass in the URL of the secret in Key Vault.  The url must be a secret, not a certificate or key.
 
-Use <a href="https://gist.github.com/bmoore-msft/425b79b7b7e226264554ec534b956a48.js">this script</a> to create a new cert and put it into the vault.  The script can be easily modified to work with an existing cert.
+Use <a href="https://gist.github.com/bmoore-msft/425b79b7b7e226264554ec534b956a48">this script</a> to create a new cert and put it into the vault.  The script can be easily modified to work with an existing cert.
 
 


### PR DESCRIPTION


### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Remove .js from url to gist, as it doesn't work.

