### PR TITLE
Update allowedValues for kubernetesVersion in jenkins-cicd template

### DIFF
--- a/jenkins-cicd-container/azuredeploy.json
+++ b/jenkins-cicd-container/azuredeploy.json
@@ -147,10 +147,13 @@
     },
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.11.4",
+      "defaultValue": "1.12.6",
       "allowedValues": [
-        "1.11.5",
-        "1.11.4"
+        "1.12.6",
+        "1.12.5",
+        "1.11.8",
+        "1.11.7",
+        "1.10.13"
       ],
       "metadata": {
         "description": "The version of Kubernetes."


### PR DESCRIPTION
Related to #5483.

I have updated ```allowedValues``` to the five newest versions of Kubernetes available in East US. For reference:

```
C:\Dev> az aks get-versions --location eastus --output table
KubernetesVersion    Upgrades
-------------------  ------------------------
1.12.6               None available
1.12.5               1.12.6
1.11.8               1.12.5, 1.12.6
1.11.7               1.11.8, 1.12.5, 1.12.6
1.10.13              1.11.7, 1.11.8
1.10.12              1.10.13, 1.11.7, 1.11.8
1.9.11               1.10.12, 1.10.13
1.9.10               1.9.11, 1.10.12, 1.10.13
```
 
### Changelog

* Update allowedValues for kubernetesVersion in jenkins-cicd template

