### PR TITLE
Added network security groups

### DIFF
--- a/101-sql-managed-instance-azure-environment/azuredeploy.json
+++ b/101-sql-managed-instance-azure-environment/azuredeploy.json
@@ -51,6 +51,13 @@
         "description": "The name of the existing or new route table that enables access to Azure SQL Managed Instance Management Service that controls the instance, manages backups and other maintenance operations"
       }
     },
+    "nsgForManagedInstanceSubnet": {
+      "type": "string",
+      "defaultValue": "nsg-ManagedInstances",
+      "metadata": {
+        "description": "Name of network security group dedicated to managed instance subnet"
+      }
+    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
@@ -91,6 +98,676 @@
           }
         ]
       }
+    },
+    {
+      "apiVersion": "2019-06-01",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "name": "[parameters('nsgForManagedInstanceSubnet')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "allow_management_inbound",
+            "properties": {
+                "description": "Allow inbound management traffic",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 100,
+                "direction": "Inbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [
+                    "9000",
+                    "9003",
+                    "1438",
+                    "1440",
+                    "1452"
+                ],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_misubnet_inbound",
+            "properties": {
+                "description": "Allow inbound traffic inside the subnet",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "[parameters('virtualNetworkAddressPrefix')]",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 200,
+                "direction": "Inbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_health_probe_inbound",
+            "properties": {
+                "description": "Allow health probe",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "AzureLoadBalancer",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 300,
+                "direction": "Inbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_tds_inbound",
+            "properties": {
+                "description": "Allow access to data",
+                "protocol": "TCP",
+                "sourcePortRange": "*",
+                "destinationPortRange": "1433",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 1000,
+                "direction": "Inbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_redirect_inbound",
+            "properties": {
+                "description": "Allow inbound redirect traffic to Managed Instance inside the virtual network",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "11000-11999",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 1100,
+                "direction": "Inbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_geodr_inbound",
+            "properties": {
+                "description": "Allow inbound geodr traffic inside the virtual network",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "5022",
+                "sourceAddressPrefix": "VirtualNetwork",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 1200,
+                "direction": "Inbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "deny_all_inbound",
+            "properties": {
+                "description": "Deny all other inbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 4096,
+                "direction": "Inbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_management_outbound",
+            "properties": {
+                "description": "Allow outbound management traffic",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Allow",
+                "priority": 100,
+                "direction": "Outbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [
+                    "80",
+                    "443",
+                    "12000"
+                ],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_misubnet_outbound",
+            "properties": {
+                "description": "Allow outbound traffic inside the subnet",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "[parameters('virtualNetworkAddressPrefix')]",
+                "access": "Allow",
+                "priority": 200,
+                "direction": "Outbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_linkedserver_outbound",
+            "properties": {
+                "description": "Allow outbound linkedserver traffic inside the virtual network",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "1433",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 1000,
+                "direction": "Outbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_redirect_outbound",
+            "properties": {
+                "description": "Allow outbound redirect traffic to Managed Instance inside the virtual network",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "11000-11999",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 1100,
+                "direction": "Outbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "allow_geodr_outbound",
+            "properties": {
+                "description": "Allow outbound geodr traffic inside the virtual network",
+                "protocol": "Tcp",
+                "sourcePortRange": "*",
+                "destinationPortRange": "5022",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "VirtualNetwork",
+                "access": "Allow",
+                "priority": 1200,
+                "direction": "Outbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        },
+        {
+            "name": "deny_all_outbound",
+            "properties": {
+                "description": "Deny all other outbound traffic",
+                "protocol": "*",
+                "sourcePortRange": "*",
+                "destinationPortRange": "*",
+                "sourceAddressPrefix": "*",
+                "destinationAddressPrefix": "*",
+                "access": "Deny",
+                "priority": 4096,
+                "direction": "Outbound",
+                "sourcePortRanges": [],
+                "destinationPortRanges": [],
+                "sourceAddressPrefixes": [],
+                "destinationAddressPrefixes": []
+            }
+        }
+        ],
+        "defaultSecurityRules": [
+            {
+                "name": "AllowVnetInBound",
+                "properties": {
+                    "description": "Allow inbound traffic from all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Inbound",
+                    "sourcePortRanges": [],
+                    "destinationPortRanges": [],
+                    "sourceAddressPrefixes": [],
+                    "destinationAddressPrefixes": []
+                }
+            },
+            {
+                "name": "AllowAzureLoadBalancerInBound",
+                "properties": {
+                    "description": "Allow inbound traffic from azure load balancer",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "AzureLoadBalancer",
+                    "destinationAddressPrefix": "*",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Inbound",
+                    "sourcePortRanges": [],
+                    "destinationPortRanges": [],
+                    "sourceAddressPrefixes": [],
+                    "destinationAddressPrefixes": []
+                }
+            },
+            {
+                "name": "DenyAllInBound",
+                "properties": {
+                    "description": "Deny all inbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Inbound",
+                    "sourcePortRanges": [],
+                    "destinationPortRanges": [],
+                    "sourceAddressPrefixes": [],
+                    "destinationAddressPrefixes": []
+                }
+            },
+            {
+                "name": "AllowVnetOutBound",
+                "properties": {
+                    "description": "Allow outbound traffic from all VMs to all VMs in VNET",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "VirtualNetwork",
+                    "destinationAddressPrefix": "VirtualNetwork",
+                    "access": "Allow",
+                    "priority": 65000,
+                    "direction": "Outbound",
+                    "sourcePortRanges": [],
+                    "destinationPortRanges": [],
+                    "sourceAddressPrefixes": [],
+                    "destinationAddressPrefixes": []
+                }
+            },
+            {
+                "name": "AllowInternetOutBound",
+                "properties": {
+                    "description": "Allow outbound traffic from all VMs to Internet",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "Internet",
+                    "access": "Allow",
+                    "priority": 65001,
+                    "direction": "Outbound",
+                    "sourcePortRanges": [],
+                    "destinationPortRanges": [],
+                    "sourceAddressPrefixes": [],
+                    "destinationAddressPrefixes": []
+                }
+            },
+            {
+                "name": "DenyAllOutBound",
+                "properties": {
+                    "description": "Deny all outbound traffic",
+                    "protocol": "*",
+                    "sourcePortRange": "*",
+                    "destinationPortRange": "*",
+                    "sourceAddressPrefix": "*",
+                    "destinationAddressPrefix": "*",
+                    "access": "Deny",
+                    "priority": 65500,
+                    "direction": "Outbound",
+                    "sourcePortRanges": [],
+                    "destinationPortRanges": [],
+                    "sourceAddressPrefixes": [],
+                    "destinationAddressPrefixes": []
+                }
+            }
+        ]
+      }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_geodr_inbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow inbound geodr traffic inside the virtual network",
+            "protocol": "Tcp",
+            "sourcePortRange": "*",
+            "destinationPortRange": "5022",
+            "sourceAddressPrefix": "VirtualNetwork",
+            "destinationAddressPrefix": "*",
+            "access": "Allow",
+            "priority": 1200,
+            "direction": "Inbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_geodr_outbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow outbound geodr traffic inside the virtual network",
+            "protocol": "Tcp",
+            "sourcePortRange": "*",
+            "destinationPortRange": "5022",
+            "sourceAddressPrefix": "*",
+            "destinationAddressPrefix": "VirtualNetwork",
+            "access": "Allow",
+            "priority": 1200,
+            "direction": "Outbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_health_probe_inbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow health probe",
+            "protocol": "*",
+            "sourcePortRange": "*",
+            "destinationPortRange": "*",
+            "sourceAddressPrefix": "AzureLoadBalancer",
+            "destinationAddressPrefix": "*",
+            "access": "Allow",
+            "priority": 300,
+            "direction": "Inbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_linkedserver_outbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow outbound linkedserver traffic inside the virtual network",
+            "protocol": "Tcp",
+            "sourcePortRange": "*",
+            "destinationPortRange": "1433",
+            "sourceAddressPrefix": "*",
+            "destinationAddressPrefix": "VirtualNetwork",
+            "access": "Allow",
+            "priority": 1000,
+            "direction": "Outbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_management_inbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow inbound management traffic",
+            "protocol": "Tcp",
+            "sourcePortRange": "*",
+            "sourceAddressPrefix": "*",
+            "destinationAddressPrefix": "*",
+            "access": "Allow",
+            "priority": 100,
+            "direction": "Inbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [
+                "9000",
+                "9003",
+                "1438",
+                "1440",
+                "1452"
+            ],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_management_outbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow outbound management traffic",
+            "protocol": "Tcp",
+            "sourcePortRange": "*",
+            "sourceAddressPrefix": "*",
+            "destinationAddressPrefix": "*",
+            "access": "Allow",
+            "priority": 100,
+            "direction": "Outbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [
+                "80",
+                "443",
+                "12000"
+            ],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_misubnet_inbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow inbound traffic inside the subnet",
+            "protocol": "*",
+            "sourcePortRange": "*",
+            "destinationPortRange": "*",
+            "sourceAddressPrefix": "[parameters('virtualNetworkAddressPrefix')]",
+            "destinationAddressPrefix": "*",
+            "access": "Allow",
+            "priority": 200,
+            "direction": "Inbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_misubnet_outbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow outbound traffic inside the subnet",
+            "protocol": "*",
+            "sourcePortRange": "*",
+            "destinationPortRange": "*",
+            "sourceAddressPrefix": "*",
+            "destinationAddressPrefix": "[parameters('virtualNetworkAddressPrefix')]",
+            "access": "Allow",
+            "priority": 200,
+            "direction": "Outbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_redirect_inbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow inbound redirect traffic to Managed Instance inside the virtual network",
+            "protocol": "Tcp",
+            "sourcePortRange": "*",
+            "destinationPortRange": "11000-11999",
+            "sourceAddressPrefix": "VirtualNetwork",
+            "destinationAddressPrefix": "*",
+            "access": "Allow",
+            "priority": 1100,
+            "direction": "Inbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_redirect_outbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow outbound redirect traffic to Managed Instance inside the virtual network",
+            "protocol": "Tcp",
+            "sourcePortRange": "*",
+            "destinationPortRange": "11000-11999",
+            "sourceAddressPrefix": "*",
+            "destinationAddressPrefix": "VirtualNetwork",
+            "access": "Allow",
+            "priority": 1100,
+            "direction": "Outbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/allow_tds_inbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Allow access to data",
+            "protocol": "TCP",
+            "sourcePortRange": "*",
+            "destinationPortRange": "1433",
+            "sourceAddressPrefix": "VirtualNetwork",
+            "destinationAddressPrefix": "*",
+            "access": "Allow",
+            "priority": 1000,
+            "direction": "Inbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/deny_all_inbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "provisioningState": "Succeeded",
+            "description": "Deny all other inbound traffic",
+            "protocol": "*",
+            "sourcePortRange": "*",
+            "destinationPortRange": "*",
+            "sourceAddressPrefix": "*",
+            "destinationAddressPrefix": "*",
+            "access": "Deny",
+            "priority": 4096,
+            "direction": "Inbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
+    },
+    {
+        "type": "Microsoft.Network/networkSecurityGroups/securityRules",
+        "apiVersion": "2019-06-01",
+        "name": "[concat(parameters('nsgForManagedInstanceSubnet'), '/deny_all_outbound')]",
+        "dependsOn": [
+            "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgForManagedInstanceSubnet'))]"
+        ],
+        "properties": {
+            "description": "Deny all other outbound traffic",
+            "protocol": "*",
+            "sourcePortRange": "*",
+            "destinationPortRange": "*",
+            "sourceAddressPrefix": "*",
+            "destinationAddressPrefix": "*",
+            "access": "Deny",
+            "priority": 4096,
+            "direction": "Outbound",
+            "sourcePortRanges": [],
+            "destinationPortRanges": [],
+            "sourceAddressPrefixes": [],
+            "destinationAddressPrefixes": []
+        }
     },
     {
       "type": "Microsoft.Network/routeTables",

--- a/101-sql-managed-instance-azure-environment/metadata.json
+++ b/101-sql-managed-instance-azure-environment/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template allows you to create an environment required to deploy Azure SQL Managed Instance - Virtual Network with two subnets.",
   "summary": "Create a Virtual Network with two Subnets. One dedicated to SQL Managed Instances and other default for other resources",
   "githubUsername": "jovanpop-msft",
-  "dateUpdated": "2018-07-01"
+  "dateUpdated": "2019-09-04"
 }
 
 

--- a/azure-sql-managed-instance/azuredeploy.json
+++ b/azure-sql-managed-instance/azuredeploy.json
@@ -157,13 +157,6 @@
             "metadata": {
                 "description": "Managed Instance Subnet range"
             }
-        },
-        "miManagementIps": {
-            "type": "array",
-            "defaultValue": [],
-            "metadata": {
-                "description": "List of MI management IP ranges"
-            }
         }
     },
     "variables": {
@@ -201,9 +194,6 @@
                     },
                     "managedInstanceRouteTableName": {
                         "value": "[parameters('managedInstanceRouteTableName')]"
-                    },
-                    "miManagementIps": {
-                        "value": "[parameters('miManagementIps')]"
                     }
                 }
             }

--- a/azure-sql-managed-instance/metadata.json
+++ b/azure-sql-managed-instance/metadata.json
@@ -5,5 +5,5 @@
     "description": "Deploy UDR and NSG to support Azure SQL Managed Instance and deploy the Managed Instance ",
     "summary": "Deploy UDR and NSG to support Azure SQL Managed Instance and deploy the Managed Instance",
     "githubUsername": "jftl6y",
-    "dateUpdated": "2019-04-22"
+    "dateUpdated": "2019-09-06"
   }

--- a/azure-sql-managed-instance/nestedtemplates/vnet.json
+++ b/azure-sql-managed-instance/nestedtemplates/vnet.json
@@ -43,12 +43,6 @@
             "metadata": {
                 "description": "Name of the Managed Instance Route Table"
             }
-        },
-        "miManagementIps": {
-            "type": "array",
-            "metadata": {
-                "description": "List of MI management IP ranges"
-            }
         }
     },
     "resources": [
@@ -149,20 +143,836 @@
                 "displayName": "Deploy Azure SQL Managed Instance UDR"
             },
             "properties": {
-                "copy": [
-                    {
-                        "name": "routes",
-                        "count": "[length(parameters('miManagementIps'))]",
-                        "input": {
-                            "name": "[if(equals(copyIndex('routes'),0),'subnet_to_vnetlocal',concat(replace(parameters('miManagementIps')[copyIndex('routes')],'/','-'),'-next-hop-internet-route'))]",
-                            "properties": {
-                                "addressPrefix": "[if(equals(copyIndex('routes'),0),parameters('managedInstanceSubnetAddressRange'),parameters('miManagementIps')[copyIndex('routes')])]",
-                                "nextHopType": "[if(equals(copyIndex('routes'),0),'VnetLocal','Internet')]"
-                            }
-                        }
-                    }
-                ]
-            }
+              "disableBgpRoutePropagation": false,
+              "routes": [
+                  {
+                      "name": "subnet_to_vnetlocal",
+                      "properties": {
+                          "addressPrefix": "[parameters('managedInstanceSubnetPrefix')]",
+                          "nextHopType": "VnetLocal"
+                      }
+                  },                    
+                  {
+                      "name": "mi-13-64-11-nexthop-internet",
+                      "properties": {
+                          "addressPrefix": "13.64.0.0/11",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-13-96-13-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "13.96.0.0/13",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-13-104-14-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "13.104.0.0/14",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-20-8-nexthop-internet",
+                      "properties": {      
+                          "addressPrefix": "20.0.0.0/8",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-23-96-13-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "23.96.0.0/13",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-40-64-10-nexthop-internet",
+                      "properties": {         
+                          "addressPrefix": "40.64.0.0/10",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-42-159-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "42.159.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-51-8-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "51.0.0.0/8",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-52-8-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "52.0.0.0/8",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-64-4-18-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "64.4.0.0/18",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-65-52-14-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "65.52.0.0/14",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-66-119-144-20-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "66.119.144.0/20",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-70-37-17-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "70.37.0.0/17",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-70-37-128-18-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "70.37.128.0/18",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-91-190-216-21-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "91.190.216.0/21",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-94-245-64-18-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "94.245.64.0/18",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-103-9-8-22-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "103.9.8.0/22",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-103-25-156-22-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "103.25.156.0/22",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-103-36-96-22-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "103.36.96.0/22",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-103-255-140-22-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "103.255.140.0/22",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-104-40-13-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "104.40.0.0/13",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-104-146-15-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "104.146.0.0/15",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-104-208-13-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "104.208.0.0/13",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-111-221-16-20-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "111.221.16.0/20",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-111-221-64-18-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "111.221.64.0/18",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-129-75-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "129.75.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-131-253-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "131.253.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-132-245-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "132.245.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-134-170-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "134.170.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-134-177-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "134.177.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-137-116-15-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "137.116.0.0/15",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-137-135-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "137.135.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-138-91-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "138.91.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-138-196-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "138.196.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-139-217-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "139.217.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-139-219-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "139.219.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-141-251-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "141.251.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-146-147-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "146.147.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-147-243-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "147.243.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-150-171-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "150.171.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-150-242-48-22-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "150.242.48.0/22",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-157-54-15-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "157.54.0.0/15",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-157-56-14-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "157.56.0.0/14",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-157-60-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "157.60.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-167-220-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "167.220.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-168-61-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "168.61.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-168-62-15-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "168.62.0.0/15",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-191-232-13-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "191.232.0.0/13",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-192-32-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "192.32.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-192-48-225-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "192.48.225.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-192-84-159-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "192.84.159.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-192-84-160-23-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "192.84.160.0/23",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-192-100-102-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "192.100.102.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-192-100-103-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "192.100.103.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-192-197-157-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "192.197.157.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-193-149-64-19-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "193.149.64.0/19",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-193-221-113-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "193.221.113.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-194-69-96-19-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "194.69.96.0/19",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-194-110-197-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "194.110.197.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-198-105-232-22-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "198.105.232.0/22",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-198-200-130-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "198.200.130.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-198-206-164-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "198.206.164.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-199-60-28-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "199.60.28.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-199-74-210-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "199.74.210.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-199-103-90-23-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "199.103.90.0/23",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-199-103-122-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "199.103.122.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-199-242-32-20-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "199.242.32.0/20",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-199-242-48-21-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "199.242.48.0/21",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-202-89-224-20-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "202.89.224.0/20",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-13-120-21-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.13.120.0/21",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-14-180-22-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.14.180.0/22",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-79-135-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.79.135.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-79-179-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.79.179.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-79-181-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.79.181.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-79-188-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.79.188.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-79-195-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.79.195.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-79-196-23-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.79.196.0/23",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-79-252-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.79.252.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-152-18-23-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.152.18.0/23",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-152-140-23-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.152.140.0/23",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-231-192-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.231.192.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-231-194-23-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.231.194.0/23",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-231-197-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.231.197.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-231-198-23-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.231.198.0/23",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-231-200-21-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.231.200.0/21",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-231-208-20-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.231.208.0/20",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-204-231-236-24-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "204.231.236.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-205-174-224-20-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "205.174.224.0/20",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-206-138-168-21-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "206.138.168.0/21",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-206-191-224-19-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "206.191.224.0/19",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-207-46-16-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "207.46.0.0/16",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-207-68-128-18-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "207.68.128.0/18",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-208-68-136-21-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "208.68.136.0/21",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-208-76-44-22-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "208.76.44.0/22",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-208-84-21-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "208.84.0.0/21",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-209-240-192-19-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "209.240.192.0/19",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-213-199-128-18-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "213.199.128.0/18",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-216-32-180-22-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "216.32.180.0/22",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "mi-216-220-208-20-nexthop-internet",
+                      "properties": {            
+                          "addressPrefix": "216.220.208.0/20",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_deployment",
+                      "properties": {            
+                          "addressPrefix": "65.55.188.0/24",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_supportability_1",
+                      "properties": {            
+                          "addressPrefix": "207.68.190.32/27",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_supportability_2",
+                      "properties": {            
+                          "addressPrefix": "13.106.78.32/27",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_supportability_3",
+                      "properties": {            
+                          "addressPrefix": "13.106.174.32/27",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_supportability_4",
+                      "properties": {            
+                          "addressPrefix": "13.106.4.96/27",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_automation_global",
+                      "properties": {            
+                          "addressPrefix": "104.214.108.80/32",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_security_global_1",
+                      "properties": {            
+                          "addressPrefix": "52.179.184.76/32",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_security_global_2",
+                      "properties": {            
+                          "addressPrefix": "52.187.116.202/32",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_security_global_3",
+                      "properties": {            
+                          "addressPrefix": "52.177.202.6/32",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_controlPlane_primary",
+                      "properties": {            
+                          "addressPrefix": "13.75.149.87/32",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_controlPlane_backup1",
+                      "properties": {            
+                          "addressPrefix": "40.79.161.1/32",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_controlPlane_az01",
+                      "properties": {            
+                          "addressPrefix": "13.70.72.160/27",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_controlPlane_az02",
+                      "properties": {            
+                          "addressPrefix": "40.79.170.160/27",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_controlPlane_az03",
+                      "properties": {            
+                          "addressPrefix": "40.79.162.64/27",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_automation_backup",
+                      "properties": {            
+                          "addressPrefix": "52.243.87.200/32",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_automation_primary",
+                      "properties": {            
+                          "addressPrefix": "40.126.238.47/32",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_security_primary",
+                      "properties": {            
+                          "addressPrefix": "191.239.183.225/32",
+                          "nextHopType": "Internet"
+                      }
+                  },
+                  {
+                      "name": "SqlManagement_security_backup",
+                      "properties": {            
+                          "addressPrefix": "52.187.228.131/32",
+                          "nextHopType": "Internet"
+                      }
+                  }
+              ]
+          }
         },
         {
             "type": "Microsoft.Network/virtualNetworks",


### PR DESCRIPTION
If deploying managed instance through azure portal or using script for preparing virtual network for managed instance deployment, network security group is always added, while this is not the case with this template. In this change network security groups are added as part of virtual network deployment

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

