### PR TITLE
Adding Network Security Group to 101-vm-linux-serial-output

### DIFF
--- a/101-vm-linux-serial-output/azuredeploy.json
+++ b/101-vm-linux-serial-output/azuredeploy.json
@@ -43,7 +43,7 @@
     "storageAccountName": "[concat(uniquestring(resourceGroup().id),'storage')]",
     "imagePublisher": "Canonical",
     "imageOffer": "UbuntuServer",
-    "imageSKU": "14.04.2-LTS",
+    "imageSKU": "14.04.5-LTS",
     "nicName": "serialOutputSampleNic",
     "addressPrefix": "10.0.0.0/16",
     "subnetName": "serialOutputSampleSubnet",

--- a/101-vm-linux-serial-output/azuredeploy.json
+++ b/101-vm-linux-serial-output/azuredeploy.json
@@ -52,7 +52,7 @@
     "publicIPAddressName": "serialOutputSamplePublicIP",
     "publicIPAddressType": "Dynamic",
     "vmName": "serialOutputSampleVM",
-    "vmSize": "Standard_D2",
+    "vmSize": "Standard_D2_v2",
     "virtualNetworkName": "serialOutputSampleVNET",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
     "apiVersion": "2015-06-15",

--- a/101-vm-linux-serial-output/azuredeploy.json
+++ b/101-vm-linux-serial-output/azuredeploy.json
@@ -66,7 +66,8 @@
           }
         ]
       }
-    }
+    },
+    "networkSecurityGroupName": "[concat(variables('subnetName'), '-nsg')]"
   },
   "resources": [
     {
@@ -91,10 +92,37 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-22",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "22",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -105,7 +133,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/101-vm-linux-serial-output/metadata.json
+++ b/101-vm-linux-serial-output/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template creates a simple Linux VM with minimal parameters and serial/console configured to output to storage",
   "summary": "This template create a single and simple Linux VM with console and serial output turned on.",
   "githubUsername": "coreysa",
-  "dateUpdated": "2019-05-30"
+  "dateUpdated": "2020-03-02"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-vm-linux-serial-output

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnetName')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
serialOutputSampleVM | Tcp | 22 | True | Standard remote access

