### PR TITLE
Add SSH Auth to 201-vmss-ubuntu-web-ssl

### DIFF
--- a/101-jenkins/azuredeploy.json
+++ b/101-jenkins/azuredeploy.json
@@ -8,12 +8,6 @@
         "description": "User name for the Virtual Machine."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for the Virtual Machine."
-      }
-    },
     "jenkinsDnsPrefix": {
       "type": "string",
       "metadata": {
@@ -38,6 +32,23 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -54,7 +65,18 @@
     "vmPrivateIP": "10.0.0.5",
     "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.30.0/",
     "_extensionScript": "install_jenkins.sh",
-    "_artifactsLocationSasToken": ""
+    "_artifactsLocationSasToken": "",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -179,7 +201,8 @@
         "osProfile": {
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {

--- a/101-jenkins/azuredeploy.parameters.json
+++ b/101-jenkins/azuredeploy.parameters.json
@@ -3,16 +3,16 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "azureuser"
-    },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
+      "value": "GEN-UNIQUE"
     },
     "jenkinsDnsPrefix": {
       "value": "GEN-UNIQUE"
     },
     "jenkinsReleaseType": {
       "value": "LTS"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/201-vmss-ubuntu-web-ssl/azuredeploy.json
+++ b/201-vmss-ubuntu-web-ssl/azuredeploy.json
@@ -39,12 +39,6 @@
         "description": "Admin username on all VMs."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Admin password on all VMs."
-      }
-    },
     "vaultName": {
       "type": "string",
       "metadata": {
@@ -107,6 +101,23 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -134,7 +145,18 @@
       "sku": "[parameters('ubuntuOSVersion')]",
       "version": "latest"
     },
-    "imageReference": "[variables('osType')]"
+    "imageReference": "[variables('osType')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -305,7 +327,7 @@
           "osProfile": {
             "computerNamePrefix": "[variables('namingInfix')]",
             "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPassword')]",
+            "adminPassword": "[parameters('adminPasswordOrKey')]",
             "secrets": [
               {
                 "sourceVault": {
@@ -320,7 +342,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
           },
           "networkProfile": {
             "networkInterfaceConfigurations": [

--- a/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
+++ b/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
@@ -12,37 +12,34 @@
       "value": 1
     },
     "adminUsername": {
-      "value": "ubuntu"
+      "value": "GEN-UNIQUE"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
-    },
-
     "vaultResourceGroup": {
       "value": "REPLACE_VAULTRG"
     },
     "vaultName": {
-      "value" : "REPLACE_VAULTNAME"
+      "value": "REPLACE_VAULTNAME"
     },
-    "certThumbPrint" :
-    {
-        "value": "REPLACE_CERTPRINT"
+    "certThumbPrint": {
+      "value": "REPLACE_CERTPRINT"
     },
-    "caCertThumbPrint" :
-    {
-        "value": "REPLACE_CACERTPRINT"
+    "caCertThumbPrint": {
+      "value": "REPLACE_CACERTPRINT"
     },
-    "_artifactsLocation" : {
-        "value" : "https://REPLACE_SCRIPTSTORAGE.blob.core.windows.net/scripts"
+    "_artifactsLocation": {
+      "value": "https://REPLACE_SCRIPTSTORAGE.blob.core.windows.net/scripts"
     },
-    "scriptFileName" : {
-      "value" : "configuressl.sh"
+    "scriptFileName": {
+      "value": "configuressl.sh"
     },
     "httpssecretUrlWithVersion": {
       "value": "REPLACE_CERTURL"
     },
     "httpssecretCaUrlWithVersion": {
       "value": "REPLACE_CACERTURL"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
*
*