### PR TITLE
Add SSH Auth to 201-vmss-ubuntu-web-ssl

### DIFF
--- a/201-vmss-ubuntu-web-ssl/azuredeploy.json
+++ b/201-vmss-ubuntu-web-ssl/azuredeploy.json
@@ -39,12 +39,6 @@
         "description": "Admin username on all VMs."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Admin password on all VMs."
-      }
-    },
     "vaultName": {
       "type": "string",
       "metadata": {
@@ -107,6 +101,23 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -134,7 +145,18 @@
       "sku": "[parameters('ubuntuOSVersion')]",
       "version": "latest"
     },
-    "imageReference": "[variables('osType')]"
+    "imageReference": "[variables('osType')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -305,7 +327,7 @@
           "osProfile": {
             "computerNamePrefix": "[variables('namingInfix')]",
             "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPassword')]",
+            "adminPassword": "[parameters('adminPasswordOrKey')]",
             "secrets": [
               {
                 "sourceVault": {
@@ -320,7 +342,8 @@
                   }
                 ]
               }
-            ]
+            ],
+            "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
           },
           "networkProfile": {
             "networkInterfaceConfigurations": [

--- a/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
+++ b/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
@@ -21,10 +21,10 @@
       "value": "GEN-KEYVAULT-NAME"
     },
     "certThumbPrint": {
-      "value": "SF-CERT-THUMBPRINT"
+      "value": "GEN-SF-CERT-THUMBPRINT"
     },
     "caCertThumbPrint": {
-      "value": "SF-CERT-THUMBPRINT"
+      "value": "GEN-SF-CERT-THUMBPRINT"
     },
     "scriptFileName": {
       "value": "configuressl.sh"

--- a/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
+++ b/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
@@ -36,7 +36,7 @@
       "value": "GEN-KEYVAULT-SSL-SECRET-URI"
     },
     "httpssecretCaUrlWithVersion": {
-      "value": "GEN-KEYVAULT-SSL-SECRET-URIL"
+      "value": "GEN-KEYVAULT-SSL-SECRET-URI"
     },
     "adminPasswordOrKey": {
       "value": "GEN-SSH-PUB-KEY"

--- a/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
+++ b/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
@@ -26,9 +26,6 @@
     "caCertThumbPrint": {
       "value": "GEN-CUSTOM-DOMAIN-SSLCERT-THUMBPRINT"
     },
-    "_artifactsLocation": {
-      "value": "https://REPLACE_SCRIPTSTORAGE.blob.core.windows.net/scripts"
-    },
     "scriptFileName": {
       "value": "configuressl.sh"
     },

--- a/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
+++ b/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
@@ -15,16 +15,16 @@
       "value": "GEN-UNIQUE"
     },
     "vaultResourceGroup": {
-      "value": "REPLACE_VAULTRG"
+      "value": "GEN-KEYVAULT-RESOURCEGROUP-NAME"
     },
     "vaultName": {
-      "value": "REPLACE_VAULTNAME"
+      "value": "GEN-KEYVAULT-NAME"
     },
     "certThumbPrint": {
-      "value": "REPLACE_CERTPRINT"
+      "value": "GEN-CUSTOM-DOMAIN-SSLCERT-THUMBPRINT"
     },
     "caCertThumbPrint": {
-      "value": "REPLACE_CACERTPRINT"
+      "value": "GEN-CUSTOM-DOMAIN-SSLCERT-THUMBPRINT"
     },
     "_artifactsLocation": {
       "value": "https://REPLACE_SCRIPTSTORAGE.blob.core.windows.net/scripts"
@@ -33,10 +33,10 @@
       "value": "configuressl.sh"
     },
     "httpssecretUrlWithVersion": {
-      "value": "REPLACE_CERTURL"
+      "value": "GEN-KEYVAULT-SSL-SECRET-URI"
     },
     "httpssecretCaUrlWithVersion": {
-      "value": "REPLACE_CACERTURL"
+      "value": "GEN-KEYVAULT-SSL-SECRET-URIL"
     },
     "adminPasswordOrKey": {
       "value": "GEN-SSH-PUB-KEY"

--- a/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
+++ b/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
@@ -12,37 +12,34 @@
       "value": 1
     },
     "adminUsername": {
-      "value": "ubuntu"
+      "value": "GEN-UNIQUE"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
-    },
-
     "vaultResourceGroup": {
       "value": "REPLACE_VAULTRG"
     },
     "vaultName": {
-      "value" : "REPLACE_VAULTNAME"
+      "value": "REPLACE_VAULTNAME"
     },
-    "certThumbPrint" :
-    {
-        "value": "REPLACE_CERTPRINT"
+    "certThumbPrint": {
+      "value": "REPLACE_CERTPRINT"
     },
-    "caCertThumbPrint" :
-    {
-        "value": "REPLACE_CACERTPRINT"
+    "caCertThumbPrint": {
+      "value": "REPLACE_CACERTPRINT"
     },
-    "_artifactsLocation" : {
-        "value" : "https://REPLACE_SCRIPTSTORAGE.blob.core.windows.net/scripts"
+    "_artifactsLocation": {
+      "value": "https://REPLACE_SCRIPTSTORAGE.blob.core.windows.net/scripts"
     },
-    "scriptFileName" : {
-      "value" : "configuressl.sh"
+    "scriptFileName": {
+      "value": "configuressl.sh"
     },
     "httpssecretUrlWithVersion": {
       "value": "REPLACE_CERTURL"
     },
     "httpssecretCaUrlWithVersion": {
       "value": "REPLACE_CACERTURL"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
+++ b/201-vmss-ubuntu-web-ssl/azuredeploy.parameters.json
@@ -21,19 +21,19 @@
       "value": "GEN-KEYVAULT-NAME"
     },
     "certThumbPrint": {
-      "value": "GEN-CUSTOM-DOMAIN-SSLCERT-THUMBPRINT"
+      "value": "SF-CERT-THUMBPRINT"
     },
     "caCertThumbPrint": {
-      "value": "GEN-CUSTOM-DOMAIN-SSLCERT-THUMBPRINT"
+      "value": "SF-CERT-THUMBPRINT"
     },
     "scriptFileName": {
       "value": "configuressl.sh"
     },
     "httpssecretUrlWithVersion": {
-      "value": "GEN-KEYVAULT-SSL-SECRET-URI"
+      "value": "GEN-SF-CERT-URL"
     },
     "httpssecretCaUrlWithVersion": {
-      "value": "GEN-KEYVAULT-SSL-SECRET-URI"
+      "value": "GEN-SF-CERT-URL"
     },
     "adminPasswordOrKey": {
       "value": "GEN-SSH-PUB-KEY"

--- a/201-vmss-ubuntu-web-ssl/metadata.json
+++ b/201-vmss-ubuntu-web-ssl/metadata.json
@@ -5,5 +5,5 @@
   "description": "Deploys web servers configures with SSL certificates deployed securely form Azure Key Vault",
   "summary": "illustrates how to Store SSL certs from a 3rd party CA securely in Key Vault and deploy to a VMSS",
   "githubUsername": "xtophs",
-  "dateUpdated": "2019-04-25"
+  "dateUpdated": "2019-07-09"
 }

--- a/201-vmss-ubuntu-web-ssl/metadata.json
+++ b/201-vmss-ubuntu-web-ssl/metadata.json
@@ -5,7 +5,5 @@
   "description": "Deploys web servers configures with SSL certificates deployed securely form Azure Key Vault",
   "summary": "illustrates how to Store SSL certs from a 3rd party CA securely in Key Vault and deploy to a VMSS",
   "githubUsername": "xtophs",
-  "dateUpdated": "2017-05-07"
+  "dateUpdated": "2019-04-25"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
*
*