### PR TITLE
Adding Network Security Group to 201-vm-winrm-windows

### DIFF
--- a/201-vm-winrm-windows/azuredeploy.json
+++ b/201-vm-winrm-windows/azuredeploy.json
@@ -89,7 +89,8 @@
     "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
     "apiVersion": "2015-06-15",
-    "hostDNSNameScriptArgument": "[concat('*.',parameters('location'),'.cloudapp.azure.com')]"
+    "hostDNSNameScriptArgument": "[concat('*.',parameters('location'),'.cloudapp.azure.com')]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -105,10 +106,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -119,7 +147,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/201-vm-winrm-windows/azuredeploy.parameters.json
+++ b/201-vm-winrm-windows/azuredeploy.parameters.json
@@ -1,30 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {        
-        "adminUsername": {
-            "value": "yourusername"
-        },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "dnsLabelPrefix": {
-            "value": "GEN-UNIQUE-13"
-        },
-        "vmName": {
-            "value": "MyVM"
-        },
-        "nicName": {
-            "value": "myVMNic"
-        },
-        "virtualNetworkName": {
-            "value": "MyVNET"
-        },
-        "publicIPAddressName": {
-            "value": "myPublicIP"
-        },
-        "subnetName": {
-            "value": "Subnet"
-        }
-   }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "value": "yourusername"
+    },
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "dnsLabelPrefix": {
+      "value": "GEN-UNIQUE-13"
+    },
+    "vmName": {
+      "value": "MyVM"
+    },
+    "nicName": {
+      "value": "myVMNic"
+    },
+    "virtualNetworkName": {
+      "value": "MyVNET"
+    },
+    "publicIPAddressName": {
+      "value": "myPublicIP"
+    },
+    "subnetName": {
+      "value": "Subnet"
+    }
+  }
 }

--- a/201-vm-winrm-windows/metadata.json
+++ b/201-vm-winrm-windows/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to deploy a simple Windows VM using a few different options for the Windows version. This will then configure a WinRM https listener. User need to provide the value of parameter 'hostNameScriptArgument' which is the fqdn of the VM. Example: testvm.westus.cloupdapp.azure.com or *.westus.cloupdapp.azure.com",
   "summary": "This template takes a minimum amount of parameters and deploys a Windows VM and configures the WinRM https listener",
   "githubUsername": "MnrGreg",
-  "dateUpdated": "2017-09-19"
+  "dateUpdated": "2019-11-20"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vm-winrm-windows

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
MyVM | Tcp | 135 | svchost.exe
MyVM | Tcp | 445 | 
MyVM | Tcp | 3389 | svchost.exe
MyVM | Tcp | 5985 | 
MyVM | Tcp | 5986 | 
MyVM | Tcp | 47001 | 
MyVM | Tcp | 49152 | wininit.exe
MyVM | Tcp | 49153 | lsass.exe
MyVM | Tcp | 49154 | svchost.exe
MyVM | Tcp | 49156 | svchost.exe
MyVM | Tcp | 49157 | spoolsv.exe
MyVM | Tcp | 49158 | 
MyVM | Udp | 123 | svchost.exe
MyVM | Udp | 3389 | svchost.exe
MyVM | Udp | 5355 | svchost.exe
