### PR TITLE
Add SSH Auth to mysql-mha-haproxy-ubuntu

### DIFF
--- a/mysql-mha-haproxy-ubuntu/azuredeploy.json
+++ b/mysql-mha-haproxy-ubuntu/azuredeploy.json
@@ -29,48 +29,14 @@
     },
     "haproxyVmSize": {
       "type": "string",
-      "defaultValue": "Standard_D3",
-      "allowedValues": [
-        "Standard_A1",
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_A4",
-        "Standard_A5",
-        "Standard_A6",
-        "Standard_A7",
-        "Standard_D1",
-        "Standard_D2",
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D1_v2",
-        "Standard_D2_v2",
-        "Standard_D3_v2",
-        "Standard_D4_v2"
-      ],
+      "defaultValue": "Standard_D3_v2",
       "metadata": {
         "description": "The size of the virtual machines used when provisioning the Lap node"
       }
     },
     "mysqlVmSize": {
       "type": "string",
-      "defaultValue": "Standard_D3",
-      "allowedValues": [
-        "Standard_A1",
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_A4",
-        "Standard_A5",
-        "Standard_A6",
-        "Standard_A7",
-        "Standard_D1",
-        "Standard_D2",
-        "Standard_D3",
-        "Standard_D4",
-        "Standard_D1_v2",
-        "Standard_D2_v2",
-        "Standard_D3_v2",
-        "Standard_D4_v2"
-      ],
+      "defaultValue": "Standard_D3_v2",
       "metadata": {
         "description": "The size of the virtual machines used when provisioning Mysql node(s)"
       }

--- a/mysql-mha-haproxy-ubuntu/azuredeploy.json
+++ b/mysql-mha-haproxy-ubuntu/azuredeploy.json
@@ -15,6 +15,12 @@
         "description": "Administrator user name used when provisioning virtual machines"
       }
     },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Administrator password used when provisioning virtual machines"
+      }
+    },
     "mysqlPassword": {
       "type": "securestring",
       "metadata": {
@@ -75,38 +81,34 @@
         "description": "The size of the virtual machines used when provisioning Mysql node(s)"
       }
     },
+    "_artifactsLocation": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-mha-haproxy-ubuntu/",
+      "metadata": {
+        "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+      }
+    },
+    "_artifactsLocationSasToken": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+      }
+    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Location for all resources."
       }
-    },
-    "authenticationType": {
-      "type": "string",
-      "defaultValue": "sshPublicKey",
-      "allowedValues": [
-        "sshPublicKey",
-        "password"
-      ],
-      "metadata": {
-        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
-      }
-    },
-    "adminPasswordOrKey": {
-      "type": "securestring",
-      "metadata": {
-        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
-      }
     }
   },
   "variables": {
-    "templateBaseUrl": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-mha-haproxy-ubuntu/nested/",
-    "sharedTemplateUrl": "[concat(variables('templateBaseUrl'), 'shared-resources.json')]",
-    "haproxyTemplateUrl": "[concat(variables('templateBaseUrl'), 'haproxy-resources.json')]",
-    "masterTemplateUrl": "[concat(variables('templateBaseUrl'), 'master-resources.json')]",
-    "slaveTemplateUrl01": "[concat(variables('templateBaseUrl'), 'slave01-resources.json')]",
-    "slaveTemplateUrl02": "[concat(variables('templateBaseUrl'), 'slave02-resources.json')]",
+    "sharedTemplateUrl": "[uri(parameters('_artifactsLocation'), concat('nested/shared-resources.json', parameters('_artifactsLocationSasToken')))]",
+    "haproxyTemplateUrl": "[uri(parameters('_artifactsLocation'), concat('nested/haproxy-resources.json', parameters('_artifactsLocationSasToken')))]",
+    "masterTemplateUrl": "[uri(parameters('_artifactsLocation'), concat('nested/master-resources.json', parameters('_artifactsLocationSasToken')))]",
+    "slaveTemplateUrl01": "[uri(parameters('_artifactsLocation'), concat('nested/slave01-resources.json', parameters('_artifactsLocationSasToken')))]",
+    "slaveTemplateUrl02": "[uri(parameters('_artifactsLocation'), concat('nested/slave02-resources.json', parameters('_artifactsLocationSasToken')))]",
     "namespace": "mha-",
     "networkSettings": {
       "virtualNetworkName": "[parameters('virtualNetworkName')]",
@@ -137,7 +139,7 @@
         "version": "latest"
       },
       "scripts": [
-        "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-mha-haproxy-ubuntu/scripts/haproxy.sh"
+        "[uri(parameters('_artifactsLocation'), concat('scripts/haproxy.sh', parameters('_artifactsLocationSasToken')))]"
       ]
     },
     "masterOsSettings": {
@@ -148,7 +150,7 @@
         "version": "latest"
       },
       "scripts": [
-        "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-mha-haproxy-ubuntu/scripts/master.sh"
+        "[uri(parameters('_artifactsLocation'), concat('scripts/master.sh', parameters('_artifactsLocationSasToken')))]"
       ]
     },
     "slaveOsSettings01": {
@@ -159,7 +161,7 @@
         "version": "latest"
       },
       "scripts": [
-        "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-mha-haproxy-ubuntu/scripts/slave01.sh"
+        "[uri(parameters('_artifactsLocation'), concat('scripts/slave01.sh', parameters('_artifactsLocationSasToken')))]"
       ]
     },
     "slaveOsSettings02": {
@@ -170,7 +172,7 @@
         "version": "latest"
       },
       "scripts": [
-        "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-mha-haproxy-ubuntu/scripts/slave02.sh"
+        "[uri(parameters('_artifactsLocation'), concat('scripts/slave02.sh', parameters('_artifactsLocationSasToken')))]"
       ]
     }
   },
@@ -209,6 +211,9 @@
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
           },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
@@ -232,12 +237,6 @@
           },
           "osSettings": {
             "value": "[variables('haproxyOsSettings')]"
-          },
-          "authenticationType": {
-            "value": "[parameters('authenticationType')]"
-          },
-          "adminPasswordOrKey": {
-            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }
@@ -260,6 +259,9 @@
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
           },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
+          },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
@@ -280,12 +282,6 @@
           },
           "osSettings": {
             "value": "[variables('masterOsSettings')]"
-          },
-          "authenticationType": {
-            "value": "[parameters('authenticationType')]"
-          },
-          "adminPasswordOrKey": {
-            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }
@@ -308,6 +304,9 @@
         "parameters": {
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
           },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
@@ -332,12 +331,6 @@
           },
           "osSettings": {
             "value": "[variables('slaveOsSettings01')]"
-          },
-          "authenticationType": {
-            "value": "[parameters('authenticationType')]"
-          },
-          "adminPasswordOrKey": {
-            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }
@@ -360,6 +353,9 @@
         "parameters": {
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
+          },
+          "adminPassword": {
+            "value": "[parameters('adminPassword')]"
           },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
@@ -384,12 +380,6 @@
           },
           "osSettings": {
             "value": "[variables('slaveOsSettings02')]"
-          },
-          "authenticationType": {
-            "value": "[parameters('authenticationType')]"
-          },
-          "adminPasswordOrKey": {
-            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }

--- a/mysql-mha-haproxy-ubuntu/azuredeploy.json
+++ b/mysql-mha-haproxy-ubuntu/azuredeploy.json
@@ -83,7 +83,7 @@
       }
     },
     "_artifactsLocationSasToken": {
-      "type": "string",
+      "type": "securestring",
       "defaultValue": "",
       "metadata": {
         "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."

--- a/mysql-mha-haproxy-ubuntu/azuredeploy.json
+++ b/mysql-mha-haproxy-ubuntu/azuredeploy.json
@@ -15,12 +15,6 @@
         "description": "Administrator user name used when provisioning virtual machines"
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Administrator password used when provisioning virtual machines"
-      }
-    },
     "mysqlPassword": {
       "type": "securestring",
       "metadata": {
@@ -100,6 +94,23 @@
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Location for all resources."
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
     }
   },
@@ -211,9 +222,6 @@
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
           },
-          "adminPassword": {
-            "value": "[parameters('adminPassword')]"
-          },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
@@ -237,6 +245,12 @@
           },
           "osSettings": {
             "value": "[variables('haproxyOsSettings')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }
@@ -259,9 +273,6 @@
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
           },
-          "adminPassword": {
-            "value": "[parameters('adminPassword')]"
-          },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
@@ -282,6 +293,12 @@
           },
           "osSettings": {
             "value": "[variables('masterOsSettings')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }
@@ -304,9 +321,6 @@
         "parameters": {
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
-          },
-          "adminPassword": {
-            "value": "[parameters('adminPassword')]"
           },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
@@ -331,6 +345,12 @@
           },
           "osSettings": {
             "value": "[variables('slaveOsSettings01')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }
@@ -353,9 +373,6 @@
         "parameters": {
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
-          },
-          "adminPassword": {
-            "value": "[parameters('adminPassword')]"
           },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
@@ -380,6 +397,12 @@
           },
           "osSettings": {
             "value": "[variables('slaveOsSettings02')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }

--- a/mysql-mha-haproxy-ubuntu/azuredeploy.json
+++ b/mysql-mha-haproxy-ubuntu/azuredeploy.json
@@ -15,12 +15,6 @@
         "description": "Administrator user name used when provisioning virtual machines"
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Administrator password used when provisioning virtual machines"
-      }
-    },
     "mysqlPassword": {
       "type": "securestring",
       "metadata": {
@@ -86,6 +80,23 @@
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Location for all resources."
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
     }
   },
@@ -198,9 +209,6 @@
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
           },
-          "adminPassword": {
-            "value": "[parameters('adminPassword')]"
-          },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
@@ -224,6 +232,12 @@
           },
           "osSettings": {
             "value": "[variables('haproxyOsSettings')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }
@@ -246,9 +260,6 @@
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
           },
-          "adminPassword": {
-            "value": "[parameters('adminPassword')]"
-          },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
           },
@@ -269,6 +280,12 @@
           },
           "osSettings": {
             "value": "[variables('masterOsSettings')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }
@@ -291,9 +308,6 @@
         "parameters": {
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
-          },
-          "adminPassword": {
-            "value": "[parameters('adminPassword')]"
           },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
@@ -318,6 +332,12 @@
           },
           "osSettings": {
             "value": "[variables('slaveOsSettings01')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }
@@ -340,9 +360,6 @@
         "parameters": {
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
-          },
-          "adminPassword": {
-            "value": "[parameters('adminPassword')]"
           },
           "mysqlPassword": {
             "value": "[parameters('mysqlPassword')]"
@@ -367,6 +384,12 @@
           },
           "osSettings": {
             "value": "[variables('slaveOsSettings02')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }

--- a/mysql-mha-haproxy-ubuntu/azuredeploy.parameters.json
+++ b/mysql-mha-haproxy-ubuntu/azuredeploy.parameters.json
@@ -1,27 +1,27 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "virtualNetworkName": {
-            "value": "GEN-UNIQUE"
-        },
-        "adminUsername": {
-            "value": "GEN-UNIQUE"
-        },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "mysqlPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "dnsNamePrefix": {
-            "value": "GEN-UNIQUE"
-        },
-        "haproxyVmSize": {
-            "value": "Standard_D3"
-        },
-        "mysqlVmSize": {
-            "value": "Standard_D3"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "virtualNetworkName": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminUsername": {
+      "value": "GEN-UNIQUE"
+    },
+    "mysqlPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "dnsNamePrefix": {
+      "value": "GEN-UNIQUE"
+    },
+    "haproxyVmSize": {
+      "value": "Standard_D3"
+    },
+    "mysqlVmSize": {
+      "value": "Standard_D3"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
+  }
 }

--- a/mysql-mha-haproxy-ubuntu/azuredeploy.parameters.json
+++ b/mysql-mha-haproxy-ubuntu/azuredeploy.parameters.json
@@ -15,10 +15,10 @@
       "value": "GEN-UNIQUE"
     },
     "haproxyVmSize": {
-      "value": "Standard_D3"
+      "value": "Standard_D3_v2"
     },
     "mysqlVmSize": {
-      "value": "Standard_D3"
+      "value": "Standard_D3_v2"
     },
     "adminPasswordOrKey": {
       "value": "GEN-SSH-PUB-KEY"

--- a/mysql-mha-haproxy-ubuntu/metadata.json
+++ b/mysql-mha-haproxy-ubuntu/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template deploys a MySQL MHA + Haproxy solution:  the objective of MHA is automating master failover and slave promotion within short (usually 10-30 seconds) downtime, without suffering from replication consistency problems, without spending money for lots of new servers, without performance penalty, without complexity (easy-to-install), and without changing existing deployments; Haproxy is the interface which apps access mysql",
   "summary": "This template deploys a MySQL MHA + Haproxy solution: 3 mysql nodes and 1 haproxy node ",
   "githubUsername": "251744647",
-  "dateUpdated": "2018-07-02"  
+  "dateUpdated": "2019-11-15"
 }
-
-

--- a/mysql-mha-haproxy-ubuntu/nested/haproxy-resources.json
+++ b/mysql-mha-haproxy-ubuntu/nested/haproxy-resources.json
@@ -5,9 +5,6 @@
     "adminUsername": {
       "type": "string"
     },
-    "adminPassword": {
-      "type": "securestring"
-    },
     "mysqlPassword": {
       "type": "securestring"
     },
@@ -38,12 +35,29 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string"
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
-    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]"
+    "securityGroupName": "[concat(parameters('namespace'), parameters('vmbasename'), 'nsg')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -117,12 +131,11 @@
       "location": "[parameters('location')]",
       "sku": {
         "name": "Aligned"
-          },
-        "properties": { 
-            "platformFaultDomainCount": 2,
-            "platformUpdateDomainCount": 5
-            }
-        
+      },
+      "properties": {
+        "platformFaultDomainCount": 2,
+        "platformUpdateDomainCount": 5
+      }
     },
     {
       "apiVersion": "2015-06-15",
@@ -168,12 +181,13 @@
         "osProfile": {
           "computerName": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": "[parameters('osSettings').imageReference]",
           "osDisk": {
-            "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm','_OSDisk')]",   
+            "name": "[concat(parameters('namespace'), parameters('vmbasename'), 'vm','_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           }

--- a/mysql-mha-haproxy-ubuntu/nested/master-resources.json
+++ b/mysql-mha-haproxy-ubuntu/nested/master-resources.json
@@ -5,9 +5,6 @@
     "adminUsername": {
       "type": "string"
     },
-    "adminPassword": {
-      "type": "securestring"
-    },
     "mysqlPassword": {
       "type": "securestring"
     },
@@ -35,26 +32,42 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string"
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]"
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
-      "apiVersion": "2017-12-01", 
+      "apiVersion": "2017-12-01",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Aligned"
-          },
-        "properties": { 
-            "platformFaultDomainCount": 2,
-            "platformUpdateDomainCount": 5
-            }
-        
+      },
+      "properties": {
+        "platformFaultDomainCount": 2,
+        "platformUpdateDomainCount": 5
+      }
     },
     {
       "apiVersion": "2015-06-15",
@@ -77,7 +90,7 @@
       }
     },
     {
-      "apiVersion":"2017-03-30", 
+      "apiVersion": "2017-03-30",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[parameters('location')]",
@@ -91,12 +104,13 @@
         "osProfile": {
           "computerName": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": "[parameters('osSettings').imageReference]",
           "osDisk": {
-            "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'),'_OSDisk')]",   
+            "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'),'_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           }

--- a/mysql-mha-haproxy-ubuntu/nested/slave01-resources.json
+++ b/mysql-mha-haproxy-ubuntu/nested/slave01-resources.json
@@ -5,9 +5,6 @@
     "adminUsername": {
       "type": "string"
     },
-    "adminPassword": {
-      "type": "securestring"
-    },
     "mysqlPassword": {
       "type": "securestring"
     },
@@ -38,26 +35,42 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string"
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]"
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
-      "apiVersion": "2017-12-01", 
+      "apiVersion": "2017-12-01",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Aligned"
-          },
-        "properties": { 
-            "platformFaultDomainCount": 2,
-            "platformUpdateDomainCount": 5
-            }
-        
+      },
+      "properties": {
+        "platformFaultDomainCount": 2,
+        "platformUpdateDomainCount": 5
+      }
     },
     {
       "apiVersion": "2015-06-15",
@@ -80,7 +93,7 @@
       }
     },
     {
-      "apiVersion": "2017-03-30", 
+      "apiVersion": "2017-03-30",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
       "location": "[parameters('location')]",
@@ -94,12 +107,13 @@
         "osProfile": {
           "computerName": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": "[parameters('osSettings').imageReference]",
           "osDisk": {
-            "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'),'_OSDisk')]",   
+            "name": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'),'_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           }

--- a/mysql-mha-haproxy-ubuntu/nested/slave02-resources.json
+++ b/mysql-mha-haproxy-ubuntu/nested/slave02-resources.json
@@ -5,9 +5,6 @@
     "adminUsername": {
       "type": "string"
     },
-    "adminPassword": {
-      "type": "securestring"
-    },
     "mysqlPassword": {
       "type": "securestring"
     },
@@ -38,26 +35,42 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string"
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring"
     }
   },
   "variables": {
     "subnetRef": "[concat(resourceId('Microsoft.Network/virtualNetworks', parameters('subnet').vnet), '/subnets/', parameters('subnet').name)]",
-    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]"
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'standardsa')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
-      "apiVersion": "2017-12-01", 
+      "apiVersion": "2017-12-01",
       "type": "Microsoft.Compute/availabilitySets",
       "name": "[concat(parameters('namespace'), 'set')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Aligned"
-          },
-        "properties": { 
-            "platformFaultDomainCount": 2,
-            "platformUpdateDomainCount": 5
-            }
-        
+      },
+      "properties": {
+        "platformFaultDomainCount": 2,
+        "platformUpdateDomainCount": 5
+      }
     },
     {
       "apiVersion": "2015-06-15",
@@ -94,7 +107,8 @@
         "osProfile": {
           "computerName": "[concat(parameters('namespace'), concat(parameters('vmbasename'), 'vm'))]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": "[parameters('osSettings').imageReference]",


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

 * Added SSH key authentication as default option instead of a password for Linux VM