### PR TITLE
Updated to subnets as properties of VNET

### DIFF
--- a/101-vnet-two-subnets/azuredeploy.json
+++ b/101-vnet-two-subnets/azuredeploy.json
@@ -64,34 +64,22 @@
           "addressPrefixes": [
             "[parameters('vnetAddressPrefix')]"
           ]
-        }
-      },
-      "resources": [
-        {
-          "apiVersion": "2018-10-01",
-          "type": "subnets",
-          "location": "[parameters('location')]",
-          "name": "[parameters('subnet1Name')]",
-          "dependsOn": [
-            "[parameters('vnetName')]"
-          ],
-          "properties": {
-            "addressPrefix": "[parameters('subnet1Prefix')]"
-          }
         },
-        {
-          "apiVersion": "2018-10-01",
-          "type": "subnets",
-          "location": "[parameters('location')]",
-          "name": "[parameters('subnet2Name')]",
-          "dependsOn": [
-            "[parameters('vnetName')]"
-          ],
-          "properties": {
-            "addressPrefix": "[parameters('subnet2Prefix')]"
+        "subnets": [
+          {
+            "name": "[parameters('subnet1Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet1Prefix')]"
+            }
+          },
+          {
+            "name": "[parameters('subnet2Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet2Prefix')]"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
Prevents an error when deploying - another operation is in progress. This way subnets are properties of the parent vnet therefore prevents a race condition

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

