### PR TITLE
NetworkInterfaceIDs AzureRM command corrected.

### DIFF
--- a/asr-automation-recovery/scripts/ASR-AddMultipleLoadBalancers.ps1
+++ b/asr-automation-recovery/scripts/ASR-AddMultipleLoadBalancers.ps1
@@ -123,7 +123,7 @@ Try
                 Write-Output "Availability Set is present for VM: `n" $AzureVm.Name
             }
             #Join the VMs NICs to backend pool of the Load Balancer
-            $ARMNic = Get-AzureRmResource -ResourceId $AzureVm.NetworkInterfaceIDs[0]
+            $ARMNic = Get-AzureRmResource -ResourceId $AzureVm.NetworkProfile.NetworkInterfaces[0].Id
             $Nic = Get-AzureRmNetworkInterface -Name $ARMNic.Name -ResourceGroupName $ARMNic.ResourceGroupName
             $Nic.IpConfigurations[0].LoadBalancerBackendAddressPools.Add($LoadBalancer.BackendAddressPools[0]);        
             $Nic | Set-AzureRmNetworkInterface    

--- a/asr-automation-recovery/scripts/ASR-AddPublicIp.ps1
+++ b/asr-automation-recovery/scripts/ASR-AddPublicIp.ps1
@@ -89,7 +89,7 @@ Try
  {
     foreach ($VM in $VMs)
     {
-        $ARMNic = Get-AzureRmResource -ResourceId $VM.NetworkInterfaceIDs[0]
+        $ARMNic = Get-AzureRmResource -ResourceId $VM.NetworkProfile.NetworkInterfaces[0].Id
         $NIC = Get-AzureRmNetworkInterface -Name $ARMNic.Name -ResourceGroupName $ARMNic.ResourceGroupName
         $PIP = New-AzureRmPublicIpAddress -Name $VM.Name -ResourceGroupName $RGName -Location $VM.Location -AllocationMethod Dynamic
         $NIC.IpConfigurations[0].PublicIpAddress = $PIP

--- a/asr-automation-recovery/scripts/ASR-AddSingleLoadBalancer.ps1
+++ b/asr-automation-recovery/scripts/ASR-AddSingleLoadBalancer.ps1
@@ -27,7 +27,7 @@
  
     .NOTES 
         AUTHOR: krnese@microsoft.com - AzureCAT
-        LASTEDIT: 20 March, 2017 
+        LASTEDIT: 20 March, 2017
 #> 
 param ( 
         [Object]$RecoveryPlanContext 
@@ -113,7 +113,7 @@ Try
             Write-Output "Availability Set is present for VM: `n" $AzureVm.Name
         }
         #Join the VMs NICs to backend pool of the Load Balancer
-        $ARMNic = Get-AzureRmResource -ResourceId $AzureVm.NetworkInterfaceIDs[0]
+        $ARMNic = Get-AzureRmResource -ResourceId $AzureVm.NetworkProfile.NetworkInterfaces[0].Id
         $Nic = Get-AzureRmNetworkInterface -Name $ARMNic.Name -ResourceGroupName $ARMNic.ResourceGroupName
         $Nic.IpConfigurations[0].LoadBalancerBackendAddressPools.Add($LoadBalancer.BackendAddressPools[0]);        
         $Nic | Set-AzureRmNetworkInterface    

--- a/asr-automation-recovery/scripts/ASR-AddSingleNSGPublicIp.ps1
+++ b/asr-automation-recovery/scripts/ASR-AddSingleNSGPublicIp.ps1
@@ -113,7 +113,8 @@ workflow ASR-AddSingleNSGPublicIp {
                              
                 $azurevm = Get-AzureRMVM -ResourceGroupName $Using:VM.ResourceGroupName -Name $Using:VM.RoleName 
                 write-output "Azure VM Id", $azurevm.Id 
-                $NicArmObject = Get-AzureRmResource -ResourceId $azurevm.NetworkInterfaceIDs[0] 
+                $NicArmObject = Get-AzureRmResource -ResourceId $azurevm.NetworkProfile.NetworkInterfaces[0].Id
+                
                 write-output "Nic Arm Object Id = ", $NicArmObject.Id 
                 $VMNetworkInterfaceObject = Get-AzureRmNetworkInterface -Name $NicArmObject.Name -ResourceGroupName $NicArmObject.ResourceGroupName 
                 write-output "Nic Interface Id", $VMNetworkInterfaceObject.Id  

--- a/asr-automation-recovery/scripts/ASR-DNS-UpdateIP.ps1
+++ b/asr-automation-recovery/scripts/ASR-DNS-UpdateIP.ps1
@@ -111,7 +111,7 @@ Catch
             InlineScript{
                 $azurevm = Get-AzureRMVM -ResourceGroupName $Using:VM.ResourceGroupName -Name $Using:VM.RoleName 
                 write-output "Updating DNS for" $azurevm.Id 
-                $NicArmObject = Get-AzureRmResource -ResourceId $azurevm.NetworkInterfaceIDs[0] 
+                $NicArmObject = Get-AzureRmResource -ResourceId $azurevm.NetworkProfile.NetworkInterfaces[0].Id
                 $VMNetworkInterfaceObject = Get-AzureRmNetworkInterface -Name $NicArmObject.Name -ResourceGroupName $NicArmObject.ResourceGroupName
                 $IPconfiguration = $VMNetworkInterfaceObject.IpConfigurations[0]
                 $IP =  $IPconfiguration.PrivateIpAddress


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [X ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Mainly I updated this line "Get-AzureRmResource -ResourceId $AzureVm.NetworkInterfaceIDs[0]" to "Get-AzureRmResource -ResourceId $AzureVm.NetworkProfile.NetworkInterfaces[0].Id" which would be the correct version..
* I have tested with ASR-AddSingleLoadBalancer.ps1 file, it worked, I haven't tested for the rest of the files.

