### PR TITLE
Added bypass for jitAccessPolicy and managedResourceGroupId parameters

### DIFF
--- a/test/template-validation-tests/test/createUiDefTests.js
+++ b/test/template-validation-tests/test/createUiDefTests.js
@@ -71,7 +71,7 @@ describe('createUiDefinition.json file - ', () => {
     var outputsInCreateUiDef = Object.keys(createUiDefFileJSONObject.parameters.outputs);
     it.each(outputsInCreateUiDef, 'output %s must be present in mainTemplate parameters', ['element'], function(element, next) {
         /** if this is a managed app, applicationresourcename will be added by the RP and not in mainTemplate, so skip it */
-        if (element != 'applicationresourcename') {
+        if ((element != 'applicationresourcename') && (element != 'jitaccesspolicy') && (element != 'managedresourcegroupid')) {
             parametersInTemplate.should.contain(element);
         }
         next();


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [X ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

