### PR TITLE
Updated route tables

### DIFF
--- a/101-sql-managed-instance-azure-environment/azuredeploy.json
+++ b/101-sql-managed-instance-azure-environment/azuredeploy.json
@@ -93,22 +93,841 @@
       }
     },
     {
-        "type": "Microsoft.Network/routeTables",
-        "name": "[parameters('routeTableToAzureService')]",
-        "apiVersion": "2018-02-01",
-        "location": "[parameters('location')]",
-        "properties": {
-            "disableBgpRoutePropagation": false,
-            "routes": [
-                {
-                    "name": "[parameters('routeTableToAzureService')]",
-                    "properties": {
-                        "addressPrefix": "0.0.0.0/0",
-                        "nextHopType": "Internet"
-                    }
-                }
-            ]
-        }
-    }
+      "type": "Microsoft.Network/routeTables",
+      "apiVersion": "2019-04-01",
+      "name": "[parameters('routeTableToAzureService')]",
+      "location": "[parameters('location')]",
+      "properties": {
+          "disableBgpRoutePropagation": false,
+          "routes": [
+              {
+                  "name": "subnet_to_vnetlocal",
+                  "properties": {
+                      "addressPrefix": "[parameters('defaultsubnetPrefix')]",
+                      "nextHopType": "VnetLocal"
+                  }
+              },                    
+              {
+                  "name": "mi-13-64-11-nexthop-internet",
+                  "properties": {
+                      "addressPrefix": "13.64.0.0/11",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-13-96-13-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "13.96.0.0/13",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-13-104-14-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "13.104.0.0/14",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-20-8-nexthop-internet",
+                  "properties": {      
+                      "addressPrefix": "20.0.0.0/8",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-23-96-13-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "23.96.0.0/13",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-40-64-10-nexthop-internet",
+                  "properties": {         
+                      "addressPrefix": "40.64.0.0/10",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-42-159-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "42.159.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-51-8-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "51.0.0.0/8",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-52-8-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "52.0.0.0/8",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-64-4-18-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "64.4.0.0/18",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-65-52-14-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "65.52.0.0/14",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-66-119-144-20-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "66.119.144.0/20",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-70-37-17-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "70.37.0.0/17",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-70-37-128-18-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "70.37.128.0/18",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-91-190-216-21-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "91.190.216.0/21",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-94-245-64-18-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "94.245.64.0/18",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-103-9-8-22-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "103.9.8.0/22",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-103-25-156-22-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "103.25.156.0/22",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-103-36-96-22-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "103.36.96.0/22",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-103-255-140-22-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "103.255.140.0/22",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-104-40-13-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "104.40.0.0/13",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-104-146-15-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "104.146.0.0/15",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-104-208-13-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "104.208.0.0/13",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-111-221-16-20-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "111.221.16.0/20",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-111-221-64-18-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "111.221.64.0/18",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-129-75-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "129.75.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-131-253-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "131.253.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-132-245-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "132.245.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-134-170-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "134.170.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-134-177-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "134.177.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-137-116-15-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "137.116.0.0/15",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-137-135-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "137.135.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-138-91-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "138.91.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-138-196-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "138.196.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-139-217-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "139.217.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-139-219-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "139.219.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-141-251-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "141.251.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-146-147-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "146.147.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-147-243-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "147.243.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-150-171-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "150.171.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-150-242-48-22-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "150.242.48.0/22",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-157-54-15-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "157.54.0.0/15",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-157-56-14-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "157.56.0.0/14",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-157-60-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "157.60.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-167-220-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "167.220.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-168-61-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "168.61.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-168-62-15-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "168.62.0.0/15",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-191-232-13-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "191.232.0.0/13",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-192-32-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "192.32.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-192-48-225-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "192.48.225.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-192-84-159-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "192.84.159.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-192-84-160-23-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "192.84.160.0/23",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-192-100-102-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "192.100.102.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-192-100-103-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "192.100.103.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-192-197-157-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "192.197.157.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-193-149-64-19-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "193.149.64.0/19",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-193-221-113-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "193.221.113.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-194-69-96-19-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "194.69.96.0/19",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-194-110-197-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "194.110.197.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-198-105-232-22-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "198.105.232.0/22",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-198-200-130-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "198.200.130.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-198-206-164-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "198.206.164.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-199-60-28-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "199.60.28.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-199-74-210-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "199.74.210.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-199-103-90-23-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "199.103.90.0/23",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-199-103-122-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "199.103.122.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-199-242-32-20-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "199.242.32.0/20",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-199-242-48-21-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "199.242.48.0/21",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-202-89-224-20-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "202.89.224.0/20",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-13-120-21-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.13.120.0/21",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-14-180-22-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.14.180.0/22",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-79-135-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.79.135.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-79-179-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.79.179.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-79-181-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.79.181.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-79-188-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.79.188.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-79-195-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.79.195.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-79-196-23-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.79.196.0/23",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-79-252-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.79.252.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-152-18-23-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.152.18.0/23",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-152-140-23-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.152.140.0/23",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-231-192-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.231.192.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-231-194-23-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.231.194.0/23",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-231-197-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.231.197.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-231-198-23-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.231.198.0/23",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-231-200-21-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.231.200.0/21",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-231-208-20-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.231.208.0/20",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-204-231-236-24-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "204.231.236.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-205-174-224-20-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "205.174.224.0/20",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-206-138-168-21-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "206.138.168.0/21",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-206-191-224-19-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "206.191.224.0/19",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-207-46-16-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "207.46.0.0/16",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-207-68-128-18-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "207.68.128.0/18",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-208-68-136-21-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "208.68.136.0/21",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-208-76-44-22-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "208.76.44.0/22",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-208-84-21-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "208.84.0.0/21",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-209-240-192-19-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "209.240.192.0/19",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-213-199-128-18-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "213.199.128.0/18",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-216-32-180-22-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "216.32.180.0/22",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "mi-216-220-208-20-nexthop-internet",
+                  "properties": {            
+                      "addressPrefix": "216.220.208.0/20",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_deployment",
+                  "properties": {            
+                      "addressPrefix": "65.55.188.0/24",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_supportability_1",
+                  "properties": {            
+                      "addressPrefix": "207.68.190.32/27",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_supportability_2",
+                  "properties": {            
+                      "addressPrefix": "13.106.78.32/27",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_supportability_3",
+                  "properties": {            
+                      "addressPrefix": "13.106.174.32/27",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_supportability_4",
+                  "properties": {            
+                      "addressPrefix": "13.106.4.96/27",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_automation_global",
+                  "properties": {            
+                      "addressPrefix": "104.214.108.80/32",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_security_global_1",
+                  "properties": {            
+                      "addressPrefix": "52.179.184.76/32",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_security_global_2",
+                  "properties": {            
+                      "addressPrefix": "52.187.116.202/32",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_security_global_3",
+                  "properties": {            
+                      "addressPrefix": "52.177.202.6/32",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_controlPlane_primary",
+                  "properties": {            
+                      "addressPrefix": "13.75.149.87/32",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_controlPlane_backup1",
+                  "properties": {            
+                      "addressPrefix": "40.79.161.1/32",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_controlPlane_az01",
+                  "properties": {            
+                      "addressPrefix": "13.70.72.160/27",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_controlPlane_az02",
+                  "properties": {            
+                      "addressPrefix": "40.79.170.160/27",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_controlPlane_az03",
+                  "properties": {            
+                      "addressPrefix": "40.79.162.64/27",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_automation_backup",
+                  "properties": {            
+                      "addressPrefix": "52.243.87.200/32",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_automation_primary",
+                  "properties": {            
+                      "addressPrefix": "40.126.238.47/32",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_security_primary",
+                  "properties": {            
+                      "addressPrefix": "191.239.183.225/32",
+                      "nextHopType": "Internet"
+                  }
+              },
+              {
+                  "name": "SqlManagement_security_backup",
+                  "properties": {            
+                      "addressPrefix": "52.187.228.131/32",
+                      "nextHopType": "Internet"
+                  }
+              }
+          ]
+      }
+  }
   ]
 }

--- a/101-sqlmi-new-vnet/azuredeploy.json
+++ b/101-sqlmi-new-vnet/azuredeploy.json
@@ -234,16 +234,835 @@
         },
         {
             "type": "Microsoft.Network/routeTables",
+            "apiVersion": "2019-04-01",
             "name": "[variables('routeTableName')]",
-            "apiVersion": "2018-02-01",
             "location": "[parameters('location')]",
             "properties": {
                 "disableBgpRoutePropagation": false,
                 "routes": [
                     {
-                        "name": "default",
+                        "name": "subnet_to_vnetlocal",
                         "properties": {
-                            "addressPrefix": "0.0.0.0/0",
+                            "addressPrefix": "[parameters('subnetPrefix')]",
+                            "nextHopType": "VnetLocal"
+                        }
+                    },                    
+                    {
+                        "name": "mi-13-64-11-nexthop-internet",
+                        "properties": {
+                            "addressPrefix": "13.64.0.0/11",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-13-96-13-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "13.96.0.0/13",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-13-104-14-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "13.104.0.0/14",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-20-8-nexthop-internet",
+                        "properties": {      
+                            "addressPrefix": "20.0.0.0/8",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-23-96-13-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "23.96.0.0/13",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-40-64-10-nexthop-internet",
+                        "properties": {         
+                            "addressPrefix": "40.64.0.0/10",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-42-159-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "42.159.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-51-8-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "51.0.0.0/8",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-52-8-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "52.0.0.0/8",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-64-4-18-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "64.4.0.0/18",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-65-52-14-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "65.52.0.0/14",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-66-119-144-20-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "66.119.144.0/20",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-70-37-17-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "70.37.0.0/17",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-70-37-128-18-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "70.37.128.0/18",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-91-190-216-21-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "91.190.216.0/21",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-94-245-64-18-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "94.245.64.0/18",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-103-9-8-22-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "103.9.8.0/22",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-103-25-156-22-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "103.25.156.0/22",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-103-36-96-22-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "103.36.96.0/22",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-103-255-140-22-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "103.255.140.0/22",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-104-40-13-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "104.40.0.0/13",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-104-146-15-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "104.146.0.0/15",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-104-208-13-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "104.208.0.0/13",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-111-221-16-20-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "111.221.16.0/20",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-111-221-64-18-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "111.221.64.0/18",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-129-75-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "129.75.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-131-253-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "131.253.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-132-245-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "132.245.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-134-170-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "134.170.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-134-177-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "134.177.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-137-116-15-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "137.116.0.0/15",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-137-135-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "137.135.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-138-91-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "138.91.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-138-196-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "138.196.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-139-217-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "139.217.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-139-219-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "139.219.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-141-251-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "141.251.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-146-147-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "146.147.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-147-243-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "147.243.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-150-171-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "150.171.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-150-242-48-22-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "150.242.48.0/22",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-157-54-15-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "157.54.0.0/15",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-157-56-14-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "157.56.0.0/14",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-157-60-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "157.60.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-167-220-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "167.220.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-168-61-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "168.61.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-168-62-15-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "168.62.0.0/15",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-191-232-13-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "191.232.0.0/13",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-192-32-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "192.32.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-192-48-225-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "192.48.225.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-192-84-159-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "192.84.159.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-192-84-160-23-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "192.84.160.0/23",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-192-100-102-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "192.100.102.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-192-100-103-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "192.100.103.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-192-197-157-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "192.197.157.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-193-149-64-19-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "193.149.64.0/19",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-193-221-113-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "193.221.113.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-194-69-96-19-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "194.69.96.0/19",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-194-110-197-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "194.110.197.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-198-105-232-22-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "198.105.232.0/22",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-198-200-130-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "198.200.130.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-198-206-164-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "198.206.164.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-199-60-28-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "199.60.28.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-199-74-210-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "199.74.210.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-199-103-90-23-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "199.103.90.0/23",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-199-103-122-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "199.103.122.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-199-242-32-20-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "199.242.32.0/20",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-199-242-48-21-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "199.242.48.0/21",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-202-89-224-20-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "202.89.224.0/20",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-13-120-21-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.13.120.0/21",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-14-180-22-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.14.180.0/22",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-79-135-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.79.135.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-79-179-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.79.179.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-79-181-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.79.181.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-79-188-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.79.188.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-79-195-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.79.195.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-79-196-23-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.79.196.0/23",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-79-252-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.79.252.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-152-18-23-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.152.18.0/23",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-152-140-23-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.152.140.0/23",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-231-192-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.231.192.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-231-194-23-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.231.194.0/23",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-231-197-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.231.197.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-231-198-23-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.231.198.0/23",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-231-200-21-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.231.200.0/21",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-231-208-20-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.231.208.0/20",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-204-231-236-24-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "204.231.236.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-205-174-224-20-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "205.174.224.0/20",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-206-138-168-21-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "206.138.168.0/21",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-206-191-224-19-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "206.191.224.0/19",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-207-46-16-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "207.46.0.0/16",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-207-68-128-18-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "207.68.128.0/18",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-208-68-136-21-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "208.68.136.0/21",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-208-76-44-22-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "208.76.44.0/22",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-208-84-21-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "208.84.0.0/21",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-209-240-192-19-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "209.240.192.0/19",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-213-199-128-18-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "213.199.128.0/18",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-216-32-180-22-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "216.32.180.0/22",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "mi-216-220-208-20-nexthop-internet",
+                        "properties": {            
+                            "addressPrefix": "216.220.208.0/20",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_deployment",
+                        "properties": {            
+                            "addressPrefix": "65.55.188.0/24",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_supportability_1",
+                        "properties": {            
+                            "addressPrefix": "207.68.190.32/27",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_supportability_2",
+                        "properties": {            
+                            "addressPrefix": "13.106.78.32/27",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_supportability_3",
+                        "properties": {            
+                            "addressPrefix": "13.106.174.32/27",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_supportability_4",
+                        "properties": {            
+                            "addressPrefix": "13.106.4.96/27",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_automation_global",
+                        "properties": {            
+                            "addressPrefix": "104.214.108.80/32",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_security_global_1",
+                        "properties": {            
+                            "addressPrefix": "52.179.184.76/32",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_security_global_2",
+                        "properties": {            
+                            "addressPrefix": "52.187.116.202/32",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_security_global_3",
+                        "properties": {            
+                            "addressPrefix": "52.177.202.6/32",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_controlPlane_primary",
+                        "properties": {            
+                            "addressPrefix": "13.75.149.87/32",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_controlPlane_backup1",
+                        "properties": {            
+                            "addressPrefix": "40.79.161.1/32",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_controlPlane_az01",
+                        "properties": {            
+                            "addressPrefix": "13.70.72.160/27",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_controlPlane_az02",
+                        "properties": {            
+                            "addressPrefix": "40.79.170.160/27",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_controlPlane_az03",
+                        "properties": {            
+                            "addressPrefix": "40.79.162.64/27",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_automation_backup",
+                        "properties": {            
+                            "addressPrefix": "52.243.87.200/32",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_automation_primary",
+                        "properties": {            
+                            "addressPrefix": "40.126.238.47/32",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_security_primary",
+                        "properties": {            
+                            "addressPrefix": "191.239.183.225/32",
+                            "nextHopType": "Internet"
+                        }
+                    },
+                    {
+                        "name": "SqlManagement_security_backup",
+                        "properties": {            
+                            "addressPrefix": "52.187.228.131/32",
                             "nextHopType": "Internet"
                         }
                     }


### PR DESCRIPTION
The templates were failing to deploy due to the network intent policy identifying configuration problems with routing. I’ve updated the templates to include the network routes as per this documentation in order to be compliant with the SQL MI network intent policy.

https://docs.microsoft.com/en-us/azure/sql-database/sql-database-managed-instance-connectivity-architecture#network-requirements