### PR TITLE
Adding Network Security Group to gluster-file-system

### DIFF
--- a/gluster-file-system/azuredeploy.json
+++ b/gluster-file-system/azuredeploy.json
@@ -161,14 +161,42 @@
           }
         ]
       }
-    }
+    },
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
+    {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-22",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "22",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
     {
       "apiVersion": "2018-04-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -179,7 +207,10 @@
           {
             "name": "[parameters('gfsSubnetName')]",
             "properties": {
-              "addressPrefix": "[parameters('gfsSubnetPrefix')]"
+              "addressPrefix": "[parameters('gfsSubnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/gluster-file-system/metadata.json
+++ b/gluster-file-system/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template deploys a 2, 4, 6, or 8 node Gluster File System with 2 replicas on Ubuntu",
   "summary": "deploys a 2, 4, 6, or 8 node Gluster File System with 2 replicas on Ubuntu, each node has 2 disks stripped into raid0",
   "githubUsername": "liupeirong",
-  "dateUpdated": "2019-12-09"
+  "dateUpdated": "2019-12-12"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to gluster-file-system

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
gluster1 | Tcp | 22 | sshd
gluster1 | Tcp | 111 | rpcbind
gluster1 | Tcp | 900 | glusterfs
gluster1 | Tcp | 2049 | glusterfs
gluster1 | Tcp | 24007 | glusterd
gluster1 | Tcp | 38465 | glusterfs
gluster1 | Tcp | 38466 | glusterfs
gluster1 | Tcp | 38468 | glusterfs
gluster1 | Tcp | 38469 | glusterfs
gluster1 | Tcp | 47054 | rpc.statd
gluster1 | Tcp | 47743 | rpc.statd
gluster1 | Tcp | 49152 | glusterfsd
gluster1 | Tcp | 52641 | rpc.statd
gluster1 | Tcp | 55830 | rpc.statd
gluster1 | Udp | 68 | dhclient
gluster1 | Udp | 111 | rpcbind
gluster1 | Udp | 123 | ntpd
gluster1 | Udp | 692 | rpcbind
gluster1 | Udp | 899 | glusterfs
gluster1 | Udp | 47924 | rpc.statd
gluster1 | Udp | 52362 | rpc.statd
gluster1 | Udp | 54098 | dhclient
gluster1 | Udp | 54593 | rpc.statd
gluster1 | Udp | 55309 | rpc.statd
gluster1 | Udp | 62691 | dhclient
gluster0 | Tcp | 22 | sshd
gluster0 | Tcp | 111 | rpcbind
gluster0 | Tcp | 852 | glusterfs
gluster0 | Tcp | 2049 | glusterfs
gluster0 | Tcp | 24007 | glusterd
gluster0 | Tcp | 38465 | glusterfs
gluster0 | Tcp | 38466 | glusterfs
gluster0 | Tcp | 38468 | glusterfs
gluster0 | Tcp | 38469 | glusterfs
gluster0 | Tcp | 40317 | rpc.statd
gluster0 | Tcp | 49152 | glusterfsd
gluster0 | Tcp | 51958 | rpc.statd
gluster0 | Tcp | 52886 | rpc.statd
gluster0 | Tcp | 53724 | rpc.statd
gluster0 | Udp | 68 | dhclient
gluster0 | Udp | 111 | rpcbind
gluster0 | Udp | 123 | ntpd
gluster0 | Udp | 704 | rpcbind
gluster0 | Udp | 851 | glusterfs
gluster0 | Udp | 36281 | rpc.statd
gluster0 | Udp | 38624 | rpc.statd
gluster0 | Udp | 40058 | rpc.statd
gluster0 | Udp | 45000 | dhclient
gluster0 | Udp | 55541 | rpc.statd
gluster0 | Udp | 62338 | dhclient
