### PR TITLE
Updating storage accounts API version

### DIFF
--- a/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
+++ b/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "location": {
@@ -154,12 +154,11 @@
     "supportLogStorageAccountName": "[concat( uniqueString(resourceGroup().id),'2')]",
     "applicationDiagnosticsStorageAccountName": "[concat(uniqueString(resourceGroup().id), '3' )]",
     "lbName": "[concat('LB','-', parameters('clusterName'),'-',variables('vmNodeType0Name'))]",
-    "lbID0": "[resourceId('Microsoft.Network/loadBalancers',concat('LB','-', parameters('clusterName'),'-',variables('vmNodeType0Name')))]",
-    "lbIPConfig0": "[concat(variables('lbID0'),'/frontendIPConfigurations/LoadBalancerIPConfig')]",
-    "lbPoolID0": "[concat(variables('lbID0'),'/backendAddressPools/LoadBalancerBEAddressPool')]",
-    "lbProbeID0": "[concat(variables('lbID0'),'/probes/FabricGatewayProbe')]",
-    "lbHttpProbeID0": "[concat(variables('lbID0'),'/probes/FabricHttpGatewayProbe')]",
-    "lbNatPoolID0": "[concat(variables('lbID0'),'/inboundNatPools/LoadBalancerBEAddressNatPool')]",
+    "lbIPConfig0": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations/', variables('lbName'), 'LoadBalancerIPConfig')]",
+    "lbPoolID0": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('lbName'), 'LoadBalancerBEAddressPool')]",
+    "lbProbeID0": "[resourceId('Microsoft.Network/loadBalancers/probes', variables('lbName'), 'FabricGatewayProbe')]",
+    "lbHttpProbeID0": "[resourceId('Microsoft.Network/loadBalancers/probes', variables('lbName'), 'FabricHttpGatewayProbe')]",
+    "lbNatPoolID0": "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('lbName'), 'LoadBalancerBEAddressNatPool')]",
     "vmNodeType0Name": "[toLower(concat('NT1', variables('vmName')))]",
     "vmNodeType0Size": "[parameters('nodeTypeSize')]"
   },
@@ -169,7 +168,6 @@
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('supportLogStorageAccountName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [],
       "properties": {},
       "kind": "Storage",
       "sku": {
@@ -185,7 +183,6 @@
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('applicationDiagnosticsStorageAccountName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [],
       "properties": {},
       "kind": "Storage",
       "sku": {
@@ -315,7 +312,7 @@
               "frontendPort": "[parameters('loadBalancedAppPort1')]",
               "idleTimeoutInMinutes": 5,
               "probe": {
-                "id": "[concat(variables('lbID0'),'/probes/AppPortProbe1')]"
+                "id": "[resourceId('Microsoft.Network/loadBalancers/probes',  variables('lbName'), 'AppPortProbe1')]"
               },
               "protocol": "Tcp"
             }
@@ -334,7 +331,7 @@
               "frontendPort": "[parameters('loadBalancedAppPort2')]",
               "idleTimeoutInMinutes": 5,
               "probe": {
-                "id": "[concat(variables('lbID0'),'/probes/AppPortProbe2')]"
+                "id": "[resourceId('Microsoft.Network/loadBalancers/probes', variables('lbName'), 'AppPortProbe2')]"
               },
               "protocol": "Tcp"
             }
@@ -583,15 +580,13 @@
           "thumbprint": "[parameters('certificateThumbprint')]",
           "x509StoreName": "[parameters('certificateStoreValue')]"
         },
-        "clientCertificateCommonNames": [],
-        "clientCertificateThumbprints": [],
         "clusterState": "Default",
         "diagnosticsStorageAccountConfig": {
-          "blobEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('supportLogStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
+          "blobEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')), '2018-07-01').primaryEndpoints.blob]",
           "protectedAccountKeyName": "StorageAccountKey1",
-          "queueEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('supportLogStorageAccountName')), '2018-07-01').primaryEndpoints.queue]",
+          "queueEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')), '2018-07-01').primaryEndpoints.queue]",
           "storageAccountName": "[variables('supportLogStorageAccountName')]",
-          "tableEndpoint": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('supportLogStorageAccountName')), '2018-07-01').primaryEndpoints.table]"
+          "tableEndpoint": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('supportLogStorageAccountName')), '2018-07-01').primaryEndpoints.table]"
         },
         "fabricSettings": [
           {

--- a/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
+++ b/service-fabric-secure-cluster-5-node-1-nodetype/azuredeploy.json
@@ -165,7 +165,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2018-07-01",
+      "apiVersion": "2019-04-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('supportLogStorageAccountName')]",
       "location": "[parameters('location')]",
@@ -181,7 +181,7 @@
       }
     },
     {
-      "apiVersion": "2018-07-01",
+      "apiVersion": "2019-04-01",
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('applicationDiagnosticsStorageAccountName')]",
       "location": "[parameters('location')]",


### PR DESCRIPTION
To ensure secure transfer only on storage accounts, we set the `apiVersion` to the minimum where property `supportsHttpsTrafficOnly` is set by default. Alternatively, we can specify `supportsHttpsTrafficOnly` explicitly in the `properties`.

See REST API docs for [Storage Accounts - Create](https://docs.microsoft.com/en-us/rest/api/storagerp/storageaccounts/create).

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Changed `apiVersion` for storage account resources to `2019-04-01` to automatically enable secure data transfer.