### PR TITLE
Add SSH Auth to 201-vmss-azure-files-linux

### DIFF
--- a/201-vmss-azure-files-linux/azuredeploy.json
+++ b/201-vmss-azure-files-linux/azuredeploy.json
@@ -29,12 +29,6 @@
         "description": "Admin username on all VMs."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "Admin password on all VMs."
-      }
-    },
     "storageAccountName": {
       "type": "string",
       "metadata": {
@@ -58,6 +52,23 @@
       "defaultValue": "/mnt/azurefiles",
       "metadata": {
         "description": "Path on VM to mount file share - will also link to user home dir."
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }
     }
   },
@@ -88,7 +99,18 @@
     "imageReference": "[variables('osType')]",
     "computeApiVersion": "2017-03-30",
     "networkApiVersion": "2017-04-01",
-    "insightsApiVersion": "2015-04-01"
+    "insightsApiVersion": "2015-04-01",
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    }
   },
   "resources": [
     {
@@ -98,7 +120,9 @@
       "apiVersion": "2018-10-01",
       "properties": {
         "addressSpace": {
-          "addressPrefixes": ["[variables('addressPrefix')]"]
+          "addressPrefixes": [
+            "[variables('addressPrefix')]"
+          ]
         },
         "subnets": [
           {
@@ -204,7 +228,8 @@
           "osProfile": {
             "computerNamePrefix": "[parameters('vmssName')]",
             "adminUsername": "[parameters('adminUsername')]",
-            "adminPassword": "[parameters('adminPassword')]"
+            "adminPassword": "[parameters('adminPasswordOrKey')]",
+            "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
           },
           "networkProfile": {
             "networkInterfaceConfigurations": [

--- a/201-vmss-azure-files-linux/azuredeploy.parameters.json
+++ b/201-vmss-azure-files-linux/azuredeploy.parameters.json
@@ -4,7 +4,7 @@
   "parameters": {
     "vmSku": {
       "value": "Standard_D1_v2"
-    },  
+    },
     "vmssName": {
       "value": "GEN-UNIQUE-8"
     },
@@ -12,10 +12,7 @@
       "value": 3
     },
     "adminUsername": {
-      "value": "ubuntu"
-    },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
+      "value": "GEN-UNIQUE"
     },
     "storageAccountName": {
       "value": "GEN-UNIQUE-8"
@@ -25,9 +22,12 @@
     },
     "shareName": {
       "value": "azurefilesshare"
-    },    
+    },
     "mountpointPath": {
       "value": "/mnt/azurefiles"
+    },
+    "adminPasswordOrKey": {
+      "value": "GEN-SSH-PUB-KEY"
     }
   }
 }

--- a/201-vmss-azure-files-linux/metadata.json
+++ b/201-vmss-azure-files-linux/metadata.json
@@ -5,6 +5,5 @@
   "description": "This template deploys an Ubuntu Virtual Machine Scale Set and uses a custom script extension to connect each VM to an Azure Files share",
   "summary": "This template creates a mount point on every VM and connects it to an Azure Files SMB share.",
   "githubUsername": "gbowerman",
-  "dateUpdated": "2017-06-27"
+  "dateUpdated": "2019-12-19"
 }
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added SSH key authentication as default option instead of a password for Linux VM
