### PR TITLE
Adding Network Security Group to 301-vm-32-data-disks-high-iops

### DIFF
--- a/301-vm-32-data-disks-high-iops/azuredeploy.json
+++ b/301-vm-32-data-disks-high-iops/azuredeploy.json
@@ -49,7 +49,6 @@
       "metadata": {
         "description": "The number of data disks to include in the storage pool."
       }
-
     },
     "dnsName": {
       "type": "string",
@@ -111,7 +110,8 @@
     "configurationFunction": "StoragePool.ps1\\StoragePool",
     "modulesUrl": "[uri(parameters('_artifactsLocation'), 'DSC/StoragePool.zip')]",
     "DscExtensionName": "DscExtension",
-    "subnet1Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'),variables('subnet1Name'))]"
+    "subnet1Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'),variables('subnet1Name'))]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -127,10 +127,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2018-04-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -141,7 +168,10 @@
           {
             "name": "[variables('subnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
+              "addressPrefix": "[variables('subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/301-vm-32-data-disks-high-iops/metadata.json
+++ b/301-vm-32-data-disks-high-iops/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template creates a Standard D14 VM with 32 data disks attached.  Using DSC they are automatically striped per best practices to get maximum IOPS and formatted into a single volume.",
   "summary": "Create a Standard D14 VM from 32 Data Disks configured for high IOPS",
   "githubUsername": "jvallery",
-  "dateUpdated": "2018-07-02"
+  "dateUpdated": "2019-12-11"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 301-vm-32-data-disks-high-iops

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
vm-high-iops | Tcp | 135 | svchost.exe
vm-high-iops | Tcp | 445 | 
vm-high-iops | Tcp | 3389 | svchost.exe
vm-high-iops | Tcp | 5985 | 
vm-high-iops | Tcp | 47001 | 
vm-high-iops | Tcp | 49664 | 
vm-high-iops | Tcp | 49665 | lsass.exe
vm-high-iops | Tcp | 49666 | svchost.exe
vm-high-iops | Tcp | 49668 | svchost.exe
vm-high-iops | Tcp | 49669 | spoolsv.exe
vm-high-iops | Tcp | 49670 | 
vm-high-iops | Udp | 123 | svchost.exe
vm-high-iops | Udp | 3389 | svchost.exe
vm-high-iops | Udp | 5050 | svchost.exe
vm-high-iops | Udp | 5353 | svchost.exe
vm-high-iops | Udp | 5355 | svchost.exe
