### PR TITLE
Updating Formatter to report Failures in Azure DevOps

### DIFF
--- a/test/template-tests/AzRMTester.ezformat.ps1
+++ b/test/template-tests/AzRMTester.ezformat.ps1
@@ -50,32 +50,21 @@ Write-FormatView -Action {
         $foregroundColor = 'Yellow'
         $statusChar = '?'        
     }
-    $azoStatus = 
-        if ($env:AgentId) {
-            if ($errorCount) {
-                "##vso[task.logissue type=error;]"
-            } elseif ($warningCount) {
-                "##vso[task.logissue type=warning;]"
-            } else {
-                ''
-            }
-        }
-    $statusLine = "    [$statusChar]$azoStatus $($testOut.Name) ($([Math]::Round($testOut.Timespan.TotalMilliseconds)) ms)"
+    
+    $statusLine = "    [$statusChar] $($testOut.Name) ($([Math]::Round($testOut.Timespan.TotalMilliseconds)) ms)"
     Write-Host $statusLine -ForegroundColor $foregroundColor -NoNewline
-
-    $null
 
     $indent = 4
     if ($errorLines) {
         Write-Host " " # end of line
-        $azoErrorStatus = if ($env:AgentId) { "##vso[task.logissue type=error;]"} else { '' }         
+        $azoErrorStatus = if ($ENV:Agent_ID) { "##vso[task.logissue type=error;]"} else { '' }         
         foreach ($line in $errorLines) {
             Write-Host "$azoErrorStatus$(' ' * $indent)$line" -foregroundColor Red    
         }
     }
     if ($warningLines) {
         Write-Host " " # end of line
-        $azoWarnStatus = if ($env:AgentId) { "##vso[task.logissue type=error;]"} else { '' }         
+        $azoWarnStatus = if ($ENV:Agent_ID) { "##vso[task.logissue type=error;]"} else { '' }         
         foreach ($line in $warningLines) {
             Write-Host "$azoWarnStatus$(' ' * $indent)$line" -foregroundColor DarkYellow 
         }

--- a/test/template-tests/AzRMTester.ezformat.ps1
+++ b/test/template-tests/AzRMTester.ezformat.ps1
@@ -14,6 +14,7 @@ Write-FormatView -Action {
         $global:_LastFile = ''
         $global:_LastHistoryId = $h.id
     }
+    
 
     if ($global:_LastFile -ne $testOut.File.FullPath) {
         Write-Host -ForegroundColor Magenta "Validating $($testOut.File.Name)" 
@@ -49,7 +50,17 @@ Write-FormatView -Action {
         $foregroundColor = 'Yellow'
         $statusChar = '?'        
     }
-    $statusLine = "    [$statusChar] $($testOut.Name) ($([Math]::Round($testOut.Timespan.TotalMilliseconds)) ms)"
+    $azoStatus = 
+        if ($env:AgentId) {
+            if ($errorCount) {
+                "##vso[task.logissue type=error;]"
+            } elseif ($warningCount) {
+                "##vso[task.logissue type=warning;]"
+            } else {
+                ''
+            }
+        }
+    $statusLine = "    [$statusChar]$azoStatus $($testOut.Name) ($([Math]::Round($testOut.Timespan.TotalMilliseconds)) ms)"
     Write-Host $statusLine -ForegroundColor $foregroundColor -NoNewline
 
     $null
@@ -57,14 +68,16 @@ Write-FormatView -Action {
     $indent = 4
     if ($errorLines) {
         Write-Host " " # end of line
+        $azoErrorStatus = if ($env:AgentId) { "##vso[task.logissue type=error;]"} else { '' }         
         foreach ($line in $errorLines) {
-            Write-Host "$(' ' * $indent)$line" -foregroundColor Red    
+            Write-Host "$azoErrorStatus$(' ' * $indent)$line" -foregroundColor Red    
         }
     }
     if ($warningLines) {
         Write-Host " " # end of line
+        $azoWarnStatus = if ($env:AgentId) { "##vso[task.logissue type=error;]"} else { '' }         
         foreach ($line in $warningLines) {
-            Write-Host "$(' ' * $indent)$line" -foregroundColor DarkYellow 
+            Write-Host "$azoWarnStatus$(' ' * $indent)$line" -foregroundColor DarkYellow 
         }
     }
     

--- a/test/template-tests/AzRMTester.format.ps1xml
+++ b/test/template-tests/AzRMTester.format.ps1xml
@@ -10,10 +10,8 @@
         <CustomEntries>
           <CustomEntry>
             <CustomItem>
-              <Frame>
-                <CustomItem>
-                  <ExpressionBinding>
-                    <ScriptBlock>
+              <ExpressionBinding>
+                <ScriptBlock>
     $h = Get-History -Count 1
     $testOut = $_
     if ($global:_LastHistoryId -ne $h.id) {
@@ -58,41 +56,28 @@
         $foregroundColor = 'Yellow'
         $statusChar = '?'        
     }
-    $azoStatus = 
-        if ($env:AgentId) {
-            if ($errorCount) {
-                "##vso[task.logissue type=error;]"
-            } elseif ($warningCount) {
-                "##vso[task.logissue type=warning;]"
-            } else {
-                ''
-            }
-        }
-    $statusLine = "    [$statusChar]$azoStatus $($testOut.Name) ($([Math]::Round($testOut.Timespan.TotalMilliseconds)) ms)"
+    
+    $statusLine = "    [$statusChar] $($testOut.Name) ($([Math]::Round($testOut.Timespan.TotalMilliseconds)) ms)"
     Write-Host $statusLine -ForegroundColor $foregroundColor -NoNewline
-
-    $null
 
     $indent = 4
     if ($errorLines) {
         Write-Host " " # end of line
-        $azoErrorStatus = if ($env:AgentId) { "##vso[task.logissue type=error;]"} else { '' }         
+        $azoErrorStatus = if ($ENV:Agent_ID) { "##vso[task.logissue type=error;]"} else { '' }         
         foreach ($line in $errorLines) {
             Write-Host "$azoErrorStatus$(' ' * $indent)$line" -foregroundColor Red    
         }
     }
     if ($warningLines) {
         Write-Host " " # end of line
-        $azoWarnStatus = if ($env:AgentId) { "##vso[task.logissue type=error;]"} else { '' }         
+        $azoWarnStatus = if ($ENV:Agent_ID) { "##vso[task.logissue type=error;]"} else { '' }         
         foreach ($line in $warningLines) {
             Write-Host "$azoWarnStatus$(' ' * $indent)$line" -foregroundColor DarkYellow 
         }
     }
     
 </ScriptBlock>
-                  </ExpressionBinding>
-                </CustomItem>
-              </Frame>
+              </ExpressionBinding>
             </CustomItem>
           </CustomEntry>
         </CustomEntries>

--- a/test/template-tests/AzRMTester.format.ps1xml
+++ b/test/template-tests/AzRMTester.format.ps1xml
@@ -22,6 +22,7 @@
         $global:_LastFile = ''
         $global:_LastHistoryId = $h.id
     }
+    
 
     if ($global:_LastFile -ne $testOut.File.FullPath) {
         Write-Host -ForegroundColor Magenta "Validating $($testOut.File.Name)" 
@@ -57,7 +58,17 @@
         $foregroundColor = 'Yellow'
         $statusChar = '?'        
     }
-    $statusLine = "    [$statusChar] $($testOut.Name) ($([Math]::Round($testOut.Timespan.TotalMilliseconds)) ms)"
+    $azoStatus = 
+        if ($env:AgentId) {
+            if ($errorCount) {
+                "##vso[task.logissue type=error;]"
+            } elseif ($warningCount) {
+                "##vso[task.logissue type=warning;]"
+            } else {
+                ''
+            }
+        }
+    $statusLine = "    [$statusChar]$azoStatus $($testOut.Name) ($([Math]::Round($testOut.Timespan.TotalMilliseconds)) ms)"
     Write-Host $statusLine -ForegroundColor $foregroundColor -NoNewline
 
     $null
@@ -65,14 +76,16 @@
     $indent = 4
     if ($errorLines) {
         Write-Host " " # end of line
+        $azoErrorStatus = if ($env:AgentId) { "##vso[task.logissue type=error;]"} else { '' }         
         foreach ($line in $errorLines) {
-            Write-Host "$(' ' * $indent)$line" -foregroundColor Red    
+            Write-Host "$azoErrorStatus$(' ' * $indent)$line" -foregroundColor Red    
         }
     }
     if ($warningLines) {
         Write-Host " " # end of line
+        $azoWarnStatus = if ($env:AgentId) { "##vso[task.logissue type=error;]"} else { '' }         
         foreach ($line in $warningLines) {
-            Write-Host "$(' ' * $indent)$line" -foregroundColor DarkYellow 
+            Write-Host "$azoWarnStatus$(' ' * $indent)$line" -foregroundColor DarkYellow 
         }
     }
     


### PR DESCRIPTION
Using the $env:AgentID variable to identify if we are in Azure DevOps, and report errors and warnings accordingly.