### PR TITLE
Add SSH Auth to chef-json-parameters-linux-vm

### DIFF
--- a/chef-json-parameters-linux-vm/azuredeploy.json
+++ b/chef-json-parameters-linux-vm/azuredeploy.json
@@ -14,12 +14,6 @@
         "description": "Admin user name for the Virtual Machines"
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Admin password for the Virtual Machine"
-      }
-    },
     "osType": {
       "type": "string",
       "allowedValues": [
@@ -123,6 +117,23 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -164,7 +175,18 @@
     "subnet1Prefix": "10.0.0.0/24",
     "subnet2Prefix": "10.0.1.0/24",
     "nicName": "myVMNic",
-    "dnsName": "[variables('subnet1Name')]"
+    "dnsName": "[variables('subnet1Name')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -242,8 +264,8 @@
       }
     },
     {
-      "apiVersion": "2017-03-30", 
-       "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2017-03-30",
+      "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
       "dependsOn": [
@@ -257,7 +279,8 @@
         "osProfile": {
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {
@@ -267,7 +290,7 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "[concat(variables('vmName'),'_OSDisk')]", 
+            "name": "[concat(variables('vmName'),'_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           }

--- a/chef-json-parameters-linux-vm/azuredeploy.parameters.json
+++ b/chef-json-parameters-linux-vm/azuredeploy.parameters.json
@@ -1,54 +1,54 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-      "adminUsername": {
-        "value": "GEN-UNIQUE"
-      },
-      "adminPassword": {
-        "value": "GEN-PASSWORD"
-      },
-      "vmDnsName": {
-        "value": "GET-PREREQ-vmdnsName"
-      },
-      "osType": {
-        "value": "Ubuntu-14.04.2-LTS"
-      },
-      "vmSize": {
-        "value": "Standard_A0"
-      },
-      "chef_node_name": {
-        "value": "GEN-UNIQUE"
-      },
-      "chef_server_url": {
-        "value": "GET-PREREQ-chefserverurl"
-      },
-      "validation_client_name": {
-        "value": "GEN-UNIQUE"
-      },
-      "runlist": {
-        "value": "recipe[getting-started]"
-      },
-      "validation_key": {
-        "value": "GEN-UNIQUE"
-      },
-      "validation_key_format": {
-        "value": "plaintext"
-      },
-      "bootstrap_version": {
-        "value": "12.15.19"
-      },
-      "bootstrap_channel": {
-        "value": "stable"
-      },
-      "daemon": {
-        "value": "none"
-      },
-      "chef_service_interval": {
-        "value": "60"
-      },
-      "secret": {
-        "value": "GEN-UNIQUE"
-      }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "value": "GEN-UNIQUE"
+    },
+    "vmDnsName": {
+      "value": "GET-PREREQ-vmdnsName"
+    },
+    "osType": {
+      "value": "Ubuntu-14.04.2-LTS"
+    },
+    "vmSize": {
+      "value": "Standard_A0"
+    },
+    "chef_node_name": {
+      "value": "GEN-UNIQUE"
+    },
+    "chef_server_url": {
+      "value": "GET-PREREQ-chefserverurl"
+    },
+    "validation_client_name": {
+      "value": "GEN-UNIQUE"
+    },
+    "runlist": {
+      "value": "recipe[getting-started]"
+    },
+    "validation_key": {
+      "value": "GEN-UNIQUE"
+    },
+    "validation_key_format": {
+      "value": "plaintext"
+    },
+    "bootstrap_version": {
+      "value": "12.15.19"
+    },
+    "bootstrap_channel": {
+      "value": "stable"
+    },
+    "daemon": {
+      "value": "none"
+    },
+    "chef_service_interval": {
+      "value": "60"
+    },
+    "secret": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
+    }
   }
 }

--- a/chef-json-parameters-linux-vm/metadata.json
+++ b/chef-json-parameters-linux-vm/metadata.json
@@ -5,8 +5,5 @@
   "description": "Deploy an Ubuntu/Centos VM With Chef with JSON parameters",
   "summary": "Deploy an Ubuntu/Centos VM With Chef with JSON parameters",
   "githubUsername": "kundanap",
-  "dateUpdated": "2018-08-07" 
-
+  "dateUpdated": "2019-05-02"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
*
*