### PR TITLE
Changing VM size to DS2_v2

### DIFF
--- a/201-2-vms-loadbalancer-lbrules/azuredeploy.json
+++ b/201-2-vms-loadbalancer-lbrules/azuredeploy.json
@@ -327,7 +327,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[concat('http://',parameters('storageAccountName'),'.blob.core.windows.net')]"
+            "storageUri": "[reference(parameters('storageAccountName'), '2019-06-01').primaryEndpoints.blob]"
           }
         }
       }

--- a/201-2-vms-loadbalancer-lbrules/azuredeploy.json
+++ b/201-2-vms-loadbalancer-lbrules/azuredeploy.json
@@ -84,7 +84,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_D1",
+      "defaultValue": "Standard_DS2_v2",
       "metadata": {
         "description": "Size of the VM"
       }


### PR DESCRIPTION
The Standard D1 VM size is no longer available in many regions and causes errors during the deployment, changing size to Standard_DS2_v2

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

*
*
*

