### PR TITLE
Adding Network Security Group to 201-vm-custom-script-windows

### DIFF
--- a/201-vm-custom-script-windows/azuredeploy.json
+++ b/201-vm-custom-script-windows/azuredeploy.json
@@ -194,7 +194,7 @@
             "autoUpgradeMinorVersion": true,
             "settings": {
               "fileUris": [
-                "[concat(parameters('_artifactsLocation'), '/', variables('ScriptFolder'), '/', variables('ScriptFileName'), parameters('_artifactsLocationSasToken'))]"
+                "[uri(parameters('_artifactsLocation'), concat(variables('ScriptFileName'), parameters('_artifactsLocationSasToken')))]"
               ],
               "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -File ', variables('scriptFolder'), '/', variables('scriptFileName'), ' ', variables('scriptParameters'))]"
             }

--- a/201-vm-custom-script-windows/azuredeploy.json
+++ b/201-vm-custom-script-windows/azuredeploy.json
@@ -49,7 +49,8 @@
     "scriptFolder": ".",
     "scriptFileName": "Copy-FileFromAzure.ps1",
     "fileToBeCopied": "FileToBeCopied.txt",
-    "scriptParameters": "[concat('-artifactsLocation ', parameters('_artifactsLocation'), ' -artifactsLocationSasToken \"', parameters('_artifactsLocationSasToken'), '\" -folderName ', variables('scriptFolder'), ' -fileToInstall ', variables('fileToBeCopied'))]"
+    "scriptParameters": "[concat('-artifactsLocation ', parameters('_artifactsLocation'), ' -artifactsLocationSasToken \"', parameters('_artifactsLocationSasToken'), '\" -folderName ', variables('scriptFolder'), ' -fileToInstall ', variables('fileToBeCopied'))]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -65,10 +66,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2018-04-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -79,7 +107,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/201-vm-custom-script-windows/azuredeploy.parameters.json
+++ b/201-vm-custom-script-windows/azuredeploy.parameters.json
@@ -1,12 +1,12 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "adminUsername": {
-            "value": "GEN-UNIQUE"
-        },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        }
-   }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    }
+  }
 }

--- a/201-vm-custom-script-windows/metadata.json
+++ b/201-vm-custom-script-windows/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to deploy a Windows VM and run a custom PowerShell script to install a file on that VM.",
   "summary": "Deploys a Windows VM and install a file on that VM using the Custom Script Extension",
   "githubUsername": "bmoore-msft",
-  "dateUpdated": "2016-11-08"
+  "dateUpdated": "2019-11-18"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vm-custom-script-windows

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
MyVM | Tcp | 135 | svchost.exe
MyVM | Tcp | 445 | 
MyVM | Tcp | 3389 | svchost.exe
MyVM | Tcp | 5985 | 
MyVM | Tcp | 47001 | 
MyVM | Tcp | 49664 | 
MyVM | Tcp | 49665 | lsass.exe
MyVM | Tcp | 49666 | svchost.exe
MyVM | Tcp | 49667 | svchost.exe
MyVM | Tcp | 49668 | spoolsv.exe
MyVM | Tcp | 49669 | 
MyVM | Udp | 123 | svchost.exe
MyVM | Udp | 3389 | svchost.exe
MyVM | Udp | 5050 | svchost.exe
MyVM | Udp | 5353 | svchost.exe
MyVM | Udp | 5355 | svchost.exe
