### PR TITLE
[Telegraf/Grafana/InfluxDb template] Ubuntu changed from 14.04 to 18.04

### DIFF
--- a/101-Telegraf-InfluxDB-Grafana/azuredeploy.json
+++ b/101-Telegraf-InfluxDB-Grafana/azuredeploy.json
@@ -200,8 +200,7 @@
             "settings": {
               "fileUris": [
                 "[concat(parameters('_artifactsLocation'),'scripts/',variables('_extensionScript'),parameters('_artifactsLocationSasToken'))]"
-              ],
-              "timestamp": 16012018
+              ]
             },
             "protectedSettings": {
               "commandToExecute": "[concat('sh tigscript.sh',' ',variables('_configfilelocation'))]"

--- a/101-Telegraf-InfluxDB-Grafana/azuredeploy.json
+++ b/101-Telegraf-InfluxDB-Grafana/azuredeploy.json
@@ -199,11 +199,11 @@
             "autoUpgradeMinorVersion": true,
             "settings": {
               "fileUris": [
-                "[concat(parameters('_artifactsLocation'),'scripts/',variables('_extensionScript'),parameters('_artifactsLocationSasToken'))]"
+                "[uri(parameters('_artifactsLocation'), concat('scripts/', variables('_extensionScript'), parameters('_artifactsLocationSasToken')))]"
               ]
             },
             "protectedSettings": {
-              "commandToExecute": "[concat('sh tigscript.sh',' ',variables('_configfilelocation'))]"
+              "commandToExecute": "[concat('sh tigscript.sh', ' ', variables('_configfilelocation'))]"
             }
           }
         }

--- a/101-Telegraf-InfluxDB-Grafana/azuredeploy.json
+++ b/101-Telegraf-InfluxDB-Grafana/azuredeploy.json
@@ -160,7 +160,7 @@
           "imageReference": {
             "publisher": "Canonical",
             "offer": "UbuntuServer",
-            "sku": "14.04.5-LTS",
+            "sku": "18.04-LTS",
             "version": "latest"
           },
           "osDisk": {

--- a/101-Telegraf-InfluxDB-Grafana/azuredeploy.json
+++ b/101-Telegraf-InfluxDB-Grafana/azuredeploy.json
@@ -103,7 +103,7 @@
       }
     },
     {
-      "apiVersion": "2016-09-01",
+      "apiVersion": "2017-10-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Telegraf-InfluxDB-Grafana template - changed Ubuntu version from 14.04 LTS to 18.04 to make sure that Ansible (which is installed by script during deployment) can get properly installed. 14.04 uses Python 2.7 as default one, which makes Ansible throw deprecated error, as it no longer supports this Python version. By changing Ubuntu version to 18.4 template deploys properly.