### PR TITLE
fixed Get-AzTableRow

### DIFF
--- a/test/ci-scripts/Copy-Badges.ps1
+++ b/test/ci-scripts/Copy-Badges.ps1
@@ -14,8 +14,10 @@ param(
     [Parameter(mandatory=$true)]$StorageAccountKey
 )
 
-if($SampleName = ""){
+if([string]::IsNullOrWhiteSpace($SampleName)){
     Write-Error "SampleName is empty"
+} else {
+    Write-Host "SampleName: $SampleName"
 }
 
 $storageFolder = $SampleName.Replace("\", "@").Replace("/", "@")
@@ -26,15 +28,15 @@ Write-Host "RowKey: $RowKey"
 $ctx = New-AzStorageContext -StorageAccountName $StorageAccountName -StorageAccountKey $StorageAccountKey -Environment AzureCloud
 $cloudTable = (Get-AzStorageTable –Name $tableName –Context $ctx).CloudTable
 
-#Get the row to update
-$r = Get-AzTableRow -table $cloudTable -RowKey $RowKey
+#Get the row to update - can't search by rowkey only since we don't know the partition key, but row key is guaranteed unique
+$r = Get-AzTableRow -table $cloudTable -ColumnName "RowKey" -Value $RowKey -Operator Equal
+
 if ($r.status -eq $null) {
     Add-Member -InputObject $r -NotePropertyName "status" -NotePropertyValue "Live"
 }
 else {
     $r.status = "Live"
 }
-
 
 Write-Host "Updating to new results:"
 $r | ft


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

