### PR TITLE
Add SSH Auth to 101-vmms-with-public-ip-prefix

### DIFF
--- a/101-vmms-with-public-ip-prefix/azuredeploy.json
+++ b/101-vmms-with-public-ip-prefix/azuredeploy.json
@@ -1,5 +1,4 @@
 {
-
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
@@ -39,12 +38,6 @@
         "description": "Admin username on all VMs."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Admin password on all VMs."
-      }
-    },
     "publicIPPrefixLength": {
       "type": "int",
       "defaultValue": 28,
@@ -53,8 +46,24 @@
       },
       "maxValue": 31,
       "minValue": 28
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
     }
-
   },
   "variables": {
     "addressPrefix": "10.0.0.0/16",
@@ -80,7 +89,18 @@
       "sku": "16.04-LTS",
       "version": "latest"
     },
-    "imageReference": "[variables('osType')]"
+    "imageReference": "[variables('osType')]",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -203,18 +223,15 @@
               "caching": "ReadOnly",
               "createOption": "FromImage"
             },
-
             "imageReference": "[variables('imageReference')]"
           },
-
           "osProfile": {
             "computerNamePrefix": "[parameters('vmssName')]",
             "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPassword')]"
+            "adminPassword": "[parameters('adminPasswordOrKey')]",
+            "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
           },
-
           "networkProfile": {
-
             "networkInterfaceConfigurations": [
               {
                 "name": "[variables('nicName')]",
@@ -257,5 +274,4 @@
       }
     }
   ]
-
 }

--- a/101-vmms-with-public-ip-prefix/azuredeploy.parameters.json
+++ b/101-vmms-with-public-ip-prefix/azuredeploy.parameters.json
@@ -8,8 +8,8 @@
     "adminUsername": {
       "value": "GEN-UNIQUE"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/101-vmms-with-public-ip-prefix/metadata.json
+++ b/101-vmms-with-public-ip-prefix/metadata.json
@@ -4,6 +4,6 @@
   "description": "Template for deploying VMSS with Public IP Prefix",
   "summary": "Template for deploying VMSS with Public IP Prefix",
   "githubUsername": "allegradomel",
-  "dateUpdated": "2019-10-22",
+  "dateUpdated": "2019-12-19",
   "type": "QuickStart"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
