### PR TITLE
Adding Network Security Group to dsc-pullserver-to-win-server

### DIFF
--- a/dsc-pullserver-to-win-server/azuredeploy.json
+++ b/dsc-pullserver-to-win-server/azuredeploy.json
@@ -92,7 +92,8 @@
     "deployDSCPullServerConfigurationFunction": "ConfigurePullServer.ps1\\ConfigurePullServer",
     "windowsOSVersion": "2012-R2-Datacenter",
     "imagePublisher": "MicrosoftWindowsServer",
-    "imageOffer": "WindowsServer"
+    "imageOffer": "WindowsServer",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -109,11 +110,50 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-80",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "80",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          },
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1001,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "dscVirtualNetwork",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[parameters('location')]",
       "apiVersion": "2015-05-01-preview",
-      "dependsOn": [],
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "tags": {
         "displayName": "VirtualNetwork"
       },
@@ -127,7 +167,10 @@
           {
             "name": "[variables('VirtualNetworkSubnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('VirtualNetworkSubnet1Prefix')]"
+              "addressPrefix": "[variables('VirtualNetworkSubnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           },
           {
@@ -172,7 +215,7 @@
       "name": "[parameters('dscPullSrvName')]",
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[parameters('location')]",
-      "apiVersion": "2017-03-30", 
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "[concat('Microsoft.Storage/storageAccounts/', parameters('newStorageAccount'))]",
         "[concat('Microsoft.Network/networkInterfaces/', variables('dscPullSrvNicName'))]"
@@ -197,7 +240,7 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "[concat(parameters('dscPullSrvName'),'_OSDisk')]", 
+            "name": "[concat(parameters('dscPullSrvName'),'_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           }

--- a/dsc-pullserver-to-win-server/metadata.json
+++ b/dsc-pullserver-to-win-server/metadata.json
@@ -5,7 +5,5 @@
   "description": "This example allows to you deploy a powershell desired state configuration pull server.",
   "summary": "This template serves as a powershell dsc pull server reference",
   "githubUsername": "tcsatheesh",
-  "dateUpdated": "2018-08-01" 
+  "dateUpdated": "2019-12-12"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to dsc-pullserver-to-win-server

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
PullSrv | Tcp | 80 | 
PullSrv | Tcp | 135 | svchost.exe
PullSrv | Tcp | 445 | 
PullSrv | Tcp | 3389 | svchost.exe
PullSrv | Tcp | 5985 | 
PullSrv | Tcp | 8080 | 
PullSrv | Tcp | 9080 | 
PullSrv | Tcp | 47001 | 
PullSrv | Tcp | 49152 | wininit.exe
PullSrv | Tcp | 49153 | svchost.exe
PullSrv | Tcp | 49154 | svchost.exe
PullSrv | Tcp | 49155 | spoolsv.exe
PullSrv | Tcp | 49161 | lsass.exe
PullSrv | Tcp | 49163 | 
PullSrv | Udp | 123 | svchost.exe
PullSrv | Udp | 3389 | svchost.exe
PullSrv | Udp | 5355 | svchost.exe
