### PR TITLE
omsWorkspaceRegion - add North Europe

### DIFF
--- a/oms-all-deploy/azuredeploy.json
+++ b/oms-all-deploy/azuredeploy.json
@@ -44,10 +44,14 @@
       "type": "string",
       "defaultValue": "West Europe",
       "allowedValues": [
+        "Australia Southeast",
         "East US",
-        "West Europe",
+        "Japan East",
         "Southeast Asia",
-        "Australia Southeast"
+        "UK South",
+        "West Central US",
+        "West Europe",
+        "North Europe"
       ],
       "metadata": {
         "description": "Specify the region for your Workspace"

--- a/oms-all-deploy/nestedtemplates/omsWorkspace.json
+++ b/oms-all-deploy/nestedtemplates/omsWorkspace.json
@@ -12,10 +12,14 @@
             "type": "string",
             "defaultValue": "West Europe",
             "allowedValues": [
+                "Australia Southeast",
                 "East US",
-                "West Europe",
+                "Japan East",
                 "Southeast Asia",
-                "Australia Southeast"
+                "UK South",
+                "West Central US",
+                "West Europe",
+                "North Europe"
             ],
             "metadata": {
                 "description": "Specify the region for your Workspace"

--- a/oms-cloudfoundry-solution/azuredeploy.json
+++ b/oms-cloudfoundry-solution/azuredeploy.json
@@ -19,7 +19,8 @@
         "Southeast Asia",
         "UK South",
         "West Central US",
-        "West Europe"
+        "West Europe",
+        "North Europe"
       ],
       "metadata": {
         "description": "Specify the region for your Workspace"

--- a/oms-cloudfoundry-solution/nested/omsCustomViews.json
+++ b/oms-cloudfoundry-solution/nested/omsCustomViews.json
@@ -18,7 +18,8 @@
                 "Southeast Asia",
                 "UK South",
                 "West Central US",
-                "West Europe"
+                "West Europe",
+                "North Europe"
             ],
             "metadata": {
                 "description": "Specify the region for your Workspace"

--- a/oms-cloudfoundry-solution/nested/omsWorkspace.json
+++ b/oms-cloudfoundry-solution/nested/omsWorkspace.json
@@ -18,7 +18,8 @@
                 "Southeast Asia",
                 "UK South",
                 "West Central US",
-                "West Europe"
+                "West Europe",
+                "North Europe"
             ],
             "metadata": {
                 "description": "Specify the region for your Workspace"


### PR DESCRIPTION
North Europe region is now enabled for Azure OMS Log Analytics.

Commit adds North Europe region to allowedValues for `omsWorkspaceRegion`. Also updates two files under oms-all-deploy to make sure oms-cloudfoundry-solution list is in sync with that template. 

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Add Support for North Europe region in Azure OMS Log Analytics.
