### PR TITLE
Adding Network Security Group to 101-vm-secure-password

### DIFF
--- a/101-vm-secure-password/azuredeploy.json
+++ b/101-vm-secure-password/azuredeploy.json
@@ -56,7 +56,8 @@
     "vmSize": "Standard_A1",
     "virtualNetworkName": "MyVNET",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
-    "apiVersion": "2015-06-15"
+    "apiVersion": "2015-06-15",
+    "networkSecurityGroupName": "[concat(variables('subnetName'), '-nsg')]"
   },
   "resources": [
     {
@@ -81,10 +82,37 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -95,7 +123,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/101-vm-secure-password/azuredeploy.parameters.json
+++ b/101-vm-secure-password/azuredeploy.parameters.json
@@ -8,9 +8,9 @@
     "adminPassword": {
       "reference": {
         "keyVault": {
-          "id": "/subscriptions/XXXXXXX/resourceGroups/resourceGroupName/providers/Microsoft.KeyVault/vaults/vaultName"
+          "id": "GEN-KEYVAULT-NAME"
         },
-        "secretName": "secretName"
+        "secretName": "GEN-KEYVAULT-PASSWORD-REFERENCE"
       }
     },
     "dnsLabelPrefix": {

--- a/101-vm-secure-password/azuredeploy.parameters.json
+++ b/101-vm-secure-password/azuredeploy.parameters.json
@@ -8,7 +8,7 @@
     "adminPassword": {
       "reference": {
         "keyVault": {
-          "id": "GEN-KEYVAULT-NAME"
+          "id": "GEN-KEYVAULT-RESOURCE-ID"
         },
         "secretName": "GEN-KEYVAULT-PASSWORD-REFERENCE"
       }

--- a/101-vm-secure-password/azuredeploy.parameters.json
+++ b/101-vm-secure-password/azuredeploy.parameters.json
@@ -3,15 +3,10 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "adminUsername": {
-      "value": "azureuser"
+      "value": "GEN-UNIQUE"
     },
     "adminPassword": {
-      "reference": {
-        "keyVault": {
-          "id": "GEN-KEYVAULT-RESOURCE-ID"
-        },
-        "secretName": "GEN-KEYVAULT-PASSWORD-REFERENCE"
-      }
+      "reference": "GEN-KEYVAULT-PASSWORD-REFERENCE"
     },
     "dnsLabelPrefix": {
       "value": "GEN-UNIQUE"

--- a/101-vm-secure-password/metadata.json
+++ b/101-vm-secure-password/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to deploy a simple Windows VM by retrieving the password that is stored in a Key Vault. Therefore the password is never put in plain text in the template parameter file",
   "summary": "This template takes deploys a VM by retrieving the password securely from a Key Vault",
   "githubUsername": "singhkays",
-  "dateUpdated": "2016-02-09"
+  "dateUpdated": "2020-03-02"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-vm-secure-password

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnetName')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
SimpleWindowsVM | Tcp | 3389 | True | Standard remote access

