### PR TITLE
Fix reference to adminPassword in 301-drupal8-vmss-glusterfs-mysql

### DIFF
--- a/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
+++ b/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
@@ -504,14 +504,8 @@
           "hostOs": {
             "value": "[variables('glusterOS')]"
           },
-          "storageAccountName": {
-            "value": "[variables('glusterStorageAccountName')]"
-          },
           "scaleNumber": {
             "value": "[parameters('glusterInstanceCount')]"
-          },
-          "virtualNetworkName": {
-            "value": "[variables('glusterVnetName')]"
           },
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
@@ -528,9 +522,6 @@
           "vmNamePrefix": {
             "value": "[variables('glusterVMNamePrefix')]"
           },
-          "vmIPPrefix": {
-            "value": "[variables('glusterVMIPPrefix')]"
-          },
           "vnetAddressPrefix": {
             "value": "[variables('glusterVnetAddressPrefix')]"
           },
@@ -539,12 +530,6 @@
           },
           "gfsSubnetPrefix": {
             "value": "[variables('glusterSubnetPrefix')]"
-          },
-          "customScriptFilePath": {
-            "value": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/gluster-file-system/azuregfs.sh"
-          },
-          "customScriptCommandToExecute": {
-            "value": "bash azuregfs.sh"
           },
           "volumeName": {
             "value": "gfsvol"

--- a/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
+++ b/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
@@ -418,8 +418,11 @@
           "vmUserName": {
             "value": "[parameters('newMySqlVmUserName')]"
           },
-          "vmPassword": {
-            "value": "[parameters('newMySqlVmPassword')]"
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
           },
           "mysqlRootPassword": {
             "value": "[parameters('mysqlUserPassword')]"

--- a/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
+++ b/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
@@ -153,14 +153,6 @@
         "description": "file location for gluster template"
       }
     },
-    "templateLocation": {
-      "type": "string",
-      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/301-drupal8-vmss-glusterfs-mysql",
-      "metadata": {
-        "description": "template file location",
-        "artifactsBaseUrl": "Base URL of the Publisher Template gallery package"
-      }
-    },
     "storageAccountNamePrefix": {
       "type": "string",
       "defaultValue": "drustoacc",
@@ -204,6 +196,20 @@
       "metadata": {
         "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
+    },
+    "_artifactsLocation": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/301-drupal8-vmss-glusterfs-mysql/",
+      "metadata": {
+        "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+      }
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+      },
+      "defaultValue": ""
     }
   },
   "variables": {
@@ -399,7 +405,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('templateLocation'), '/nested/mysql-resources_',parameters('createNewMySQLServer'),'.json')]",
+          "uri": "[uri(parameters('_artifactsLocation'), concat('nested/mysql-resources_',parameters('createNewMySQLServer'),'.json', parameters('_artifactsLocationSasToken')))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -613,7 +619,7 @@
                   "autoUpgradeMinorVersion": true,
                   "settings": {
                     "fileUris": [
-                      "[concat(parameters('templateLocation'),'/scripts/install_drupal.sh')]"
+                      "[uri(parameters('_artifactsLocation'), concat('scripts/install_drupal.sh', parameters('_artifactsLocationSasToken')))]"
                     ],
                     "commandToExecute": "[concat('sudo bash install_drupal.sh -d ',parameters('drupalVersion') ,' -u ',parameters('drupalAdminUser'),' -p ',parameters('drupalAdminPassword') ,' -g ',variables('glusterVMNamePrefix'),'0 -v gfsvol -s ', parameters('existingMySqlFQDN'),' -n ', parameters('existingMysqlUser'),' -P ', parameters('mysqlUserPassword'),' -k ',parameters('drupalInstallationDatabaseName'),' -z ',parameters('createNewMySQLServer'),' -S ',parameters('newMySqlDnsLabelPrefix'), '.', variables('location'), '.cloudapp.azure.com')]"
                   }

--- a/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
+++ b/301-drupal8-vmss-glusterfs-mysql/azuredeploy.json
@@ -516,8 +516,11 @@
           "adminUsername": {
             "value": "[parameters('adminUsername')]"
           },
-          "adminPassword": {
-            "value": "[parameters('adminPassword')]"
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
           },
           "vmSize": {
             "value": "[parameters('glusterVMSize')]"

--- a/301-drupal8-vmss-glusterfs-mysql/azuredeploy.parameters.json
+++ b/301-drupal8-vmss-glusterfs-mysql/azuredeploy.parameters.json
@@ -62,9 +62,6 @@
     "glusterTemplateLocation": {
       "value": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/gluster-file-system/"
     },
-    "templateLocation": {
-      "value": "https://raw.githubusercontent.com/maniSbindra/azure-quickstart-templates/master/301-drupal8-vmss-glusterfs-mysql"
-    },
     "storageAccountNamePrefix": {
       "value": "dru611stacc"
     },

--- a/301-drupal8-vmss-glusterfs-mysql/metadata.json
+++ b/301-drupal8-vmss-glusterfs-mysql/metadata.json
@@ -5,5 +5,5 @@
   "description": "Deploy a VM Scale Set behind a load balancer/NAT & each VM running  Drupal (Apache / PHP). All nodes share the created glusterfs file storage, and MySQL database",
   "summary": "Deploy a VM Scale Set behind a load balancer/NAT & each VM running  Drupal (Apache / PHP). All nodes share the created glusterfs file storage, and MySQL database",
   "githubUsername": "manisbindra",
-  "dateUpdated": "2019-08-10"
+  "dateUpdated": "2019-12-10"
 }

--- a/301-drupal8-vmss-glusterfs-mysql/nested/mysql-resources_no.json
+++ b/301-drupal8-vmss-glusterfs-mysql/nested/mysql-resources_no.json
@@ -21,12 +21,6 @@
         "description": "user name to ssh to the VMs"
       }
     },
-    "vmPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "password to ssh to the VMs"
-      }
-    },
     "mysqlRootPassword": {
       "type": "securestring",
       "metadata": {
@@ -211,6 +205,23 @@
       "type": "string",
       "metadata": {
         "description": "Storage account name prefix for the cluster"
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
     }
   },

--- a/301-drupal8-vmss-glusterfs-mysql/nested/mysql-resources_yes.json
+++ b/301-drupal8-vmss-glusterfs-mysql/nested/mysql-resources_yes.json
@@ -251,7 +251,7 @@
           "vmSize": {
             "value": "[parameters('vmSize')]"
           },
-          "storageAccountType": {
+          "diskType": {
             "value": "[parameters('storageAccountType')]"
           },
           "virtualNetworkName": {

--- a/301-drupal8-vmss-glusterfs-mysql/nested/mysql-resources_yes.json
+++ b/301-drupal8-vmss-glusterfs-mysql/nested/mysql-resources_yes.json
@@ -21,12 +21,6 @@
         "description": "user name to ssh to the VMs"
       }
     },
-    "vmPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "password to ssh to the VMs"
-      }
-    },
     "mysqlRootPassword": {
       "type": "securestring",
       "metadata": {
@@ -212,6 +206,23 @@
       "metadata": {
         "description": "Storage account name prefix for the cluster"
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -236,8 +247,11 @@
           "vmUserName": {
             "value": "[parameters('vmUserName')]"
           },
-          "vmPassword": {
-            "value": "[parameters('vmPassword')]"
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
           },
           "mysqlRootPassword": {
             "value": "[parameters('mysqlRootPassword')]"


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Fix reference to adminPassword in 301-drupal8-vmss-glusterfs-mysql
*
*

