### PR TITLE
Adding Network Security Group to 201-vm-linux-dynamic-data-disks

### DIFF
--- a/201-vm-linux-dynamic-data-disks/azuredeploy.json
+++ b/201-vm-linux-dynamic-data-disks/azuredeploy.json
@@ -248,7 +248,8 @@
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('networkSettings').virtualNetworkName, variables('networkSettings').subnet.dse.name)]",
     "installationCLI": "[concat('bash azuredeploy.sh ', parameters('masterVMName'), ' ', parameters('mountFolder'), ' ', parameters('numDataDisks'), ' ', parameters('dockerVer'), ' ', parameters('dockerComposeVer'), ' ', parameters('adminUsername'), ' ', parameters('imageSku'), ' ', parameters('dockerMachineVer'))]",
     "storageAccountType": "[parameters('storageType')]",
-    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]"
+    "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -267,17 +268,44 @@
       "location": "[parameters('location')]",
       "sku": {
         "name": "Aligned"
-          },
-        "properties": { 
-            "platformFaultDomainCount": 2,
-            "platformUpdateDomainCount": 5
-        }
+      },
+      "properties": {
+        "platformFaultDomainCount": 2,
+        "platformUpdateDomainCount": 5
+      }
+    },
+    {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-22",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "22",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
     },
     {
       "apiVersion": "2017-03-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('networkSettings').virtualNetworkName]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -288,7 +316,10 @@
           {
             "name": "[variables('networkSettings').subnet.dse.name]",
             "properties": {
-              "addressPrefix": "[variables('networkSettings').subnet.dse.prefix]"
+              "addressPrefix": "[variables('networkSettings').subnet.dse.prefix]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]
@@ -373,7 +404,7 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "[concat(parameters('masterVMName'),'_OSDisk')]", 
+            "name": "[concat(parameters('masterVMName'),'_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           },

--- a/201-vm-linux-dynamic-data-disks/metadata.json
+++ b/201-vm-linux-dynamic-data-disks/metadata.json
@@ -5,7 +5,5 @@
   "description": "This is a common template for creating single instance CentOS 7.2/7.1/6.5 or Ubuntu Server 16.04.0-LTS with configurable number of data disks (configurable sizes). Maximum 16 disks can be mentioned in the portal parameters and maximum size of each disk should be less than 1023 GB. The MDADM RAID0 Array is automounted and survives restarts. Latest Docker 1.12(cs3) (Swarm), docker-compose 1.9.0 & docker-machine 0.8.2 is available for usage from user azure-cli is auto running as a docker container. This single instance template is an offshoot of the HPC/GPU Clusters Template @ https://aka.ms/azurebigcompute",
   "summary": "This is a common template for creating single instance CentOS or UbuntuServer  with configurable number of data disks automounted (configurable sizes)[MDADM RAID0 Array]. Docker 1.12.x is available.",
   "githubUsername": "dwaiba",
-  "dateUpdated": "2018-06-18"
+  "dateUpdated": "2019-11-18"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vm-linux-dynamic-data-disks

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
centos | Tcp | 22 | sshd
centos | Tcp | 53 | dnsmasq
centos | Tcp | 111 | rpcbind;systemd
centos | Tcp | 2049 | 
centos | Tcp | 20048 | rpc.mountd
centos | Tcp | 44600 | 
centos | Tcp | 52401 | rpc.statd
centos | Udp | 53 | dnsmasq
centos | Udp | 68 | dhclient
centos | Udp | 111 | rpcbind;systemd
centos | Udp | 1018 | rpcbind
centos | Udp | 2049 | 
centos | Udp | 20048 | rpc.mountd
centos | Udp | 29262 | dhclient
centos | Udp | 44266 | 
centos | Udp | 59926 | rpc.statd
