### PR TITLE
Adding Network Security Group to storage-iops-latency-throughput-demo

### DIFF
--- a/storage-iops-latency-throughput-demo/azuredeploy.json
+++ b/storage-iops-latency-throughput-demo/azuredeploy.json
@@ -75,7 +75,8 @@
     "vmNicName": "[concat(variables('vmName'),'-nic-','0')]",
     "vmPIPName": "[concat(variables('vmName'),'-PIP')]",
     "dscResourceFolder": "dsc",
-    "dscResourceConfig": "vmDemo"
+    "dscResourceConfig": "vmDemo",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -96,11 +97,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "[parameters('vNetName')]",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[parameters('location')]",
       "apiVersion": "2016-03-30",
-      "dependsOn": [],
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "tags": {
         "displayName": "[parameters('vNetName')]"
       },
@@ -114,7 +141,10 @@
           {
             "name": "[variables('vNetSubnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('vNetSubnet1Prefix')]"
+              "addressPrefix": "[variables('vNetSubnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]
@@ -153,7 +183,7 @@
       "name": "[variables('vmName')]",
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[parameters('location')]",
-      "apiVersion": "2017-03-30",  
+      "apiVersion": "2017-03-30",
       "dependsOn": [
         "storageAccountCopy",
         "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]"
@@ -178,43 +208,38 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "[concat(variables('vmName'),'_OSDisk')]",   
+            "name": "[concat(variables('vmName'),'_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           },
           "dataDisks": [
             {
-             
-              "name": "[concat(variables('vmName'),'_DataDisk1')]" ,
+              "name": "[concat(variables('vmName'),'_DataDisk1')]",
               "lun": 0,
               "diskSizeGB": "100",
               "caching": "None",
               "createOption": "Empty"
-                
             },
             {
-              "name": "[concat(variables('vmName'),'_DataDisk2')]" ,
+              "name": "[concat(variables('vmName'),'_DataDisk2')]",
               "lun": 1,
               "diskSizeGB": "100",
               "caching": "ReadOnly",
               "createOption": "Empty"
-             
             },
             {
-              "name": "[concat(variables('vmName'),'_DataDisk3')]" ,
+              "name": "[concat(variables('vmName'),'_DataDisk3')]",
               "lun": 2,
               "diskSizeGB": "100",
               "caching": "ReadWrite",
               "createOption": "Empty"
-              
             },
             {
-              "name": "[concat(variables('vmName'),'_DataDisk4')]" ,
+              "name": "[concat(variables('vmName'),'_DataDisk4')]",
               "lun": 3,
               "diskSizeGB": 1023,
               "caching": "None",
               "createOption": "Empty"
-             
             }
           ]
         },

--- a/storage-iops-latency-throughput-demo/azuredeploy.json
+++ b/storage-iops-latency-throughput-demo/azuredeploy.json
@@ -270,7 +270,7 @@
             "autoUpgradeMinorVersion": true,
             "settings": {
               "configuration": {
-                "url": "[concat(parameters('_artifactsLocation'),'/',variables('dscResourceFolder'),'/',variables('dscResourceConfig'),'.zip')]",
+                "url": "[uri(parameters('_artifactsLocation'), concat(variables('dscResourceFolder'), '/', variables('dscResourceConfig'), '.zip', parameters('_artifactsLocationSasToken')))]",
                 "script": "[concat(variables('dscResourceConfig'),'.ps1')]",
                 "function": "[variables('dscResourceConfig')]"
               },

--- a/storage-iops-latency-throughput-demo/metadata.json
+++ b/storage-iops-latency-throughput-demo/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template creates a single VM running Windows Server 2016 with multiple data disks attached.",
   "summary": "1 VM in vNet - Multiple data disks",
   "githubUsername": "jamesbannan",
-  "dateUpdated": "2018-07-02"  
+  "dateUpdated": "2019-12-12"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to storage-iops-latency-throughput-demo

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
demo-01 | Tcp | 135 | svchost.exe
demo-01 | Tcp | 445 | 
demo-01 | Tcp | 3389 | svchost.exe
demo-01 | Tcp | 5985 | 
demo-01 | Tcp | 47001 | 
demo-01 | Tcp | 49664 | 
demo-01 | Tcp | 49665 | lsass.exe
demo-01 | Tcp | 49666 | svchost.exe
demo-01 | Tcp | 49668 | svchost.exe
demo-01 | Tcp | 49669 | spoolsv.exe
demo-01 | Tcp | 49670 | 
demo-01 | Udp | 123 | svchost.exe
demo-01 | Udp | 3389 | svchost.exe
demo-01 | Udp | 5050 | svchost.exe
demo-01 | Udp | 5353 | svchost.exe
demo-01 | Udp | 5355 | svchost.exe
