### PR TITLE
Update Test-AzTemplate.ps1

### DIFF
--- a/test/arm-ttk/Test-AzTemplate.ps1
+++ b/test/arm-ttk/Test-AzTemplate.ps1
@@ -434,9 +434,16 @@ Each test script has access to a set of well-known variables:
                     if ($IsPesterLoaded?) {
                         $true
                     } else {
-                        $env:PSModulePath -split ';' | 
-                            Get-ChildItem -Filter Pester |
-                            Import-Module -Global -PassThru        
+                    
+                        if ($PSVersionTable.Platform -eq 'Unix') {
+                            $delimiter = ':' # used for bash
+                        } else {
+                            $delimiter = ';' # used for windows
+                        }
+
+                        $env:PSModulePath -split $delimiter | 
+                        Get-ChildItem -Filter Pester |
+                        Import-Module -Global -PassThru     
                     }
 
                 if (-not $DoesPesterExist?){


### PR DESCRIPTION
I used Test-AzTemplate.ps1 in an Ubuntu-based Build Agent (Azure DevOps) and recognized that it's using the wrong delimiter (; instead of :) I added an if-statement based on $PSVersionTable.Platform to set the delimiter based on the decision if the underlaying Platform is Unix (:) or not (;)

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

