### PR TITLE
Fixes and Enhancements

### DIFF
--- a/test/template-tests/AzRMTester.ezformat.ps1
+++ b/test/template-tests/AzRMTester.ezformat.ps1
@@ -30,10 +30,11 @@ Write-FormatView -Action {
     $foregroundColor = 'Green'
     $statusChar = '+'
 
-    $messageLines = @(
+    $errorLines = @(
         foreach ($_ in $testOut.Errors) {
             "$_"
-        }
+        })
+    $warningLines = @(
         foreach ($_ in $testOut.Warnings) {
             "$_"
         }
@@ -54,10 +55,16 @@ Write-FormatView -Action {
     $null
 
     $indent = 4
-    if ($messageLines) {
+    if ($errorLines) {
         Write-Host " " # end of line
-        foreach ($line in $messageLines) {
-            Write-Host "$(' ' * $indent)$line" -foregroundColor $foregroundColor    
+        foreach ($line in $errorLines) {
+            Write-Host "$(' ' * $indent)$line" -foregroundColor Red    
+        }
+    }
+    if ($warningLines) {
+        Write-Host " " # end of line
+        foreach ($line in $warningLines) {
+            Write-Host "$(' ' * $indent)$line" -foregroundColor DarkYellow 
         }
     }
     

--- a/test/template-tests/AzRMTester.format.ps1xml
+++ b/test/template-tests/AzRMTester.format.ps1xml
@@ -38,10 +38,11 @@
     $foregroundColor = 'Green'
     $statusChar = '+'
 
-    $messageLines = @(
+    $errorLines = @(
         foreach ($_ in $testOut.Errors) {
             "$_"
-        }
+        })
+    $warningLines = @(
         foreach ($_ in $testOut.Warnings) {
             "$_"
         }
@@ -62,10 +63,16 @@
     $null
 
     $indent = 4
-    if ($messageLines) {
+    if ($errorLines) {
         Write-Host " " # end of line
-        foreach ($line in $messageLines) {
-            Write-Host "$(' ' * $indent)$line" -foregroundColor $foregroundColor    
+        foreach ($line in $errorLines) {
+            Write-Host "$(' ' * $indent)$line" -foregroundColor Red    
+        }
+    }
+    if ($warningLines) {
+        Write-Host " " # end of line
+        foreach ($line in $warningLines) {
+            Write-Host "$(' ' * $indent)$line" -foregroundColor DarkYellow 
         }
     }
     

--- a/test/template-tests/Test-AzureRMTemplate.cmd
+++ b/test/template-tests/Test-AzureRMTemplate.cmd
@@ -1,1 +1,1 @@
-powershell.exe -noprofile -nologo -command "Import-Module Pester, '%~dp0AzRMTester.psd1'; Test-AzureRMTemplate %*; if ($error.Count) { exit 1}"
+powershell.exe -noprofile -nologo -command "Import-Module '%~dp0AzRMTester.psd1'; Test-AzureRMTemplate %*; if ($error.Count) { exit 1}"

--- a/test/template-tests/Test-AzureRMTemplate.ps1
+++ b/test/template-tests/Test-AzureRMTemplate.ps1
@@ -88,9 +88,9 @@ Each test script has access to a set of well-known variables:
     [Collections.IDictionary]
     $TestGroup = [Ordered]@{},
 
-    # If set, will not run tests in Pester.
+    # If set, will run tests in Pester.
     [switch]
-    $NoPester)
+    $Pester)
 
     begin {
         # First off, let's get all of the built-in test scripts.   
@@ -167,7 +167,7 @@ Each test script has access to a set of well-known variables:
                 }
             }
             
-            if ($NoPester) {
+            if (-not $Pester) {
                 & $TheTest @testInput 2>&1 3>&1
             } else {
                 & $TheTest @testInput
@@ -190,7 +190,7 @@ Each test script has access to a set of well-known variables:
                     continue
                 }
 
-                if ($NoPester) {
+                if (-not $Pester) {
                     $testStartedAt = [DateTime]::Now
                     $testCaseOutput = Test-Case $testCase.$dq $TestInput 2>&1 3>&1
                     $testTook = [DateTime]::Now - $testStartedAt
@@ -277,7 +277,7 @@ Each test script has access to a set of well-known variables:
                     } else {
                         $null
                     }
-                    if ($NoPester) {
+                    if (-not $Pester) {
                         $context = "$($fileInfo.Name)->$groupName"
                         Test-Group
                     } else {
@@ -383,7 +383,7 @@ Each test script has access to a set of well-known variables:
         
         
             # Now that the filelist and test groups are set up, we use Test-FileList to test the list of files.                   
-            if (-not $NoPester) {
+            if ($Pester) {
                 $IsPesterLoaded? = $(
                     $loadedModules = Get-module
                     foreach ($_ in $loadedModules) { 
@@ -404,11 +404,11 @@ Each test script has access to a set of well-known variables:
 
                 if (-not $DoesPesterExist?){
                     Write-Warning "Pester not found.  Please install Pester (Install-Module Pester)"
-                    $NoPester = $true
+                    $Pester = $false
                 }
             }
         
-            if ($NoPester) { # If we're not running Pester, 
+            if (-not $Pester) { # If we're not running Pester, 
                 Test-FileList # we just call it directly.
             }
             else { 

--- a/test/template-tests/Test-AzureRMTemplate.sh
+++ b/test/template-tests/Test-AzureRMTemplate.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-powershell -noprofile -nologo -command "Import-Module Pester, '$(dirname $(readlink -f $0))/AzRMTester.psd1'; Test-AzureRMTemplate $@ ; if (\$error.Count) { exit 1}"
+powershell -noprofile -nologo -command "Import-Module '$(dirname $(readlink -f $0))/AzRMTester.psd1'; Test-AzureRMTemplate $@ ; if (\$error.Count) { exit 1}"

--- a/test/template-tests/testcases/deploymentTemplate/Location-Should-Not-Be-Hardcoded.test.ps1
+++ b/test/template-tests/testcases/deploymentTemplate/Location-Should-Not-Be-Hardcoded.test.ps1
@@ -3,7 +3,7 @@
 [string]$TemplateText,
 
 [Parameter(Mandatory=$true,Position=1)]
-[string]$TemplateObject,
+[PSObject]$TemplateObject,
 
 [Parameter(Mandatory=$true,Position=1)]
 [switch]$IsMainTemplate
@@ -26,7 +26,7 @@ if ($locationParameter -and
     "$($locationParameter.defaultValue)".Trim() -ne 'global' -and 
     $IsMainTemplate) {
     # If it wasn't, write an error
-    Write-Error "Location parameter must not be hardcoded.  The default value should be [resourceGroup().location]." -ErrorId Location.Parameter.Hardcoded -TargetObject $parameter
+    Write-Error "Location parameter must not be hardcoded.  The default value should be [resourceGroup().location]. It is $($locationParameter.defaultValue)" -ErrorId Location.Parameter.Hardcoded -TargetObject $parameter
 }
 
 # Now check that the rest of the template doesn't use [resourceGroup().location] 

--- a/test/template-tests/testcases/deploymentTemplate/Location-Should-Not-Be-Hardcoded.test.ps1
+++ b/test/template-tests/testcases/deploymentTemplate/Location-Should-Not-Be-Hardcoded.test.ps1
@@ -22,11 +22,10 @@ $locationParameter = $templateObject.parameters.location
 
 # Make sure that the template parameter's default is the expression [resourceGroup().location] 
 if ($locationParameter -and 
-    "$($locationParameter.defaultvalue)".Trim() -ne '[resourceGroup().location]' -and
-    "$($locationParameter.defaultValue)".Trim() -ne 'global' -and 
+    "$($locationParameter.defaultvalue)".Trim() -ne '[resourceGroup().location]' -and 
     $IsMainTemplate) {
     # If it wasn't, write an error
-    Write-Error "Location parameter must not be hardcoded.  The default value should be [resourceGroup().location]. It is $($locationParameter.defaultValue)" -ErrorId Location.Parameter.Hardcoded -TargetObject $parameter
+    Write-Error "The defaultValue of the location parameter must not be a specific location. The default value must be [resourceGroup().location]. It is $($locationParameter.defaultValue)" -ErrorId Location.Parameter.Hardcoded -TargetObject $parameter
 }
 
 # Now check that the rest of the template doesn't use [resourceGroup().location] 

--- a/test/template-tests/testcases/deploymentTemplate/Min-And-Max-Value-Are-Numbers.test.ps1
+++ b/test/template-tests/testcases/deploymentTemplate/Min-And-Max-Value-Are-Numbers.test.ps1
@@ -10,29 +10,29 @@ foreach ($parameterInfo in $templateObject.parameters.psobject.properties) {
     $parameter = $parameterInfo.Value
     $Min = $null
     $Max = $null
-    if ($parameter.psobject.properties.item('MaxValue')) {
+    if ($parameter.psobject.properties.item('maxValue')) {
         if ($parameter.maxValue -isnot [int]) {
-            Write-Error "$($Parameter.Name) maxValue is not an [int] (it's a [$($parameter.maxValue.GetType())])" `
+            Write-Error "$($ParameterName) maxValue is not an [int] (it's a [$($parameter.maxValue.GetType())])" `
                 -ErrorId Parameter.Max.Not.Int -TargetObject $parameter
         } else {
             $max = $parameter.maxValue
         }
 
     }
-    if ($parameter.psobject.properties.item('MinValue')) {
+    if ($parameter.psobject.properties.item('minValue')) {
         if ($parameter.minValue -isnot [int]) {
-            Write-Error "$($Parameter.Name) minValue is not an [int] (it's a [$($parameter.minValue.GetType())])" `
+            Write-Error "$($ParameterName) minValue is not an [int] (it's a [$($parameter.minValue.GetType())])" `
                 -ErrorId Parameter.Max.Not.Int -TargetObject $parameter           
         } else {
-            $min = $ParameterName.minValue
+            $min = $Parameter.minValue
         }
     }
 
     if ($max -eq $null -and $min -ne $null){
-        Write-Error "$($Parameter.Name) missing max value" -ErrorId Parameter.Missing.Max -TargetObject $parameter           
+        Write-Error "$ParameterName missing max value" -ErrorId Parameter.Missing.Max -TargetObject $parameter           
     }
 
     if ($max -ne $null -and $min -eq $null){
-        Write-Error "$($Parameter.Name) missing min value" -ErrorId Parameter.Missing.Min -TargetObject $parameter           
+        Write-Error "$ParameterName missing min value" -ErrorId Parameter.Missing.Min -TargetObject $parameter           
     }
 }

--- a/test/template-tests/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
+++ b/test/template-tests/testcases/deploymentTemplate/Parameters-Must-Be-Referenced.test.ps1
@@ -1,7 +1,11 @@
 ﻿param(
 [Parameter(Mandatory=$true,Position=0)]
 [PSObject]
-$TemplateObject
+$TemplateObject,
+
+[Parameter(Mandatory=$true,Position=0)]
+[PSObject]
+$TemplateText
 )
 foreach ($parameter in $TemplateObject.parameters.psobject.properties) {
     if ($TemplateText -notmatch "parameters\(['`"]$($Parameter.Name)['`"]\)") {

--- a/test/template-tests/testcases/deploymentTemplate/Template-Should-Not-Contain-Blanks.test.ps1
+++ b/test/template-tests/testcases/deploymentTemplate/Template-Should-Not-Contain-Blanks.test.ps1
@@ -10,8 +10,18 @@ $emptyItems = @([Regex]::Matches($TemplateText, "\{\s{0,}\}")) + # Empty objects
 
 $lineBreaks = [Regex]::Matches($TemplateText, "`n|$([Environment]::NewLine)")
 
+$PropertiesThatCanBeEmpty = 'resources','outputs','variables','parameters','properties','defaultValue'
+
 if ($emptyItems) {
     foreach ($emptyItem in $emptyItems) {
+        $nearbyContext = [Regex]::new('"(?<PropertyName>[^"]{1,})"\s{0,}:', "RightToLeft").Match($TemplateText, $emptyItem.Index)
+        if ($nearbyContext -and $nearbyContext.Success) {
+            $emptyPropertyName = $nearbyContext.Groups["PropertyName"].Value
+            if ($PropertiesThatCanBeEmpty -contains $emptyPropertyName) {
+                continue
+            }
+        } 
+        
         $lineNumber = @($lineBreaks | ? { $_.Index -lt $emptyItem.Index }).Count + 1
         Write-Error "Empty property found on line: $lineNumber" -TargetObject $emptyItem
     }

--- a/test/template-tests/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
+++ b/test/template-tests/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
@@ -66,13 +66,6 @@ foreach ($av in $allApiVersions) { # Then walk over each object containing an Ap
             }
         })
 
-
-    # If the actual string in the template was not in the list of APIs,
-    if ($validApiVersions -notcontains $av.ApiVersion) {
-        # write an error
-        Write-Error "$FullResourceType has an invalid API version.  Valid API versions are: $validApiVersions" -TargetObject $av
-        continue
-    }
     
     if ($av.ApiVersion -like '*-*-*-*') {
         #! Determine the index without respect to preview versions

--- a/test/template-tests/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
+++ b/test/template-tests/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
@@ -39,23 +39,32 @@ foreach ($av in $allApiVersions) { # Then walk over each object containing an Ap
 
     # Now, get the API version as a string
     $apiString = $av.ApiVersion 
-    if ($apiString -like '*-preview') { # If it was a preview API, 
-        # chop off the -preview from the text
-        $apiString = $apiString.Substring(0, $apiString.Length - '-preview'.Length)
-    }
+    $hasDate = $apiString -match "(?<Year>\d{4,4})-(?<Month>\d{2,2})-(?<Day>\d{2,2})"
     
-    $apiDate = $apiString -as [DateTime] # now coerce the apiVersion into a DateTime
-    if (-not $apiDate) {
+    
+    
+    if (-not $hasDate) {
         # If this failed, write an error.
         Write-Error "Api versions must be a fixed date. $FullResourceType is not." -TargetObject $av -ErrorId ApiVersion.Not.Date
         continue
     }
+    $apiDate = [DateTime]::new($matches.Year, $matches.Month, $matches.Day) # now coerce the apiVersion into a DateTime
+
     
 
     # Now find all of the valid versions from this API
-    $validApiVersions = $AllAzureResources.$FullResourceType | 
-        Select-Object -ExpandProperty apiVersions 
-    #! sort this yourself, because it might not be
+    $validApiVersions = # This is made a little tricky by the fact that some resources don't directly have an API version        
+        @(for ($i = $FullResourceTypes.Count - 1; $i -ge 0; $i--) { # so we need to walk backwards thru the list of items
+            $resourceTypeName = $FullResourceTypes[0..$i] -join '/' # construct the resource type name
+            $apiVersionsOfType = $AllAzureResources.$resourceTypeName | # and see if there's an apiVersion.
+                Select-Object -ExpandProperty apiVersions |
+                Sort-Object -Descending
+
+            if ($apiVersionsOfType) { # If there was,
+                $apiVersionsOfType # set it and break the loop
+                break
+            }
+        })
 
 
     # If the actual string in the template was not in the list of APIs,
@@ -65,22 +74,17 @@ foreach ($av in $allApiVersions) { # Then walk over each object containing an Ap
         continue
     }
     
-    if ($av.ApiVersion -like '*-preview') {
+    if ($av.ApiVersion -like '*-*-*-*') {
         #! Determine the index without respect to preview versions
         $howRecent? = $validApiVersions.IndexOf($av.ApiVersion) 
         if ($howRecent?) {
-            Write-Error "$FullResourceType uses a -preview version when there are $($howRecent?) more recent versions available" -TargetObject $av
+            Write-Error "$FullResourceType uses an preview version ( $($av.apiVersion) ) when there are $($howRecent?) more recent versions available" -TargetObject $av
         } 
     }
-
-    #! need to make sure that if it is an old apiVersion, that there is a later one that can be used.
     # Finally, check how long it's been since the ApiVersion's date
     $timeSinceApi = [DateTime]::Now - $apiDate
-    if ($timeSinceApi.TotalDays -gt 730) {  # If it's older than a year
+    if ($timeSinceApi.TotalDays -gt 365) {  # If it's older than a year
         # write a warning        
-        Write-Error "Api versions must be no more than 2 years old ($FullResourceType is $([Math]::Floor($timeSinceApi.TotalDays)) days old)" 
-    }elseif ($timeSinceApi.TotalDays -gt 365) {
-        # write a warning        
-        Write-Warning "Api versions should be less than a year old ($FullResourceType is $([Math]::Floor($timeSinceApi.TotalDays)) days old)"         
+        Write-Warning "Api versions should be under a year old ($FullResourceType is $([Math]::Floor($timeSinceApi.TotalDays)) days old)" 
     }
 }

--- a/test/template-tests/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
+++ b/test/template-tests/testcases/deploymentTemplate/apiVersions-Should-Be-Recent.test.ps1
@@ -78,7 +78,7 @@ foreach ($av in $allApiVersions) { # Then walk over each object containing an Ap
         #! Determine the index without respect to preview versions
         $howRecent? = $validApiVersions.IndexOf($av.ApiVersion) 
         if ($howRecent?) {
-            Write-Error "$FullResourceType uses an preview version ( $($av.apiVersion) ) when there are $($howRecent?) more recent versions available" -TargetObject $av
+            Write-Error "$FullResourceType uses a preview version ( $($av.apiVersion) ) when there are $($howRecent?) more recent versions available" -TargetObject $av
         } 
     }
     # Finally, check how long it's been since the ApiVersion's date


### PR DESCRIPTION
* Changing Default to Not Use Pester (can still be run in Pester with -Pester)
* Fixed Location-Should-Not-Be-Hardcoded ( templateObject was being passed incorrectly)
* Fixed Min-and-Max-Value-Are-Numbers ( incomplete error messages and bad pairing)
* Enhanced test for blanks (added whitelist of acceptable blanks)
* Enhanced test for apiVersions (enabling more exotic preview versions, handling resource type inheritance)