### PR TITLE
Updating to make v2 the standard

### DIFF
--- a/101-application-gateway-waf/azuredeploy.json
+++ b/101-application-gateway-waf/azuredeploy.json
@@ -26,12 +26,6 @@
     "applicationGatewaySize": {
       "type": "string",
       "allowedValues": [
-        "Standard_Small",
-        "Standard_Medium",
-        "Standard_Large",
-        "WAF_Medium",
-        "WAF_Large",
-        "Standard_v2",
         "WAF_v2"
       ],
       "defaultValue": "WAF_Medium",

--- a/101-application-gateway-waf/azuredeploy.json
+++ b/101-application-gateway-waf/azuredeploy.json
@@ -121,6 +121,9 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
         "publicIPAllocationMethod": "Static"
       }

--- a/101-application-gateway-waf/azuredeploy.json
+++ b/101-application-gateway-waf/azuredeploy.json
@@ -28,7 +28,7 @@
       "allowedValues": [
         "WAF_v2"
       ],
-      "defaultValue": "WAF_Medium",
+      "defaultValue": "WAF_v2",
       "metadata": {
         "description": "Specifies the application gateway SKU name."
       }

--- a/101-application-gateway-waf/azuredeploy.json
+++ b/101-application-gateway-waf/azuredeploy.json
@@ -122,7 +122,7 @@
       "name": "[variables('publicIPAddressName')]",
       "location": "[parameters('location')]",
       "properties": {
-        "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Static"
       }
     },
     {

--- a/101-application-gateway-waf/azuredeploy.json
+++ b/101-application-gateway-waf/azuredeploy.json
@@ -164,7 +164,7 @@
       "properties": {
         "sku": {
           "name": "[parameters('applicationGatewaySize')]",
-          "tier": "WAF",
+          "tier": "WAF_v2",
           "capacity": "[parameters('applicationGateWayCapacity')]"
         },
         "gatewayIPConfigurations": [


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*made WAF_v2 the standard
*
*

