### PR TITLE
fixed typo

### DIFF
--- a/monitor-servicehealth-alert/azuredeploy.json
+++ b/monitor-servicehealth-alert/azuredeploy.json
@@ -71,7 +71,7 @@
         "condition": {
           "allOf": [
             {
-              "field": "Category",
+              "field": "category",
               "equals": "ServiceHealth"
             }
           ]

--- a/monitor-servicehealth-alert/azuredeploy.json
+++ b/monitor-servicehealth-alert/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "actionGroupName": {
@@ -37,22 +37,18 @@
   "resources": [
     {
       "type": "Microsoft.Insights/actionGroups",
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2019-06-01",
       "name": "[parameters('actionGroupName')]",
       "location": "Global",
       "properties": {
         "groupShortName": "[parameters('actionGroupShortName')]",
         "enabled": true,
-        "smsReceivers": [
-        ],
         "emailReceivers": [
           {
             "name": "emailReceiver",
             "emailAddress": "[parameters('emailAddress')]"
           }
         ],
-        "webhookReceivers": [
-        ]
       }
     },
     {


### PR DESCRIPTION
I think that this file has a typo.
We cannot deploy in case of "Category" in "condition" field.
But when we changed "Category" to "category", we can deploy this resource.

without this change, following alert is occured.
Deployment failed. Correlation ID: c180e936-8344-499e-8e48-ade0b3edc3c6. {
  "Code": "UnsupportedCondition",
  "Message": "The category field is missing in the condition."
}