### PR TITLE
Adding SQL license type to template parameters

### DIFF
--- a/101-sql-vm-ag-setup/azuredeploy.json
+++ b/101-sql-vm-ag-setup/azuredeploy.json
@@ -176,6 +176,9 @@
                     "location": {
                         "value": "[parameters('location')]"
                     },
+                    "sqlServerLicenseType": {
+                        "value": "[parameters('sqlServerLicenseType')]"
+                    },
                     "existingVmResourceGroup": {
                         "value": "[parameters('existingVmResourceGroup')]"
                     },

--- a/101-sql-vm-ag-setup/azuredeploy.json
+++ b/101-sql-vm-ag-setup/azuredeploy.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "FailoverClusterName": {
+        "failoverClusterName": {
             "type": "string",
             "metadata": {
                 "description": "Specify the Windows Failover Cluster Name"
@@ -14,6 +14,12 @@
                 "description": "Specify comma separated list of names of SQL Server VM's to participate in the Availability Group (e.g. SQLVM1, SQLVM2). OS underneath should be at least WS 2016."
             }
         },
+        "sqlServerLicenseType": {
+            "type": "string",
+            "metadata": {
+                "description": "Specify the SQL Server License type for all VM's. Allowed values are PAYG or AHUB."
+            }
+        },
         "existingVmResourceGroup": {
             "type": "string",
             "metadata": {
@@ -21,7 +27,7 @@
             },
             "defaultValue": "[resourceGroup().name]"
         },
-        "SqlServerVersion": {
+        "sqlServerVersion": {
             "allowedValues": [ "SQL2017", "SQL2016" ],
             "type": "string",
             "metadata": {
@@ -47,7 +53,7 @@
                 "description": "Specify the account for WS failover cluster creation in UPN format (e.g. example@contoso.com). This account can either be a Domain Admin or at least have permissions to create Computer Objects in default or specified OU."
             }
         },
-        "DomainAccountPassword": {
+        "domainAccountPassword": {
             "type": "SecureString",
             "metadata": {
                 "description": "Specify the password for the domain account"
@@ -59,13 +65,13 @@
                 "description": "Specify the domain account under which SQL Server service will run for AG setup in UPN format (e.g. sqlservice@contoso.com)"
             }
         },
-        "SqlServicePassword": {
+        "sqlServicePassword": {
             "type": "SecureString",
             "metadata": {
                 "description": "Specify the password for Sql Server service account"
             }
         },
-        "CloudWitnessName": {
+        "cloudWitnessName": {
             "type": "string",
             "metadata": {
                 "description": "Specify the name of the storage account to be used for creating Cloud Witness for Windows server failover cluster"
@@ -86,7 +92,7 @@
             },
             "defaultValue": ""
         },
-        "Location": {
+        "location": {
             "type": "string",
             "metadata": {
                 "description": "Location for all resources."
@@ -96,7 +102,7 @@
     },
     "variables": {
         "existingVMListArray": "[split(parameters('existingVmList'),',')]",
-        "GroupResourceId": "[resourceId('Microsoft.SqlVirtualMachine/SqlVirtualMachineGroups', parameters('FailoverClusterName'))]",
+        "GroupResourceId": "[resourceId('Microsoft.SqlVirtualMachine/SqlVirtualMachineGroups', parameters('failoverClusterName'))]",
         "joinClusterTemplateURL": "[concat(parameters('_artifactsLocation'),'/nested/join-cluster.json',parameters('_artifactsLocationSasToken'))]"
     },
     "resources": [
@@ -104,24 +110,25 @@
             "type": "Microsoft.SqlVirtualMachine/SqlVirtualMachines",
             "apiVersion": "2017-03-01-preview",
             "name": "[trim(variables('existingVMListArray')[copyIndex()])]",
-            "location": "[parameters('Location')]",
+            "location": "[parameters('location')]",
             "copy": {
                 "name": "sqlvirtualMachineLoop",
                 "count": "[length(variables('existingVMListArray'))]"
             },
             "properties": {
-                "virtualMachineResourceId": "[resourceId(parameters('existingVmResourceGroup'), 'Microsoft.Compute/virtualMachines', trim(variables('existingVMListArray')[copyIndex()]))]"
+                "virtualMachineResourceId": "[resourceId(parameters('existingVmResourceGroup'), 'Microsoft.Compute/virtualMachines', trim(variables('existingVMListArray')[copyIndex()]))]",
+                "sqlServerLicenseType": "[parameters('sqlServerLicenseType')]"
             }
         },
         {
             "type": "Microsoft.Storage/storageAccounts",
             "apiVersion": "2018-07-01",
-            "name": "[parameters('CloudWitnessName')]",
+            "name": "[parameters('cloudWitnessName')]",
             "sku": {
                 "name": "Standard_LRS"
             },
             "kind": "StorageV2",
-            "location": "[parameters('Location')]",
+            "location": "[parameters('location')]",
             "properties": {
                 "accessTier": "Hot",
                 "supportsHttpsTrafficOnly": true
@@ -130,10 +137,10 @@
         {
             "type": "Microsoft.SqlVirtualMachine/SqlVirtualMachineGroups",
             "apiVersion": "2017-03-01-preview",
-            "name": "[parameters('FailoverClusterName')]",
-            "location": "[parameters('Location')]",
+            "name": "[parameters('failoverClusterName')]",
+            "location": "[parameters('location')]",
             "properties": {
-                "SqlImageOffer": "[concat(parameters('SqlServerVersion'),'-WS2016')]",
+                "SqlImageOffer": "[concat(parameters('sqlServerVersion'),'-WS2016')]",
                 "SqlImageSku": "Enterprise",
                 "WsfcDomainProfile": {
                     "DomainFqdn": "[parameters('existingFullyQualifiedDomainName')]",
@@ -141,8 +148,8 @@
                     "ClusterBootstrapAccount": "[parameters('existingDomainAccount')]",
                     "ClusterOperatorAccount": "[parameters('existingDomainAccount')]",
                     "SqlServiceAccount": "[parameters('existingSqlServiceAccount')]",
-                    "StorageAccountUrl": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('CloudWitnessName')), '2018-07-01').primaryEndpoints['blob']]",
-                    "StorageAccountPrimaryKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('CloudWitnessName')), '2018-07-01').keys[0].value]"
+                    "StorageAccountUrl": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('cloudWitnessName')), '2018-07-01').primaryEndpoints['blob']]",
+                    "StorageAccountPrimaryKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('cloudWitnessName')), '2018-07-01').keys[0].value]"
                 }
             }
         },
@@ -151,8 +158,8 @@
             "apiVersion": "2017-05-10",
             "name": "joincluster",
             "dependsOn": [
-                "[parameters('FailoverClusterName')]",
-                "[parameters('CloudWitnessName')]",
+                "[parameters('failoverClusterName')]",
+                "[parameters('cloudWitnessName')]",
                 "sqlvirtualMachineLoop"
             ],
             "properties": {
@@ -165,20 +172,20 @@
                     "existingVirtualMachineNames": {
                         "value": "[variables('existingVMListArray')]"
                     },
-                    "Location": {
-                        "value": "[parameters('Location')]"
+                    "location": {
+                        "value": "[parameters('location')]"
                     },
                     "existingVmResourceGroup": {
                         "value": "[parameters('existingVmResourceGroup')]"
                     },
-                    "GroupResourceId": {
-                        "value": "[variables('GroupResourceId')]"
+                    "groupResourceId": {
+                        "value": "[variables('groupResourceId')]"
                     },
-                    "DomainAccountPassword": {
-                        "value": "[parameters('DomainAccountPassword')]"
+                    "domainAccountPassword": {
+                        "value": "[parameters('domainAccountPassword')]"
                     },
-                    "SqlServicePassword": {
-                        "value": "[parameters('SqlServicePassword')]"
+                    "sqlServicePassword": {
+                        "value": "[parameters('sqlServicePassword')]"
                     }
                 }
             }

--- a/101-sql-vm-ag-setup/azuredeploy.json
+++ b/101-sql-vm-ag-setup/azuredeploy.json
@@ -15,9 +15,10 @@
             }
         },
         "sqlServerLicenseType": {
+            "allowedValues": [ "PAYG", "AHUB" ],
             "type": "string",
             "metadata": {
-                "description": "Specify the SQL Server License type for all VM's. Allowed values are PAYG or AHUB."
+                "description": "Specify the SQL Server License type for all VM's."
             }
         },
         "existingVmResourceGroup": {

--- a/101-sql-vm-ag-setup/metadata.json
+++ b/101-sql-vm-ag-setup/metadata.json
@@ -5,6 +5,6 @@
   "description": "Deploy SQL Always ON setup with existing SQL Virtual Machines. The virtual machines should already be joined to an existing domain and must be running enterprise version of SQL Server.",
   "summary": "Deploy SQL Always ON setup with existing SQL Virtual Machines.",
   "githubUsername": "pratraw",
-  "dateUpdated": "2018-11-16"
+  "dateUpdated": "2019-06-11"
 }
 

--- a/101-sql-vm-ag-setup/nested/join-cluster.json
+++ b/101-sql-vm-ag-setup/nested/join-cluster.json
@@ -11,13 +11,13 @@
         "existingVmResourceGroup": {
             "type": "string"
         },
-        "GroupResourceId": {
+        "groupResourceId": {
             "type": "string"
         },
-        "DomainAccountPassword": {
+        "domainAccountPassword": {
             "type": "securestring"
         },
-        "SQLServicePassword": {
+        "sqlServicePassword": {
             "type": "securestring"
         }
     },
@@ -28,18 +28,18 @@
             "name": "[trim(parameters('existingVirtualMachineNames')[copyIndex()])]",
             "type": "Microsoft.SqlVirtualMachine/SqlVirtualMachines",
             "apiVersion": "2017-03-01-preview",
-            "location": "[parameters('Location')]",
+            "location": "[parameters('location')]",
             "copy": {
                 "name": "vmToClusterLoop",
                 "count": "[length(parameters('existingVirtualMachineNames'))]"
             },
             "properties": {
                 "virtualMachineResourceId": "[resourceId(parameters('existingVmResourceGroup'),'Microsoft.Compute/virtualMachines', trim(parameters('existingVirtualMachineNames')[copyIndex()]))]",
-                "SqlVirtualMachineGroupResourceId": "[parameters('GroupResourceId')]",
+                "SqlVirtualMachineGroupResourceId": "[parameters('groupResourceId')]",
                 "WSFCDomainCredentials": {
-                    "ClusterBootstrapAccountPassword": "[parameters('DomainAccountPassword')]",
-                    "ClusterOperatorAccountPassword": "[parameters('DomainAccountPassword')]",
-                    "SqlServiceAccountPassword": "[parameters('SqlServicePassword')]"
+                    "ClusterBootstrapAccountPassword": "[parameters('domainAccountPassword')]",
+                    "ClusterOperatorAccountPassword": "[parameters('domainAccountPassword')]",
+                    "SqlServiceAccountPassword": "[parameters('sqlServicePassword')]"
                 }
             }
         }

--- a/101-sql-vm-ag-setup/nested/join-cluster.json
+++ b/101-sql-vm-ag-setup/nested/join-cluster.json
@@ -8,6 +8,9 @@
         "existingVirtualMachineNames": {
             "type": "array"
         },
+        "sqlServerLicenseType": {
+            "type": "string"
+        },
         "existingVmResourceGroup": {
             "type": "string"
         },
@@ -35,6 +38,7 @@
             },
             "properties": {
                 "virtualMachineResourceId": "[resourceId(parameters('existingVmResourceGroup'),'Microsoft.Compute/virtualMachines', trim(parameters('existingVirtualMachineNames')[copyIndex()]))]",
+                "sqlServerLicenseType": "[parameters('sqlServerLicenseType')]",
                 "SqlVirtualMachineGroupResourceId": "[parameters('groupResourceId')]",
                 "WSFCDomainCredentials": {
                     "ClusterBootstrapAccountPassword": "[parameters('domainAccountPassword')]",


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SQL Server License type to template
* Corrected all parameters to lower case

