### PR TITLE
Add SSH Auth to vm-to-vm-bandwidth-meter

### DIFF
--- a/vm-to-vm-bandwidth-meter/azuredeploy.json
+++ b/vm-to-vm-bandwidth-meter/azuredeploy.json
@@ -138,33 +138,44 @@
         "description": "Number of the requests to send to the target VM."
       }
     },
-      "adminUsername": {
-        "type": "string",
-        "metadata": {
-          "description": "Username for the probe and target VMs."
-        }
-      },
-      "adminPassword": {
-        "type": "securestring",
-        "metadata": {
-          "description": "Password for the probe and target VMs."
-        }
-      },
-      "_artifactsLocation": {
-        "type": "string",
-        "metadata": {
-          "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
-        },
-        "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/vm-to-vm-bandwidth-meter"
-      },
-      "_artifactsLocationSasToken": {
-        "type": "securestring",
-        "metadata": {
-          "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
-        },
-        "defaultValue": ""
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the probe and target VMs."
       }
     },
+    "_artifactsLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+      },
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/vm-to-vm-bandwidth-meter"
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+      },
+      "defaultValue": ""
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
+    }
+  },
   "variables": {
     "osVersion": [
       "2012-R2-Datacenter",
@@ -204,7 +215,18 @@
     "subnetRef": [
       "[concat(variables('vnetID'),'1','/subnets/',variables('subnetName'))]",
       "[concat(variables('vnetID'),'2','/subnets/',variables('subnetName'))]"
-    ]
+    ],
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -440,7 +462,8 @@
         "osProfile": {
           "computerName": "[variables('vmName')[1]]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {

--- a/vm-to-vm-bandwidth-meter/azuredeploy.json
+++ b/vm-to-vm-bandwidth-meter/azuredeploy.json
@@ -4,31 +4,6 @@
   "parameters": {
     "probeVmSize": {
       "type": "string",
-      "allowedValues": [
-        "Basic_A0",
-        "Basic_A4",
-        "Standard_A1",
-        "Standard_A5",
-        "Standard_A8",
-        "Standard_D4",
-        "Standard_D14",
-        "Standard_DS1",
-        "Standard_DS14",
-        "Standard_D1_v2",
-        "Standard_D15_v2",
-        "Standard_DS1_v2",
-        "Standard_DS15_v2",
-        "Standard_F1",
-        "Standard_F16",
-        "Standard_F1s",
-        "Standard_F16s",
-        "Standard_G1",
-        "Standard_G5",
-        "Standard_GS1",
-        "Standard_GS5",
-        "Standard_NV6",
-        "Standard_NC6"
-      ],
       "defaultValue": "Standard_A5",
       "metadata": {
         "description": "Size of the VM that runs the test."
@@ -60,31 +35,6 @@
     },
     "targetVmSize": {
       "type": "string",
-      "allowedValues": [
-        "Basic_A0",
-        "Basic_A4",
-        "Standard_A1",
-        "Standard_A5",
-        "Standard_A8",
-        "Standard_D4",
-        "Standard_D14",
-        "Standard_DS1",
-        "Standard_DS14",
-        "Standard_D1_v2",
-        "Standard_D15_v2",
-        "Standard_DS1_v2",
-        "Standard_DS15_v2",
-        "Standard_F1",
-        "Standard_F16",
-        "Standard_F1s",
-        "Standard_F16s",
-        "Standard_G1",
-        "Standard_G5",
-        "Standard_GS1",
-        "Standard_GS5",
-        "Standard_NV6",
-        "Standard_NC6"
-      ],
       "defaultValue": "Standard_A5",
       "metadata": {
         "description": "Size of the target VM."
@@ -149,7 +99,7 @@
       "metadata": {
         "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
       },
-      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/vm-to-vm-bandwidth-meter"
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/vm-to-vm-bandwidth-meter/"
     },
     "_artifactsLocationSasToken": {
       "type": "securestring",

--- a/vm-to-vm-bandwidth-meter/azuredeploy.parameters.json
+++ b/vm-to-vm-bandwidth-meter/azuredeploy.parameters.json
@@ -5,8 +5,8 @@
     "adminUsername": {
       "value": "GEN-UNIQUE"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/vm-to-vm-bandwidth-meter/metadata.json
+++ b/vm-to-vm-bandwidth-meter/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to run VM-to-VM bandwidth test with PsPing utility.",
   "summary": "This template allows you to run VM-to-VM bandwidth test with PsPing utility.",
   "githubUsername": "alekseipolkovnikov",
-  "dateUpdated": "2018-07-20"
+  "dateUpdated": "2019-10-18"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
*
*