### PR TITLE
BugFix JBoss EAP Standalone RHEL

### DIFF
--- a/jboss-eap-standalone-rhel7/README.md
+++ b/jboss-eap-standalone-rhel7/README.md
@@ -44,5 +44,8 @@ If you want to access the administration console go to http://<PUBLIC_HOSTNAME>:
 
 ## Notes
 
+If you don't have a Red Hat subscription to install a JBoss EAP, you can go through WildFly(JBoss EAP Upstream project) instead of EAP:
+
+*  <a href="https://github.com/Azure/azure-quickstart-templates/tree/master/wildfly-standalone-centos7" target="_blank"> [Red Hat WildFly 16 on an Azure VM]</a> - Standalone WildFly 16 with a sample web app on a CentOs 7 Azure VM.
 
 

--- a/jboss-eap-standalone-rhel7/README.md
+++ b/jboss-eap-standalone-rhel7/README.md
@@ -1,8 +1,8 @@
 # VM-Redhat - JBoss EAP 7 standalone mode
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-quickstart-templates%2Fmaster%2Fjboss-eap-standalone-rhel7%2Fazuredeploy.json" target="_blank">
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-quickstart-templates%2Fmaster%2Fvsts-tomcat-redhat-vm%2Fazuredeploy.json" target="_blank">
     <img src="http://azuredeploy.net/deploybutton.png"/>
 </a>
-<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-quickstart-templates%2Fmaster%2Fjboss-eap-standalone-rhel7%2Fazuredeploy.json" target="_blank">
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fazure%2Fazure-quickstart-templates%2Fmaster%2Fvsts-tomcat-redhat-vm%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
 

--- a/jboss-eap-standalone-rhel7/azuredeploy.json
+++ b/jboss-eap-standalone-rhel7/azuredeploy.json
@@ -27,7 +27,7 @@
       }
     },
     "eapPassword": {
-      "type": "string",
+      "type": "securestring",
       "metadata": {
         "description": "Password for EAP manager"
       }
@@ -39,13 +39,19 @@
       }
     },
     "rhsmPassword": {
-      "type": "string",
+      "type": "securestring",
       "metadata": {
         "description": "Password for Red Hat subscription  manager"
       }
     },
-    "sshPassPhrase": {
+    "rhsmPool": {
       "type": "string",
+      "metadata": {
+        "description": "Red Hat Subscription Manager Pool (must contain JBoss EAP entitlement)."
+      }
+    },
+    "sshPassPhrase": {
+      "type": "securestring",
       "metadata": {
         "description": "Pass phrase for SSH certificate"
       }
@@ -83,8 +89,6 @@
     "subnet1Prefix": "10.0.0.0/24",
     "publicIPAddressName": "[concat('myIP8',variables('baseName'))]",
     "publicIPAddressType": "Dynamic",
-    "vmStorageAccountContainerName": "vhds",
-    "OSDiskName": "osdisk1spec",
     "vmName": "[parameters('dnsLabelPrefix')]",
     "vmSize": "Standard_F1",
     "virtualNetworkName": "MyVNET8",
@@ -289,7 +293,7 @@
           "fileUris": [
             "[concat(parameters('_artifactsLocation'), '/', variables('ScriptFolder'), '/', variables('ScriptFileName'), parameters('_artifactsLocationSasToken'))]"
           ],
-          "commandToExecute": "[concat('sh eap-setup-redhat.sh',' ',parameters('adminUsername'),' ',parameters('eapUserName'),' ',parameters('eapPassword'),' ',parameters('rhsmUserName'),' ',parameters('rhsmPassword'),' ',parameters('sshPassPhrase'))]"
+          "commandToExecute": "[concat('sh eap-setup-redhat.sh',' ',parameters('adminUsername'),' ',parameters('eapUserName'),' ',parameters('eapPassword'),' ',parameters('rhsmUserName'),' ',parameters('rhsmPassword'),' ', parameters('rhsmPool'),' ',parameters('sshPassPhrase'))]"
         }
       }
     }

--- a/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
+++ b/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
@@ -3,10 +3,10 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "adminUsername": {
-          "value": "changeme"
+          "value": "GEN-UNIQUE"
         },
         "adminPassword": {
-          "value": "changeme"
+          "value": "GEN-PASSWORD"
         },
         "rhsmUserName": {
           "value": "changeme"
@@ -15,19 +15,19 @@
           "value": "changeme"
         },
         "dnsLabelPrefix": {
-            "value": "changeme"
+            "value": "GEN-UNIQUE"
         },
         "eapUserName": {
-          "value": "changeme"
+          "value": "GEN-UNIQUE"
         },
         "eapPassword": {
-          "value": "changeme"
+          "value": "securestring"
         },
         "rhsmPool": {
           "value": "changeme"
         },
         "sshPassPhrase": {
-          "value": "changeme"
+          "value": "GEN-PASSWORD"
         }
     }
 }

--- a/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
+++ b/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
@@ -9,10 +9,10 @@
           "value": "GEN-PASSWORD"
         },
         "rhsmUserName": {
-          "value": "changeme"
+          "value": "GEN-UNIQUE"
         },
         "rhsmPassword": {
-          "value": "changeme"
+          "value": "GEN_PASSWORD"
         },
         "dnsLabelPrefix": {
             "value": "GEN-UNIQUE"
@@ -24,7 +24,7 @@
           "value": "GEN-PASSWORD"
         },
         "rhsmPool": {
-          "value": "changeme"
+          "value": "GEN-UNIQUE"
         },
         "sshPassPhrase": {
           "value": "GEN-PASSWORD"

--- a/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
+++ b/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
@@ -21,7 +21,7 @@
           "value": "GEN-UNIQUE"
         },
         "eapPassword": {
-          "value": "securestring"
+          "value": "GEN-PASSWORD"
         },
         "rhsmPool": {
           "value": "changeme"

--- a/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
+++ b/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
@@ -3,28 +3,31 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "adminUsername": {
-          "value": "GEN-UNIQUE"
+          "value": "changeme"
         },
         "adminPassword": {
-          "value": "GEN-PASSWORD"
+          "value": "changeme"
         },
         "rhsmUserName": {
-          "value": "mfentane@redhat.com"
+          "value": "changeme"
         },
         "rhsmPassword": {
-          "value": "passw0rd!"
+          "value": "changeme"
         },
         "dnsLabelPrefix": {
-            "value": "GEN-UNIQUE"
+            "value": "changeme"
         },
         "eapUserName": {
-          "value": "GEN-UNIQUE"
+          "value": "changeme"
         },
         "eapPassword": {
-          "value": "securestring"
+          "value": "changeme"
+        },
+        "rhsmPool": {
+          "value": "changeme"
         },
         "sshPassPhrase": {
-          "value": "GEN-PASSWORD"
+          "value": "changeme"
         }
     }
 }

--- a/jboss-eap-standalone-rhel7/metadata.json
+++ b/jboss-eap-standalone-rhel7/metadata.json
@@ -4,8 +4,8 @@
   "itemDisplayName": "JBoss EAP server running a test application called dukes",
   "description": "This template allows you to create an Red Hat VM running JBoss EAP 7 and and also deploy a web application called dukes, you can login into the admin console using the user and password configured at the time of the deployment.",
   "summary": "Deploy a web application to test Red Hat VM running JBoss EAP7 in standalone mode",
-  "githubUsername": "myriamfentanes",
-  "dateUpdated": "2018-07-31"
+  "githubUsername": "danieloh30",
+  "dateUpdated": "2019-04-02"
 }
 
 

--- a/jboss-eap-standalone-rhel7/scripts/eap-setup-redhat.sh
+++ b/jboss-eap-standalone-rhel7/scripts/eap-setup-redhat.sh
@@ -13,15 +13,18 @@ EAP_USER=$2
 EAP_PASSWORD=$3
 RHSM_USER=$4
 RHSM_PASSWORD=$5
+export RHSM_POOL=$6
+
 PROFILE=standalone 
 echo "EAP admin user"+${EAP_USER} >> /home/$1/install.progress.txt
 echo "Initial EAP7 setup" >> /home/$1/install.progress.txt
-subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD --auto-attach >> /home/$1/install.progress.txt 2>&1
+subscription-manager register --username $RHSM_USER --password $RHSM_PASSWORD  >> /home/$1/install.progress.txt 2>&1
+subscription-manager attach --pool=${RHSM_POOL} >> /home/$1/install.progress.txt 2>&1
 echo "Subscribing the system to get access to EAP 7 repos" >> /home/$1/install.progress.txt
+
 # Install EAP7 
 subscription-manager repos --enable=jb-eap-7-for-rhel-7-server-rpms >> /home/$1/install.out.txt 2>&1
 yum-config-manager --disable rhel-7-server-htb-rpms
-yum update
 
 echo "Installing EAP7 repos" >> /home/$1/install.progress.txt
 yum groupinstall -y jboss-eap7 >> /home/$1/install.out.txt 2>&1
@@ -47,8 +50,7 @@ echo "Configuring EAP managment user" >> /home/$1/install.progress.txt
 $EAP_HOME/bin/add-user.sh -u $EAP_USER -p $EAP_PASSWORD -g 'guest,mgmtgroup'
 
 echo "Start EAP 7" >> /home/$1/install.progress.txt
-systemctl start eap7-standalone.service > /home/$1/install.out.txt 2>&1
-
+systemctl restart eap7-standalone.service 
 
 # Open Red Hat software firewall for port 8080 and 9990:
 firewall-cmd --zone=public --add-port=8080/tcp --permanent  >> /home/$1/install.out.txt 2>&1

--- a/jboss-eap-standalone-rhel7/scripts/eap-setup-redhat.sh
+++ b/jboss-eap-standalone-rhel7/scripts/eap-setup-redhat.sh
@@ -9,10 +9,10 @@ export EAP_HOME="/opt/rh/eap7/root/usr/share/wildfly"
 export EAP_RPM_CONF_STANDALONE="/etc/opt/rh/eap7/wildfly/eap7-standalone.conf"
 export EAP_RPM_CONF_DOMAIN="/etc/opt/rh/eap7/wildfly/eap7-domain.conf"
 
-EAP_USER=$2
-EAP_PASSWORD=$3
-RHSM_USER=$4
-RHSM_PASSWORD=$5
+export EAP_USER=$2
+export EAP_PASSWORD=$3
+export RHSM_USER=$4
+export RHSM_PASSWORD=$5
 export RHSM_POOL=$6
 
 PROFILE=standalone 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [v] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog
@rgardler 
* Add a rhsmPool parameter
* Change type of password parameters to securestring


