### PR TITLE
Add SSH Auth to wordpress-mysql-replication

### DIFF
--- a/wordpress-mysql-replication/azuredeploy.json
+++ b/wordpress-mysql-replication/azuredeploy.json
@@ -57,12 +57,6 @@
         "description": "user name to ssh to the VMs"
       }
     },
-    "vmPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "password to ssh to the VMs"
-      }
-    },
     "mysqlRootPassword": {
       "type": "securestring",
       "metadata": {
@@ -213,6 +207,23 @@
       "metadata": {
         "description": "MySQL public port slave"
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -240,9 +251,6 @@
           },
           "vmUserName": {
             "value": "[parameters('vmUserName')]"
-          },
-          "vmPassword": {
-            "value": "[parameters('vmPassword')]"
           },
           "mysqlRootPassword": {
             "value": "[parameters('mysqlRootPassword')]"
@@ -309,6 +317,12 @@
           },
           "publicIPName": {
             "value": "[parameters('publicIPName')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "adminPasswordOrKey": {
+            "value": "[parameters('adminPasswordOrKey')]"
           }
         }
       }

--- a/wordpress-mysql-replication/azuredeploy.json
+++ b/wordpress-mysql-replication/azuredeploy.json
@@ -224,12 +224,23 @@
       "metadata": {
         "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
+    },
+    "_artifactsLocation": {
+      "type": "string",
+      "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/wordpress-mysql-replication/",
+      "metadata": {
+        "description": "The base URI where artifacts required by this template are located. When the template is deployed using the accompanying scripts, a private location in the subscription will be used and this value will be automatically generated."
+      }
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated."
+      },
+      "defaultValue": ""
     }
   },
   "variables": {
-    "template": {
-      "base": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/wordpress-mysql-replication"
-    },
     "templateAPIVersion": "2015-01-01",
     "resourceAPIVersion": "2015-06-15",
     "wpdbname": "[concat(uniquestring(resourceGroup().id),'wordpress')]"
@@ -242,7 +253,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('template').base, '/nested/mysql-replication.json')]",
+          "uri": "[uri(parameters('_artifactsLocation'), concat('nested/mysql-replication.json', parameters('_artifactsLocationSasToken')))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -312,9 +323,6 @@
           "mysqlProbePort1": {
             "value": "[parameters('mysqlProbePort1')]"
           },
-          "artifactsPath": {
-            "value": "[variables('template').base]"
-          },
           "publicIPName": {
             "value": "[parameters('publicIPName')]"
           },
@@ -323,6 +331,12 @@
           },
           "adminPasswordOrKey": {
             "value": "[parameters('adminPasswordOrKey')]"
+          },
+          "_artifactsLocation": {
+            "value": "[parameters('_artifactsLocation')]"
+          },
+          "_artifactsLocationSasToken": {
+            "value": "[parameters('_artifactsLocationSasToken')]"
           }
         }
       }
@@ -337,7 +351,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('template').base, '/nested/website.json')]",
+          "uri": "[uri(parameters('_artifactsLocation'), concat('nested/website.json', parameters('_artifactsLocationSasToken')))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/wordpress-mysql-replication/azuredeploy.parameters.json
+++ b/wordpress-mysql-replication/azuredeploy.parameters.json
@@ -1,30 +1,30 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "siteName": {
-            "value": "GEN-UNIQUE"
-        },
-        "dnsName": {
-            "value": "GEN-UNIQUE"
-        },
-        "hostingPlanName": {
-            "value": "GEN-UNIQUE"
-        },
-        "vmUserName": {
-            "value": "azureuser"
-        },
-        "vmPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "mysqlReplicationPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "mysqlRootPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "mysqlProbePassword": {
-            "value": "GEN-PASSWORD"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "siteName": {
+      "value": "GEN-UNIQUE"
+    },
+    "dnsName": {
+      "value": "GEN-UNIQUE"
+    },
+    "hostingPlanName": {
+      "value": "GEN-UNIQUE"
+    },
+    "vmUserName": {
+      "value": "GEN-UNIQUE"
+    },
+    "mysqlReplicationPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "mysqlRootPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "mysqlProbePassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
+  }
 }

--- a/wordpress-mysql-replication/metadata.json
+++ b/wordpress-mysql-replication/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template deploys a wordpress web site backed by a master/slave MySQL replication cluster",
   "summary": "Deploys a wordpress web site with MySQL replication backend",
   "githubUsername": "sunbuild",
-  "dateUpdated": "2018-08-16"
+  "dateUpdated": "2019-12-17"
 }
-
-

--- a/wordpress-mysql-replication/nested/mysql-replication.json
+++ b/wordpress-mysql-replication/nested/mysql-replication.json
@@ -165,13 +165,6 @@
         "description": "MySQL public port slave"
       }
     },
-    "artifactsPath": {
-      "type": "string",
-      "metadata": {
-        "description": "template and script file location",
-        "artifactsBaseUrl": "Base URL of the Publisher Template gallery package"
-      }
-    },
     "customScriptCommandToExecute": {
       "type": "string",
       "defaultValue": "bash azuremysql.sh",
@@ -198,6 +191,12 @@
     },
     "adminPasswordOrKey": {
       "type": "securestring"
+    },
+    "_artifactsLocation": {
+      "type": "string"
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring"
     }
   },
   "variables": {
@@ -214,10 +213,10 @@
     "sshIPConfig": "[concat(variables('lbID'),'/frontendIPConfigurations/',variables('sshIPConfigName'))]",
     "nicName": "[concat(parameters('dnsName'), '-nic')]",
     "availabilitySetName": "[concat(parameters('dnsName'), '-set')]",
-    "customScriptFilePath": "[concat(parameters('artifactsPath'), '/scripts/azuremysql.sh')]",
-    "mysqlConfigFilePath": "[concat(parameters('artifactsPath'), '/scripts/my.cnf.template')]",
+    "customScriptFilePath": "[uri(parameters('_artifactsLocation'), concat('scripts/azuremysql.sh', parameters('_artifactsLocationSasToken')))]",
+    "mysqlConfigFilePath": "[uri(parameters('_artifactsLocation'), concat('scripts/my.cnf.template', parameters('_artifactsLocationSasToken')))]",
     "singleQuote": "",
-    "virtualNetworkSetupURL": "[concat(parameters('artifactsPath'),'/nested/vnet-',parameters('vnetNewOrExisting'),'.json')]",
+    "virtualNetworkSetupURL": "[uri(parameters('_artifactsLocation'), concat('nested/vnet-',parameters('vnetNewOrExisting'),'.json', parameters('_artifactsLocationSasToken')))]",
     "sa": "[parameters('dbSubnetStartAddress')]",
     "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
     "ipOctet2": "[int(split(variables('sa'), '.')[2])]",

--- a/wordpress-mysql-replication/nested/mysql-replication.json
+++ b/wordpress-mysql-replication/nested/mysql-replication.json
@@ -14,12 +14,6 @@
         "description": "user name to ssh to the VMs"
       }
     },
-    "vmPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "password to ssh to the VMs"
-      }
-    },
     "mysqlRootPassword": {
       "type": "securestring",
       "metadata": {
@@ -198,6 +192,12 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string"
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring"
     }
   },
   "variables": {
@@ -222,7 +222,18 @@
     "ipOctet01": "[concat(split(variables('sa'), '.')[0], '.', split(variables('sa'), '.')[1], '.')]",
     "ipOctet2": "[int(split(variables('sa'), '.')[2])]",
     "ipOctet3": "[int(split(variables('sa'), '.')[3])]",
-    "DBName": "[concat(uniquestring(resourceGroup().id),'wordpress')]"
+    "DBName": "[concat(uniquestring(resourceGroup().id),'wordpress')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('vmUserName'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -273,11 +284,11 @@
       "location": "[parameters('location')]",
       "sku": {
         "name": "Aligned"
-        },
-        "properties": { 
+      },
+      "properties": {
         "platformFaultDomainCount": 2,
         "platformUpdateDomainCount": 5
-        }
+      }
     },
     {
       "apiVersion": "2015-06-15",
@@ -346,7 +357,8 @@
         "osProfile": {
           "computerName": "[concat(parameters('dnsName'), copyIndex())]",
           "adminUsername": "[parameters('vmUserName')]",
-          "adminPassword": "[parameters('vmPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
