### PR TITLE
update templates with new index policy defaults

### DIFF
--- a/101-cosmosdb-gremlin/azuredeploy.json
+++ b/101-cosmosdb-gremlin/azuredeploy.json
@@ -196,8 +196,7 @@
                         "indexingMode": "consistent",
                         "includedPaths": [
                             {
-                                "path": "/*",
-                                "indexes": []
+                                "path": "/*"
                             }
                         ],
                         "excludedPaths": [
@@ -229,8 +228,7 @@
                         "indexingMode": "consistent",
                         "includedPaths": [
                             {
-                                "path": "/*",
-                                "indexes": []
+                                "path": "/*"
                             }
                         ]
                     },

--- a/101-cosmosdb-gremlin/azuredeploy.json
+++ b/101-cosmosdb-gremlin/azuredeploy.json
@@ -197,18 +197,7 @@
                         "includedPaths": [
                             {
                                 "path": "/*",
-                                "indexes": [
-                                    {
-                                        "kind": "Range",
-                                        "dataType": "number",
-                                        "precision": -1
-                                    },
-                                    {
-                                        "kind": "Range",
-                                        "dataType": "string",
-                                        "precision": -1
-                                    }
-                                ]
+                                "indexes": []
                             }
                         ],
                         "excludedPaths": [
@@ -241,18 +230,7 @@
                         "includedPaths": [
                             {
                                 "path": "/*",
-                                "indexes": [
-                                    {
-                                        "kind": "Range",
-                                        "dataType": "number",
-                                        "precision": -1
-                                    },
-                                    {
-                                        "kind": "Range",
-                                        "dataType": "string",
-                                        "precision": -1
-                                    }
-                                ]
+                                "indexes": []
                             }
                         ]
                     },

--- a/101-cosmosdb-sql/azuredeploy.json
+++ b/101-cosmosdb-sql/azuredeploy.json
@@ -179,8 +179,7 @@
 					"indexingPolicy": {
 						"indexingMode": "consistent",
 						"includedPaths": [{
-								"path": "/*",
-								"indexes": []
+								"path": "/*"
 							}
 						],
 						"excludedPaths": [{
@@ -209,8 +208,7 @@
 					"indexingPolicy": {
 						"indexingMode": "consistent",
 						"includedPaths": [{
-								"path": "/*",
-								"indexes": []
+								"path": "/*"
 							}
 						]
 					}

--- a/101-cosmosdb-sql/azuredeploy.json
+++ b/101-cosmosdb-sql/azuredeploy.json
@@ -180,18 +180,7 @@
 						"indexingMode": "consistent",
 						"includedPaths": [{
 								"path": "/*",
-								"indexes": [
-									{
-										"kind": "Range",
-										"dataType": "number",
-										"precision": -1
-									},
-									{
-										"kind": "Range",
-										"dataType": "string",
-										"precision": -1
-									}
-								]
+								"indexes": []
 							}
 						],
 						"excludedPaths": [{
@@ -221,18 +210,7 @@
 						"indexingMode": "consistent",
 						"includedPaths": [{
 								"path": "/*",
-								"indexes": [
-									{
-										"kind": "Range",
-										"dataType": "number",
-										"precision": -1
-									},
-									{
-										"kind": "Range",
-										"dataType": "string",
-										"precision": -1
-									}
-								]
+								"indexes": []
 							}
 						]
 					}


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog
updated the ARM templates for SQL and Gremlin to remove the range index types on strings and numbers. The previous values are now default in the back-end service. The result is they look like what they have been updated to now.
*
*
*

