### PR TITLE
Revert SSH key as auth type for couchbase

### DIFF
--- a/couchbase/azuredeploy.json
+++ b/couchbase/azuredeploy.json
@@ -46,6 +46,12 @@
         "description": "Admin Username"
       }
     },
+    "adminPassword": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Admin Password"
+      }
+    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
@@ -59,39 +65,11 @@
       "metadata": {
         "description": "License can be hourly_pricing or byol"
       }
-    },
-    "authenticationType": {
-      "type": "string",
-      "defaultValue": "sshPublicKey",
-      "allowedValues": [
-        "sshPublicKey",
-        "password"
-      ],
-      "metadata": {
-        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
-      }
-    },
-    "adminPasswordOrKey": {
-      "type": "securestring",
-      "metadata": {
-        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
-      }
     }
   },
   "variables": {
     "extensionUrl": "[concat(parameters('_artifactsLocation'), 'scripts/')]",
-    "uniqueString": "[uniquestring(resourceGroup().id, deployment().name)]",
-    "linuxConfiguration": {
-      "disablePasswordAuthentication": true,
-      "ssh": {
-        "publicKeys": [
-          {
-            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
-            "keyData": "[parameters('adminPasswordOrKey')]"
-          }
-        ]
-      }
-    }
+    "uniqueString": "[uniquestring(resourceGroup().id, deployment().name)]"
   },
   "resources": [
     {

--- a/couchbase/azuredeploy.json
+++ b/couchbase/azuredeploy.json
@@ -68,7 +68,6 @@
     }
   },
   "variables": {
-    "extensionUrl": "[concat(parameters('_artifactsLocation'), 'scripts/')]",
     "uniqueString": "[uniquestring(resourceGroup().id, deployment().name)]"
   },
   "resources": [
@@ -326,8 +325,8 @@
                   "autoUpgradeMinorVersion": true,
                   "settings": {
                     "fileUris": [
-                      "[concat(variables('extensionUrl'), 'server.sh')]",
-                      "[concat(variables('extensionUrl'), 'util.sh')]"
+                      "[uri(parameters('_artifactsLocation'), concat('scripts/server.sh', parameters('_artifactsLocationSasToken')))]",
+                      "[uri(parameters('_artifactsLocation'), concat('scripts/util.sh', parameters('_artifactsLocationSasToken')))]"
                     ],
                     "commandToExecute": "[concat('bash server.sh ', parameters('adminUsername'), ' ', parameters('adminPassword'), ' ', variables('uniqueString'), ' ', parameters('location'))]"
                   }
@@ -418,8 +417,8 @@
                   "autoUpgradeMinorVersion": true,
                   "settings": {
                     "fileUris": [
-                      "[concat(variables('extensionUrl'), 'syncGateway.sh')]",
-                      "[concat(variables('extensionUrl'), 'util.sh')]"
+                      "[uri(parameters('_artifactsLocation'), concat('scripts/syncGateway.sh', parameters('_artifactsLocationSasToken')))]",
+                      "[uri(parameters('_artifactsLocation'), concat('scripts/util.sh', parameters('_artifactsLocationSasToken')))]"
                     ],
                     "commandToExecute": "[concat('bash syncGateway.sh ', variables('uniqueString'), ' ', parameters('location'))]"
                   }

--- a/couchbase/azuredeploy.json
+++ b/couchbase/azuredeploy.json
@@ -284,8 +284,7 @@
           "osProfile": {
             "computerNamePrefix": "server",
             "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPasswordOrKey')]",
-            "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
+            "adminPassword": "[parameters('adminPassword')]"
           },
           "networkProfile": {
             "networkInterfaceConfigurations": [
@@ -377,8 +376,7 @@
           "osProfile": {
             "computerNamePrefix": "syncgateway",
             "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPasswordOrKey')]",
-            "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
+            "adminPassword": "[parameters('adminPassword')]"
           },
           "networkProfile": {
             "networkInterfaceConfigurations": [

--- a/couchbase/azuredeploy.parameters.json
+++ b/couchbase/azuredeploy.parameters.json
@@ -17,8 +17,8 @@
     "adminUsername": {
       "value": "GEN-UNIQUE"
     },
-    "adminPasswordOrKey": {
-      "value": "GEN-SSH-PUB-KEY"
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
     }
   }
 }

--- a/couchbase/metadata.json
+++ b/couchbase/metadata.json
@@ -5,5 +5,5 @@
   "description": "Azure Resource Manager (ARM) templates to install Couchbase Enterprise",
   "summary": "Azure Resource Manager (ARM) templates to install Couchbase Enterprise",
   "githubUsername": "benofben",
-  "dateUpdated": "2019-07-08"
+  "dateUpdated": "2019-11-25"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Revert SSH key as auth type for couchbase
*
*

