### PR TITLE
Add SSH Auth to 101-hdinsight-hbase-replication-geo

### DIFF
--- a/101-hdinsight-hbase-replication-geo/azuredeploy.json
+++ b/101-hdinsight-hbase-replication-geo/azuredeploy.json
@@ -15,17 +15,28 @@
         "description": "These credentials can be used to remotely access the cluster."
       }
     },
-    "sshPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "The password must be at least 10 characters in length and must contain at least one digit, one non-alphanumeric character, and one upper or lower case letter."
-      }
-    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Location for all resources."
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
     }
   },
@@ -38,7 +49,7 @@
     },
     "vNet1": {
       "name": "[concat(parameters('clusterNamePrefix'),'-vnet1')]",
-      "location": "West US",      
+      "location": "West US",
       "addressSpacePrefix": "10.1.0.0/16",
       "subnetName": "subnet1",
       "subnetPrefix": "10.1.0.0/24",
@@ -70,6 +81,17 @@
       "name1": "vnet1tovnet2",
       "name2": "vnet2tovnet1",
       "sharedKey": "A1b2C3D4"
+    },
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('sshUserName'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
     }
   },
   "resources": [
@@ -84,7 +106,7 @@
             "[variables('vNet1').addressSpacePrefix]"
           ]
         },
-        "dhcpOptions":{
+        "dhcpOptions": {
           "dnsServers": [
             "[variables('vNet1').dnsIPAddress]"
           ]
@@ -157,7 +179,7 @@
             "[variables('vNet2').addressSpacePrefix]"
           ]
         },
-        "dhcpOptions":{
+        "dhcpOptions": {
           "dnsServers": [
             "[variables('vNet2').dnsIPAddress]"
           ]
@@ -273,7 +295,7 @@
       "location": "[variables('vNet1').location]",
       "apiVersion": "2017-08-01",
       "properties": {
-          "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Dynamic"
       }
     },
     {
@@ -284,7 +306,6 @@
       "dependsOn": [
         "[concat('Microsoft.Network/virtualNetworks/',variables('vNet1').name)]",
         "[concat('Microsoft.Network/publicIPAddresses/', variables('vNet1').dnsIPName)]"
-
       ],
       "properties": {
         "ipConfigurations": [
@@ -318,7 +339,8 @@
         "osProfile": {
           "computerName": "[variables('vNet1').dnsName]",
           "adminUsername": "[parameters('sshUserName')]",
-          "adminPassword": "[parameters('sshPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": "[variables('ubuntu')]",
@@ -341,7 +363,7 @@
       "location": "[variables('vNet2').location]",
       "apiVersion": "2017-08-01",
       "properties": {
-          "publicIPAllocationMethod": "Dynamic"
+        "publicIPAllocationMethod": "Dynamic"
       }
     },
     {
@@ -385,7 +407,8 @@
         "osProfile": {
           "computerName": "[variables('vNet2').dnsName]",
           "adminUsername": "[parameters('sshUserName')]",
-          "adminPassword": "[parameters('sshPassword')]"
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
         },
         "storageProfile": {
           "imageReference": "[variables('ubuntu')]",

--- a/101-hdinsight-hbase-replication-geo/azuredeploy.parameters.json
+++ b/101-hdinsight-hbase-replication-geo/azuredeploy.parameters.json
@@ -1,15 +1,15 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "clusterNamePrefix": {
-          "value": "GEN-UNIQUE-5"
-        },
-        "sshUserName": {
-            "value": "GEN-UNIQUE"
-        },
-        "sshPassword": {
-          "value": "GEN-PASSWORD"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "clusterNamePrefix": {
+      "value": "GEN-UNIQUE-5"
+    },
+    "sshUserName": {
+      "value": "GEN-UNIQUE"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
+  }
 }

--- a/101-hdinsight-hbase-replication-geo/metadata.json
+++ b/101-hdinsight-hbase-replication-geo/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to configure an Azure environment for HBase replication across two different regions with VPN vnet-to-vnet connection.",
   "summary": "Deploy two HBase clustes with each in its own VNet across two different regions.",
   "githubUsername": "mumian",
-  "dateUpdated": "2018-05-11"
+  "dateUpdated": "2019-12-19"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
