### PR TITLE
Adding Network Security Group to 101-rbac-builtinrole-virtualmachine

### DIFF
--- a/101-rbac-builtinrole-virtualmachine/metadata.json
+++ b/101-rbac-builtinrole-virtualmachine/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template grants applicable role based access to an existing VM in a Resource Group",
   "summary": "This template grants applicable role based access to an existing VM in a existing Resource Group",
   "githubUsername": "ManaviS",
-  "dateUpdated": "2019-11-15"
+  "dateUpdated": "2020-02-28"
 }

--- a/101-rbac-builtinrole-virtualmachine/prereqs/prereq.azuredeploy.json
+++ b/101-rbac-builtinrole-virtualmachine/prereqs/prereq.azuredeploy.json
@@ -62,7 +62,7 @@
       "properties": {}
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2019-08-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
@@ -89,7 +89,7 @@
       }
     },
     {
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2019-08-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",
@@ -111,7 +111,7 @@
       }
     },
     {
-      "apiVersion": "2017-03-30",
+      "apiVersion": "2019-12-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",

--- a/101-rbac-builtinrole-virtualmachine/prereqs/prereq.azuredeploy.json
+++ b/101-rbac-builtinrole-virtualmachine/prereqs/prereq.azuredeploy.json
@@ -49,14 +49,26 @@
           }
         ]
       }
-    }
+    },
+    "networkSecurityGroupName": "[concat(variables('subnetName'), '-nsg')]"
   },
   "resources": [
+    {
+      "comments": "Simple Network Security Group for subnet [variables('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {}
+    },
     {
       "apiVersion": "2017-04-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -67,7 +79,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "10.0.0.0/24"
+              "addressPrefix": "10.0.0.0/24",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-rbac-builtinrole-virtualmachine

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnetName')]:**
(No VMs with public IP in subnet.  Attached NSG will be empty.)

