### PR TITLE
Updated Gateway Manager inbound ports to include 4443

### DIFF
--- a/101-azure-bastion/azuredeploy.json
+++ b/101-azure-bastion/azuredeploy.json
@@ -92,7 +92,7 @@
                             "protocol": "Tcp",
                             "sourcePortRange": "*",
                             "sourceAddressPrefix": "GatewayManager",
-                            "destinationPortRange": "443",
+                            "destinationPortRange": "443, 4443",
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
                             "priority": 120,

--- a/101-azure-bastion/azuredeploy.json
+++ b/101-azure-bastion/azuredeploy.json
@@ -92,7 +92,10 @@
                             "protocol": "Tcp",
                             "sourcePortRange": "*",
                             "sourceAddressPrefix": "GatewayManager",
-                            "destinationPortRange": "443, 4443",
+                            "destinationPortRanges": [
+                                "443",
+                                "4443"
+                            ],
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
                             "priority": 120,


### PR DESCRIPTION
this is a short term change, will revert soon as we ship the change which is ready to be rolled out.   Shouldn't need 4443 after the change is rolled out.

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

