### PR TITLE
Adding Network Security Group to symantec-extension-windows-vm

### DIFF
--- a/symantec-extension-windows-vm/azuredeploy.json
+++ b/symantec-extension-windows-vm/azuredeploy.json
@@ -121,7 +121,8 @@
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id),'storage')]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',parameters('virtualNetworkName'))]",
-    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',parameters('subnet1Name'))]"
+    "subnet1Ref": "[concat(variables('vnetID'),'/subnets/',parameters('subnet1Name'))]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -143,10 +144,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2015-05-01-preview",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -157,7 +185,10 @@
           {
             "name": "[parameters('subnet1Name')]",
             "properties": {
-              "addressPrefix": "[parameters('subnet1Prefix')]"
+              "addressPrefix": "[parameters('subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/symantec-extension-windows-vm/metadata.json
+++ b/symantec-extension-windows-vm/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template creates a Windows VM and sets up a trial version of Symantec Endpoint Protection",
   "summary": "Windows VM with Symantec Endpoint Protection",
   "githubUsername": "sung-msft",
-  "dateUpdated": "2018-06-01"
+  "dateUpdated": "2019-12-12"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to symantec-extension-windows-vm

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
azureVM | Tcp | 135 | svchost.exe
azureVM | Tcp | 445 | 
azureVM | Tcp | 3389 | svchost.exe
azureVM | Tcp | 5985 | 
azureVM | Tcp | 47001 | 
azureVM | Tcp | 49152 | wininit.exe
azureVM | Tcp | 49153 | lsass.exe
azureVM | Tcp | 49154 | svchost.exe
azureVM | Tcp | 49155 | svchost.exe
azureVM | Tcp | 49156 | spoolsv.exe
azureVM | Tcp | 49158 | 
azureVM | Udp | 123 | svchost.exe
azureVM | Udp | 3389 | svchost.exe
azureVM | Udp | 5355 | svchost.exe
