### PR TITLE
Add SSH Auth to jboss-eap-standalone-rhel7

### DIFF
--- a/jboss-eap-standalone-rhel7/azuredeploy.json
+++ b/jboss-eap-standalone-rhel7/azuredeploy.json
@@ -314,7 +314,7 @@
         "autoUpgradeMinorVersion": true,
         "settings": {
           "fileUris": [
-            "[concat(parameters('_artifactsLocation'), '/', variables('ScriptFolder'), '/', variables('ScriptFileName'), parameters('_artifactsLocationSasToken'))]"
+            "[uri(parameters('_artifactsLocation'), concat(variables('ScriptFolder'), '/', variables('ScriptFileName'), parameters('_artifactsLocationSasToken')))]"
           ],
           "commandToExecute": "[concat('sh eap-setup-redhat.sh',' ',parameters('adminUsername'),' ',parameters('eapUserName'),' ',parameters('eapPassword'),' ',parameters('rhsmUserName'),' ',parameters('rhsmPassword'),' ', parameters('rhsmPool'),' ',parameters('sshPassPhrase'))]"
         }

--- a/jboss-eap-standalone-rhel7/azuredeploy.json
+++ b/jboss-eap-standalone-rhel7/azuredeploy.json
@@ -8,12 +8,6 @@
         "description": "Linux VM user account name"
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Administrator password for Linux VM user account"
-      }
-    },
     "dnsLabelPrefix": {
       "type": "string",
       "metadata": {
@@ -76,6 +70,23 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
   },
   "variables": {
@@ -97,7 +108,18 @@
     "storageAccountName": "[concat('vsts8',variables('baseName'))]",
     "ScriptFolder": "scripts",
     "ScriptFileName": "eap-setup-redhat.sh",
-    "subnet1Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]"
+    "subnet1Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -236,7 +258,7 @@
       }
     },
     {
-      "apiVersion":  "2017-03-30", 
+      "apiVersion": "2017-03-30",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
@@ -251,8 +273,9 @@
         "osProfile": {
           "computerName": "[variables('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]",
-          "customData": "[base64(variables('publicIPAddressName'))]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "customData": "[base64(variables('publicIPAddressName'))]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": {

--- a/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
+++ b/jboss-eap-standalone-rhel7/azuredeploy.parameters.json
@@ -1,33 +1,33 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "adminUsername": {
-          "value": "GEN-UNIQUE"
-        },
-        "adminPassword": {
-          "value": "GEN-PASSWORD"
-        },
-        "rhsmUserName": {
-          "value": "GEN-UNIQUE"
-        },
-        "rhsmPassword": {
-          "value": "GEN_PASSWORD"
-        },
-        "dnsLabelPrefix": {
-            "value": "GEN-UNIQUE"
-        },
-        "eapUserName": {
-          "value": "GEN-UNIQUE"
-        },
-        "eapPassword": {
-          "value": "GEN-PASSWORD"
-        },
-        "rhsmPool": {
-          "value": "GEN-UNIQUE"
-        },
-        "sshPassPhrase": {
-          "value": "GEN-PASSWORD"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "adminUsername": {
+      "value": "GEN-UNIQUE"
+    },
+    "rhsmUserName": {
+      "value": "GEN-UNIQUE"
+    },
+    "rhsmPassword": {
+      "value": "GEN_PASSWORD"
+    },
+    "dnsLabelPrefix": {
+      "value": "GEN-UNIQUE"
+    },
+    "eapUserName": {
+      "value": "GEN-UNIQUE"
+    },
+    "eapPassword": {
+      "value": "GEN-PASSWORD"
+    },
+    "rhsmPool": {
+      "value": "GEN-UNIQUE"
+    },
+    "sshPassPhrase": {
+      "value": "GEN-PASSWORD"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
+  }
 }

--- a/jboss-eap-standalone-rhel7/metadata.json
+++ b/jboss-eap-standalone-rhel7/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to create an Red Hat VM running JBoss EAP 7 and and also deploy a web application called dukes, you can login into the admin console using the user and password configured at the time of the deployment.",
   "summary": "Deploy a web application to test Red Hat VM running JBoss EAP7 in standalone mode",
   "githubUsername": "danieloh30",
-  "dateUpdated": "2019-04-02"
+  "dateUpdated": "2019-12-17"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
