### PR TITLE
updates with newer reference() function signature

### DIFF
--- a/101-functions-managed-identity/azuredeploy.json
+++ b/101-functions-managed-identity/azuredeploy.json
@@ -202,7 +202,7 @@
         {
             "name": "[parameters('functionAppName')]",
             "type": "Microsoft.Web/sites",
-            "apiVersion": "2018-02-01",
+            "apiVersion": "2018-11-01",
             "location": "[parameters('location')]",
             "kind": "functionapp",            
             "dependsOn": [
@@ -292,7 +292,7 @@
     "outputs": {
         "principalId": {
           "type": "string",
-          "value": "[reference(concat(resourceId('Microsoft.Web/sites/', parameters('functionAppName')), '/providers/Microsoft.ManagedIdentity/Identities/default'), '2015-08-31-PREVIEW').principalId]"
+          "value": "[reference(concat(resourceId('Microsoft.Web/sites/', parameters('functionAppName'))), '2018-11-01', 'Full').identity.principalId]"
         }
     }
 }

--- a/101-functions-managed-identity/azuredeploy.json
+++ b/101-functions-managed-identity/azuredeploy.json
@@ -292,7 +292,7 @@
     "outputs": {
         "principalId": {
           "type": "string",
-          "value": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')), '2018-11-01').identity.principalId]"
+          "value": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')), '2018-11-01', 'Full').identity.principalId]"
         }
     }
 }

--- a/101-functions-managed-identity/azuredeploy.json
+++ b/101-functions-managed-identity/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
         "functionAppName": {
@@ -268,7 +268,7 @@
             }
         },
         {
-            "apiVersion": "2017-06-01",
+            "apiVersion": "2019-06-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
             "location": "[parameters('location')]",
@@ -292,7 +292,7 @@
     "outputs": {
         "principalId": {
           "type": "string",
-          "value": "[reference(concat(resourceId('Microsoft.Web/sites/', parameters('functionAppName'))), '2018-11-01', 'Full').identity.principalId]"
+          "value": "[reference(resourceId('Microsoft.Web/sites', parameters('functionAppName')), '2018-11-01').identity.principalId]"
         }
     }
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* fixes the solution by updating [reference()](https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource#reference) function with newer parameter signature.

This issue was originally reported by customers via MicrosoftDocs/azure-docs#43203