### PR TITLE
Adding Network Security Group to 101-vsts-cloudloadtest-rig

### DIFF
--- a/101-vsts-cloudloadtest-rig/azuredeploy.json
+++ b/101-vsts-cloudloadtest-rig/azuredeploy.json
@@ -78,7 +78,8 @@
     "nicName": "[concat('nic', variables('uniqueStringValue'))]",
     "windowsOSVersion": "2012-R2-Datacenter",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
-    "defaultAgentGroupName": "[resourceGroup().name]"
+    "defaultAgentGroupName": "[resourceGroup().name]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -104,10 +105,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "apiVersion": "2015-06-15",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -118,7 +146,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/101-vsts-cloudloadtest-rig/azuredeploy.parameters.json
+++ b/101-vsts-cloudloadtest-rig/azuredeploy.parameters.json
@@ -1,24 +1,24 @@
 {
-   "$schema":"https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-   "contentVersion":"1.0.0.0",
-   "parameters":{
-        "azureDevOpsServicesAccount":{
-            "value":"GEN-UNIQUE"
-        },
-        "personalAccessToken":{
-            "value": "GEN-UNIQUE"
-        },
-        "adminPassword":{
-            "value":"GEN-PASSWORD"
-        },
-        "agentCount":{
-            "value":1
-        },
-        "adminUsername":{
-            "value":"cltuser"
-        },
-        "agentGroupName":{
-            "value":"default"
-        }
-   }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "azureDevOpsServicesAccount": {
+      "value": "GEN-UNIQUE"
+    },
+    "personalAccessToken": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "agentCount": {
+      "value": 1
+    },
+    "adminUsername": {
+      "value": "cltuser"
+    },
+    "agentGroupName": {
+      "value": "default"
+    }
+  }
 }

--- a/101-vsts-cloudloadtest-rig/metadata.json
+++ b/101-vsts-cloudloadtest-rig/metadata.json
@@ -5,5 +5,5 @@
   "description": "Using this template, you can create your own load test rig on Azure IaaS virtual machines. The test rig will be configured for your Azure DevOps Services account and can be used to run cloud-based load tests using Visual Studio. The cloud-load testing service will use this registered rig instead of provisioning one dynamically.",
   "summary": "Yet to come",
   "githubUsername": "cltshivash",
-  "dateUpdated": "2018-11-02"
+  "dateUpdated": "2019-11-12"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-vsts-cloudloadtest-rig

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
vmnmos4kui0 | Tcp | 135 | svchost.exe
vmnmos4kui0 | Tcp | 445 | 
vmnmos4kui0 | Tcp | 3389 | svchost.exe
vmnmos4kui0 | Tcp | 5985 | 
vmnmos4kui0 | Tcp | 47001 | 
vmnmos4kui0 | Tcp | 49152 | wininit.exe
vmnmos4kui0 | Tcp | 49154 | svchost.exe
vmnmos4kui0 | Udp | 123 | svchost.exe
vmnmos4kui0 | Udp | 3389 | svchost.exe
vmnmos4kui0 | Udp | 5355 | svchost.exe
