### PR TITLE
Add SSH Auth to gluster-file-system

### DIFF
--- a/gluster-file-system/azuredeploy.json
+++ b/gluster-file-system/azuredeploy.json
@@ -31,12 +31,6 @@
         "description": "ssh user name"
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "ssh password"
-      }
-    },
     "vmSize": {
       "type": "string",
       "defaultValue": "Standard_A1",
@@ -116,6 +110,23 @@
         "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
       },
       "defaultValue": ""
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -139,7 +150,18 @@
       }
     },
     "customScriptFilePath": "[uri(parameters('_artifactsLocation'), concat('azuregfs.sh', parameters('_artifactsLocationSasToken')))]",
-    "customScriptCommandToExecute": "bash azuregfs.sh"
+    "customScriptCommandToExecute": "bash azuregfs.sh",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -226,19 +248,19 @@
         "osProfile": {
           "computerName": "[concat(parameters('vmNamePrefix'), copyIndex())]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": "[variables('imageReference')[parameters('hostOS')]]",
-            "osDisk": {
+          "osDisk": {
             "name": "[concat(parameters('vmNamePrefix'), copyIndex(), '_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage",
             "managedDisk": {
-                "storageAccountType": "Standard_LRS"
+              "storageAccountType": "Standard_LRS"
             }
-        },
-        
+          },
           "dataDisks": [
             {
               "name": "[concat(parameters('vmNamePrefix'), copyIndex(), '_DataDisk1')]",

--- a/gluster-file-system/azuredeploy.parameters.json
+++ b/gluster-file-system/azuredeploy.parameters.json
@@ -5,8 +5,8 @@
     "adminUsername": {
       "value": "GEN-UNIQUE"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/gluster-file-system/metadata.json
+++ b/gluster-file-system/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template deploys a 2, 4, 6, or 8 node Gluster File System with 2 replicas on Ubuntu",
   "summary": "deploys a 2, 4, 6, or 8 node Gluster File System with 2 replicas on Ubuntu, each node has 2 disks stripped into raid0",
   "githubUsername": "liupeirong",
-  "dateUpdated": "2018-07-03"
+  "dateUpdated": "2019-12-09"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
