### PR TITLE
Add SSH Auth to 301-jenkins-aptly-spinnaker-vmss

### DIFF
--- a/301-jenkins-aptly-spinnaker-vmss/azuredeploy.json
+++ b/301-jenkins-aptly-spinnaker-vmss/azuredeploy.json
@@ -14,12 +14,6 @@
         "description": "Username for the DevOps Virtual Machine, the Jenkins instance, and the VM Scale Sets deployed by Spinnaker."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for the DevOps Virtual Machine, the Jenkins instance, and the VM Scale Sets deployed by Spinnaker."
-      }
-    },
     "servicePrincipalAppId": {
       "type": "string",
       "metadata": {
@@ -37,6 +31,23 @@
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Location for all resources."
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
     }
   },
@@ -58,7 +69,18 @@
     "spinnakerOSDiskName": "[concat(variables('scenarioPrefix'), 'OSDisk')]",
     "_artifactsLocation": "https://raw.githubusercontent.com/Azure/azure-devops-utils/v0.24.0/",
     "_extensionScript": "301-jenkins-aptly-spinnaker-vmss.sh",
-    "_artifactsLocationSasToken": ""
+    "_artifactsLocationSasToken": "",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -285,7 +307,8 @@
         "osProfile": {
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {
@@ -296,7 +319,7 @@
           },
           "osDisk": {
             "name": "[concat(variables('vmName'),'_OSDisk')]",
-           "caching": "ReadWrite",
+            "caching": "ReadWrite",
             "createOption": "FromImage"
           }
         },

--- a/301-jenkins-aptly-spinnaker-vmss/azuredeploy.parameters.json
+++ b/301-jenkins-aptly-spinnaker-vmss/azuredeploy.parameters.json
@@ -5,9 +5,6 @@
     "adminUsername": {
       "value": "GEN-UNIQUE"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
-    },
     "devopsDnsPrefix": {
       "value": "GEN-UNIQUE"
     },
@@ -16,6 +13,9 @@
     },
     "servicePrincipalAppKey": {
       "value": "GEN-PASSWORD"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/301-jenkins-aptly-spinnaker-vmss/metadata.json
+++ b/301-jenkins-aptly-spinnaker-vmss/metadata.json
@@ -5,6 +5,5 @@
   "description": "This template allows you to deploy and configure a DevOps pipeline from an Aptly repository to a VM Scale Set in Azure.",
   "summary": "This template allows you to deploy and configure a DevOps pipeline from an Aptly repository to a VM Scale Set in Azure. It deploys an instance of Jenkins and Spinnaker on a Linux Ubuntu 14.04 LTS VM.",
   "githubUsername": "azure-devops",
-  "dateUpdated": "2018-06-15"
+  "dateUpdated": "2019-05-30"
 }
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
*
*