### PR TITLE
Adding Network Security Group to vm-to-vm-throughput-meter-multithreaded

### DIFF
--- a/vm-to-vm-throughput-meter-multithreaded/azuredeploy.json
+++ b/vm-to-vm-throughput-meter-multithreaded/azuredeploy.json
@@ -205,7 +205,8 @@
       "[parameters('probeVmSize')]",
       "[parameters('targetVmSize')]"
     ],
-    "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
+    "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
+    "networkSecurityGroupName": "default-NSG"
   },
   "resources": [
     {
@@ -236,10 +237,37 @@
       }
     },
     {
+      "comments": "Default Network Security Group for template",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -250,7 +278,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/vm-to-vm-throughput-meter-multithreaded/azuredeploy.json
+++ b/vm-to-vm-throughput-meter-multithreaded/azuredeploy.json
@@ -4,48 +4,14 @@
   "parameters": {
     "probeVmSize": {
       "type": "string",
-      "allowedValues": [
-        "Basic_A0",
-        "Basic_A4",
-        "Standard_A1",
-        "Standard_A7",
-        "Standard_A11",
-        "Standard_D4",
-        "Standard_D14",
-        "Standard_D1_v2",
-        "Standard_D15_v2",
-        "Standard_F1",
-        "Standard_F16",
-        "Standard_G1",
-        "Standard_G5",
-        "Standard_NV6",
-        "Standard_NC6"
-      ],
-      "defaultValue": "Standard_A7",
+      "defaultValue": "Standard_A8m_v2",
       "metadata": {
         "description": "Size of the VM that runs the test."
       }
     },
     "targetVmSize": {
       "type": "string",
-      "allowedValues": [
-        "Basic_A0",
-        "Basic_A4",
-        "Standard_A1",
-        "Standard_A7",
-        "Standard_A11",
-        "Standard_D4",
-        "Standard_D14",
-        "Standard_D1_v2",
-        "Standard_D15_v2",
-        "Standard_F1",
-        "Standard_F16",
-        "Standard_G1",
-        "Standard_G5",
-        "Standard_NV6",
-        "Standard_NC6"
-      ],
-      "defaultValue": "Standard_A7",
+      "defaultValue": "Standard_A8m_v2",
       "metadata": {
         "description": "Size of the target VM."
       }
@@ -376,7 +342,7 @@
             "autoUpgradeMinorVersion": true,
             "settings": {
               "fileUris": [
-                "[concat(parameters('_artifactsLocation'), '/', variables('ScriptFolder'), '/', variables('ScriptFileName'), parameters('_artifactsLocationSasToken'))]"
+                "[uri(parameters('_artifactsLocation'), concat(variables('ScriptFolder'), '/', variables('ScriptFileName'), parameters('_artifactsLocationSasToken')))]"
               ],
               "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -File ', variables('ScriptFileName'), ' -ReceiverIP ', reference(concat(variables('nicName'), '2')).ipConfigurations[0].properties.privateIPAddress, ' -Mode ', variables('testMode')[copyIndex(0)], ' -BufferSize ', variables('testBufferSize')[copyIndex(0)], ' -OverlappedBuffers ', variables('testOverlappedBuffers')[copyIndex(0)], ' -DataTransferMode ', parameters('testDataTransferMode'), ' -ThreadNumber ', variables('testThreadNumber')[copyIndex(0)], ' -Duration ', parameters('testDurationSeconds'))]"
             }

--- a/vm-to-vm-throughput-meter-multithreaded/metadata.json
+++ b/vm-to-vm-throughput-meter-multithreaded/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to run VM-to-VM throughput test with NTttcp utility.",
   "summary": "This template allows you to run VM-to-VM throughput test with NTttcp utility.",
   "githubUsername": "alekseipolkovnikov",
-  "dateUpdated": "2018-07-20"
+  "dateUpdated": "2019-12-12"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to vm-to-vm-throughput-meter-multithreaded

Netstat (or equivalent) found the following processes listening on the VMs deployed:

VM | Protocol | Port | Process (or chain)
--- | --- | --- | ---
targetVM | Tcp | 135 | svchost.exe
targetVM | Tcp | 445 | 
targetVM | Tcp | 3389 | svchost.exe
targetVM | Tcp | 5985 | 
targetVM | Tcp | 47001 | 
targetVM | Tcp | 49152 | wininit.exe
targetVM | Tcp | 49153 | lsass.exe
targetVM | Tcp | 49154 | svchost.exe
targetVM | Tcp | 49156 | svchost.exe
targetVM | Tcp | 49157 | spoolsv.exe
targetVM | Tcp | 49158 | 
targetVM | Udp | 123 | svchost.exe
targetVM | Udp | 3389 | svchost.exe
targetVM | Udp | 5355 | svchost.exe
probeVM | Tcp | 135 | svchost.exe
probeVM | Tcp | 445 | 
probeVM | Tcp | 3389 | svchost.exe
probeVM | Tcp | 5985 | 
probeVM | Tcp | 47001 | 
probeVM | Tcp | 49152 | wininit.exe
probeVM | Tcp | 49153 | lsass.exe
probeVM | Tcp | 49154 | svchost.exe
probeVM | Tcp | 49156 | svchost.exe
probeVM | Tcp | 49157 | spoolsv.exe
probeVM | Tcp | 49158 | 
probeVM | Udp | 123 | svchost.exe
probeVM | Udp | 3389 | svchost.exe
probeVM | Udp | 5355 | svchost.exe
