### PR TITLE
Adding Network Security Group to 101-azurefirewall-create-with-ipgroups-and-linux-jumpbox

### DIFF
--- a/101-azurefirewall-create-with-ipgroups-and-linux-jumpbox/azuredeploy.json
+++ b/101-azurefirewall-create-with-ipgroups-and-linux-jumpbox/azuredeploy.json
@@ -1,499 +1,512 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "virtualNetworkName": {
-            "type": "string",
-            "defaultValue": "[concat('vnet', uniqueString(resourceGroup().id))]",
-            "metadata": {
-                "description": "virtual network name"
-            }
-        },
-        "ipgroups_name1": {
-            "defaultValue": "[concat('ipgroup1', uniqueString(resourceGroup().id))]",
-            "type": "String"
-        },
-        "ipgroups_name2": {
-            "defaultValue": "[concat('ipgroup2', uniqueString(resourceGroup().id))]",
-            "type": "String"
-        },
-        "adminUsername": {
-            "type": "string",
-            "metadata": {
-                "description": "Username for the Virtual Machine."
-            }
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": "[resourceGroup().location]",
-            "metadata": {
-                "description": "Location for all resources."
-            }
-        },
-        "vmSize": {
-            "type": "string",
-            "defaultValue": "Standard_DS1_v2",
-            "metadata": {
-                "description": "Zone numbers e.g. 1,2,3."
-            }
-        },
-        "numberOfFirewallPublicIPAddresses": {
-            "type": "int",
-            "defaultValue": 1,
-            "minValue": 1,
-            "maxValue": 100,
-            "metadata": {
-                "description": "Number of public IP addresses for the Azure Firewall"
-            }
-        },
-        "authenticationType": {
-            "type": "string",
-            "defaultValue": "sshPublicKey",
-            "allowedValues": [
-                "sshPublicKey",
-                "password"
-            ],
-            "metadata": {
-                "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
-            }
-        },
-        "adminPasswordOrKey": {
-            "type": "securestring",
-            "metadata": {
-                "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "[concat('vnet', uniqueString(resourceGroup().id))]",
+      "metadata": {
+        "description": "virtual network name"
+      }
     },
-    "variables": {
-        "vnetAddressPrefix": "10.0.0.0/16",
-        "serversSubnetPrefix": "10.0.2.0/24",
-        "azureFirewallSubnetPrefix": "10.0.1.0/24",
-        "jumpboxSubnetPrefix": "10.0.0.0/24",
-        "nextHopIP": "10.0.1.4",
-        "azureFirewallSubnetName": "AzureFirewallSubnet",
-        "jumpBoxSubnetName": "JumpboxSubnet",
-        "serversSubnetName": "ServersSubnet",
-        "jumpBoxPublicIPAddressName": "JumpHostPublicIP",
-        "jumpBoxNsgName": "JumpHostNSG",
-        "jumpBoxNicName": "JumpHostNic",
-        "jumpBoxSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('jumpBoxSubnetName'))]",
-        "serverNicName": "ServerNic",
-        "serverSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('serversSubnetName'))]",
-        "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'sajumpbox')]",
-        "azfwRouteTableName": "AzfwRouteTable",
-        "firewallName": "firewall1",
-        "publicIPNamePrefix": "publicIP",
-        "azureFirewallSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets',parameters('virtualNetworkName'), variables('azureFirewallSubnetName'))]",
-        "azureFirewallSubnetJSON": "[json(format('{{\"id\": \"{0}\"}}', variables('azureFirewallSubnetId')))]",
-        "copy": [
-            {
-                "name": "azureFirewallIpConfigurations",
-                "count": "[parameters('numberOfFirewallPublicIPAddresses')]",
-                "input": {
-                    "name": "[concat('IpConf', copyIndex('azureFirewallIpConfigurations'))]",
-                    "properties": {
-                        "subnet": "[if(equals(copyIndex('azureFirewallIpConfigurations'), 0), variables('azureFirewallSubnetJSON'), json('null'))]",
-                        "publicIPAddress": {
-                            "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPNamePrefix'), add(copyIndex('azureFirewallIpConfigurations'), 1)))]"
-                        }
-                    }
-                }
+    "ipgroups_name1": {
+      "defaultValue": "[concat('ipgroup1', uniqueString(resourceGroup().id))]",
+      "type": "String"
+    },
+    "ipgroups_name2": {
+      "defaultValue": "[concat('ipgroup2', uniqueString(resourceGroup().id))]",
+      "type": "String"
+    },
+    "adminUsername": {
+      "type": "string",
+      "metadata": {
+        "description": "Username for the Virtual Machine."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_DS1_v2",
+      "metadata": {
+        "description": "Zone numbers e.g. 1,2,3."
+      }
+    },
+    "numberOfFirewallPublicIPAddresses": {
+      "type": "int",
+      "defaultValue": 1,
+      "minValue": 1,
+      "maxValue": 100,
+      "metadata": {
+        "description": "Number of public IP addresses for the Azure Firewall"
+      }
+    },
+    "authenticationType": {
+      "type": "string",
+      "defaultValue": "sshPublicKey",
+      "allowedValues": [
+        "sshPublicKey",
+        "password"
+      ],
+      "metadata": {
+        "description": "Type of authentication to use on the Virtual Machine. SSH key is recommended."
+      }
+    },
+    "adminPasswordOrKey": {
+      "type": "securestring",
+      "metadata": {
+        "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
+      }
+    }
+  },
+  "variables": {
+    "vnetAddressPrefix": "10.0.0.0/16",
+    "serversSubnetPrefix": "10.0.2.0/24",
+    "azureFirewallSubnetPrefix": "10.0.1.0/24",
+    "jumpboxSubnetPrefix": "10.0.0.0/24",
+    "nextHopIP": "10.0.1.4",
+    "azureFirewallSubnetName": "AzureFirewallSubnet",
+    "jumpBoxSubnetName": "JumpboxSubnet",
+    "serversSubnetName": "ServersSubnet",
+    "jumpBoxPublicIPAddressName": "JumpHostPublicIP",
+    "jumpBoxNsgName": "JumpHostNSG",
+    "jumpBoxNicName": "JumpHostNic",
+    "jumpBoxSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('jumpBoxSubnetName'))]",
+    "serverNicName": "ServerNic",
+    "serverSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('serversSubnetName'))]",
+    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'sajumpbox')]",
+    "azfwRouteTableName": "AzfwRouteTable",
+    "firewallName": "firewall1",
+    "publicIPNamePrefix": "publicIP",
+    "azureFirewallSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets',parameters('virtualNetworkName'), variables('azureFirewallSubnetName'))]",
+    "azureFirewallSubnetJSON": "[json(format('{{\"id\": \"{0}\"}}', variables('azureFirewallSubnetId')))]",
+    "copy": [
+      {
+        "name": "azureFirewallIpConfigurations",
+        "count": "[parameters('numberOfFirewallPublicIPAddresses')]",
+        "input": {
+          "name": "[concat('IpConf', copyIndex('azureFirewallIpConfigurations'))]",
+          "properties": {
+            "subnet": "[if(equals(copyIndex('azureFirewallIpConfigurations'), 0), variables('azureFirewallSubnetJSON'), json('null'))]",
+            "publicIPAddress": {
+              "id": "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPNamePrefix'), add(copyIndex('azureFirewallIpConfigurations'), 1)))]"
             }
+          }
+        }
+      }
+    ],
+    "linuxConfiguration": {
+      "disablePasswordAuthentication": true,
+      "ssh": {
+        "publicKeys": [
+          {
+            "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+            "keyData": "[parameters('adminPasswordOrKey')]"
+          }
+        ]
+      }
+    },
+    "networkSecurityGroupName": "[concat(variables('serversSubnetName'), '-nsg')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/ipGroups",
+      "apiVersion": "2019-11-01",
+      "name": "[parameters('ipgroups_name1')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "ipAddresses": [
+          "13.73.64.64/26",
+          "13.73.208.128/25",
+          "52.126.194.0/23"
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/ipGroups",
+      "apiVersion": "2019-11-01",
+      "name": "[parameters('ipgroups_name2')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "ipAddresses": [
+          "12.0.0.0/24",
+          "13.9.0.0/24"
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "name": "[variables('storageAccountName')]",
+      "apiVersion": "2019-06-01",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "Storage",
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.Network/routeTables",
+      "name": "[variables('azfwRouteTableName')]",
+      "apiVersion": "2019-11-01",
+      "location": "[parameters('location')]",
+      "properties": {
+        "disableBgpRoutePropagation": false,
+        "routes": [
+          {
+            "name": "AzfwDefaultRoute",
+            "properties": {
+              "addressPrefix": "0.0.0.0/0",
+              "nextHopType": "VirtualAppliance",
+              "nextHopIpAddress": "[variables('nextHopIP')]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "comments": "Simple Network Security Group for subnet [variables('serversSubnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {}
+    },
+    {
+      "name": "[parameters('virtualNetworkName')]",
+      "apiVersion": "2019-11-01",
+      "type": "Microsoft.Network/virtualNetworks",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/routeTables', variables('azfwRouteTableName'))]",
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
+      "tags": {
+        "displayName": "[parameters('virtualNetworkName')]"
+      },
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnetAddressPrefix')]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('jumpBoxSubnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('jumpboxSubnetPrefix')]"
+            }
+          },
+          {
+            "name": "[variables('azureFirewallSubnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('azureFirewallSubnetPrefix')]"
+            }
+          },
+          {
+            "name": "[variables('serversSubnetName')]",
+            "properties": {
+              "addressPrefix": "[variables('serversSubnetPrefix')]",
+              "routeTable": {
+                "id": "[resourceId('Microsoft.Network/routeTables', variables('azfwRouteTableName'))]"
+              },
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "[concat(variables('publicIPNamePrefix'), add(copyIndex(), 1))]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2019-11-01",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard"
+      },
+      "copy": {
+        "name": "publicIpCopy",
+        "count": "[parameters('numberOfFirewallPublicIPAddresses')]"
+      },
+      "properties": {
+        "publicIPAllocationMethod": "Static",
+        "publicIPAddressVersion": "IPv4"
+      }
+    },
+    {
+      "name": "[variables('jumpBoxPublicIPAddressName')]",
+      "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2019-11-01",
+      "location": "[parameters('location')]",
+      "properties": {
+        "publicIPAllocationMethod": "Dynamic"
+      }
+    },
+    {
+      "name": "[variables('jumpBoxNsgName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-11-01",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "myNetworkSecurityGroupRuleSSH",
+            "properties": {
+              "protocol": "Tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "22",
+              "sourceAddressPrefix": "*",
+              "destinationAddressPrefix": "*",
+              "access": "Allow",
+              "priority": 1000,
+              "direction": "Inbound"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "2019-11-01",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('JumpBoxNicName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('jumpBoxPublicIPAddressName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('jumpBoxNsgName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('jumpBoxPublicIPAddressName'))]"
+              },
+              "subnet": {
+                "id": "[variables('jumpBoxSubnetId')]"
+              }
+            }
+          }
         ],
-        "linuxConfiguration": {
-            "disablePasswordAuthentication": true,
-            "ssh": {
-                "publicKeys": [
-                    {
-                        "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
-                        "keyData": "[parameters('adminPasswordOrKey')]"
-                    }
-                ]
-            }
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('jumpBoxNsgName'))]"
         }
+      }
     },
-    "resources": [
-        {
-            "type": "Microsoft.Network/ipGroups",
-            "apiVersion": "2019-11-01",
-            "name": "[parameters('ipgroups_name1')]",
-            "location": "[parameters('location')]",
+    {
+      "apiVersion": "2019-11-01",
+      "type": "Microsoft.Network/networkInterfaces",
+      "name": "[variables('ServerNicName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ],
+      "properties": {
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
             "properties": {
-                "ipAddresses": [
-                    "13.73.64.64/26",
-                    "13.73.208.128/25",
-                    "52.126.194.0/23"
-                ]
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[variables('serverSubnetId')]"
+              }
             }
+          }
+        ]
+      }
+    },
+    {
+      "name": "JumpBox",
+      "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2019-03-01",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('JumpBoxNicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
         },
-        {
-            "type": "Microsoft.Network/ipGroups",
-            "apiVersion": "2019-11-01",
-            "name": "[parameters('ipgroups_name2')]",
-            "location": "[parameters('location')]",
-            "properties": {
-                "ipAddresses": [
-                    "12.0.0.0/24",
-                    "13.9.0.0/24"
-                ]
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "Canonical",
+            "offer": "UbuntuServer",
+            "sku": "18.04-LTS",
+            "version": "latest"
+          },
+          "osDisk": {
+            "createOption": "FromImage"
+          }
+        },
+        "osProfile": {
+          "computerName": "JumpBox",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('JumpBoxNicName'))]"
             }
+          ]
         },
-        {
-            "type": "Microsoft.Storage/storageAccounts",
-            "name": "[variables('storageAccountName')]",
-            "apiVersion": "2019-06-01",
-            "location": "[parameters('location')]",
-            "sku": {
-                "name": "Standard_LRS"
-            },
-            "kind": "Storage",
-            "properties": {}
-        },
-        {
-            "type": "Microsoft.Network/routeTables",
-            "name": "[variables('azfwRouteTableName')]",
-            "apiVersion": "2019-11-01",
-            "location": "[parameters('location')]",
-            "properties": {
-                "disableBgpRoutePropagation": false,
-                "routes": [
-                    {
-                        "name": "AzfwDefaultRoute",
-                        "properties": {
-                            "addressPrefix": "0.0.0.0/0",
-                            "nextHopType": "VirtualAppliance",
-                            "nextHopIpAddress": "[variables('nextHopIP')]"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "name": "[parameters('virtualNetworkName')]",
-            "apiVersion": "2019-11-01",
-            "type": "Microsoft.Network/virtualNetworks",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/routeTables', variables('azfwRouteTableName'))]"
-            ],
-            "tags": {
-                "displayName": "[parameters('virtualNetworkName')]"
-            },
-            "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('vnetAddressPrefix')]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('jumpBoxSubnetName')]",
-                        "properties": {
-                            "addressPrefix": "[variables('jumpboxSubnetPrefix')]"
-                        }
-                    },
-                    {
-                        "name": "[variables('azureFirewallSubnetName')]",
-                        "properties": {
-                            "addressPrefix": "[variables('azureFirewallSubnetPrefix')]"
-                        }
-                    },
-                    {
-                        "name": "[variables('serversSubnetName')]",
-                        "properties": {
-                            "addressPrefix": "[variables('serversSubnetPrefix')]",
-                            "routeTable": {
-                                "id": "[resourceId('Microsoft.Network/routeTables', variables('azfwRouteTableName'))]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "name": "[concat(variables('publicIPNamePrefix'), add(copyIndex(), 1))]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "apiVersion": "2019-11-01",
-            "location": "[parameters('location')]",
-            "sku": {
-                "name": "Standard"
-            },
-            "copy": {
-                "name": "publicIpCopy",
-                "count": "[parameters('numberOfFirewallPublicIPAddresses')]"
-            },
-            "properties": {
-                "publicIPAllocationMethod": "Static",
-                "publicIPAddressVersion": "IPv4"
-            }
-        },
-        {
-            "name": "[variables('jumpBoxPublicIPAddressName')]",
-            "type": "Microsoft.Network/publicIPAddresses",
-            "apiVersion": "2019-11-01",
-            "location": "[parameters('location')]",
-            "properties": {
-                "publicIPAllocationMethod": "Dynamic"
-            }
-        },
-        {
-            "name": "[variables('jumpBoxNsgName')]",
-            "type": "Microsoft.Network/networkSecurityGroups",
-            "apiVersion": "2019-11-01",
-            "location": "[parameters('location')]",
-            "properties": {
-                "securityRules": [
-                    {
-                        "name": "myNetworkSecurityGroupRuleSSH",
-                        "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "22",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 1000,
-                            "direction": "Inbound"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "apiVersion": "2019-11-01",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[variables('JumpBoxNicName')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/publicIPAddresses', variables('jumpBoxPublicIPAddressName'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('jumpBoxNsgName'))]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "ipconfig1",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "publicIPAddress": {
-                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('jumpBoxPublicIPAddressName'))]"
-                            },
-                            "subnet": {
-                                "id": "[variables('jumpBoxSubnetId')]"
-                            }
-                        }
-                    }
-                ],
-                "networkSecurityGroup": {
-                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('jumpBoxNsgName'))]"
-                }
-            }
-        },
-        {
-            "apiVersion": "2019-11-01",
-            "type": "Microsoft.Network/networkInterfaces",
-            "name": "[variables('ServerNicName')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
-            ],
-            "properties": {
-                "ipConfigurations": [
-                    {
-                        "name": "ipconfig1",
-                        "properties": {
-                            "privateIPAllocationMethod": "Dynamic",
-                            "subnet": {
-                                "id": "[variables('serverSubnetId')]"
-                            }
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "name": "JumpBox",
-            "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2019-03-01",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
-                "[resourceId('Microsoft.Network/networkInterfaces', variables('JumpBoxNicName'))]"
-            ],
-            "properties": {
-                "hardwareProfile": {
-                    "vmSize": "[parameters('vmSize')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "Canonical",
-                        "offer": "UbuntuServer",
-                        "sku": "18.04-LTS",
-                        "version": "latest"
-                    },
-                    "osDisk": {
-                        "createOption": "FromImage"
-                    }
-                },
-                "osProfile": {
-                    "computerName": "JumpBox",
-                    "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPasswordOrKey')]",
-                    "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('JumpBoxNicName'))]"
-                        }
-                    ]
-                },
-                "diagnosticsProfile": {
-                    "bootDiagnostics": {
-                        "enabled": true,
-                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob]"
-                    }
-                }
-            }
-        },
-        {
-            "name": "Server",
-            "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2019-07-01",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
-                "[resourceId('Microsoft.Network/networkInterfaces', variables('ServerNicName'))]"
-            ],
-            "properties": {
-                "hardwareProfile": {
-                    "vmSize": "[parameters('vmSize')]"
-                },
-                "storageProfile": {
-                    "imageReference": {
-                        "publisher": "Canonical",
-                        "offer": "UbuntuServer",
-                        "sku": "18.04-LTS",
-                        "version": "latest"
-                    },
-                    "osDisk": {
-                        "createOption": "FromImage"
-                    }
-                },
-                "osProfile": {
-                    "computerName": "Server",
-                    "adminUsername": "[parameters('adminUsername')]",
-                    "adminPassword": "[parameters('adminPasswordOrKey')]",
-                    "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
-                },
-                "networkProfile": {
-                    "networkInterfaces": [
-                        {
-                            "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('ServerNicName'))]"
-                        }
-                    ]
-                },
-                "diagnosticsProfile": {
-                    "bootDiagnostics": {
-                        "enabled": true,
-                        "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob]"
-                    }
-                }
-            }
-        },
-        {
-            "apiVersion": "2019-11-01",
-            "type": "Microsoft.Network/azureFirewalls",
-            "name": "[variables('firewallName')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name1'))]",
-                "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name2'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-                "publicIpCopy"
-            ],
-            "properties": {
-                "ipConfigurations": "[variables('azureFirewallIpConfigurations')]",
-                "applicationRuleCollections": [
-                    {
-                        "name": "appRc1",
-                        "properties": {
-                            "priority": 101,
-                            "action": {
-                                "type": "Allow"
-                            },
-                            "rules": [
-                                {
-                                    "name": "someAppRule",
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Http",
-                                            "port": 8080
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "*bing.com"
-                                    ],
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name1'))]"
-                                    ]
-                                },
-                                {
-                                    "name": "someOtherAppRule",
-                                    "protocols": [
-                                        {
-                                            "protocolType": "Mssql",
-                                            "port": 1433
-                                        }
-                                    ],
-                                    "targetFqdns": [
-                                        "sql1.database.windows.net"
-                                    ],
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name1'))]",
-                                        "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name2'))]"
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                ],
-                "networkRuleCollections": [
-                    {
-                        "name": "netRc1",
-                        "properties": {
-                            "priority": 200,
-                            "action": {
-                                "type": "Allow"
-                            },
-                            "rules": [
-                                {
-                                    "name": "networkRule",
-                                    "description": "desc1",
-                                    "protocols": [
-                                        "UDP",
-                                        "TCP",
-                                        "ICMP"
-                                    ],
-                                    "sourceAddresses": [
-                                        "10.0.0.0",
-                                        "111.1.0.0/23"
-                                    ],
-                                    "sourceIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name1'))]"
-                                    ],
-                                    "destinationIpGroups": [
-                                        "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name2'))]"
-                                    ],
-                                    "destinationPorts": [
-                                        "90"
-                                    ]
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": true,
+            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob]"
+          }
         }
-    ]
+      }
+    },
+    {
+      "name": "Server",
+      "type": "Microsoft.Compute/virtualMachines",
+      "apiVersion": "2019-07-01",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('ServerNicName'))]"
+      ],
+      "properties": {
+        "hardwareProfile": {
+          "vmSize": "[parameters('vmSize')]"
+        },
+        "storageProfile": {
+          "imageReference": {
+            "publisher": "Canonical",
+            "offer": "UbuntuServer",
+            "sku": "18.04-LTS",
+            "version": "latest"
+          },
+          "osDisk": {
+            "createOption": "FromImage"
+          }
+        },
+        "osProfile": {
+          "computerName": "Server",
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPasswordOrKey')]",
+          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('ServerNicName'))]"
+            }
+          ]
+        },
+        "diagnosticsProfile": {
+          "bootDiagnostics": {
+            "enabled": true,
+            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob]"
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "2019-11-01",
+      "type": "Microsoft.Network/azureFirewalls",
+      "name": "[variables('firewallName')]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name1'))]",
+        "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name2'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
+        "publicIpCopy"
+      ],
+      "properties": {
+        "ipConfigurations": "[variables('azureFirewallIpConfigurations')]",
+        "applicationRuleCollections": [
+          {
+            "name": "appRc1",
+            "properties": {
+              "priority": 101,
+              "action": {
+                "type": "Allow"
+              },
+              "rules": [
+                {
+                  "name": "someAppRule",
+                  "protocols": [
+                    {
+                      "protocolType": "Http",
+                      "port": 8080
+                    }
+                  ],
+                  "targetFqdns": [
+                    "*bing.com"
+                  ],
+                  "sourceIpGroups": [
+                    "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name1'))]"
+                  ]
+                },
+                {
+                  "name": "someOtherAppRule",
+                  "protocols": [
+                    {
+                      "protocolType": "Mssql",
+                      "port": 1433
+                    }
+                  ],
+                  "targetFqdns": [
+                    "sql1.database.windows.net"
+                  ],
+                  "sourceIpGroups": [
+                    "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name1'))]",
+                    "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name2'))]"
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        "networkRuleCollections": [
+          {
+            "name": "netRc1",
+            "properties": {
+              "priority": 200,
+              "action": {
+                "type": "Allow"
+              },
+              "rules": [
+                {
+                  "name": "networkRule",
+                  "description": "desc1",
+                  "protocols": [
+                    "UDP",
+                    "TCP",
+                    "ICMP"
+                  ],
+                  "sourceAddresses": [
+                    "10.0.0.0",
+                    "111.1.0.0/23"
+                  ],
+                  "sourceIpGroups": [
+                    "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name1'))]"
+                  ],
+                  "destinationIpGroups": [
+                    "[resourceId('Microsoft.Network/ipGroups', parameters('ipgroups_name2'))]"
+                  ],
+                  "destinationPorts": [
+                    "90"
+                  ]
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/101-azurefirewall-create-with-ipgroups-and-linux-jumpbox/metadata.json
+++ b/101-azurefirewall-create-with-ipgroups-and-linux-jumpbox/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template creates an Azure Firewall with Application and Network Rules referring to IpGroups. Also, includes a Linux Jumpbox vm setup",
   "summary": "Create an Azure Firewall with Availability Zones",
   "githubUsername": "ssripadham",
-  "dateUpdated": "2020-02-10"
+  "dateUpdated": "2020-02-28"
 }

--- a/101-azurefirewall-create-with-ipgroups-and-linux-jumpbox/metadata.json
+++ b/101-azurefirewall-create-with-ipgroups-and-linux-jumpbox/metadata.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
   "type": "QuickStart",
+  "environments": [
+    "AzureCloud"
+  ],
   "itemDisplayName": "Create an Azure Firewall with IpGroups",
   "description": "This template creates an Azure Firewall with Application and Network Rules referring to IpGroups. Also, includes a Linux Jumpbox vm setup",
   "summary": "Create an Azure Firewall with Availability Zones",


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-azurefirewall-create-with-ipgroups-and-linux-jumpbox

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('serversSubnetName')]:**
(No VMs with public IP in subnet.  Attached NSG will be empty.)

