### PR TITLE
Add SSH Auth to vertx-openjdk-apache-mysql-on-ubuntu

### DIFF
--- a/vertx-openjdk-apache-mysql-on-ubuntu/azuredeploy.json
+++ b/vertx-openjdk-apache-mysql-on-ubuntu/azuredeploy.json
@@ -14,12 +14,6 @@
         "description": "User name for the Virtual Machine."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for the Virtual Machine."
-      }
-    },
     "dnsNameForPublicIP": {
       "type": "string",
       "metadata": {
@@ -45,6 +39,23 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -61,7 +72,18 @@
     "vmStorageAccountContainerName": "vhds",
     "vmSize": "Standard_A2",
     "virtualNetworkName": "vertxVNET",
-    "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
+    "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -148,7 +170,8 @@
         "osProfile": {
           "computerName": "[parameters('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {
@@ -158,7 +181,7 @@
             "version": "latest"
           },
           "osDisk": {
-            "name":"[concat(parameters('vmName'),'_OSDisk')]",
+            "name": "[concat(parameters('vmName'),'_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           }

--- a/vertx-openjdk-apache-mysql-on-ubuntu/azuredeploy.parameters.json
+++ b/vertx-openjdk-apache-mysql-on-ubuntu/azuredeploy.parameters.json
@@ -1,21 +1,21 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "newStorageAccountName": {
-            "value": "GEN-UNIQUE-10"
-        },
-        "adminUsername": {
-            "value": "GEN-UNIQUE-8"
-        },
-        "dnsNameForPublicIP": {
-            "value": "GEN-UNIQUE-11"
-        },
-        "vmName": {
-            "value": "GEN-UNIQUE-8"
-        },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "newStorageAccountName": {
+      "value": "GEN-UNIQUE-10"
+    },
+    "adminUsername": {
+      "value": "GEN-UNIQUE-8"
+    },
+    "dnsNameForPublicIP": {
+      "value": "GEN-UNIQUE-11"
+    },
+    "vmName": {
+      "value": "GEN-UNIQUE-8"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
+  }
 }

--- a/vertx-openjdk-apache-mysql-on-ubuntu/metadata.json
+++ b/vertx-openjdk-apache-mysql-on-ubuntu/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template uses the Azure Linux CustomScript extension to deploy Vert.x, OpenJDK, Apache, and MySQL Server on Ubuntu 14.04 LTS.",
   "summary": "Deploy an Ubuntu VM with Vert.x, OpenJDK, Apache, and MySQL Server",
   "githubUsername": "oguzpastirmaci",
-  "dateUpdated": "2018-07-20"
+  "dateUpdated": "2019-05-03"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
*
*