### PR TITLE
Test

### DIFF
--- a/test/template-tests/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
+++ b/test/template-tests/testcases/deploymentTemplate/IDs-Should-Be-Derived-From-ResourceIDs.test.ps1
@@ -41,6 +41,7 @@ foreach ($id in $ids) { # Then loop over each object with an ID
     # Check to make sure the resourceId function does not use the resourceGroup().name function
     # it's the default and won't work with an existing resource in another resourceGroup
     # Search the entire template
+    #
     $txt = $TemplateObject | ConvertTo-JSON
     if ($txt -match "\s{0,}\[\s{0,}resourceId\s{0,}\(\s{0,}resourceGroup\(" ){
         Write-Error "ResourceId function must not use resourceGroup().name function." -TargetObject $id -ErrorId ResourceId.Contains.ResourceGroup.Name.Function

--- a/test/unit-tests/resourceId-tests.json
+++ b/test/unit-tests/resourceId-tests.json
@@ -27,6 +27,9 @@
         "fail4": {
             "id": "[concat( variables('id'))]" //technicall it works, but not a best practice
         },
+        "fail5": {
+            "test": "[resourceId ( resourceGroup().name, 'Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+        },
         "pass1": {
             "id": "[ resourceId ( 'Microsoft.Network/applicationGateways/httpListeners', 'appGW', 'appGatewayHttpListener')]"
         },
@@ -35,6 +38,9 @@
         },
         "pass3": {
             "id": "[variables('id')]"
+        },
+        "pass4": {
+            "id": "[resourceId(parameters('storageResourceGroupName'), 'Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
         }
     },
     "resources": [


### PR DESCRIPTION
### Changelog

* remove requirement for single quote in match of resourceId function
* new test for resourceGroup().name function
*

