### PR TITLE
Adding Network Security Group to 201-vnet-2subnets-service-endpoints-storage-integration

### DIFF
--- a/201-vnet-2subnets-service-endpoints-storage-integration/azuredeploy.json
+++ b/201-vnet-2subnets-service-endpoints-storage-integration/azuredeploy.json
@@ -84,14 +84,55 @@
     "subnetId": [
       "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnet1Name'))]",
       "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnet2Name'))]"
-    ]
+    ],
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
+    {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          },
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1001,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
     {
       "apiVersion": "2017-09-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('vnetName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -107,7 +148,10 @@
                 {
                   "service": "Microsoft.Storage"
                 }
-              ]
+              ],
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           },
           {
@@ -122,7 +166,7 @@
     {
       "apiVersion": "2017-09-01",
       "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
+      "name": "[concat(variables('publicIPAddressName'), 0)]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "pipLoop",
@@ -135,7 +179,7 @@
     {
       "apiVersion": "2016-10-01",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat('nic', copyIndex())]",
+      "name": "[concat('nic', 0)]",
       "location": "[parameters('location')]",
       "dependsOn": [
         "[parameters('vnetName')]",
@@ -152,10 +196,10 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[variables('subnetId')[copyIndex()]]"
+                "id": "[variables('subnetId')[0]]"
               },
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), copyIndex()))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), 0))]"
               }
             }
           }
@@ -203,7 +247,7 @@
     {
       "apiVersion": "2017-03-30",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmName'), copyIndex())]",
+      "name": "[concat(variables('vmName'), 0)]",
       "location": "[parameters('location')]",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
@@ -222,7 +266,7 @@
           "vmSize": "Standard_A1"
         },
         "osProfile": {
-          "computername": "[concat(variables('vmName'), copyIndex())]",
+          "computername": "[concat(variables('vmName'), 0)]",
           "adminUsername": "[parameters('adminUserName')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -244,7 +288,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat('nic',copyIndex()))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat('nic',0))]"
             }
           ]
         }

--- a/201-vnet-2subnets-service-endpoints-storage-integration/azuredeploy.json
+++ b/201-vnet-2subnets-service-endpoints-storage-integration/azuredeploy.json
@@ -108,19 +108,6 @@
               "sourcePortRange": "*",
               "destinationAddressPrefix": "*"
             }
-          },
-          {
-            "name": "default-allow-3389",
-            "properties": {
-              "priority": 1001,
-              "access": "Allow",
-              "direction": "Inbound",
-              "destinationPortRange": "3389",
-              "protocol": "Tcp",
-              "sourceAddressPrefix": "*",
-              "sourcePortRange": "*",
-              "destinationAddressPrefix": "*"
-            }
           }
         ]
       }
@@ -166,7 +153,7 @@
     {
       "apiVersion": "2017-09-01",
       "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[concat(variables('publicIPAddressName'), 0)]",
+      "name": "[concat(variables('publicIPAddressName'), copyIndex())]",
       "location": "[parameters('location')]",
       "copy": {
         "name": "pipLoop",
@@ -179,7 +166,7 @@
     {
       "apiVersion": "2016-10-01",
       "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat('nic', 0)]",
+      "name": "[concat('nic', copyIndex())]",
       "location": "[parameters('location')]",
       "dependsOn": [
         "[parameters('vnetName')]",
@@ -196,10 +183,10 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[variables('subnetId')[0]]"
+                "id": "[variables('subnetId')[copyIndex()]]"
               },
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), 0))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), copyIndex()))]"
               }
             }
           }
@@ -247,7 +234,7 @@
     {
       "apiVersion": "2017-03-30",
       "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmName'), 0)]",
+      "name": "[concat(variables('vmName'), copyIndex())]",
       "location": "[parameters('location')]",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
@@ -266,7 +253,7 @@
           "vmSize": "Standard_A1"
         },
         "osProfile": {
-          "computername": "[concat(variables('vmName'), 0)]",
+          "computername": "[concat(variables('vmName'), copyIndex())]",
           "adminUsername": "[parameters('adminUserName')]",
           "adminPassword": "[parameters('adminPassword')]"
         },
@@ -288,7 +275,7 @@
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat('nic',0))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', concat('nic',copyIndex()))]"
             }
           ]
         }

--- a/201-vnet-2subnets-service-endpoints-storage-integration/metadata.json
+++ b/201-vnet-2subnets-service-endpoints-storage-integration/metadata.json
@@ -5,6 +5,5 @@
   "description": "Creates 2 new VMs with a NIC each, in two different subnets within the same VNet. Sets service endpoint on one of the subnets and secures storage account to that subnet.",
   "summary": "Sets service endpoint on one of the 2 subnets in a VNet and secures storage account to that subnet",
   "githubUsername": "anithaadusumilli",
-  "dateUpdated": "2017-09-17"
+  "dateUpdated": "2019-12-11"
 }
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vnet-2subnets-service-endpoints-storage-integration

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
testvm0 | Tcp | 135 | svchost.exe
testvm0 | Tcp | 445 | 
testvm0 | Tcp | 3389 | svchost.exe
testvm0 | Tcp | 5985 | 
testvm0 | Tcp | 47001 | 
testvm0 | Tcp | 49664 | 
testvm0 | Tcp | 49665 | lsass.exe
testvm0 | Tcp | 49666 | svchost.exe
testvm0 | Tcp | 49668 | svchost.exe
testvm0 | Tcp | 49669 | spoolsv.exe
testvm0 | Tcp | 49670 | 
testvm0 | Udp | 123 | svchost.exe
testvm0 | Udp | 3389 | svchost.exe
testvm0 | Udp | 5050 | svchost.exe
testvm0 | Udp | 5353 | svchost.exe
testvm0 | Udp | 5355 | svchost.exe
testvm1 | Tcp | 135 | svchost.exe
testvm1 | Tcp | 445 | 
testvm1 | Tcp | 3389 | svchost.exe
testvm1 | Tcp | 5985 | 
testvm1 | Tcp | 47001 | 
testvm1 | Tcp | 49664 | 
testvm1 | Tcp | 49665 | lsass.exe
testvm1 | Tcp | 49666 | svchost.exe
testvm1 | Tcp | 49668 | svchost.exe
testvm1 | Tcp | 49669 | spoolsv.exe
testvm1 | Tcp | 49670 | 
testvm1 | Udp | 123 | svchost.exe
testvm1 | Udp | 3389 | svchost.exe
testvm1 | Udp | 5050 | svchost.exe
testvm1 | Udp | 5353 | svchost.exe
testvm1 | Udp | 5355 | svchost.exe
