### PR TITLE
Fix location attribute for AppInsights resource

### DIFF
--- a/101-function-app-create-dynamic/azuredeploy.json
+++ b/101-function-app-create-dynamic/azuredeploy.json
@@ -119,7 +119,7 @@
       "apiVersion": "2018-05-01-preview",
       "name": "[variables('applicationInsightsName')]",
       "type": "microsoft.insights/components",
-      "location": "East US",
+      "location": "[parameters('location')]",
       "tags": {
         "[concat('hidden-link:', resourceGroup().id, '/providers/Microsoft.Web/sites/', variables('applicationInsightsName'))]": "Resource"
       },


### PR DESCRIPTION
App Insights resource location should reference dynamic location from Resource Group as other resources.
* defaultValue set to resourceGroup().location instead of static eastus