### PR TITLE
Fix #6693: "PasswordBox" located in multiple-level hierarchy is not recognized

### DIFF
--- a/test/arm-ttk/testcases/CreateUIDefinition/Password-Textboxes-Must-Be-Used-For-Password-Parameters.test.ps1
+++ b/test/arm-ttk/testcases/CreateUIDefinition/Password-Textboxes-Must-Be-Used-For-Password-Parameters.test.ps1
@@ -14,10 +14,8 @@ $passwordBoxes = $CreateUIDefinitionObject |
     
 foreach ($pwb in $passwordBoxes) { # Loop over each password box
     $controlName = $pwb.Name # and find the output it maps to.
-    $stepName = $pwb.ParentObject[0].name
-    $lookingFor= if ($stepName) { "*steps(*$stepName*).$controlName*"} else {"*basics(*$($controlName)*"} 
     $theOutput = foreach ($out in $CreateUIDefinitionObject.parameters.outputs.psobject.properties) {
-        if ($out.Value -like $lookingFor) { 
+        if (($out.Value -like "*steps(*$controlName*") -or ($out.Value -like "*basics(*$controlName*")) { 
             $out; break
         }
     }
@@ -35,8 +33,8 @@ foreach ($pwb in $passwordBoxes) { # Loop over each password box
         continue
     }
 
-    # If the main template parameter type is not a Secure String
-    if ($MainTemplateParam.type -ne 'SecureString') {
+    # If the main template parameter type is neither a Secure String nor a Secure Object
+    if (($MainTemplateParam.type -ne 'SecureString') -and ($MainTemplateParam.type -ne 'SecureObject')) {
         # write an error.
         Write-Error "Password boxes must be used for secure string parameters.  The Main template parameter $($pwb.Name) is a $($MainTemplateParam.type)" -TargetObject @($pwb, $MainTemplateParam)
     }

--- a/test/arm-ttk/testcases/CreateUIDefinition/Password-Textboxes-Must-Be-Used-For-Password-Parameters.test.ps1
+++ b/test/arm-ttk/testcases/CreateUIDefinition/Password-Textboxes-Must-Be-Used-For-Password-Parameters.test.ps1
@@ -36,6 +36,6 @@ foreach ($pwb in $passwordBoxes) { # Loop over each password box
     # If the main template parameter type is neither a Secure String nor a Secure Object
     if (($MainTemplateParam.type -ne 'SecureString') -and ($MainTemplateParam.type -ne 'SecureObject')) {
         # write an error.
-        Write-Error "Password boxes must be used for secure string parameters.  The Main template parameter $($pwb.Name) is a $($MainTemplateParam.type)" -TargetObject @($pwb, $MainTemplateParam)
+        Write-Error "Password boxes must be used for secure string or secure object parameters.  The Main template parameter $($pwb.Name) is a $($MainTemplateParam.type)" -TargetObject @($pwb, $MainTemplateParam)
     }
 }


### PR DESCRIPTION
Fix #6693.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* replace current strict "looking-for" pattern with more flexible one to allow "PasswordBox" elements being recognized even they're located in multi-level hierarchy;
* honor "secure object" also;

