### PR TITLE
Adding Network Security Group to 201-web-app-vm-dsc

### DIFF
--- a/201-web-app-vm-dsc/azuredeploy.json
+++ b/201-web-app-vm-dsc/azuredeploy.json
@@ -132,7 +132,8 @@
     "subnet2Prefix": "10.0.1.0/24",
     "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',variables('subnet1Name'))]",
     "publicIPAddressName": "[concat(parameters('vmName'), '-PublicIP-VM')]",
-    "storageAccountType": "Standard_LRS"
+    "storageAccountType": "Standard_LRS",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -151,10 +152,50 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-80",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "80",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          },
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1001,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "tags": {
         "displayName": "VirtualNetwork"
       },
@@ -168,7 +209,10 @@
           {
             "name": "[variables('subnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
+              "addressPrefix": "[variables('subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           },
           {
@@ -210,7 +254,7 @@
       }
     },
     {
-      "apiVersion": "2017-03-30", 
+      "apiVersion": "2017-03-30",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",
@@ -237,8 +281,7 @@
             "version": "latest"
           },
           "osDisk": {
-           
-           "name": "[concat(parameters('vmName'),'_OSDisk')]", 
+            "name": "[concat(parameters('vmName'),'_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           }

--- a/201-web-app-vm-dsc/azuredeploy.parameters.json
+++ b/201-web-app-vm-dsc/azuredeploy.parameters.json
@@ -1,45 +1,45 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "vmName": {
-            "value": "GEN-UNIQUE-10"
-        },
-        "adminUsername": {
-            "value": "GEN-UNIQUE-8"
-        },
-        "dnsName": {
-            "value": "GEN-UNIQUE-10"
-        },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "webdeploypkg": {
-            "value": "https://github.com/Azure/azure-quickstart-templates/raw/master/201-web-app-vm-dsc/WebApplication3.zip"
-        },
-        "configurationFunction": {
-            "value": "ConfigureWebServer.ps1\\Main"
-        },
-        "DatabaseServerName": {
-            "value": "GEN-UNIQUE"
-        },
-        "DatabaseServerLocation": {
-            "value": "westus"
-        },
-        "databaseServerAdminLogin": {
-            "value": "GEN-UNIQUE-8"
-        },
-        "databaseServerAdminLoginPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "databaseName": {
-            "value": "GEN-UNIQUE"
-        },
-        "databaseEdition": {
-            "value": "Basic"
-        },
-        "modulesUrl": {
-            "value": "https://github.com/Azure/azure-quickstart-templates/raw/master/201-web-app-vm-dsc/ConfigureWebServer.ps1.zip"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "vmName": {
+      "value": "GEN-UNIQUE-10"
+    },
+    "adminUsername": {
+      "value": "GEN-UNIQUE-8"
+    },
+    "dnsName": {
+      "value": "GEN-UNIQUE-10"
+    },
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "webdeploypkg": {
+      "value": "https://github.com/Azure/azure-quickstart-templates/raw/master/201-web-app-vm-dsc/WebApplication3.zip"
+    },
+    "configurationFunction": {
+      "value": "ConfigureWebServer.ps1\\Main"
+    },
+    "DatabaseServerName": {
+      "value": "GEN-UNIQUE"
+    },
+    "DatabaseServerLocation": {
+      "value": "westus"
+    },
+    "databaseServerAdminLogin": {
+      "value": "GEN-UNIQUE-8"
+    },
+    "databaseServerAdminLoginPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "databaseName": {
+      "value": "GEN-UNIQUE"
+    },
+    "databaseEdition": {
+      "value": "Basic"
+    },
+    "modulesUrl": {
+      "value": "https://github.com/Azure/azure-quickstart-templates/raw/master/201-web-app-vm-dsc/ConfigureWebServer.ps1.zip"
     }
+  }
 }

--- a/201-web-app-vm-dsc/metadata.json
+++ b/201-web-app-vm-dsc/metadata.json
@@ -5,7 +5,5 @@
   "description": "Create and configure a Windows VM with SQL Azure database, and deploy web application to the environment using PowerShell DSC",
   "summary": "This template creates a VM with webdeploy enabled, and deploys the Web Application using DSC extension",
   "githubUsername": "cawams",
-  "dateUpdated":  "2018-08-15" 
+  "dateUpdated": "2019-12-11"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-web-app-vm-dsc

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
cia7e0a976 | Tcp | 80 | 
cia7e0a976 | Tcp | 135 | svchost.exe
cia7e0a976 | Tcp | 445 | 
cia7e0a976 | Tcp | 3389 | svchost.exe
cia7e0a976 | Tcp | 5985 | 
cia7e0a976 | Tcp | 47001 | 
cia7e0a976 | Tcp | 49152 | wininit.exe
cia7e0a976 | Tcp | 49153 | svchost.exe
cia7e0a976 | Tcp | 49154 | svchost.exe
cia7e0a976 | Tcp | 49155 | spoolsv.exe
cia7e0a976 | Tcp | 49157 | lsass.exe
cia7e0a976 | Tcp | 49162 | 
cia7e0a976 | Udp | 123 | svchost.exe
cia7e0a976 | Udp | 3389 | svchost.exe
cia7e0a976 | Udp | 5355 | svchost.exe
