### PR TITLE
use subnetname from variable instead of hardcoded value

### DIFF
--- a/101-vm-multiple-ipconfig/azuredeploy.json
+++ b/101-vm-multiple-ipconfig/azuredeploy.json
@@ -155,7 +155,7 @@
                 "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               },
               "subnet": {
-                "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '/subnets/mySubnet')]"
+                "id": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName')), '/subnets/', variables('subnetName'))]"
               }
             }
           },

--- a/101-vm-multiple-ipconfig/metadata.json
+++ b/101-vm-multiple-ipconfig/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template allows you to deploy a VM with 3 IP configurations. This template will deploy a Linux/Windows VM called *myVM1* with 3 IP configurations: *IPConfig-1*, *IPConfig-2* and *IPConfig-3*, respectively.",
   "summary": "This template deploys a VM with 3 IP configurations, two of which have public IP addresses associated with them.",
   "githubUsername": "anavinahar",
-  "dateUpdated": "2016-12-01"
+  "dateUpdated": "2019-10-09"
 }
 
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [*] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

