### PR TITLE
Update default authentication type to sshkey for 201-vm-new-or-existing-conditions

### DIFF
--- a/201-vm-new-or-existing-conditions/azuredeploy.json
+++ b/201-vm-new-or-existing-conditions/azuredeploy.json
@@ -24,7 +24,7 @@
     },
     "authenticationType": {
       "type": "string",
-      "defaultValue": "password",
+      "defaultValue": "sshPublicKey",
       "allowedValues": [
         "password",
         "sshPublicKey"

--- a/201-vm-new-or-existing-conditions/azuredeploy.parameters.json
+++ b/201-vm-new-or-existing-conditions/azuredeploy.parameters.json
@@ -6,7 +6,7 @@
             "value": "GEN-UNIQUE"
         },
         "adminPasswordOrKey": {
-            "value": "GEN-PASSWORD"
+            "value": "GEN-SSH-PUB-KEY"
         }
     }
 }

--- a/201-vm-new-or-existing-conditions/metadata.json
+++ b/201-vm-new-or-existing-conditions/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template allows deploying a linux VM using new or existing resources for the Virtual Network, Storage and Public IP Address.  It also allows for choosing between SSH and Password authenticate.  The templates uses conditions and logic functions to remove the need for nested deployments.",
   "summary": "This template allows deploying a linux VM using new or existing resources for the Virtual Network, Storage and Public IP Address.  It also allows for choosing between SSH and Password authenticate.",
   "githubUsername": "bmoore-msft",
-  "dateUpdated": "2019-05-29"
+  "dateUpdated": "2019-11-19"
 }
 
 


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Updated default authentication type value to be ssh key for 201-vm-new-or-existing-conditions
*
*

