### PR TITLE
Adding Network Security Group to 101-recovery-services-create-vm-and-configure-backup

### DIFF
--- a/101-recovery-services-create-vm-and-configure-backup/azuredeploy.json
+++ b/101-recovery-services-create-vm-and-configure-backup/azuredeploy.json
@@ -63,7 +63,8 @@
     "backupFabric": "Azure",
     "backupPolicyName": "DefaultPolicy",
     "protectionContainer": "[concat('iaasvmcontainer;iaasvmcontainerv2;', resourceGroup().name, ';', variables('vmName'))]",
-    "protectedItem": "[concat('vm;iaasvmcontainerv2;', resourceGroup().name, ';', variables('vmName'))]"
+    "protectedItem": "[concat('vm;iaasvmcontainerv2;', resourceGroup().name, ';', variables('vmName'))]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -90,10 +91,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2018-11-01",
       "name": "[variables('vNetName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -104,7 +132,10 @@
           {
             "name": "[variables('vNetSubnetName')]",
             "properties": {
-              "addressPrefix": "[variables('vNetSubnetAddressPrefix')]"
+              "addressPrefix": "[variables('vNetSubnetAddressPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/101-recovery-services-create-vm-and-configure-backup/azuredeploy.parameters.json
+++ b/101-recovery-services-create-vm-and-configure-backup/azuredeploy.parameters.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    "projectName":{
+    "projectName": {
       "value": "GEN-UNIQUE-8"
     },
     "adminUsername": {

--- a/101-recovery-services-create-vm-and-configure-backup/metadata.json
+++ b/101-recovery-services-create-vm-and-configure-backup/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to deploy simple Windows VM and Recovery Services Vault configured with the DefaultPolicy for Protection.",
   "summary": "This template takes a minimum amount of parameters and deploys a Windows VM and configures backup protection",
   "githubUsername": "nilaydshah",
-  "dateUpdated": "2019-03-17"
+  "dateUpdated": "2019-11-12"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-recovery-services-create-vm-and-configure-backup

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
cid74610-vm | Tcp | 135 | svchost.exe
cid74610-vm | Tcp | 445 | 
cid74610-vm | Tcp | 3389 | svchost.exe
cid74610-vm | Tcp | 5985 | 
cid74610-vm | Tcp | 47001 | 
cid74610-vm | Tcp | 49664 | 
cid74610-vm | Udp | 123 | svchost.exe
cid74610-vm | Udp | 3389 | svchost.exe
cid74610-vm | Udp | 5050 | svchost.exe
cid74610-vm | Udp | 5353 | svchost.exe
cid74610-vm | Udp | 5355 | svchost.exe
