### PR TITLE
Adding 201-rbac-*-maps for Azure AD RBAC data-plane Azure Maps

### DIFF
--- a/201-rbac-managedidentity-maps/README.md
+++ b/201-rbac-managedidentity-maps/README.md
@@ -1,0 +1,35 @@
+# "RBAC - Grant Azure AD authorization access on Azure Maps for a Managed Identity
+
+<IMG SRC="https://azurequickstartsservice.blob.core.windows.net/badges/201-rbac-managedidentity-maps/PublicLastTestDate.svg" />&nbsp;
+<IMG SRC="https://azurequickstartsservice.blob.core.windows.net/badges/201-rbac-managedidentity-maps/PublicDeployment.svg" />&nbsp;
+
+<IMG SRC="https://azurequickstartsservice.blob.core.windows.net/badges/201-rbac-managedidentity-maps/BestPracticeResult.svg" />&nbsp;
+<IMG SRC="https://azurequickstartsservice.blob.core.windows.net/badges/201-rbac-managedidentity-maps/CredScanResult.svg" />&nbsp;
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-rbac-managedidentity-maps%2Fazuredeploy.json" target="_blank">
+    <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-rbac-managedidentity-maps%2Fazuredeploy.json" target="_blank">
+  <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.png"/>
+</a>
+
+This template assigns Azure Maps Data Reader access for a Manaaged Identity on an Azure Maps account in a resource group. It **does not assign the identity** to an Azure resource such as `Azure App Service` or `Azure Virtual Machines`. Inputs to this template are following fields:
+
+1. Subscription ID
+2. Resource Group Name
+3. GUID
+4. Azure Managed Identity name
+5. Azure Map account name
+6. Built In Role Type
+
+## Enable Service to Service authentication to Azure Maps
+
+This template will grant a service principal access to Azure Maps. Using Azure Managed identity in your application code removes the complexity of managing credentials in a deployed Azure service. Running your application in an App Service or other Azure service which supports Managed Identity enables a restricted endpoint to retrieve access tokens for Service to Service authorization.
+
+## Parameter #5: 'GUID' represent randomly generated GUID
+
+These values should be unique per element as they represent the id of the role assignment. They can be generated any way you prefer.
+
+## For Automation on role assignments you must assign 'User Access Administrator'
+
+For automation scenarios without a user's principal, the built in role you must assign your automation is "User Access Adminstrator". This role with grant access to add and remove role assignments. The other option can be to create a [custom role definition](https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles) with the permissions `Microsoft.Authorization/roleAssignments/write` and `Microsoft.Authorization/roleAssignments/delete`.

--- a/201-rbac-managedidentity-maps/azuredeploy.json
+++ b/201-rbac-managedidentity-maps/azuredeploy.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "subscriptionId": {
+      "type": "string",
+      "defaultValue": "2498e3dd-307d-4f0d-bc19-bdc139ce0c30",
+      "metadata": {
+        "description": "Subscription ID GUID"
+      }
+    },
+     "resourceGroup": {
+      "type": "string",
+      "defaultValue": "CloudDep",
+      "metadata": {
+        "description": "Input string for resource group name."
+      }
+    },
+    "userAssignedIdentityName": {
+      "type": "string",
+      "metadata": {
+        "description": "the name of the Managed Identity resource."
+      }
+    },
+    "mapsAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "the name of the Azure Map Account"
+      }
+    },
+    "builtInRoleType": {
+      "type": "string",
+      "defaultValue": "Azure Maps Data Reader",
+      "metadata": {
+        "description": "Input string for built in role type"
+      }
+    },
+    "guid": {
+      "type": "string",
+      "defaultValue": "916369fe-4b07-4b79-aa53-add064735d33",
+      "metadata": {
+        "description": "Input string for new GUID associated with assigning built in role types"
+      }
+    }
+  },
+  "variables": {
+    "Azure Maps Data Reader": "[concat('/subscriptions/', parameters('subscriptionId'), '/providers/Microsoft.Authorization/roleDefinitions/', '423170ca-a8f6-4b0f-8487-9e4eb8f49bfa')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "name": "[parameters('userAssignedIdentityName')]",
+      "apiVersion": "2018-11-30",
+      "location": "[resourceGroup().location]"
+    },
+    {
+      "apiVersion": "2018-05-01",
+      "name": "[parameters('mapsAccountName')]",
+      "location": "global",
+      "type": "Microsoft.Maps/accounts",
+      "sku": {
+        "name": "S0"
+      }
+    },
+    {
+      "apiVersion": "2018-01-01-preview",
+      "name": "[concat(parameters('mapsAccountName'), '/Microsoft.Authorization/', parameters('guid'))]",
+      "type": "Microsoft.Maps/accounts/providers/roleAssignments",
+      "dependsOn": [
+        "[parameters('mapsAccountName')]",
+        "[parameters('userAssignedIdentityName')]"
+      ],
+      "properties": {
+        "roleDefinitionId": "[variables(parameters('builtInRoleType'))]",
+        "principalId": "[reference(concat(resourceGroup().id, '/providers/Microsoft.ManagedIdentity/userAssignedIdentities/', parameters('userAssignedIdentityName')), '2018-11-30').principalId]"
+      }
+    }
+  ]
+}

--- a/201-rbac-managedidentity-maps/azuredeploy.parameters.json
+++ b/201-rbac-managedidentity-maps/azuredeploy.parameters.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceGroup": {
+      "value": "CloudDep"
+    },
+    "builtInRoleType": {
+      "value": "Azure Maps Data Reader"
+    },
+    "subscriptionId": {
+      "value": "fb9c3b38-0fa0-4aeb-b209-d942f80602d7"
+    },
+    "mapsAccountName": {
+      "value": "GEN-UNIQUE"
+    },
+    "userAssignedIdentityName": {
+      "value": "GEN-UNIQUE"
+    },
+    "guid": {
+      "value": "916369fe-4b07-4b79-aa53-add064735d33"
+    }
+  }
+}

--- a/201-rbac-managedidentity-maps/metadata.json
+++ b/201-rbac-managedidentity-maps/metadata.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
+  "type": "QuickStart",
+  "itemDisplayName": "RBAC - Create Managed Identity Access on Azure Maps account",
+  "description": "This template creates a Managed Identity and assigns it access to an a created Azure Maps account.",
+  "summary": "This template uses Azure Managed Identity to assign access to Azure Maps. See more at https://aka.ms/amauth",
+  "githubUsername": "stack111",
+  "dateUpdated": "2019-10-06"
+}

--- a/201-rbac-multipleprincipals-maps/README.md
+++ b/201-rbac-multipleprincipals-maps/README.md
@@ -1,0 +1,51 @@
+# "RBAC - Grant Azure AD authorization access on Azure Maps for multiple principals
+
+<IMG SRC="https://azurequickstartsservice.blob.core.windows.net/badges/201-rbac-multipleprincipals-maps/PublicLastTestDate.svg" />&nbsp;
+<IMG SRC="https://azurequickstartsservice.blob.core.windows.net/badges/201-rbac-multipleprincipals-maps/PublicDeployment.svg" />&nbsp;
+
+<IMG SRC="https://azurequickstartsservice.blob.core.windows.net/badges/201-rbac-multipleprincipals-maps/BestPracticeResult.svg" />&nbsp;
+<IMG SRC="https://azurequickstartsservice.blob.core.windows.net/badges/201-rbac-multipleprincipals-maps/CredScanResult.svg" />&nbsp;
+
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-rbac-multipleprincipals-maps%2Fazuredeploy.json" target="_blank">
+    <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.png"/>
+</a>
+<a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F201-rbac-multipleprincipals-maps%2Fazuredeploy.json" target="_blank">
+  <img src="https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.png"/>
+</a>
+
+This template assigns Azure Maps Data Reader access for multiple users, groups, or applications to an Azure Maps account in a resource group. Inputs to this template are following fields:
+
+1. Subscription ID
+2. Principal IDs (also known as: Object IDs)
+3. Resource Group Name
+4. Role Definition ID
+5. GUIDs
+6. Azure Map account name
+7. Built In Role Types
+8. Count of Principals
+
+## Use following powershell command to get Principal ID
+
+This id is associated with a user using their email or display name. **Please note** principal id maps to the object id inside the directory and can point to a user, service principal, or security group.
+
+ObjectId is referred to as Principal ID
+
+    PS C:\> $account = Connect-AzureRmAccount -SubscriptionId xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    PS C:\> Connect-AzureAD -TenantId $account.Context.Tenant.Id
+    PS C:\> Get-AzureADUser -SearchString "Display name or mail"
+
+    ObjectId                             DisplayName                   UserPrincipalName
+    -----------                          -----------                   -----------------
+    xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx <display name>                <email>
+
+### Using groups can reduce role assignments and deployments
+
+Using a security group is ideal if you have a group of principals you wish to maintain access without consistant deployments which change access.
+
+## Parameter #5: 'GUIDs' represent randomly generated GUIDs
+
+These values should be unique per element as they represent the id of the role assignment. They can be generate any way you prefer.
+
+## For Automation on role assignments you must assign 'User Access Administrator'
+
+For automation scenarios without a user's principal, the built in role you must assign your automation is "User Access Adminstrator". This role with grant access to add and remove role assignments. The other option can be to create a [custom role definition](https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles) with the permissions `Microsoft.Authorization/roleAssignments/write` and `Microsoft.Authorization/roleAssignments/delete`.

--- a/201-rbac-multipleprincipals-maps/azuredeploy.json
+++ b/201-rbac-multipleprincipals-maps/azuredeploy.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "subscriptionId": {
+      "type": "string",
+      "defaultValue": "2498e3dd-307d-4f0d-bc19-bdc139ce0c30",
+      "metadata": {
+        "description": "Subscription ID GUID"
+      }
+    },
+    "principalId": {
+      "type": "array",
+      "defaultValue": [
+        "5cbf4bd6-b342-49d7-9515-b905462b6df8",
+        "a3edd088-f344-44ec-a798-ff3e00ad5819"
+      ],
+      "metadata": {
+        "description": "Input array for object IDs associated with users, groups, or applications."
+      }
+    },
+     "resourceGroup": {
+      "type": "array",
+      "defaultValue": [
+        "CloudDep",
+        "CloudDep"
+      ],
+      "metadata": {
+        "description": "Input array for resource group names."
+      }
+    },
+    "mapsAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "the name of the Azure Map Account"
+      }
+    },
+    "builtInRoleType": {
+      "type": "array",
+      "defaultValue": [
+        "Azure Maps Data Reader",
+        "Azure Maps Data Reader"
+      ],
+      "metadata": {
+        "description": "Input array for built in types"
+      }
+    },
+    "guid": {
+      "type": "array",
+      "defaultValue": [
+        "099A9D93-B94F-44A0-9794-B949BCD76968",
+        "71121498-465D-465A-AA4A-861DC8116095"
+      ],
+      "metadata": {
+        "description": "Input array for new GUIDs associated with assigning built in role types"
+      }
+    },
+    "count": {
+      "type": "int",
+      "defaultValue": 2,
+      "metadata": {
+        "description": "Size of array"
+      }
+    }
+  },
+  "variables": {
+    "Azure Maps Data Reader": "[concat('/subscriptions/',parameters('subscriptionId'), '/providers/Microsoft.Authorization/roleDefinitions/', '423170ca-a8f6-4b0f-8487-9e4eb8f49bfa')]"
+  },
+  "resources": [
+    {
+      "apiVersion": "2018-05-01",
+      "name": "[parameters('mapsAccountName')]",
+      "location": "global",
+      "type": "Microsoft.Maps/accounts",
+      "sku": {
+        "name": "S0"
+      }
+    },
+    {
+      "apiVersion": "2018-01-01-preview",
+      "name": "[concat(parameters('mapsAccountName'), '/Microsoft.Authorization/', parameters('guid')[copyIndex()])]",
+      "type": "Microsoft.Maps/accounts/providers/roleAssignments",
+      "dependsOn": [
+        "[parameters('mapsAccountName')]"
+      ],
+      "copy": {
+        "name": "anyname",
+        "count": "[parameters('count')]"
+      },
+      "properties": {
+        "roleDefinitionId": "[variables(parameters('builtInRoleType')[copyIndex()])]",
+        "principalId": "[parameters('principalId')[copyIndex()]]"
+      }
+    }
+  ]
+}

--- a/201-rbac-multipleprincipals-maps/azuredeploy.parameters.json
+++ b/201-rbac-multipleprincipals-maps/azuredeploy.parameters.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "resourceGroup": {
+      "value": [
+        "CloudDep",
+        "CloudDep"
+      ]
+    },
+    "builtInRoleType": {
+      "value": [
+        "Azure Maps Data Reader",
+        "Azure Maps Data Reader"
+      ]
+    },
+    "subscriptionId": {
+      "value": "fb9c3b38-0fa0-4aeb-b209-d942f80602d7"
+    },
+    "mapsAccountName": {
+      "value": "GEN-UNIQUE"
+    },
+    "principalId": {
+      "value": [
+        "20a99c47-a546-4465-be71-cfc84e934eca",
+        "81f196d6-affb-451a-893e-36200d96a068"
+      ]
+    },
+    "guid": {
+      "value": [
+        "099A9D93-B94F-44A0-9794-B949BCD76968",
+        "71121498-465D-465A-AA4A-861DC8116095"
+      ]
+    }
+  }
+}

--- a/201-rbac-multipleprincipals-maps/metadata.json
+++ b/201-rbac-multipleprincipals-maps/metadata.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
+  "type": "QuickStart",
+  "itemDisplayName": "RBAC - Grant Azure AD RBAC for an Azure Maps account",
+  "description": "This template grants applicable Azure AD role based access to mutliple users, groups, or applications to Azure Maps.",
+  "summary": "This template grants applicable role based access to multiple principals on a Azure Maps account in Resource Group. See more at https://aka.ms/amauth",
+  "githubUsername": "stack111",
+  "dateUpdated": "2019-10-04"
+}


### PR DESCRIPTION
1. uri's compatible with all clouds (Stack, China, Government)
N/A
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
N/A
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
Yes
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
N/A
1. Use literal values for apiVersion (no variables)
Yes
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
Yes, some exceptions on parameters.
1. $schema and other uris use https
Yes
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
Yes
1. Update the metadata.json with the current date
Yes

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog
Azure Maps supports Azure AD RBAC for data-plane, I would like to provide samples to quick start template authoring to use this feature. Once this is approved I plan to create some 3xx and scenarios using App Service. 
* Added 201-rbac-multipleprincipals-maps
* Added 201-rbac-managedidentity-maps


