### PR TITLE
Adding Network Security Group to 101-azurefirewall-sandbox-linux

### DIFF
--- a/101-azurefirewall-sandbox-linux/azuredeploy.json
+++ b/101-azurefirewall-sandbox-linux/azuredeploy.json
@@ -120,7 +120,8 @@
           }
         ]
       }
-    }
+    },
+    "networkSecurityGroupName": "[concat(variables('serversSubnetName'), '-nsg')]"
   },
   "resources": [
     {
@@ -154,12 +155,21 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('serversSubnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {}
+    },
+    {
       "name": "[parameters('virtualNetworkName')]",
       "apiVersion": "2019-04-01",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[resourceId('Microsoft.Network/routeTables', variables('azfwRouteTableName'))]"
+        "[resourceId('Microsoft.Network/routeTables', variables('azfwRouteTableName'))]",
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
       ],
       "tags": {
         "displayName": "[parameters('virtualNetworkName')]"
@@ -189,6 +199,9 @@
               "addressPrefix": "[variables('serversSubnetPrefix')]",
               "routeTable": {
                 "id": "[resourceId('Microsoft.Network/routeTables', variables('azfwRouteTableName'))]"
+              },
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
               }
             }
           }

--- a/101-azurefirewall-sandbox-linux/metadata.json
+++ b/101-azurefirewall-sandbox-linux/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template creates a virtual network with 3 subnets (server subnet, jumpbox subet and AzureFirewall subnet), a jumpbox VM with public IP, A server VM, UDR route to point to Azure Firewall for the Server Subnet and an Azure Firewall with 1 or more Public IP addresses, 1 sample application rule, 1 sample network rule and default private ranges",
   "summary": "Create a sandbox setup of Azure Firewall with Linux jumpbox and Linux server",
   "githubUsername": "iatodoro",
-  "dateUpdated": "2020-02-13"
+  "dateUpdated": "2020-02-28"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-azurefirewall-sandbox-linux

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('serversSubnetName')]:**
(No VMs with public IP in subnet.  Attached NSG will be empty.)

