### PR TITLE
Adding Network Security Group to 201-vmss-windows-jumpbox

### DIFF
--- a/201-vmss-windows-jumpbox/azuredeploy.json
+++ b/201-vmss-windows-jumpbox/azuredeploy.json
@@ -74,14 +74,42 @@
       "sku": "[parameters('windowsOSVersion')]",
       "version": "latest"
     },
-    "imageReference": "[variables('osType')]"
+    "imageReference": "[variables('osType')]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
+    {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
     {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
       "apiVersion": "2017-04-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -92,7 +120,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/201-vmss-windows-jumpbox/metadata.json
+++ b/201-vmss-windows-jumpbox/metadata.json
@@ -1,11 +1,9 @@
 {
-  "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",  
+  "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
   "itemDisplayName": "Deploy a simple VM Scale Set with Windows VMs and a Jumpbox",
   "type": "QuickStart",
   "description": "This template allows you to deploy a simple VM Scale Set of Windows VMs using the lastest patched version of serveral Windows versions. This template also deploys a jumpbox with a public IP address in the same virtual network. You can connect to the jumpbox via this public IP address, then connect from there to VMs in the scale set via private IP addresses.",
   "summary": "This template deploys a VM Scale Set of Windows VMs with a jumpbox.",
   "githubUsername": "gatneil",
-  "dateUpdated": "2018-08-30"
+  "dateUpdated": "2019-11-20"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vmss-windows-jumpbox

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
ci01b22a2jbox | Tcp | 135 | svchost.exe
ci01b22a2jbox | Tcp | 445 | 
ci01b22a2jbox | Tcp | 3389 | svchost.exe
ci01b22a2jbox | Tcp | 5985 | 
ci01b22a2jbox | Tcp | 47001 | 
ci01b22a2jbox | Tcp | 49664 | 
ci01b22a2jbox | Tcp | 49665 | lsass.exe
ci01b22a2jbox | Tcp | 49666 | svchost.exe
ci01b22a2jbox | Tcp | 49668 | svchost.exe
ci01b22a2jbox | Tcp | 49669 | spoolsv.exe
ci01b22a2jbox | Tcp | 49670 | 
ci01b22a2jbox | Udp | 123 | svchost.exe
ci01b22a2jbox | Udp | 3389 | svchost.exe
ci01b22a2jbox | Udp | 5050 | svchost.exe
ci01b22a2jbox | Udp | 5353 | svchost.exe
ci01b22a2jbox | Udp | 5355 | svchost.exe
