### PR TITLE
Adding Network Security Group to 201-vm-multiple-nics-linux

### DIFF
--- a/201-vm-multiple-nics-linux/azuredeploy.json
+++ b/201-vm-multiple-nics-linux/azuredeploy.json
@@ -115,7 +115,7 @@
       "comments": "Default Network Security Group for template",
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-08-01",
-      "name": "[variables('networkSecurityGroupName')]",
+      "name": "[resourceGroup().location]",
       "location": "[parameters('location')]",
       "properties": {
         "securityRules": [

--- a/201-vm-multiple-nics-linux/azuredeploy.json
+++ b/201-vm-multiple-nics-linux/azuredeploy.json
@@ -98,7 +98,8 @@
     "subnet2PrivateAddress": "10.0.2.5",
     "publicIPAddressName": "[concat(uniquestring(resourceGroup().id), 'PublicIp')]",
     "publicIPAddressType": "Dynamic",
-    "publicIPAddressId": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+    "publicIPAddressId": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -111,10 +112,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-22",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "22",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2015-06-15",
       "location": "[resourceGroup().location]",
       "name": "[variables('vnetName')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -125,13 +153,19 @@
           {
             "name": "[variables('subnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
+              "addressPrefix": "[variables('subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           },
           {
             "name": "[variables('subnet2Name')]",
             "properties": {
-              "addressPrefix": "[variables('subnet2Prefix')]"
+              "addressPrefix": "[variables('subnet2Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/201-vm-multiple-nics-linux/azuredeploy.json
+++ b/201-vm-multiple-nics-linux/azuredeploy.json
@@ -115,8 +115,8 @@
       "comments": "Default Network Security Group for template",
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-08-01",
-      "name": "[resourceGroup().location]",
-      "location": "[parameters('location')]",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[resourceGroup().location]",
       "properties": {
         "securityRules": [
           {

--- a/201-vm-multiple-nics-linux/metadata.json
+++ b/201-vm-multiple-nics-linux/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template creates a VNet with multiple subnets and deploys a Ubuntu VM with multiple NICs",
   "summary": "This template creates a VNet with multiple subnets and deploys a Ubuntu VM with multiple NICs",
   "githubUsername": "sivaedupuganti",
-  "dateUpdated": "2016-05-23"
+  "dateUpdated": "2019-11-18"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vm-multiple-nics-linux

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
cib98f3992e9ce48d1 | Tcp | 22 | sshd
cib98f3992e9ce48d1 | Udp | 68 | dhclient
cib98f3992e9ce48d1 | Udp | 123 | ntpd
cib98f3992e9ce48d1 | Udp | 6813 | dhclient
cib98f3992e9ce48d1 | Udp | 18089 | dhclient
cib98f3992e9ce48d1 | Udp | 41522 | dhclient
cib98f3992e9ce48d1 | Udp | 44078 | dhclient
