### PR TITLE
Updated App Service Environment creation template

### DIFF
--- a/201-web-app-asev2-create/README.md
+++ b/201-web-app-asev2-create/README.md
@@ -10,3 +10,10 @@
 For more details on App Service Environments, see the [Introduction to App Service Environments](https://docs.microsoft.com/en-us/azure/app-service/app-service-environment/intro).
 
 This template enables creation of an External or ILB ASE. An External ASE has a public address for application traffic and an ILB ASE has an address in your VNet for application traffic. Apps made in an External ASE will be accessible, by default, at the domain name *&lt;app name&gt;.&lt;ASE name&gt;.p.azurewebsites.net*   Apps made in an ILB ASE will be accesible, by default, at the domain name *&lt;app name&gt;.&lt;ASE name&gt;.appserviceenvironment.net* 
+
+Creation of an ASE, with this template, requires a pre-existing resource manager virtual network and an empty subnet within it. The recommended subnet size is a /24 with 256 addresses. To deploy an ASE with this template you must provide:
+
+- aseName:  This is the name of your ASE which is used in the default name of the apps made in this ASE
+- aseLocation: This is the region that the VNet is in which you are using to host your ASE
+- existing SubnetResourceId: This is the resource ID of the subnet which is used for this ASE. It is the same as the &lt;VNet resource ID&gt;/subnets/&lt;subnet name&gt;
+- internalLoadBalancingMode: There are two options. A value of 0 means create an external ASE with a public address for the apps in the ASE. A value of 3 will create an ILB ASE which has a private address in your VNet for the apps within your ASE.

--- a/201-web-app-asev2-create/README.md
+++ b/201-web-app-asev2-create/README.md
@@ -8,3 +8,5 @@
 </a>
 
 For more details on App Service Environments, see the [Introduction to App Service Environments](https://docs.microsoft.com/en-us/azure/app-service/app-service-environment/intro).
+
+This template enables creation of an External or ILB ASE. An External ASE has a public address for application traffic and an ILB ASE has an address in your VNet for application traffic. Apps made in an External ASE will be accessible, by default, at the domain name *&lt;app name&gt;.&lt;ASE name&gt;.p.azurewebsites.net*   Apps made in an ILB ASE will be accesible, by default, at the domain name *&lt;app name&gt;.&lt;ASE name&gt;.appserviceenvironment.net* 

--- a/201-web-app-asev2-create/azuredeploy.json
+++ b/201-web-app-asev2-create/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "aseName": {

--- a/201-web-app-asev2-create/azuredeploy.json
+++ b/201-web-app-asev2-create/azuredeploy.json
@@ -38,7 +38,6 @@
         "properties": {
           "name": "[parameters('aseName')]",
           "location": "[parameters('aseLocation')]",
-          "ipSslAddressCount": 0,
           "internalLoadBalancingMode": "[parameters('internalLoadBalancingMode')]",
           "virtualNetwork": {
             "Id": "[parameters('existingSubnetResourceId')]",

--- a/201-web-app-asev2-create/azuredeploy.json
+++ b/201-web-app-asev2-create/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "aseName": {
@@ -10,36 +10,27 @@
         },
         "aseLocation": { 
             "type": "string",
-            "defaultValue": "South Central US",
             "metadata": { 
                 "description": "Location of the App Service Environment" 
             } 
-        }, 
-        "existingVirtualNetworkName": {
+         },
+        "existingSubnetResourceId": {
             "type": "string",
             "metadata": {
-              "description": "Name of the existing VNET"
+                "description": "ARM Url reference for the subnet that will contain the ASE.  Only Microsoft.Network is supported for ASEv2.  /subscriptions/subIDGoesHere/resourceGroups/rgNameGoesHere/providers/Microsoft.Network/virtualNetworks/vnetnamegoeshere/subnets/subnetnamegoeshere"
             }
         },
-        "existingVirtualNetworkResourceGroup": {
-            "type": "string",
+        "internalLoadBalancingMode": {
+            "type": "int",
+            "allowedValues": [0,3],
             "metadata": {
-              "description": "Name of the existing VNET resource group"
-            }
-        }, 
-        "subnetName": {
-            "type": "string",
-            "metadata": {
-                "description": "Subnet name that will contain the App Service Environment"
+                "description": "0 = public VIP only, 3 = both ports 80/443 and FTP ports are mapped to an ILB VIP."
             }
         }
     },
-    "variables":{
-        "vnetID": "[resourceId(parameters('existingVirtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', parameters('existingVirtualNetworkName'))]"
-    },
     "resources": [
       {
-        "apiVersion": "2015-08-01",
+        "apiVersion": "2019-02-01",
         "type": "Microsoft.Web/hostingEnvironments",
         "name": "[parameters('aseName')]",
         "kind": "ASEV2",
@@ -47,9 +38,10 @@
         "properties": {
           "name": "[parameters('aseName')]",
           "location": "[parameters('aseLocation')]",
+          "ipSslAddressCount": 0,
+          "internalLoadBalancingMode": "[parameters('internalLoadBalancingMode')]",
           "virtualNetwork": {
-            "Id": "[variables('vnetID')]",
-            "Subnet": "[parameters('subnetName')]"
+            "Id": "[parameters('existingSubnetResourceId')]",
           }
         }
       }

--- a/201-web-app-asev2-create/azuredeploy.parameters.json
+++ b/201-web-app-asev2-create/azuredeploy.parameters.json
@@ -1,18 +1,18 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json",
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "aseName": {
             "value": "GEN-UNIQUE"
         },
         "aseLocation": {
-            "value": "changeme"
+            "value": "South Central US"
         },
         "existingSubnetResourceId": {
-            "value": "/subscriptions/changeme/resourceGroups/changeme/providers/Microsoft.Network/virtualNetworks/changeme/subnets/changeme"
+            "value": "GEN-VNET-SUBNET-RESOURCE-ID"
         },
         "internalLoadBalancingMode": {
-            "value": "changeme"
+            "value": "3"
         }
     }
 }

--- a/201-web-app-asev2-create/azuredeploy.parameters.json
+++ b/201-web-app-asev2-create/azuredeploy.parameters.json
@@ -1,21 +1,18 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json",
+    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "aseName": {
-            "value": "GEN_UNIQUE"
+            "value": "GEN-UNIQUE"
         },
         "aseLocation": {
-            "value": "South Central US"
+            "value": "changeme"
         },
-        "existingVirtualNetworkName": {
-            "value": "GET-PREREQ-virtualNetwork"
+        "existingSubnetResourceId": {
+            "value": "/subscriptions/changeme/resourceGroups/changeme/providers/Microsoft.Network/virtualNetworks/changeme/subnets/changeme"
         },
-        "existingVirtualNetworkResourceGroup": {
-            "value": "GET-PREREQ-rgName"
-        },
-        "subnetName": {
-            "value": "GET-PREREQ-subnet"
+        "internalLoadBalancingMode": {
+            "value": "changeme"
         }
     }
 }

--- a/201-web-app-asev2-create/metadata.json
+++ b/201-web-app-asev2-create/metadata.json
@@ -4,7 +4,7 @@
   "itemDisplayName": "Create an App Service Environment v2",
   "description": "Creates an App Service Environment v2 in your virtual network",
   "summary": "Create an App Service Environment v2",
-  "githubUsername": "ccompy",
+  "githubUsername": "stefsch",
   "dateUpdated": "2019-05-09"
 }
 

--- a/201-web-app-asev2-create/metadata.json
+++ b/201-web-app-asev2-create/metadata.json
@@ -4,8 +4,8 @@
   "itemDisplayName": "Create an App Service Environment v2",
   "description": "Creates an App Service Environment v2 in your virtual network",
   "summary": "Create an App Service Environment v2",
-  "githubUsername": "stefsch",
-  "dateUpdated": "2018-04-03"
+  "githubUsername": "ccompy",
+  "dateUpdated": "2019-05-09"
 }
 
 


### PR DESCRIPTION
The new ASE creation template solves several problems that customers have today with their ASEs. 
Because the ASE is itself still an RDFE cloud service under the covers, there is only so much that can be done around automated testing, GEN field values, and similar things. The user of the template must have a pre-existing VNet in order to run the template. The four values they are required to provide include:
name of the ASE, location the ASE is deployed into, resource ID of the subnet the ASE is deployed into, and the internal load balancing mode.  
We will explore being able to perform automated deployment testing with travis CI but this update will skip it it like with the previous version.
