### PR TITLE
Add SSH Auth to 301-multi-vmss-linux-lb-zones

### DIFF
--- a/301-multi-vmss-linux-lb-zones/azuredeploy.json
+++ b/301-multi-vmss-linux-lb-zones/azuredeploy.json
@@ -1,341 +1,364 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string",
-            "allowedValues": [
-                "CentralUS",
-                "FranceCentral"
-            ],
-            "defaultValue": "CentralUS",
-            "metadata": {
-                "description": "Location for the VM, only certain regions support Availability Zones"
-            }
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Username for the Virtual Machine."
-            }
-        },
-        "adminPassword": {
-            "type": "securestring",
-            "metadata": {
-                "description": "Password for the Virtual Machine."
-            }
-        },
-        "dnsName": {
-            "type": "string",
-            "metadata": {
-                "description": "String used as a base for naming resources. Must be 3-61 characters in length and globally unique across Azure. A hash is prepended to this string for some resources and resource-specific information is appended."
-            },
-            "minLength": 3,
-            "maxLength": 61
-        },
-        "numberOfVms": {
-            "type": "int",
-            "defaultValue": 3,
-            "metadata": {
-                "description": "The number of VMs to deploy in each VMSS."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "allowedValues": [
+        "CentralUS",
+        "FranceCentral"
+      ],
+      "defaultValue": "CentralUS",
+      "metadata": {
+        "description": "Location for the VM, only certain regions support Availability Zones"
+      }
     },
-    "variables": {
-        "virtualNetworkName": "[concat(parameters('dnsName'), '-vnet')]",
-        "subnetName": "Subnet-1",
-        "networkSecurityGroupName": "allowRemoting",
-        "publicIPAddressName": "lbPublicIp",
-        "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
-        "frontEndIPConfigID": "[concat(variables('lbID'), '/frontendIPConfigurations/loadBalancerFrontEnd')]",
-        "lbName": "[concat('lb-', parameters('dnsName'))]",
-        "lbID": "[resourceId('Microsoft.Network/loadBalancers', variables('lbName'))]",
-        "lbBE": "lbBE",
-        "lbNAT": "lbNAT",
-        "myZones": [
-            "1",
-            "2",
-            "3"
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
+    },
+    "dnsName": {
+      "type": "string",
+      "metadata": {
+        "description": "String used as a base for naming resources. Must be 3-61 characters in length and globally unique across Azure. A hash is prepended to this string for some resources and resource-specific information is appended."
+      },
+      "minLength": 3,
+      "maxLength": 61
+    },
+    "numberOfVms": {
+      "type": "int",
+      "defaultValue": 3,
+      "metadata": {
+        "description": "The number of VMs to deploy in each VMSS."
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
+    }
+  },
+  "variables": {
+    "virtualNetworkName": "[concat(parameters('dnsName'), '-vnet')]",
+    "subnetName": "Subnet-1",
+    "networkSecurityGroupName": "allowRemoting",
+    "publicIPAddressName": "lbPublicIp",
+    "publicIPAddressID": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
+    "frontEndIPConfigID": "[concat(variables('lbID'), '/frontendIPConfigurations/loadBalancerFrontEnd')]",
+    "lbName": "[concat('lb-', parameters('dnsName'))]",
+    "lbID": "[resourceId('Microsoft.Network/loadBalancers', variables('lbName'))]",
+    "lbBE": "lbBE",
+    "lbNAT": "lbNAT",
+    "myZones": [
+      "1",
+      "2",
+      "3"
+    ],
+    "linuxImage": {
+      "publisher": "Canonical",
+      "offer": "UbuntuServer",
+      "sku": "16.04.0-LTS",
+      "version": "latest"
+    },
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2017-08-01",
+      "name": "[variables('virtualNetworkName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('subnetName')]",
+            "properties": {
+              "addressPrefix": "10.0.0.0/24"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2016-03-30",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "remoteConnection",
+            "properties": {
+              "description": "Allow SSH traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 101,
+              "direction": "Inbound"
+            }
+          },
+          {
+            "name": "webTraffic",
+            "properties": {
+              "description": "Allow web traffic",
+              "protocol": "Tcp",
+              "sourcePortRange": "80",
+              "destinationPortRange": "80",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2017-08-01",
+      "name": "[variables('publicIPAddressName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "dnsSettings": {
+          "domainNameLabel": "[parameters('dnsName')]"
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/loadBalancers",
+      "apiVersion": "2017-08-01",
+      "name": "[variables('lbName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard"
+      },
+      "dependsOn": [
+        "[variables('publicIPAddressName')]"
+      ],
+      "properties": {
+        "frontendIPConfigurations": [
+          {
+            "name": "LoadBalancerFrontEnd",
+            "properties": {
+              "publicIPAddress": {
+                "id": "[variables('publicIPAddressID')]"
+              }
+            }
+          }
         ],
-        "linuxImage": {
-            "publisher": "Canonical",
-            "offer": "UbuntuServer",
-            "sku": "16.04.0-LTS",
-            "version": "latest"
-        }
+        "backendAddressPools": [
+          {
+            "name": "[variables('lbBE')]"
+          }
+        ],
+        "loadbalancingRules": [
+          {
+            "name": "lbrule1",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('frontendIPConfigID')]"
+              },
+              "backendaddressPool": {
+                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('lbName'), variables('lbBE'))]"
+              },
+              "protocol": "Tcp",
+              "frontendPort": 80,
+              "backendPort": 80,
+              "probe": {
+                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', variables('lbName')), '/probes/tcpProbe')]"
+              }
+            }
+          }
+        ],
+        "probes": [
+          {
+            "name": "tcpProbe",
+            "properties": {
+              "protocol": "Tcp",
+              "port": 80,
+              "intervalInSeconds": "5",
+              "numberOfProbes": "2"
+            }
+          }
+        ],
+        "inboundNatPools": [
+          {
+            "name": "[concat(variables('lbNAT'), '1')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('frontEndIPConfigID')]"
+              },
+              "protocol": "Tcp",
+              "frontendPortRangeStart": 50100,
+              "frontendPortRangeEnd": 50199,
+              "backendPort": 22
+            }
+          },
+          {
+            "name": "[concat(variables('lbNAT'), '2')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('frontEndIPConfigID')]"
+              },
+              "protocol": "Tcp",
+              "frontendPortRangeStart": 50200,
+              "frontendPortRangeEnd": 50299,
+              "backendPort": 22
+            }
+          },
+          {
+            "name": "[concat(variables('lbNAT'), '3')]",
+            "properties": {
+              "frontendIPConfiguration": {
+                "id": "[variables('frontEndIPConfigID')]"
+              },
+              "protocol": "Tcp",
+              "frontendPortRangeStart": 50300,
+              "frontendPortRangeEnd": 50399,
+              "backendPort": 22
+            }
+          }
+        ]
+      }
     },
-    "resources": [
-        {
-            "type": "Microsoft.Network/virtualNetworks",
-            "apiVersion": "2017-08-01",
-            "name": "[variables('virtualNetworkName')]",
-            "location": "[parameters('location')]",
-            "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "10.0.0.0/16"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('subnetName')]",
-                        "properties": {
-                            "addressPrefix": "10.0.0.0/24"
-                        }
-                    }
-                ]
-            }
+    {
+      "type": "Microsoft.Compute/virtualMachineScaleSets",
+      "apiVersion": "2017-03-30",
+      "name": "[concat('myScaleset','-zone', variables('myZones')[copyindex()])]",
+      "location": "[parameters('location')]",
+      "zones": [
+        "[variables('myZones')[copyindex()]]"
+      ],
+      "copy": {
+        "name": "VMSScount",
+        "count": "[length(variables('myZones'))]"
+      },
+      "dependsOn": [
+        "[variables('virtualNetworkName')]",
+        "[variables('lbName')]",
+        "[variables('networkSecurityGroupName')]"
+      ],
+      "sku": {
+        "name": "Standard_A2_v2",
+        "capacity": "[parameters('numberOfVms')]"
+      },
+      "properties": {
+        "singlePlacementGroup": true,
+        "upgradePolicy": {
+          "mode": "Manual"
         },
-        {
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "apiVersion": "2016-03-30",
-            "name": "[variables('networkSecurityGroupName')]",
-            "location": "[parameters('location')]",
-            "properties": {
-                "securityRules": [
-                    {
-                        "name": "remoteConnection",
-                        "properties": {
-                            "description": "Allow SSH traffic",
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "22",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 101,
-                            "direction": "Inbound"
-                        }
-                    },
-                    {
-                        "name": "webTraffic",
-                        "properties": {
-                            "description": "Allow web traffic",
-                            "protocol": "Tcp",
-                            "sourcePortRange": "80",
-                            "destinationPortRange": "80",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 100,
-                            "direction": "Inbound"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/publicIPAddresses",
-            "apiVersion": "2017-08-01",
-            "name": "[variables('publicIPAddressName')]",
-            "location": "[parameters('location')]",
-            "sku": {
-                "name": "Standard"
+        "virtualMachineProfile": {
+          "storageProfile": {
+            "osDisk": {
+              "createOption": "FromImage"
             },
-            "properties": {
-                "publicIPAllocationMethod": "Static",
-                "dnsSettings": {
-                    "domainNameLabel": "[parameters('dnsName')]"
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Network/loadBalancers",
-            "apiVersion": "2017-08-01",
-            "name": "[variables('lbName')]",
-            "location": "[parameters('location')]",
-            "sku": {
-                "name": "Standard"
-            },
-            "dependsOn": [
-                "[variables('publicIPAddressName')]"
-            ],
-            "properties": {
-                "frontendIPConfigurations": [
+            "imageReference": "[variables('linuxImage')]",
+            "dataDisks": [
+              {
+                "lun": 1,
+                "createOption": "Empty",
+                "diskSizeGB": 50
+              }
+            ]
+          },
+          "osProfile": {
+            "computerNamePrefix": "vm",
+            "adminUsername": "[parameters('adminUsername')]",
+            "adminPassword": "[parameters('adminPasswordOrKey')]",
+            "customData": "[base64(variables('myZones')[copyindex()])]",
+            "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
+          },
+          "networkProfile": {
+            "networkInterfaceConfigurations": [
+              {
+                "name": "myNic",
+                "properties": {
+                  "networkSecurityGroup": {
+                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+                  },
+                  "primary": true,
+                  "ipConfigurations": [
                     {
-                        "name": "LoadBalancerFrontEnd",
-                        "properties": {
-                            "publicIPAddress": {
-                                "id": "[variables('publicIPAddressID')]"
-                            }
-                        }
-                    }
-                ],
-                "backendAddressPools": [
-                    {
-                        "name": "[variables('lbBE')]"
-                    }
-                ],
-                "loadbalancingRules": [
-                    {
-                        "name": "lbrule1",
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[variables('frontendIPConfigID')]"
-                            },
-                            "backendaddressPool": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('lbName'), variables('lbBE'))]"
-                            },
-                            "protocol": "Tcp",
-                            "frontendPort": 80,
-                            "backendPort": 80,
-                            "probe": {
-                                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', variables('lbName')), '/probes/tcpProbe')]"
-                            }
-                        }
-                    }
-                ],
-                "probes": [
-                    {
-                        "name": "tcpProbe",
-                        "properties": {
-                            "protocol": "Tcp",
-                            "port": 80,
-                            "intervalInSeconds": "5",
-                            "numberOfProbes": "2"
-                        }
-                    }
-                ],
-                "inboundNatPools": [
-                    {
-                        "name": "[concat(variables('lbNAT'), '1')]",
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[variables('frontEndIPConfigID')]"
-                            },
-                            "protocol": "Tcp",
-                            "frontendPortRangeStart": 50100,
-                            "frontendPortRangeEnd": 50199,
-                            "backendPort": 22
-                        }
-                    },
-                    {
-                        "name": "[concat(variables('lbNAT'), '2')]",
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[variables('frontEndIPConfigID')]"
-                            },
-                            "protocol": "Tcp",
-                            "frontendPortRangeStart": 50200,
-                            "frontendPortRangeEnd": 50299,
-                            "backendPort": 22
-                        }
-                    },
-                    {
-                        "name": "[concat(variables('lbNAT'), '3')]",
-                        "properties": {
-                            "frontendIPConfiguration": {
-                                "id": "[variables('frontEndIPConfigID')]"
-                            },
-                            "protocol": "Tcp",
-                            "frontendPortRangeStart": 50300,
-                            "frontendPortRangeEnd": 50399,
-                            "backendPort": 22
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "type": "Microsoft.Compute/virtualMachineScaleSets",
-            "apiVersion": "2017-03-30",
-            "name": "[concat('myScaleset','-zone', variables('myZones')[copyindex()])]",
-            "location": "[parameters('location')]",
-            "zones": [
-                "[variables('myZones')[copyindex()]]"
-            ],
-            "copy": {
-                "name": "VMSScount",
-                "count": "[length(variables('myZones'))]"
-            },
-            "dependsOn": [
-                "[variables('virtualNetworkName')]",
-                "[variables('lbName')]",
-                "[variables('networkSecurityGroupName')]"
-            ],
-            "sku": {
-                "name": "Standard_A2_v2",
-                "capacity": "[parameters('numberOfVms')]"
-            },
-            "properties": {
-                "singlePlacementGroup": true,
-                "upgradePolicy": {
-                    "mode": "Manual"
-                },
-                "virtualMachineProfile": {
-                    "storageProfile": {
-                        "osDisk": {
-                            "createOption": "FromImage"
+                      "name": "myIpConfig",
+                      "properties": {
+                        "subnet": {
+                          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
                         },
-                        "imageReference": "[variables('linuxImage')]",
-                        "dataDisks": [
-                            {
-                                "lun": 1,
-                                "createOption": "Empty",
-                                "diskSizeGB": 50
-                            }
+                        "loadBalancerBackendAddressPools": [
+                          {
+                            "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('lbName'), variables('lbBE'))]"
+                          }
+                        ],
+                        "loadBalancerInboundNatPools": [
+                          {
+                            "id": "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('lbName'), concat(variables('lbNAT'), copyindex(1)))]"
+                          }
                         ]
-                    },
-                    "osProfile": {
-                        "computerNamePrefix": "vm",
-                        "adminUsername": "[parameters('adminUsername')]",
-                        "adminPassword": "[parameters('adminPassword')]",
-                        "customData": "[base64(variables('myZones')[copyindex()])]"
-                    },
-                    "networkProfile": {
-                        "networkInterfaceConfigurations": [
-                            {
-                                "name": "myNic",
-                                "properties": {
-                                    "networkSecurityGroup": {
-                                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
-                                    },
-                                    "primary": true,
-                                    "ipConfigurations": [
-                                        {
-                                            "name": "myIpConfig",
-                                            "properties": {
-                                                "subnet": {
-                                                    "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
-                                                },
-                                                "loadBalancerBackendAddressPools": [
-                                                    {
-                                                        "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('lbName'), variables('lbBE'))]"
-                                                    }
-                                                ],
-                                                "loadBalancerInboundNatPools": [
-                                                    {
-                                                        "id": "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('lbName'), concat(variables('lbNAT'), copyindex(1)))]"
-                                                    }
-                                                ]
-                                            }
-                                        }
-                                    ]
-                                }
-                            }
-                        ]
-                    },
-                    "extensionProfile": {
-                        "extensions": [
-                            {
-                                "name": "AppInstall",
-                                "properties": {
-                                    "publisher": "Microsoft.Azure.Extensions",
-                                    "type": "CustomScript",
-                                    "typeHandlerVersion": "2.0",
-                                    "autoUpgradeMinorVersion": true,
-                                    "settings": {
-                                        "fileUris": [
-                                            "https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/automate_nginx.sh"
-                                        ],
-                                        "commandToExecute": "bash automate_nginx.sh"
-                                    }
-                                }
-                            }
-                        ]
+                      }
                     }
+                  ]
                 }
-            }
+              }
+            ]
+          },
+          "extensionProfile": {
+            "extensions": [
+              {
+                "name": "AppInstall",
+                "properties": {
+                  "publisher": "Microsoft.Azure.Extensions",
+                  "type": "CustomScript",
+                  "typeHandlerVersion": "2.0",
+                  "autoUpgradeMinorVersion": true,
+                  "settings": {
+                    "fileUris": [
+                      "https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/automate_nginx.sh"
+                    ],
+                    "commandToExecute": "bash automate_nginx.sh"
+                  }
+                }
+              }
+            ]
+          }
         }
-    ]
+      }
+    }
+  ]
 }

--- a/301-multi-vmss-linux-lb-zones/azuredeploy.parameters.json
+++ b/301-multi-vmss-linux-lb-zones/azuredeploy.parameters.json
@@ -1,15 +1,15 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-	"dnsName": {
-            "value": "GEN-UNIQUE"
-	},
-	"adminUsername": {
-			"value": "GEN-UNIQUE"
-	},
-	"adminPassword": {
-            "value": "GEN-PASSWORD"
-		}
-	}
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "dnsName": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminUsername": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
+    }
+  }
 }

--- a/301-multi-vmss-linux-lb-zones/metadata.json
+++ b/301-multi-vmss-linux-lb-zones/metadata.json
@@ -5,6 +5,5 @@
   "description": "This template creates a VMSS placed in separate Availability Zones with a load balancer.",
   "summary": "This template creates a VMSS placed in separate Availability Zones with a load balancer.",
   "githubUsername": "aaronlower",
-  "dateUpdated": "2017-09-21"
+  "dateUpdated": "2019-12-06"
 }
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
