### PR TITLE
Add principleType to avoid race condition

### DIFF
--- a/201-vmss-msi/nestedtemplates/setUpRBAC.json
+++ b/201-vmss-msi/nestedtemplates/setUpRBAC.json
@@ -21,12 +21,13 @@
   },
   "resources": [
     {
-      "apiVersion": "2016-07-01",
+      "apiVersion": "2018-09-01-preview",
       "name": "[variables('RBACResourceName')]",
       "type": "Microsoft.Storage/storageAccounts/providers/roleAssignments",
       "properties": {
         "roleDefinitionId": "[variables('contributor')]",
         "principalId": "[parameters('principalId')]",
+        "principalType":"ServicePrincipal",
         "scope": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
       }
     }


### PR DESCRIPTION
Setting the principleType to ServicePrincipal to avoid possible race conditions that exist when attempting to use a new service principal before it has replicated throughout the AAD tenant.  I also updated the API version to the version that supports the principleType property.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

