### PR TITLE
Fixed Microsoft.Web/serverfarms SKU

### DIFF
--- a/101-function-app-create-dedicated/azuredeploy.json
+++ b/101-function-app-create-dedicated/azuredeploy.json
@@ -11,12 +11,26 @@
     "sku": {
       "type": "string",
       "allowedValues": [
-        "Free",
-        "Shared",
-        "Basic",
-        "Standard"
+        "D1",
+        "F1",
+        "B1",
+        "B2",
+        "B3",
+        "S1",
+        "S2",
+        "S3",
+        "P1",
+        "P2",
+        "P3",
+        "P1V2",
+        "P2V2",
+        "P3V2",
+        "I1",
+        "I2",
+        "I3",
+        "Y1"
       ],
-      "defaultValue": "Standard",
+      "defaultValue": "S1",
       "metadata": {
         "description": "The pricing tier for the hosting plan."
       }
@@ -74,9 +88,12 @@
       "apiVersion": "2016-09-01",
       "name": "[variables('hostingPlanName')]",
       "location": "[parameters('location')]",
+      "sku": {
+        "Name": "S1"
+      },
       "properties": {
         "name": "[variables('hostingPlanName')]",
-        "sku": "[parameters('sku')]",
+
         "workerSize": "[parameters('workerSize')]",
         "hostingEnvironment": "",
         "numberOfWorkers": 1


### PR DESCRIPTION
Fixed the deployment error: "The parameter sku has an invalid value"

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

