### PR TITLE
Add SSH Auth to mysql-ha-pxc-zones

### DIFF
--- a/mysql-ha-pxc-zones/azuredeploy.json
+++ b/mysql-ha-pxc-zones/azuredeploy.json
@@ -131,7 +131,7 @@
       "metadata": {
         "description": "Linked Templates base url"
       },
-      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-ha-pxc-zones"
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/mysql-ha-pxc-zones/"
     },
     "_artifactsLocationSasToken": {
       "type": "securestring",
@@ -142,8 +142,8 @@
     }
   },
   "variables": {
-    "customScriptFilePath": "[concat(parameters('_artifactsLocation'),'/azurepxc.sh', parameters('_artifactsLocationSasToken'))]",
-    "mysqlConfigFilePath": "[concat(parameters('_artifactsLocation'),'/my.cnf.template', parameters('_artifactsLocationSasToken'))]",
+    "customScriptFilePath": "[uri(parameters('_artifactsLocation'), concat('azurepxc.sh', parameters('_artifactsLocationSasToken')))]",
+    "mysqlConfigFilePath": "[uri(parameters('_artifactsLocation'), concat('my.cnf.template', parameters('_artifactsLocationSasToken')))]",
     "dbSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('virtualNetworkName'), parameters('dbSubnetName'))]",
     "publicIpAddressName": "pip",
     "pxcClusterAddress": "[concat(parameters('vmIPs')[0], ',', parameters('vmIPs')[1], ',', parameters('vmIPs')[2])]",

--- a/mysql-ha-pxc-zones/metadata.json
+++ b/mysql-ha-pxc-zones/metadata.json
@@ -7,5 +7,3 @@
   "githubUsername": "aaronlower",
   "dateUpdated": "2017-09-21"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
