### PR TITLE
Adding Network Security Group to 101-vm-multiple-data-disk

### DIFF
--- a/101-vm-multiple-data-disk/azuredeploy.json
+++ b/101-vm-multiple-data-disk/azuredeploy.json
@@ -57,7 +57,8 @@
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
     "nicName": "myNIC",
     "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
-    "apiVersion": "2015-06-15"
+    "apiVersion": "2015-06-15",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -82,10 +83,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -96,7 +124,10 @@
           {
             "name": "[variables('subnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
+              "addressPrefix": "[variables('subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/101-vm-multiple-data-disk/azuredeploy.parameters.json
+++ b/101-vm-multiple-data-disk/azuredeploy.parameters.json
@@ -1,21 +1,21 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "adminUsername": {
-            "value": "GEN-UNIQUE"
-        },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "dnsLabelPrefix": {
-            "value": "GEN-UNIQUE"
-        },
-        "vmSize": {
-            "value": "Standard_D3"
-        },
-        "sizeOfEachDataDiskInGB": {
-            "value": "100"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "dnsLabelPrefix": {
+      "value": "GEN-UNIQUE"
+    },
+    "vmSize": {
+      "value": "Standard_D3"
+    },
+    "sizeOfEachDataDiskInGB": {
+      "value": "100"
     }
+  }
 }

--- a/101-vm-multiple-data-disk/metadata.json
+++ b/101-vm-multiple-data-disk/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to create a Windows Virtual Machine from a specified image. It also attaches 4 empty data disks. Note that you can specify the size of the empty data disks.",
   "summary": "Create a VM from a Windows Image with 4 Empty Data Disks",
   "githubUsername": "kenazk",
-  "dateUpdated": "2015-12-22"
+  "dateUpdated": "2019-12-11"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-vm-multiple-data-disk

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
myVM | Tcp | 135 | svchost.exe
myVM | Tcp | 445 | 
myVM | Tcp | 3389 | svchost.exe
myVM | Tcp | 5985 | 
myVM | Tcp | 47001 | 
myVM | Tcp | 49152 | wininit.exe
myVM | Tcp | 49153 | svchost.exe
myVM | Tcp | 49155 | svchost.exe
myVM | Tcp | 49156 | lsass.exe
myVM | Tcp | 49157 | services.exe
myVM | Udp | 3389 | svchost.exe
myVM | Udp | 5355 | svchost.exe
