### PR TITLE
Update version

### DIFF
--- a/101-aks/azuredeploy.json
+++ b/101-aks/azuredeploy.json
@@ -83,11 +83,12 @@
         },
         "kubernetesVersion": {
             "type": "string",
-            "defaultValue": "1.12.6",
+            "defaultValue": "1.13.5",
             "allowedValues": [
                 "1.10.13",
                 "1.11.8",
-                "1.12.6"
+                "1.12.7",
+                "1.13.5"
             ],
             "metadata": {
                 "description": "The version of Kubernetes."

--- a/101-aks/metadata.json
+++ b/101-aks/metadata.json
@@ -4,7 +4,7 @@
     "itemDisplayName": "Azure Container Service (AKS)",
     "description": "Deploy a managed cluster with Azure Container Service (AKS)",
     "summary": "Deploy a managed cluster with Azure Container Service (AKS)",
-    "githubUsername": "montebhoover",
+    "githubUsername": "vyta",
     "dateUpdated": "2019-07-02"
 }
 

--- a/101-aks/metadata.json
+++ b/101-aks/metadata.json
@@ -4,7 +4,7 @@
     "itemDisplayName": "Azure Container Service (AKS)",
     "description": "Deploy a managed cluster with Azure Container Service (AKS)",
     "summary": "Deploy a managed cluster with Azure Container Service (AKS)",
-    "githubUsername": "vyta",
-    "dateUpdated": "2019-03-21"
+    "githubUsername": "montebhoover",
+    "dateUpdated": "2019-07-02"
 }
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Update kubernetesVersion default value from 1.12.6 to 1.13.5
* Remove version 1.12.6 from allowedValues and add 1.12.7 and 1.13.5

Currently with 1.12.6 as the default value for kubernetesVersion, this fails when a user follows the quickstart from https://docs.microsoft.com/en-us/azure/aks/kubernetes-walkthrough-rm-template for most regions (all regions in N.A., Europe, and Asia).  There are a few choices for what should be the default, so please let me know if there is a better one.  

The current default for AKS in most regions is 1.12.8, but that is not available and fails for a user in Brazil or South Africa regions.  1.12.7 and 1.13.5 are currently available for all regions, and I opted for 1.13.5 as the default.

One option would be to remove the default and allowed values altogether, but providing them allows for a dropdown box in the portal view for the template quickstart.

Fixes #6262  

