### PR TITLE
[AKS] Update 101-aks with latest Kubernetes versions, clarify cluster name

### DIFF
--- a/101-aks/azuredeploy.json
+++ b/101-aks/azuredeploy.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "resourceName": {
+        "clusterName": {
             "type": "string",
             "defaultValue":"aks101cluster",
             "metadata": {
@@ -83,11 +83,11 @@
         },
         "kubernetesVersion": {
             "type": "string",
-            "defaultValue": "1.11.5",
+            "defaultValue": "1.12.6",
             "allowedValues": [
-                "1.9.11",
-                "1.10.9",
-                "1.11.5"
+                "1.10.13",
+                "1.11.8",
+                "1.12.6"
             ],
             "metadata": {
                 "description": "The version of Kubernetes."
@@ -99,7 +99,7 @@
             "apiVersion": "2018-03-31",
             "type": "Microsoft.ContainerService/managedClusters",
             "location": "[parameters('location')]",
-            "name": "[parameters('resourceName')]",
+            "name": "[parameters('clusterName')]",
             "properties": {
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
@@ -133,7 +133,7 @@
     "outputs": {
         "controlPlaneFQDN": {
             "type": "string",
-            "value": "[reference(parameters('resourceName')).fqdn]"
+            "value": "[reference(parameters('clusterName')).fqdn]"
         }
     }
 }

--- a/101-aks/azuredeploy.parameters.json
+++ b/101-aks/azuredeploy.parameters.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
 	"contentVersion": "1.0.0.0",
 	"parameters": {
-        "resourceName": {
+        "clusterName": {
 			"value": "GEN-UNIQUE"
 		},
 		"dnsPrefix": {

--- a/101-aks/metadata.json
+++ b/101-aks/metadata.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
-  "type": "QuickStart",
+    "type": "QuickStart",
     "itemDisplayName": "Azure Container Service (AKS)",
     "description": "Deploy a managed cluster with Azure Container Service (AKS)",
     "summary": "Deploy a managed cluster with Azure Container Service (AKS)",
     "githubUsername": "vyta",
-    "dateUpdated": "2018-12-06"
+    "dateUpdated": "2019-03-21"
 }
 


### PR DESCRIPTION
### Best Practice Checklist

- [ x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Updated _kubernetesVersion_ to latest supported releases for 1.12, 1.11, and 1.10.
* Renamed _resourceName_ to _clusterName_ to help minimize confusion since this is specific to the cluster resource name.
  * This template will be used in a quickstart on docs.microsoft.com/azure/aks, so would like to be quite clear on this _cluster_ name parameter.

CC: @mumian @tfitzmac 
