### PR TITLE
Added template to deploy HDInsight Kafka with Schema Registry as Edge node

### DIFF
--- a/101-hdinsight-kafka-with-edge-schema-registry/README.md
+++ b/101-hdinsight-kafka-with-edge-schema-registry/README.md
@@ -1,6 +1,6 @@
-# Deploy a Linux-based HDInsight cluster with Confluent Schema Registry as edge node
+# Deploy a Linux-based HDInsight Kafka cluster with Confluent Schema Registry as edge node
 
-This template allows you to create a Linux-based HDInsight cluster with a
+This template allows you to create a Linux-based HDInsight Kafka cluster with a
 Schema Registry edge node. The Schema Registry edge node is a Linux virtual
 machine with the Confluent Schema Registry package available. You can use the
 edge node for registering a schema, validating schema and managing your message

--- a/101-hdinsight-kafka-with-edge-schema-registry/README.md
+++ b/101-hdinsight-kafka-with-edge-schema-registry/README.md
@@ -1,5 +1,12 @@
 # Deploy a Linux-based HDInsight Kafka cluster with Confluent Schema Registry as edge node
 
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-hdinsight-kafka-with-edge-schema-registry%2Fazuredeploy.json" target="_blank">
+<img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-hdinsight-kafka-with-edge-schema-registry%2Fazuredeploy.json" target="_blank">
+<img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.png"/>
+</a>
+
 This template allows you to create a Linux-based HDInsight Kafka cluster with a
 Schema Registry edge node. The Schema Registry edge node is a Linux virtual
 machine with the Confluent Schema Registry package available. You can use the

--- a/101-hdinsight-kafka-with-edge-schema-registry/README.md
+++ b/101-hdinsight-kafka-with-edge-schema-registry/README.md
@@ -1,0 +1,7 @@
+# Deploy a Linux-based HDInsight cluster with Confluent Schema Registry as edge node
+
+This template allows you to create a Linux-based HDInsight cluster with a
+Schema Registry edge node. The Schema Registry edge node is a Linux virtual
+machine with the Confluent Schema Registry package available. You can use the
+edge node for registering a schema, validating schema and managing your message
+schema versions.

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
@@ -73,7 +73,7 @@
         "type": "Microsoft.Storage/storageAccounts",
         "name": "[variables('clusterStorageAccountName')]",
         "location": "[parameters('location')]",
-        "apiVersion": "2017-10-01",
+        "apiVersion": "2019-04-01",
         "sku": {
           "name": "[variables('storageAccountType')]"
         },
@@ -165,7 +165,7 @@
       {
         "name": "[concat(parameters('clusterName'),'/', variables('applicationName'))]",
         "type": "Microsoft.HDInsight/clusters/applications",
-        "apiVersion": "2015-03-01-preview",
+        "apiVersion": "2018-06-01-preview",
         "dependsOn": [
           "[concat('Microsoft.HDInsight/clusters/',parameters('clusterName'))]"
         ],

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
@@ -39,7 +39,7 @@
         "metadata": {
           "description": "The base URI where artifacts required by this template are located."
         },
-        "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-hdinsight-kafka-with-edge-schema-registry"
+        "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-hdinsight-kafka-with-edge-schema-registry/"
       },
       "_artifactsLocationSasToken": {
         "type": "securestring",
@@ -71,14 +71,14 @@
       }
     },
     "variables": {
-      "clusterStorageAccountName": "[concat(parameters('clusterName'),'store')]",
+      "clStgAcnt": "[concat(parameters('clusterName'),'store')]",
       "storageAccountType": "Standard_LRS",
       "applicationName": "schema-registry"
     },
     "resources": [
       {
         "type": "Microsoft.Storage/storageAccounts",
-        "name": "[variables('clusterStorageAccountName')]",
+        "name": "[variables('clStgAcnt')]",
         "location": "[parameters('location')]",
         "apiVersion": "2019-04-01",
         "sku": {
@@ -93,7 +93,7 @@
         "location": "[parameters('location')]",
         "apiVersion": "2018-06-01-preview",
         "dependsOn": [
-          "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]"
+          "[concat('Microsoft.Storage/storageAccounts/',variables('clStgAcnt'))]"
         ],
         "properties": {
           "clusterVersion": "3.6",
@@ -111,10 +111,10 @@
           "storageProfile": {
             "storageaccounts": [
               {
-                "name": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), '2016-01-01').primaryEndpoints.blob,'https://',''),'/','')]",
+                "name": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('clStgAcnt')), '2016-01-01').primaryEndpoints.blob,'https://',''),'/','')]",
                 "isDefault": true,
                 "container": "[parameters('clusterName')]",
-                "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), '2017-10-01').keys[0].value]"
+                "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clStgAcnt')), '2017-10-01').keys[0].value]"
               }
             ]
           },
@@ -190,7 +190,7 @@
           "installScriptActions": [
             {
               "name": "[concat('schemaregistry','-' ,uniquestring(variables('applicationName')))]",
-              "uri": "[concat(parameters('_artifactsLocation'),'/', parameters('installScriptActionFolder'), '/', parameters('installScriptAction'), parameters('_artifactsLocationSasToken'))]",
+              "uri": "[concat(parameters('_artifactsLocation'), parameters('installScriptActionFolder'), '/', parameters('installScriptAction'), parameters('_artifactsLocationSasToken'))]",
               "roles": [
                 "edgenode"
               ]

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
@@ -39,7 +39,7 @@
         "metadata": {
           "description": "The base URI where artifacts required by this template are located."
         },
-        "defaultValue": "https://raw.githubusercontent.com/rasavant-ms/101-hdinsight-linux-with-edge-schema-registry/master"
+        "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-hdinsight-kafka-with-edge-schema-registry"
       },
       "installScriptActionFolder": {
         "type": "string",
@@ -88,7 +88,6 @@
         "dependsOn": [
           "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]"
         ],
-        "tags": {},
         "properties": {
           "clusterVersion": "3.6",
           "osType": "Linux",

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
@@ -190,7 +190,7 @@
           "installScriptActions": [
             {
               "name": "[concat('schemaregistry','-' ,uniquestring(variables('applicationName')))]",
-              "uri": "[concat(parameters('_artifactsLocation'), '/', parameters('installScriptActionFolder'), '/', parameters('installScriptAction'))]",
+              "uri": "[concat(parameters('_artifactsLocation'),'/', parameters('installScriptActionFolder'), '/', parameters('installScriptAction'), parameters('_artifactsLocationSasToken'))]",
               "roles": [
                 "edgenode"
               ]

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
@@ -1,0 +1,206 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+      "clusterName": {
+        "type": "string",
+        "metadata": {
+          "description": "The name of the Kafka cluster to create. This must be a unique name."
+        }
+      },
+      "clusterLoginUserName": {
+        "type": "string",
+        "defaultValue": "kafka",
+        "metadata": {
+          "description": "Cluster Login Name"
+        }
+      },
+      "clusterLoginPassword": {
+        "type": "securestring",
+        "metadata": {
+          "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+        }
+      },
+      "sshUserName": {
+        "type": "string",
+        "defaultValue": "kafka",
+        "metadata": {
+          "description": "These credentials can be used to remotely access the cluster."
+        }
+      },
+      "sshPassword": {
+        "type": "securestring",
+        "metadata": {
+          "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
+        }
+      },
+      "_artifactsLocation": {
+        "type": "string",
+        "metadata": {
+          "description": "The base URI where artifacts required by this template are located."
+        },
+        "defaultValue": "https://raw.githubusercontent.com/rasavant-ms/101-hdinsight-linux-with-edge-schema-registry/master"
+      },
+      "installScriptActionFolder": {
+        "type": "string",
+        "metadata": {
+          "description": "A script action you can run on the empty node to install or configure additional software."
+        },
+        "defaultValue": "scripts"
+      },
+      "installScriptAction": {
+        "type": "string",
+        "metadata": {
+          "description": "A script action you can run on the empty node to install or configure additional software."
+        },
+        "defaultValue": "NodeSetup.sh"
+      },
+      "location": {
+        "type": "string",
+        "defaultValue": "[resourceGroup().location]",
+        "metadata": {
+          "description": "Location for all resources."
+        }
+      }
+    },
+    "variables": {
+      "clusterStorageAccountName": "[concat(parameters('clusterName'),'store')]",
+      "storageAccountType": "Standard_LRS",
+      "applicationName": "schema-registry"
+    },
+    "resources": [
+      {
+        "type": "Microsoft.Storage/storageAccounts",
+        "name": "[variables('clusterStorageAccountName')]",
+        "location": "[parameters('location')]",
+        "apiVersion": "2017-10-01",
+        "sku": {
+          "name": "[variables('storageAccountType')]"
+        },
+        "kind": "Storage",
+        "properties": {}
+      },
+      {
+        "name": "[parameters('clusterName')]",
+        "type": "Microsoft.HDInsight/clusters",
+        "location": "[parameters('location')]",
+        "apiVersion": "2015-03-01-preview",
+        "dependsOn": [
+          "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]"
+        ],
+        "tags": {},
+        "properties": {
+          "clusterVersion": "3.6",
+          "osType": "Linux",
+          "clusterDefinition": {
+            "kind": "KAFKA",
+            "configurations": {
+              "gateway": {
+                "restAuthCredential.isEnabled": true,
+                "restAuthCredential.username": "[parameters('clusterLoginUserName')]",
+                "restAuthCredential.password": "[parameters('clusterLoginPassword')]"
+              }
+            }
+          },
+          "storageProfile": {
+            "storageaccounts": [
+              {
+                "name": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), '2016-01-01').primaryEndpoints.blob,'https://',''),'/','')]",
+                "isDefault": true,
+                "container": "[parameters('clusterName')]",
+                "key": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('clusterStorageAccountName')), '2017-10-01').keys[0].value]"
+              }
+            ]
+          },
+          "computeProfile": {
+            "roles": [
+              {
+                "name": "headnode",
+                "targetInstanceCount": 2,
+                "hardwareProfile": {
+                  "vmSize": "Standard_D3_v2"
+                },
+                "osProfile": {
+                  "linuxOperatingSystemProfile": {
+                    "username": "[parameters('sshUserName')]",
+                    "password": "[parameters('sshPassword')]"
+                  }
+                }
+              },
+              {
+                "name": "workernode",
+                "targetInstanceCount": 4,
+                "hardwareProfile": {
+                  "vmSize": "Standard_D3_v2"
+                },
+                "dataDisksGroups": [
+                  {
+                    "disksPerNode": 2
+                  }
+                ],
+                "osProfile": {
+                  "linuxOperatingSystemProfile": {
+                    "username": "[parameters('sshUserName')]",
+                    "password": "[parameters('sshPassword')]"
+                  }
+                }
+              },
+              {
+                "name": "zookeepernode",
+                "targetInstanceCount": 3,
+                "hardwareProfile": {
+                  "vmSize": "Standard_A3"
+                },
+                "osProfile": {
+                  "linuxOperatingSystemProfile": {
+                    "username": "[parameters('sshUserName')]",
+                    "password": "[parameters('sshPassword')]"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      {
+        "name": "[concat(parameters('clusterName'),'/', variables('applicationName'))]",
+        "type": "Microsoft.HDInsight/clusters/applications",
+        "apiVersion": "2015-03-01-preview",
+        "dependsOn": [
+          "[concat('Microsoft.HDInsight/clusters/',parameters('clusterName'))]"
+        ],
+        "properties": {
+          "computeProfile": {
+            "roles": [
+              {
+                "name": "edgenode",
+                "targetInstanceCount": 1,
+                "hardwareProfile": {
+                  "vmSize": "Standard_D3_v2"
+                }
+              }
+            ]
+          },
+          "installScriptActions": [
+            {
+              "name": "[concat('schemaregistry','-' ,uniquestring(variables('applicationName')))]",
+              "uri": "[concat(parameters('_artifactsLocation'), '/', parameters('installScriptActionFolder'), '/', parameters('installScriptAction'))]",
+              "roles": [
+                "edgenode"
+              ]
+            }
+          ],
+          "uninstallScriptActions": [],
+          "httpsEndpoints": [],
+          "sshEndpoints": [
+            {
+              "location": "[concat(variables('applicationName'),'.',parameters('clusterName'),'-ssh.azurehdinsight.net')]",
+              "destinationPort": 22,
+              "publicPort": 22
+            }
+          ],
+          "applicationType": "CustomApplication"
+        }
+      }
+    ]
+}

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
@@ -4,13 +4,13 @@
     "parameters": {
       "clusterName": {
         "type": "string",
+        "defaultValue": "[uniqueString('resourceGroup().id')]",
         "metadata": {
           "description": "The name of the Kafka cluster to create. This must be a unique name."
         }
       },
       "clusterLoginUserName": {
         "type": "string",
-        "defaultValue": "kafka",
         "metadata": {
           "description": "Cluster Login Name"
         }
@@ -23,7 +23,6 @@
       },
       "sshUserName": {
         "type": "string",
-        "defaultValue": "kafka",
         "metadata": {
           "description": "These credentials can be used to remotely access the cluster."
         }

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
@@ -84,7 +84,7 @@
         "name": "[parameters('clusterName')]",
         "type": "Microsoft.HDInsight/clusters",
         "location": "[parameters('location')]",
-        "apiVersion": "2015-03-01-preview",
+        "apiVersion": "2018-06-01-preview",
         "dependsOn": [
           "[concat('Microsoft.Storage/storageAccounts/',variables('clusterStorageAccountName'))]"
         ],

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
@@ -189,8 +189,6 @@
               ]
             }
           ],
-          "uninstallScriptActions": [],
-          "httpsEndpoints": [],
           "sshEndpoints": [
             {
               "location": "[concat(variables('applicationName'),'.',parameters('clusterName'),'-ssh.azurehdinsight.net')]",

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.json
@@ -41,6 +41,13 @@
         },
         "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/101-hdinsight-kafka-with-edge-schema-registry"
       },
+      "_artifactsLocationSasToken": {
+        "type": "securestring",
+        "metadata": {
+            "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated. Use the defaultValue if the staging location is not secured."
+        },
+        "defaultValue": ""
+      },
       "installScriptActionFolder": {
         "type": "string",
         "metadata": {

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.parameters.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.parameters.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "clusterName": {
+            "value": "GEN-UNIQUE"
+        },
+        "clusterLoginUserName": {
+            "value": "GEN-UNIQUE"
+        },
+        "clusterLoginPassword": {
+            "value": "GEN-PASSWORD"
+        },
+        "sshUserName": {
+            "value": "GEN-UNIQUE"
+        },
+        "sshPassword": {
+            "value": "GEN-PASSWORD"
+        }
+    }
+}

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.parameters.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.parameters.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
+    "contentVersion": "1.0.0.1",
     "parameters": {
         "clusterName": {
             "value": "GEN-UNIQUE"

--- a/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.parameters.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/azuredeploy.parameters.json
@@ -2,9 +2,6 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.1",
     "parameters": {
-        "clusterName": {
-            "value": "GEN-UNIQUE"
-        },
         "clusterLoginUserName": {
             "value": "GEN-UNIQUE"
         },

--- a/101-hdinsight-kafka-with-edge-schema-registry/metadata.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to create an HDInsight cluster running Linux with a schema registry edge node. For more information, see https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-apps-use-edge-node",
   "summary": "Deploy a Linux-based HDInsight cluster with a schema registry edge node",
   "githubUsername": "rasavant-ms",
-  "dateUpdated": "2019-07-16"
+  "dateUpdated": "2019-07-18"
 }

--- a/101-hdinsight-kafka-with-edge-schema-registry/metadata.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/metadata.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
+  "type": "QuickStart",
+  "itemDisplayName": "Deploy HDInsight cluster + Confluent Schema Registry node",
+  "description": "This template allows you to create an HDInsight cluster running Linux with a schema registry edge node. For more information, see https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-apps-use-edge-node",
+  "summary": "Deploy a Linux-based HDInsight cluster with a schema registry edge node",
+  "githubUsername": "rasavant-ms",
+  "dateUpdated": "2019-07-15"
+}

--- a/101-hdinsight-kafka-with-edge-schema-registry/metadata.json
+++ b/101-hdinsight-kafka-with-edge-schema-registry/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to create an HDInsight cluster running Linux with a schema registry edge node. For more information, see https://docs.microsoft.com/en-us/azure/hdinsight/hdinsight-apps-use-edge-node",
   "summary": "Deploy a Linux-based HDInsight cluster with a schema registry edge node",
   "githubUsername": "rasavant-ms",
-  "dateUpdated": "2019-07-15"
+  "dateUpdated": "2019-07-16"
 }

--- a/101-hdinsight-kafka-with-edge-schema-registry/scripts/NodeSetup.sh
+++ b/101-hdinsight-kafka-with-edge-schema-registry/scripts/NodeSetup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -o errexit
+set -o xtrace
+
+# Install jq
+dpkg -s jq || sudo apt-get install -y jq
+
+# Install Confluent platform (includes Kafka schema registry)
+wget -qO - http://packages.confluent.io/deb/4.1/archive.key | sudo apt-key add -
+sudo add-apt-repository "deb http://packages.confluent.io/deb/4.1 stable main"
+sudo apt-get update
+dpkg -s confluent-platform-oss-2.11 || sudo apt-get install -y confluent-platform-oss-2.11
+
+echo "[Unit]
+Description = Confluent Schema Registry
+After = network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=1
+User=ohklvmadmin
+ExecStart=/usr/bin/schema-registry-start /etc/schema-registry/schema-registry.properties
+
+[Install]
+WantedBy=multi-user.target
+" > /etc/systemd/system/schema-registry.service
+
+echo "
+listeners=http://0.0.0.0:8081
+kafkastore.connection.url=zk0-ohkl-h:2181,zk1-ohkl-h:2181,zk2-ohkl-h:2181
+kafkastore.topic=_schemas
+debug=false
+" > /etc/schema-registry/schema-registry.properties
+
+systemctl start schema-registry
+systemctl enable schema-registry
+
+echo "Installation successful."


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added new quickstart template for HDInsight Kafka cluster deployment with a Confluent Schema Registry Edge node

