### PR TITLE
Added the vmSize parameter 201-vnet-2subnets-service-endpoints-storage-integration

### DIFF
--- a/201-vnet-2subnets-service-endpoints-storage-integration/azuredeploy.json
+++ b/201-vnet-2subnets-service-endpoints-storage-integration/azuredeploy.json
@@ -56,6 +56,13 @@
         "description": "Address prefix for subnet2"
       }
     },
+    "vmSize": {
+        "type": "string",
+        "defaultValue": "Standard_A1",
+        "metadata": {
+            "description": "Size of VM"
+        }
+    },
     "storageAccountType": {
       "type": "string",
       "defaultValue": "Standard_LRS",
@@ -250,7 +257,7 @@
           "id": "[resourceId('Microsoft.Compute/availabilitySets', 'as1')]"
         },
         "hardwareProfile": {
-          "vmSize": "Standard_A1"
+          "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
           "computername": "[concat(variables('vmName'), copyIndex())]",


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Added the vmSize parameter to 201-vnet-2subnets-service-endpoints-storage-integration
