### PR TITLE
Adding Network Security Group to nextflow-genomics-cluster-ubuntu

### DIFF
--- a/nextflow-genomics-cluster-ubuntu/azuredeploy.json
+++ b/nextflow-genomics-cluster-ubuntu/azuredeploy.json
@@ -160,14 +160,14 @@
       "metadata": {
         "description": "*Advanced* This should be left as default unless you are an advanced user. The folder in the artifacts location were shared scripts are stored."
       },
-      "defaultValue": "/shared_scripts/ubuntu"
+      "defaultValue": "shared_scripts/ubuntu"
     },
     "_artifactsNextflowFolder": {
       "type": "string",
       "metadata": {
         "description": "*Advanced* This should be left as default unless you are an advanced user. The folder in the artifacts location were nextflow scripts are stored."
       },
-      "defaultValue": "/nextflow-genomics-cluster-ubuntu/scripts"
+      "defaultValue": "nextflow-genomics-cluster-ubuntu/scripts"
     },
     "authenticationType": {
       "type": "string",
@@ -188,8 +188,8 @@
     }
   },
   "variables": {
-    "nextflowInitScript": "[concat(parameters('_artifactsLocation'), parameters('_artifactsNextflowFolder'), '/init.sh', parameters('_artifactsLocationSasToken'))]",
-    "diskInitScript": "[concat(parameters('_artifactsLocation'), parameters('_artifactsSharedFolder'), '/vm-disk-utils-0.1.sh', parameters('_artifactsLocationSasToken'))]",
+    "nextflowInitScript": "[uri(parameters('_artifactsLocation'), concat(parameters('_artifactsNextflowFolder'), '/init.sh', parameters('_artifactsLocationSasToken')))]",
+    "diskInitScript": "[uri(parameters('_artifactsLocation'), concat(parameters('_artifactsSharedFolder'), '/vm-disk-utils-0.1.sh', parameters('_artifactsLocationSasToken')))]",
     "jumpboxNICName": "jumpboxNIC",
     "addressPrefix": "10.0.0.0/16",
     "subnetPrefix": "10.0.0.0/24",

--- a/nextflow-genomics-cluster-ubuntu/azuredeploy.json
+++ b/nextflow-genomics-cluster-ubuntu/azuredeploy.json
@@ -210,7 +210,8 @@
           }
         ]
       }
-    }
+    },
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -236,10 +237,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-22",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "22",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2017-06-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('vnetName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -250,7 +278,10 @@
           {
             "name": "[parameters('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/nextflow-genomics-cluster-ubuntu/azuredeploy.parameters.json
+++ b/nextflow-genomics-cluster-ubuntu/azuredeploy.parameters.json
@@ -10,9 +10,6 @@
     },
     "adminPasswordOrKey": {
       "value": "GEN-SSH-PUB-KEY"
-    },
-    "location": {
-      "value": "eastus2"
     }
   }
 }

--- a/nextflow-genomics-cluster-ubuntu/metadata.json
+++ b/nextflow-genomics-cluster-ubuntu/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template deploys a scalable Nextflow cluster with a Jumpbox, n cluster nodes, docker support and shared storage.",
   "summary": "This deploys a Nextflow cluster for running scalable and reproducible scientific workflows using software containers.",
   "githubUsername": "lawrencegripper",
-  "dateUpdated": "2019-07-11"
+  "dateUpdated": "2019-12-12"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to nextflow-genomics-cluster-ubuntu

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
jumpboxVM | Tcp | 22 | sshd
jumpboxVM | Tcp | 111 | rpcbind
jumpboxVM | Tcp | 2049 | 
jumpboxVM | Tcp | 33049 | rpc.mountd
jumpboxVM | Tcp | 35859 | rpc.mountd
jumpboxVM | Tcp | 37287 | 
jumpboxVM | Tcp | 42531 | rpc.mountd
jumpboxVM | Tcp | 43271 | rpc.mountd
jumpboxVM | Tcp | 43767 | 
jumpboxVM | Tcp | 56689 | rpc.mountd
jumpboxVM | Tcp | 60725 | rpc.mountd
jumpboxVM | Udp | 68 | dhclient
jumpboxVM | Udp | 111 | rpcbind
jumpboxVM | Udp | 626 | rpcbind
jumpboxVM | Udp | 2049 | 
jumpboxVM | Udp | 34230 | 
jumpboxVM | Udp | 45130 | rpc.mountd
jumpboxVM | Udp | 46990 | 
jumpboxVM | Udp | 47827 | rpc.mountd
jumpboxVM | Udp | 49447 | rpc.mountd
jumpboxVM | Udp | 53232 | rpc.mountd
jumpboxVM | Udp | 55285 | rpc.mountd
jumpboxVM | Udp | 58385 | rpc.mountd
