### PR TITLE
Default to not use prerelease releases of the agent

### DIFF
--- a/201-vm-vsts-agent/scripts/InstallVstsAgent.ps1
+++ b/201-vm-vsts-agent/scripts/InstallVstsAgent.ps1
@@ -24,7 +24,9 @@ Param
 	[string]$AdminUser,
 
 	[Parameter(Mandatory=$true)]
-	[array]$Modules
+	[array]$Modules,
+	
+	[boolean]$prerelease=$false
 )
 
 Write-Verbose "Entering InstallVSOAgent.ps1" -verbose
@@ -50,7 +52,7 @@ do
   {
     Write-Verbose "Trying to get download URL for latest VSTS agent release..."
     $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/Microsoft/vsts-agent/releases"
-	$latestRelease = $latestRelease | Where-Object assets -ne $null | Sort-Object created_at -Descending | Select-Object -First 1
+	$latestRelease = $latestRelease |  Where-Object prerelease -eq $prerelease |where-object assets -ne $null | Sort-Object created_at -Descending | Select-Object -First 1
     $assetsURL = ($latestRelease.assets).browser_download_url
     $latestReleaseDownloadUrl = ((Invoke-RestMethod -Uri $assetsURL) -match 'win-x64').downloadurl
     Invoke-WebRequest -Uri $latestReleaseDownloadUrl -Method Get -OutFile "$agentTempFolderName\agent.zip"


### PR DESCRIPTION
Currently the download of the agent does not exclude prerelease releases.
This provides the option to download prerelease or not and to default to not. This is a breaking change and so the default could be made to $true to have same behaviour. My expectation is most should not use the prerelease agent

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

