### PR TITLE
Adding Network Security Group to 101-hdinsight-hbase-replication-geo

### DIFF
--- a/101-hdinsight-hbase-replication-geo/azuredeploy.json
+++ b/101-hdinsight-hbase-replication-geo/azuredeploy.json
@@ -93,8 +93,8 @@
         ]
       }
     },
-    "networkSecurityGroupName": "vNet1-subnet1-nsg')]",
-    "networkSecurityGroupName2": "vNet2-subnet1-nsg')]"
+    "networkSecurityGroupName": "vNet1-subnet1-nsg",
+    "networkSecurityGroupName2": "vNet2-subnet1-nsg"
   },
   "resources": [
     {

--- a/101-hdinsight-hbase-replication-geo/azuredeploy.json
+++ b/101-hdinsight-hbase-replication-geo/azuredeploy.json
@@ -93,8 +93,8 @@
         ]
       }
     },
-    "networkSecurityGroupName": "[concat(variables('vNet1').subnetName, '-nsg')]",
-    "networkSecurityGroupName2": "[concat(variables('vNet2').subnetName, '-nsg')]"
+    "networkSecurityGroupName": "vNet1-subnet1-nsg')]",
+    "networkSecurityGroupName2": "vNet2-subnet1-nsg')]"
   },
   "resources": [
     {

--- a/101-hdinsight-hbase-replication-geo/azuredeploy.json
+++ b/101-hdinsight-hbase-replication-geo/azuredeploy.json
@@ -92,14 +92,35 @@
           }
         ]
       }
-    }
+    },
+    "networkSecurityGroupName": "[concat(variables('vNet1').subnetName, '-nsg')]",
+    "networkSecurityGroupName2": "[concat(variables('vNet2').subnetName, '-nsg')]"
   },
   "resources": [
+    {
+      "comments": "Simple Network Security Group for subnet [variables('vNet1').subnetName]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {}
+    },
+    {
+      "comments": "Simple Network Security Group for subnet [variables('vNet2').subnetName]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName2')]",
+      "location": "[parameters('location')]",
+      "properties": {}
+    },
     {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('vNet1').name]",
       "apiVersion": "2018-02-01",
       "location": "[variables('vNet1').location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -115,7 +136,10 @@
           {
             "name": "[variables('vNet1').subnetName]",
             "properties": {
-              "addressPrefix": "[variables('vNet1').subnetPrefix]"
+              "addressPrefix": "[variables('vNet1').subnetPrefix]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           },
           {
@@ -173,6 +197,9 @@
       "name": "[variables('vNet2').name]",
       "apiVersion": "2018-02-01",
       "location": "[variables('vNet2').location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -188,7 +215,10 @@
           {
             "name": "[variables('vNet2').subnetName]",
             "properties": {
-              "addressPrefix": "[variables('vNet2').subnetPrefix]"
+              "addressPrefix": "[variables('vNet2').subnetPrefix]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
+              }
             }
           },
           {

--- a/101-hdinsight-hbase-replication-geo/azuredeploy.json
+++ b/101-hdinsight-hbase-replication-geo/azuredeploy.json
@@ -102,7 +102,7 @@
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-08-01",
       "name": "[variables('networkSecurityGroupName')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('vNet1').location]",
       "properties": {}
     },
     {
@@ -110,7 +110,7 @@
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-08-01",
       "name": "[variables('networkSecurityGroupName2')]",
-      "location": "[parameters('location')]",
+      "location": "[variables('vNet2').location]",
       "properties": {}
     },
     {

--- a/101-hdinsight-hbase-replication-geo/metadata.json
+++ b/101-hdinsight-hbase-replication-geo/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to configure an Azure environment for HBase replication across two different regions with VPN vnet-to-vnet connection.",
   "summary": "Deploy two HBase clustes with each in its own VNet across two different regions.",
   "githubUsername": "mumian",
-  "dateUpdated": "2019-12-19"
+  "dateUpdated": "2020-02-28"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-hdinsight-hbase-replication-geo

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('vNet1').subnetName]:**
(No VMs with public IP in subnet.  Attached NSG will be empty.)

**Subnet [variables('vNet2').subnetName]:**
(No VMs with public IP in subnet.  Attached NSG will be empty.)

