### PR TITLE
Update default authentication type to sshkey for 201-vm-msi-linux-terraform

### DIFF
--- a/201-vm-msi-linux-terraform/azuredeploy.json
+++ b/201-vm-msi-linux-terraform/azuredeploy.json
@@ -10,7 +10,7 @@
     },
     "authenticationType": {
       "type": "string",
-      "defaultValue": "password",
+      "defaultValue": "sshPublicKey",
       "allowedValues": [
         "password",
         "sshPublicKey"

--- a/201-vm-msi-linux-terraform/azuredeploy.json
+++ b/201-vm-msi-linux-terraform/azuredeploy.json
@@ -52,7 +52,7 @@
       "metadata": {
         "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
       },
-      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-msi-linux-terraform"
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/201-vm-msi-linux-terraform/"
     },
     "_artifactsLocationSasToken": {
       "type": "securestring",
@@ -310,10 +310,10 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
-            "[concat(parameters('_artifactsLocation'), '/scripts/infra.sh', parameters('_artifactsLocationSasToken'))]",
-            "[concat(parameters('_artifactsLocation'), '/scripts/install.sh', parameters('_artifactsLocationSasToken'))]",
-            "[concat(parameters('_artifactsLocation'), '/scripts/desktop.sh', parameters('_artifactsLocationSasToken'))]",
-            "[concat(parameters('_artifactsLocation'), '/scripts/azureProviderAndCreds.tf', parameters('_artifactsLocationSasToken'))]"
+            "[uri(parameters('_artifactsLocation'), concat('scripts/infra.sh', parameters('_artifactsLocationSasToken')))]",
+            "[uri(parameters('_artifactsLocation'), concat('scripts/install.sh', parameters('_artifactsLocationSasToken')))]",
+            "[uri(parameters('_artifactsLocation'), concat('scripts/desktop.sh', parameters('_artifactsLocationSasToken')))]",
+            "[uri(parameters('_artifactsLocation'), concat('scripts/azureProviderAndCreds.tf', parameters('_artifactsLocationSasToken')))]"
           ]
         },
         "protectedSettings": {

--- a/201-vm-msi-linux-terraform/azuredeploy.json
+++ b/201-vm-msi-linux-terraform/azuredeploy.json
@@ -244,7 +244,7 @@
           "imageReference": {
             "publisher": "Canonical",
             "offer": "UbuntuServer",
-            "sku": "17.10",
+            "sku": "18.04-LTS",
             "version": "latest"
           }
         },

--- a/201-vm-msi-linux-terraform/azuredeploy.json
+++ b/201-vm-msi-linux-terraform/azuredeploy.json
@@ -276,10 +276,9 @@
       ],
       "properties": {
         "roleDefinitionId": "[variables('contributor')]",
-        "principalId": "[reference(variables('vmName'), '2019-07-01', 'Full').identityt.principalId]",
+        "principalId": "[reference(variables('vmName'), '2019-07-01', 'Full').identity.principalId]",
         "scope": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', resourceGroup().name)]",
         "principalType": "ServicePrincipal"
-
       }
     },
     {

--- a/201-vm-msi-linux-terraform/azuredeploy.json
+++ b/201-vm-msi-linux-terraform/azuredeploy.json
@@ -80,7 +80,7 @@
     "subnetPrefix": "10.0.0.0/24",
     "publicIPAddressName": "[concat('pip',uniquestring(resourceGroup().id))]",
     "vmName": "[concat('vm',uniquestring(resourceGroup().id))]",
-    "virtualNetworkName": "[concat('vnet',uniquestring(resourceGroup().id))]",
+    "virtualNetworkName": "vnet",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
     "linuxConfiguration": {
       "disablePasswordAuthentication": true,
@@ -93,7 +93,7 @@
         ]
       }
     },
-    "contributor": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
+    "contributor": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8e3af657-a8ff-443c-a75c-2fe8c4bcb635')]",
     "installParm1": "[concat(' -u ', parameters('adminUsername'))]",
     "installParm2": "[concat(' -s ', subscription().subscriptionId)]",
     "installParm3": "[concat(' -a ', variables('stateStorageAccountName'))]",
@@ -104,7 +104,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('infraStorageAccountName')]",
-      "apiVersion": "2017-10-01",
+      "apiVersion": "2019-06-01",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Standard_LRS"
@@ -115,7 +115,7 @@
     {
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('stateStorageAccountName')]",
-      "apiVersion": "2017-10-01",
+      "apiVersion": "2019-06-01",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Standard_LRS"
@@ -124,7 +124,7 @@
       "properties": {}
     },
     {
-      "apiVersion": "2017-11-01",
+      "apiVersion": "2019-09-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[parameters('location')]",
@@ -136,7 +136,7 @@
       }
     },
     {
-      "apiVersion": "2017-11-01",
+      "apiVersion": "2019-09-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
@@ -159,7 +159,7 @@
     {
       "name": "[variables('networkSecurityGroupName')]",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2017-11-01",
+      "apiVersion": "2019-09-01",
       "location": "[parameters('location')]",
       "properties": {
         "securityRules": [
@@ -194,7 +194,7 @@
       }
     },
     {
-      "apiVersion": "2017-11-01",
+      "apiVersion": "2019-09-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",
@@ -223,7 +223,7 @@
       }
     },
     {
-      "apiVersion": "2017-12-01",
+      "apiVersion": "2019-07-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
@@ -258,41 +258,24 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference(concat('Microsoft.Storage/storageAccounts/', variables('infraStorageAccountName')),'2016-12-01').primaryEndpoints.blob]"
+            "storageUri": "[reference(variables('infraStorageAccountName')).primaryEndpoints.blob]"
           }
         }
       }
     },
     {
-      "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('vmName'),'/MSILinuxExtension')]",
-      "apiVersion": "2017-12-01",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Compute/virtualMachines/', variables('vmName'))]"
-      ],
-      "properties": {
-        "publisher": "Microsoft.ManagedIdentity",
-        "type": "ManagedIdentityExtensionForLinux",
-        "typeHandlerVersion": "1.0",
-        "autoUpgradeMinorVersion": true,
-        "settings": {
-          "port": 50342
-        },
-        "protectedSettings": {}
-      }
-    },
-    {
-      "apiVersion": "2017-09-01",
-      "name": "[guid(resourceGroup().id)]",
+      "apiVersion": "2019-04-01-preview",
+      "name": "[guid(resourceGroup().id, variables('contributor'))]",
       "type": "Microsoft.Authorization/roleAssignments",
       "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions/', variables('vmName'),'MSILinuxExtension')]"
+        "[resourceId('Microsoft.Compute/virtualMachines', variables('vmName'))]"
       ],
       "properties": {
         "roleDefinitionId": "[variables('contributor')]",
-        "principalId": "[reference(concat(resourceId('Microsoft.Compute/virtualMachines/', variables('vmName')),'/providers/Microsoft.ManagedIdentity/Identities/default'),'2015-08-31-PREVIEW').principalId]",
-        "scope": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name)]"
+        "principalId": "[reference(variables('vmName'), '2015-08-31-PREVIEW', 'Full').identityt.principalId]",
+        "scope": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', resourceGroup().name)]",
+        "principalType": "ServicePrincipal"
+
       }
     },
     {
@@ -301,7 +284,7 @@
       "apiVersion": "2017-03-30",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[resourceId('Microsoft.Authorization/roleAssignments', guid(resourceGroup().id))]"
+        "[resourceId('Microsoft.Authorization/roleAssignments', guid(resourceGroup().id, variables('contributor')))]"
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
@@ -324,7 +307,7 @@
   ],
   "outputs": {
     "fqdn": {
-      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')),'2017-10-01').dnsSettings.fqdn]",
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName')),'2019-09-01').dnsSettings.fqdn]",
       "type": "string"
     }
   }

--- a/201-vm-msi-linux-terraform/azuredeploy.json
+++ b/201-vm-msi-linux-terraform/azuredeploy.json
@@ -73,8 +73,8 @@
     "dnsLabelPrefix": "[concat('msi',uniquestring(resourceGroup().id))]",
     "infraStorageAccountName": "[take(concat('storeinfra', uniquestring(resourceGroup().id), variables('dnsLabelPrefix')),24)]",
     "stateStorageAccountName": "[take(concat('storestate', uniquestring(resourceGroup().id), variables('dnsLabelPrefix')),24)]",
-    "nicName": "[concat('nic',uniquestring(resourceGroup().id))]",
-    "networkSecurityGroupName": "[concat('nsg',uniquestring(resourceGroup().id))]",
+    "nicName": "[concat('nic', variables('vmName'))]",
+    "networkSecurityGroupName": "[concat('nsg', variables('vmName'))]",
     "addressPrefix": "10.0.0.0/16",
     "subnetName": "Subnet",
     "subnetPrefix": "10.0.0.0/24",
@@ -200,7 +200,8 @@
       "location": "[parameters('location')]",
       "dependsOn": [
         "[resourceId('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
+        "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]",
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
       ],
       "properties": {
         "ipConfigurations": [
@@ -227,6 +228,9 @@
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+          "[resourceId('Microsoft.Network/networkinterfaces', variables('nicName'))]"
+      ],
       "identity": {
         "type": "SystemAssigned"
       },
@@ -272,7 +276,7 @@
       ],
       "properties": {
         "roleDefinitionId": "[variables('contributor')]",
-        "principalId": "[reference(variables('vmName'), '2015-08-31-PREVIEW', 'Full').identityt.principalId]",
+        "principalId": "[reference(variables('vmName'), '2019-07-01', 'Full').identityt.principalId]",
         "scope": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', resourceGroup().name)]",
         "principalType": "ServicePrincipal"
 
@@ -281,7 +285,7 @@
     {
       "name": "[concat(variables('vmName'),'/customscriptextension')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "apiVersion": "2017-03-30",
+      "apiVersion": "2019-07-01",
       "location": "[parameters('location')]",
       "dependsOn": [
         "[resourceId('Microsoft.Authorization/roleAssignments', guid(resourceGroup().id, variables('contributor')))]"

--- a/201-vm-msi-linux-terraform/azuredeploy.parameters.json
+++ b/201-vm-msi-linux-terraform/azuredeploy.parameters.json
@@ -6,7 +6,7 @@
       "value": "GEN-UNIQUE"
     },
     "adminPassword": {
-      "value": "GEN-PASSWORD"
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/201-vm-msi-linux-terraform/azuredeploy.parameters.json
+++ b/201-vm-msi-linux-terraform/azuredeploy.parameters.json
@@ -6,6 +6,9 @@
       "value": "GEN-UNIQUE"
     },
     "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "sshPublicKey": {
       "value": "GEN-SSH-PUB-KEY"
     }
   }

--- a/201-vm-msi-linux-terraform/metadata.json
+++ b/201-vm-msi-linux-terraform/metadata.json
@@ -6,7 +6,7 @@
   "description": "This template allows you to deploy a Terraform workstation as a Linux VM with MSI.",
   "summary": "This template allows you to deploy a Terraform workstation as a Linux VM with MSI.",
   "githubUsername": "sebastus",
-  "dateUpdated": "2017-12-08"
+  "dateUpdated": "2019-11-19"
 }
 
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Updated default authentication type value to be ssh key for 201-vm-msi-linux-terraform
*
*

