### PR TITLE
SCCM TP: to use burstable VM size to save the overall cost

### DIFF
--- a/sccm-technicalpreview/azuredeploy.json
+++ b/sccm-technicalpreview/azuredeploy.json
@@ -55,9 +55,7 @@
     "vnetId": "[resourceId(resourceGroup().name, 'Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]",
     "generalSettings": {
       "domainName": "contoso.com",
-      "storageAccountType": "Standard_LRS",
-      "DiskstorageAccountType": "Premium_LRS",
-      "virtualMachinessize": "Standard_D2s_v3"
+      "storageAccountType": "Standard_LRS"
     },
     "networkSettings": {
       "virtualNetworkAddressPrefix": "10.0.0.0/16",
@@ -82,6 +80,16 @@
       "DC",
       "DPMP",
       "PS1"
+    ],
+    "vmDiskType": [
+      "Premium_LRS",
+      "Premium_LRS",
+      "Premium_LRS"
+    ],
+    "vmSize": [
+      "Standard_B2s",
+      "Standard_B2s",
+      "Standard_B2ms"
     ]
   },
   "resources": [
@@ -128,7 +136,7 @@
           }
         },
         "hardwareProfile": {
-          "vmSize": "[variables('generalSettings').virtualMachinessize]"
+          "vmSize": "[variables('vmSize')[copyIndex()]]"
         },
         "storageProfile": {
           "imageReference": {
@@ -143,7 +151,7 @@
             "createOption": "FromImage",
             "caching": "ReadWrite",
             "managedDisk": {
-              "storageAccountType": "[variables('generalSettings').DiskstorageAccountType]"
+              "storageAccountType": "[variables('vmDiskType')[copyIndex()]]"
             },
             "diskSizeGB": 150
           },
@@ -312,7 +320,7 @@
           }
         },
         "hardwareProfile": {
-          "vmSize": "[variables('generalSettings').virtualMachinessize]"
+          "vmSize": "[variables('vmSize')[2]]"
         },
         "storageProfile": {
           "imageReference": {
@@ -324,7 +332,7 @@
           "osDisk": {
             "createOption": "FromImage",
             "managedDisk": {
-              "storageAccountType": "[variables('generalSettings').DiskstorageAccountType]"
+              "storageAccountType": "[variables('vmDiskType')[2]]"
             }
           },
           "dataDisks": []


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

