### PR TITLE
Add SSH Auth to 201-vm-copy-index-loops

### DIFF
--- a/201-vm-copy-index-loops/azuredeploy.json
+++ b/201-vm-copy-index-loops/azuredeploy.json
@@ -8,12 +8,6 @@
         "description": "Admin username for VM"
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Admin password for VMs"
-      }
-    },
     "numberOfInstances": {
       "type": "int",
       "defaultValue": 2,
@@ -40,6 +34,23 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -61,7 +72,18 @@
       "sku": "2016-Datacenter",
       "version": "latest"
     },
-    "imageReference": "[variables(parameters('OS'))]"
+    "imageReference": "[variables(parameters('OS'))]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -144,7 +166,8 @@
         "osProfile": {
           "computerName": "[concat('vm', copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": "[variables('imageReference')]",

--- a/201-vm-copy-index-loops/azuredeploy.parameters.json
+++ b/201-vm-copy-index-loops/azuredeploy.parameters.json
@@ -5,11 +5,11 @@
     "adminUsername": {
       "value": "GEN-UNIQUE"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
-    },
     "numberOfInstances": {
       "value": 2
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/201-vm-copy-index-loops/metadata.json
+++ b/201-vm-copy-index-loops/metadata.json
@@ -5,7 +5,5 @@
   "description": "Create 2-5 VMs in Availability Sets using Resource Loops.  The VMs can be Unbuntu or Windows with a maximum of 5 VMs since this sample uses a single storageAccount",
   "summary": "Create VMs in Availability Sets using Resource Loops",
   "githubUsername": "bmoore-msft",
-  "dateUpdated": "2016-11-09"
+  "dateUpdated": "2019-12-05"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
