### PR TITLE
Remove preview instructions from VMSS disk encryption templates

### DIFF
--- a/201-decrypt-vmss-windows/README.md
+++ b/201-decrypt-vmss-windows/README.md
@@ -9,10 +9,4 @@
 
 This template disables encryption on a running VM Scale Set of Windows VMs.
 
-__Note: The VMSS encryption preview does not yet support image upgrade or reimage. Do not use this if you will need to upgrade your OS image in an encrypted scale set.__
 
-AzureDiskEncryption for VMSS is currently in preview. Consuming this feature requires enabling the preview feature on the subscription and setting up a key vault with 'EnabledForDiskEncryption' access policy using the Azure powershell cmdlets below 
-1. Set-AzureRmKeyVaultAccessPolicy -ResourceGroupName <rgName> -VaultName <vaultName> -EnabledForDiskEncryption"
-2. Register-AzureRmProviderFeature -FeatureName "UnifiedDiskEncryption" -ProviderNamespace "Microsoft.Compute"
-3. Wait 10 min until state transitions to 'Registered'
-4. Register-AzureRmResourceProvider -ProviderNamespace Microsoft.Compute

--- a/201-decrypt-vmss-windows/metadata.json
+++ b/201-decrypt-vmss-windows/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template disables encryption on a running Windows VM Scale Set",
   "summary": "This template disables encryption on a running Windows VM Scale Set",
   "githubUsername": "SudhakaraReddyEvuri",
-  "dateUpdated": "2017-05-03"
+  "dateUpdated": "2019-04-04"
 }
 
 

--- a/201-encrypt-running-vmss-linux/README.md
+++ b/201-encrypt-running-vmss-linux/README.md
@@ -9,8 +9,4 @@
 
 This template enables encryption on a running Virtual Machine Scale Set of Linux VMs.
 
-AzureDiskEncryption for VMSS is currently in preview. Consuming this feature requires enabling the preview feature on the subscription and setting up a key vault with 'EnabledForDiskEncryption' access policy using the Azure powershell cmdlets below 
-1. Register-AzureRmProviderFeature -FeatureName "UnifiedDiskEncryption" -ProviderNamespace "Microsoft.Compute"
-2. Set-AzureRmKeyVaultAccessPolicy -ResourceGroupName <rgName> -VaultName <vaultName> -EnabledForDiskEncryption"
 
-__Note: The VMSS encryption preview does not yet support image upgrade or reimage. Do not use this if you will need to upgrade your OS image in an encrypted scale set.__

--- a/201-encrypt-running-vmss-linux/metadata.json
+++ b/201-encrypt-running-vmss-linux/metadata.json
@@ -5,6 +5,6 @@
   "description": "Enables data volume encryption on a running Linux VMSS",
   "summary": "Enable data volume encryption on a running Linux VMSS",
   "githubUsername": "azure",
-  "dateUpdated": "2017-10-19"
+  "dateUpdated": "2019-04-04"
 }
 

--- a/201-encrypt-running-vmss-windows/README.md
+++ b/201-encrypt-running-vmss-windows/README.md
@@ -9,10 +9,3 @@
 
 This template enables encryption on a running VM Scale Set of Windows VMs.
 
-__Note: The VMSS encryption preview does not yet support image upgrade or reimage. Do not use this if you will need to upgrade your OS image in an encrypted scale set.__
-
-AzureDiskEncryption for VMSS is currently in preview. Consuming this feature requires enabling the preview feature on the subscription and setting up a key vault with 'EnabledForDiskEncryption' access policy using the Azure powershell cmdlets below 
-1. Set-AzureRmKeyVaultAccessPolicy -ResourceGroupName <rgName> -VaultName <vaultName> -EnabledForDiskEncryption"
-2. Register-AzureRmProviderFeature -FeatureName "UnifiedDiskEncryption" -ProviderNamespace "Microsoft.Compute"
-3. Wait 10 min until state transitions to 'Registered'
-4. Register-AzureRmResourceProvider -ProviderNamespace Microsoft.Compute

--- a/201-encrypt-running-vmss-windows/metadata.json
+++ b/201-encrypt-running-vmss-windows/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template enables encryption on a running Windows VM Scale Set",
   "summary": "This template enables encryption on a running Windows VM Scale Set",
   "githubUsername": "SudhakaraReddyEvuri",
-  "dateUpdated": "2017-05-03"
+  "dateUpdated": "2019-04-4"
 }
 
 

--- a/201-encrypt-running-vmss-windows/metadata.json
+++ b/201-encrypt-running-vmss-windows/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template enables encryption on a running Windows VM Scale Set",
   "summary": "This template enables encryption on a running Windows VM Scale Set",
   "githubUsername": "SudhakaraReddyEvuri",
-  "dateUpdated": "2019-04-4"
+  "dateUpdated": "2019-04-04"
 }
 
 

--- a/201-encrypt-vmss-linux-jumpbox/README.md
+++ b/201-encrypt-vmss-linux-jumpbox/README.md
@@ -9,11 +9,6 @@
 
 This template allows you to deploy a simple VM Scale Set of Linux VMs using the latest image version.  This template also deploys a jumpbox with a public IP address in the same virtual network. You can connect to the jumpbox via this public IP address, then connect from there to VMs in the scale set via private IP addresses. This template enables encryption on the VM Scale Set of Linux VMs.
 
-AzureDiskEncryption for VMSS is currently in preview. Consuming this feature requires enabling the preview feature on the subscription and setting up a key vault with 'EnabledForDiskEncryption' access policy using the Azure powershell cmdlets below 
-1. Register-AzureRmProviderFeature -FeatureName "UnifiedDiskEncryption" -ProviderNamespace "Microsoft.Compute"
-2. Set-AzureRmKeyVaultAccessPolicy -ResourceGroupName <rgName> -VaultName <vaultName> -EnabledForDiskEncryption"
-
-__Note: The VMSS encryption preview does not yet support image upgrade or reimage. Do not use this if you will need to upgrade your OS image in an encrypted scale set.__
 
 PARAMETER RESTRICTIONS
 ======================

--- a/201-encrypt-vmss-linux-jumpbox/metadata.json
+++ b/201-encrypt-vmss-linux-jumpbox/metadata.json
@@ -5,7 +5,7 @@
   "summary": "This template deploys a new Linux VMSS and jumpbox and enables encryption on the data volumes of the Linux VMSS instances.", 
   "description": "This template deploys a Linux VMSS using the latest Linux image, adds data volumes, and then encrypts the data volumes of each Linux VMSS instance.  It also deploys a jumpbox with a public IP address in the same virtual network as the Linux VMSS instances with private IP addresses.  This allows connecting to the jumpbox via its public IP address, and then connecting to the Linux VMSS instances via private IP addresses.",
   "githubUsername": "azure",
-  "dateUpdated": "2017-10-19"
+  "dateUpdated": "2019-04-04"
 }
 
 

--- a/201-encrypt-vmss-windows-jumpbox/README.md
+++ b/201-encrypt-vmss-windows-jumpbox/README.md
@@ -10,11 +10,6 @@
 This template allows you to deploy a simple VM Scale Set of Windows VMs using the latest patched version of serveral Windows versions. This template also deploys a jumpbox with a public IP address in the same virtual network. You can connect to the jumpbox via this public IP address, then connect from there to VMs in the scale set via private IP addresses.
 This template enables encryption on the VM Scale Set of Windows VMs.
 
-AzureDiskEncryption for VMSS is currently in preview. Consuming this feature requires enabling the preview feature on the subscription and setting up a key vault with 'EnabledForDiskEncryption' access policy using the Azure powershell cmdlets below 
-1. Register-AzureRmProviderFeature -FeatureName "UnifiedDiskEncryption" -ProviderNamespace "Microsoft.Compute"
-2. Set-AzureRmKeyVaultAccessPolicy -ResourceGroupName <rgName> -VaultName <vaultName> -EnabledForDiskEncryption"
-
-__Note: The VMSS encryption preview does not yet support image upgrade or reimage. Do not use this if you will need to upgrade your OS image in an encrypted scale set.__
 
 PARAMETER RESTRICTIONS
 ======================

--- a/201-encrypt-vmss-windows-jumpbox/metadata.json
+++ b/201-encrypt-vmss-windows-jumpbox/metadata.json
@@ -4,7 +4,7 @@
   "description": "This template allows you to deploy a simple VM Scale Set of Windows VMs using the lastest patched version of serveral Windows versions. This template also deploys a jumpbox with a public IP address in the same virtual network. You can connect to the jumpbox via this public IP address, then connect from there to VMs in the scale set via private IP addresses.This template enables encryption on the VM Scale Set of Windows VMs.",
   "summary": "This template deploys a VM Scale Set of Windows VMs with a jumpbox, enables encryption on VMSS.",
   "githubUsername": "sudhakarareddyevuri",
-  "dateUpdated": "2017-04-12"
+  "dateUpdated": "2019-04-04"
 }
 
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog
1. Removed instructions and information pertinent to VMSS preview from templates for enabling and disabling Azure disk encryption on Windows and Linux VMSS.
2. Modified date to current date in metadata.json for all the templates. 
*
*

