### PR TITLE
Update location ID to Data Center location mapping

### DIFF
--- a/201-dynamic-web-tests/README.md
+++ b/201-dynamic-web-tests/README.md
@@ -23,26 +23,26 @@ This template will help you quickly spin up any number of [Application Insights]
 }
 ```
 
-The `guid` field is an arbitrary guid for the test. The `locations` field is a collection of locations to perform the test from. Here is a table of the valid locations, and their corresponding `Id` code:
+The `guid` field is an arbitrary guid for the test. The `locations` field is a collection of locations to perform the test from. Here is a table of the valid locations, and their corresponding `Id` code. Due to historical reasons, the `Id` code sometimes does not match the actual location where the webtest is occuring.
 
 | Name | Id          |
 | ------------- | ----------- |
-| US : IL-Chicago      | us-il-ch1-azr |
-| US : CA-San Jose     | us-ca-sjc-azr |
-| US : TX-San Antonio     | us-tx-sn1-azr |
-| US : VA-Ashburn     | us-va-ash-azr |
-| US : FL-Miami     | us-fl-mia-edge |
-| SG : Singapore     | apac-sg-sin-azr |
-| SE : Stockholm     | emea-se-sto-edge |
-| RU : Moscow     | emea-ru-msa-edge |
-| NL : Amsterdam     | emea-nl-ams-azr |
-| JP : Kawaguchi     | apac-jp-kaw-edge |
-| IE : Dublin     | emea-gb-db3-azr |
-| HK : Hong Kong     | apac-hk-hkn-azr |
-| FR : Paris     | emea-fr-pra-edge |
-| CH : Zurich     | emea-ch-zrh-edge |
-| BR : Sao Paulo     | latam-br-gru-edge |
-| AU : Sydney     | emea-au-syd-edge |
+| North Central US      | us-il-ch1-azr |
+| West US     | us-ca-sjc-azr |
+| South Central US     | us-tx-sn1-azr |
+| East US     | us-va-ash-azr |
+| Central US     | us-fl-mia-edge |
+| Southeast Asia     | apac-sg-sin-azr |
+| UK West     | emea-se-sto-edge |
+| UK South     | emea-ru-msa-edge |
+| West Europe     | emea-nl-ams-azr |
+| Japan East     | apac-jp-kaw-edge |
+| North Europe     | emea-gb-db3-azr |
+| East Asia    | apac-hk-hkn-azr |
+| France Central     | emea-fr-pra-edge |
+| France Central (Formerly France South)     | emea-ch-zrh-edge |
+| Brazil South     | latam-br-gru-edge |
+| Australia East     | emea-au-syd-edge |
 
 
 You can create any number of these test descriptors and pass them in as the parameter for `tests` as shown in the [parameters file](./azuredeploy.parameters.json).

--- a/201-dynamic-web-tests/metadata.json
+++ b/201-dynamic-web-tests/metadata.json
@@ -5,7 +5,7 @@
   "description": "Create any number of App Insights web (ping) tests.",
   "summary": "Create any number of App Insights web (ping) tests by specifying a list of test descriptor objects.",
   "githubUsername": "sedouard",
-  "dateUpdated": "2017-07-14"
+  "dateUpdated": "2019-08-21"
 }
 
 


### PR DESCRIPTION
Due to historical reasons, the location ID string that is used does not always correspond to the data center from which the test is performed. I've updated the table to correctly identify the data center that is displayed in portal - which is the actual webtest location - when you create a test using ARM templates.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Update documentation on location ID to actual location mapping

