### PR TITLE
Fix deployment error caused by the new values of the SKU of SharePoint images

### DIFF
--- a/sharepoint-adfs/CHANGELOG.md
+++ b/sharepoint-adfs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log for Azure template for SharePoint 2019 / 2016 / 2013
 
+## February 2020 update
+
+* Fix deployment error caused by the new values of the SKU of SharePoint images, which changed from '2013' / '2016' / '2019' to 'sp2013' / 'sp2016' / 'sp2019'
+* Update the schema of deploymentTemplate.json to latest version
+
 ## October 2019 update
 
 * Add optional service Azure Bastion

--- a/sharepoint-adfs/azuredeploy.json
+++ b/sharepoint-adfs/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "location": {
@@ -299,7 +299,7 @@
     "vmSP": {
       "vmImagePublisher": "MicrosoftSharePoint",
       "vmImageOffer": "MicrosoftSharePointServer",
-      "vmImageSKU": "[parameters('sharePointVersion')]",
+      "vmImageSKU": "[concat('sp', parameters('sharePointVersion'))]",
       "vmOSDiskName": "Disk-SP-OS",
       "vmDataDiskName": "Disk-SP-Data",
       "vmVmSize": "[parameters('vmSPSize')]",

--- a/sharepoint-adfs/metadata.json
+++ b/sharepoint-adfs/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template deploys SharePoint with 1 web application configured with Windows and ADFS authentication, and a couple of path based / host-named site collections are created. User Profiles Application and Apps (add-ins) services are configured. Claims provider LDAPCP is installed and configured.",
   "summary": "SharePoint is configured with Windows + ADFS authentication, some site collections are created, User Profiles Application and Apps services are configured, and claims provider LDAPCP is installed.",
   "githubUsername": "yvand",
-  "dateUpdated": "2020-26-02"
+  "dateUpdated": "2020-02-26"
 }

--- a/sharepoint-adfs/metadata.json
+++ b/sharepoint-adfs/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template deploys SharePoint with 1 web application configured with Windows and ADFS authentication, and a couple of path based / host-named site collections are created. User Profiles Application and Apps (add-ins) services are configured. Claims provider LDAPCP is installed and configured.",
   "summary": "SharePoint is configured with Windows + ADFS authentication, some site collections are created, User Profiles Application and Apps services are configured, and claims provider LDAPCP is installed.",
   "githubUsername": "yvand",
-  "dateUpdated": "2019-10-11"
+  "dateUpdated": "2020-26-02"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Fix deployment error caused by the new values of the SKU of SharePoint images, which changed from '2013' / '2016' / '2019' to 'sp2013' / 'sp2016' / 'sp2019'
* Update the schema of deploymentTemplate.json to latest version
