### PR TITLE
Adding Network Security Group to dsc-extension-iis-server-windows-vm

### DIFF
--- a/dsc-extension-iis-server-windows-vm/azuredeploy.json
+++ b/dsc-extension-iis-server-windows-vm/azuredeploy.json
@@ -83,7 +83,8 @@
     "nicName": "dscNIC",
     "imagePublisher": "MicrosoftWindowsServer",
     "imageOffer": "WindowsServer",
-    "vmExtensionName": "dscExtension"
+    "vmExtensionName": "dscExtension",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -96,10 +97,50 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-80",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "80",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          },
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1001,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -110,7 +151,10 @@
           {
             "name": "[variables('subnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
+              "addressPrefix": "[variables('subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/dsc-extension-iis-server-windows-vm/azuredeploy.parameters.json
+++ b/dsc-extension-iis-server-windows-vm/azuredeploy.parameters.json
@@ -1,30 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "diskType": {
-            "value": "Standard_LRS"
-        },
-        "vmName": {
-            "value": "GEN-UNIQUE-8"
-        },
-        "vmSize": {
-            "value": "Standard_A2"
-        },
-        "imageSKU": {
-            "value": "2012-R2-Datacenter"
-        },
-        "adminUsername": {
-            "value": "GEN-UNIQUE"
-        },
-        "adminPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "modulesUrl": {
-            "value": "https://github.com/Azure/azure-quickstart-templates/raw/master/dsc-extension-iis-server-windows-vm/ContosoWebsite.ps1.zip"
-        },
-        "configurationFunction": {
-            "value": "ContosoWebsite.ps1\\ContosoWebsite"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "diskType": {
+      "value": "Standard_LRS"
+    },
+    "vmName": {
+      "value": "GEN-UNIQUE-8"
+    },
+    "vmSize": {
+      "value": "Standard_A2"
+    },
+    "imageSKU": {
+      "value": "2012-R2-Datacenter"
+    },
+    "adminUsername": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "modulesUrl": {
+      "value": "https://github.com/Azure/azure-quickstart-templates/raw/master/dsc-extension-iis-server-windows-vm/ContosoWebsite.ps1.zip"
+    },
+    "configurationFunction": {
+      "value": "ContosoWebsite.ps1\\ContosoWebsite"
     }
+  }
 }

--- a/dsc-extension-iis-server-windows-vm/metadata.json
+++ b/dsc-extension-iis-server-windows-vm/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template creates a Windows VM and sets up an IIS server using the DSC extension. NOTE: The DSC configuration module needs a SAS token to be passed in if you're using Azure Storage. For DSC module link from Github (default in this template), this is not needed.",
   "summary": "This template creates a VM with IIS server using DSC extension",
   "githubUsername": "singhkays",
-  "dateUpdated": "2018-05-19"
+  "dateUpdated": "2019-12-11"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to dsc-extension-iis-server-windows-vm

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
cie254f8 | Tcp | 80 | 
cie254f8 | Tcp | 135 | svchost.exe
cie254f8 | Tcp | 445 | 
cie254f8 | Tcp | 3389 | svchost.exe
cie254f8 | Tcp | 5985 | 
cie254f8 | Tcp | 47001 | 
cie254f8 | Tcp | 49152 | wininit.exe
cie254f8 | Tcp | 49153 | svchost.exe
cie254f8 | Tcp | 49154 | svchost.exe
cie254f8 | Tcp | 49155 | spoolsv.exe
cie254f8 | Tcp | 49161 | lsass.exe
cie254f8 | Tcp | 49163 | 
cie254f8 | Udp | 123 | svchost.exe
cie254f8 | Udp | 3389 | svchost.exe
cie254f8 | Udp | 5355 | svchost.exe
