### PR TITLE
Cleanup descriptions of 101-webapp-basic-windows/azuredeploy.json

### DIFF
--- a/101-webapp-basic-windows/azuredeploy.json
+++ b/101-webapp-basic-windows/azuredeploy.json
@@ -5,7 +5,7 @@
     "webAppName": {
       "type": "string",
       "metadata": {
-        "description": "Base name of the resource such as web app name and app service plan "
+        "description": "Base name of the resource such as web app name and app service plan"
       },
       "minLength": 2
     },

--- a/101-webapp-basic-windows/azuredeploy.json
+++ b/101-webapp-basic-windows/azuredeploy.json
@@ -13,7 +13,7 @@
       "type": "string",
       "defaultValue" : "S1",
       "metadata": {
-        "description": "The SKU of App Service Plan, by defaut is standard S1"
+        "description": "The SKU of App Service Plan, by default is standard S1"
       }
     },
     "location": {

--- a/101-webapp-basic-windows/azuredeploy.json
+++ b/101-webapp-basic-windows/azuredeploy.json
@@ -13,7 +13,7 @@
       "type": "string",
       "defaultValue" : "S1",
       "metadata": {
-        "description": "The SKU of App Service Plan, by default is standard S1"
+        "description": "The SKU of App Service Plan, by default is Standard S1"
       }
     },
     "location": {

--- a/101-webapp-basic-windows/azuredeploy.json
+++ b/101-webapp-basic-windows/azuredeploy.json
@@ -20,7 +20,7 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
-        "description": "Location for all resources."
+        "description": "Location for all resources"
       }
     }
   },


### PR DESCRIPTION
A few cosmetic changes to descriptions in `101-webapp-basic-windows/azuredeploy.json`:
- Fixed a typo.
- Fixed casing of "Standard S1" plan.
- Removed whitespace.
- Removed the ending "." for consistency.

No changes to the functionality/ARM templates itself.

Thanks,
--Neno