### PR TITLE
Add SSH Auth to 201-traffic-manager-vm-zones

### DIFF
--- a/201-traffic-manager-vm-zones/azuredeploy.json
+++ b/201-traffic-manager-vm-zones/azuredeploy.json
@@ -1,4 +1,4 @@
-  {
+{
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
@@ -25,12 +25,6 @@
         "description": "User name for the Virtual Machines."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Password for the Virtual Machines."
-      }
-    },
     "publicIpDnsName": {
       "type": "string",
       "metadata": {
@@ -44,6 +38,23 @@
       "maxValue": 10,
       "metadata": {
         "description": "Number of VMs to provision"
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
     }
   },
@@ -59,6 +70,17 @@
       "offer": "UbuntuServer",
       "sku": "16.04.0-LTS",
       "version": "latest"
+    },
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
     }
   },
   "resources": [
@@ -153,7 +175,8 @@
         "osProfile": {
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": "[variables('linuxImage')]",
@@ -167,7 +190,7 @@
               "id": "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('nicName'), copyIndex()))]"
             }
           ]
-        }        
+        }
       },
       "resources": [
         {
@@ -187,7 +210,7 @@
               "commandToExecute": "sudo bash -c 'apt-get update && apt-get -y install apache2' "
             }
           }
-        }    
+        }
       ]
     },
     {
@@ -210,11 +233,11 @@
           "port": 80,
           "path": "/"
         },
-        "copy" :[
+        "copy": [
           {
             "name": "endpoints",
             "count": "[parameters('numberOfVms')]",
-            "input":{
+            "input": {
               "name": "[concat('endpoint', copyIndex('endpoints'))]",
               "type": "Microsoft.Network/trafficManagerProfiles/azureEndpoints",
               "properties": {

--- a/201-traffic-manager-vm-zones/azuredeploy.parameters.json
+++ b/201-traffic-manager-vm-zones/azuredeploy.parameters.json
@@ -11,8 +11,8 @@
     "adminUsername": {
       "value": "GEN-UNIQUE"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/201-traffic-manager-vm-zones/metadata.json
+++ b/201-traffic-manager-vm-zones/metadata.json
@@ -5,6 +5,5 @@
   "description": "This template shows how to create an Azure Traffic Manager profile load-balancing across multiple virtual machines placed in Availability Zones.",
   "summary": "This template creates an Azure Traffic Manager profile that load-balances across multiple virtual machines placed in Availability Zones.",
   "githubUsername": "aaronlower",
-  "dateUpdated": "2017-09-21"
+  "dateUpdated": "2019-12-05"
 }
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
