### PR TITLE
Add SSH Auth to 201-vm-different-rg-vnet

### DIFF
--- a/101-jenkins/azuredeploy.json
+++ b/101-jenkins/azuredeploy.json
@@ -8,12 +8,6 @@
         "description": "User name for the Virtual Machine."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for the Virtual Machine."
-      }
-    },
     "jenkinsDnsPrefix": {
       "type": "string",
       "metadata": {
@@ -38,6 +32,23 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -54,7 +65,18 @@
     "vmPrivateIP": "10.0.0.5",
     "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.30.0/",
     "_extensionScript": "install_jenkins.sh",
-    "_artifactsLocationSasToken": ""
+    "_artifactsLocationSasToken": "",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -179,7 +201,8 @@
         "osProfile": {
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {

--- a/101-jenkins/azuredeploy.parameters.json
+++ b/101-jenkins/azuredeploy.parameters.json
@@ -3,16 +3,16 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "azureuser"
-    },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
+      "value": "GEN-UNIQUE"
     },
     "jenkinsDnsPrefix": {
       "value": "GEN-UNIQUE"
     },
     "jenkinsReleaseType": {
       "value": "LTS"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/201-vm-different-rg-vnet/azuredeploy.json
+++ b/201-vm-different-rg-vnet/azuredeploy.json
@@ -90,12 +90,6 @@
         "description": "VM Admin Username"
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "VM Password"
-      }
-    },
     "virtualNetworkName": {
       "type": "string",
       "metadata": {
@@ -126,11 +120,39 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
     "vnetID": "[resourceId(parameters('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/', parameters('subnet1Name'))]"
+    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/', parameters('subnet1Name'))]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -192,7 +214,8 @@
         "osProfile": {
           "computerName": "[parameters('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {

--- a/201-vm-different-rg-vnet/azuredeploy.parameters.json
+++ b/201-vm-different-rg-vnet/azuredeploy.parameters.json
@@ -1,36 +1,36 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "newStorageAccountName": {
-            "value": "GEN-UNIQUE"
-        },
-        "publicIPName": {
-            "value": "GEN-UNIQUE"
-        },
-        "vmName": {
-            "value": "GEN-UNIQUE-10"
-        },
-        "adminUsername": {
-            "value": "GEN-UNIQUE"
-        },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "virtualNetworkName": {
-            "value": "GET-PREREQ-virtualNetworkName"
-        },
-        "virtualNetworkResourceGroup": {
-            "value": "GET-PREREQ-virtualNetworkResourceGroup"
-        },
-        "subnet1Name": {
-            "value": "GET-PREREQ-subnet1Name"
-        },
-        "nicName": {
-            "value": "GEN-UNIQUE"
-        },
-        "imageSKU": {
-            "value": "18.04-LTS"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newStorageAccountName": {
+      "value": "GEN-UNIQUE"
+    },
+    "publicIPName": {
+      "value": "GEN-UNIQUE"
+    },
+    "vmName": {
+      "value": "GEN-UNIQUE-10"
+    },
+    "adminUsername": {
+      "value": "GEN-UNIQUE"
+    },
+    "virtualNetworkName": {
+      "value": "GET-PREREQ-virtualNetworkName"
+    },
+    "virtualNetworkResourceGroup": {
+      "value": "GET-PREREQ-virtualNetworkResourceGroup"
+    },
+    "subnet1Name": {
+      "value": "GET-PREREQ-subnet1Name"
+    },
+    "nicName": {
+      "value": "GEN-UNIQUE"
+    },
+    "imageSKU": {
+      "value": "18.04-LTS"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
+  }
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
*
*