### PR TITLE
Adding Network Security Group to 101-vm-with-rdp-port

### DIFF
--- a/101-vm-with-rdp-port/azuredeploy.json
+++ b/101-vm-with-rdp-port/azuredeploy.json
@@ -53,7 +53,7 @@
     "imagePublisher": "MicrosoftWindowsServer",
     "imageOffer": "WindowsServer",
     "imageSku": "2012-R2-Datacenter",
-    "networkSecurityGroupName": "[concat(Subnet, '-nsg')]"
+    "networkSecurityGroupName": "Subnet-nsg"
   },
   "resources": [
     {

--- a/101-vm-with-rdp-port/azuredeploy.json
+++ b/101-vm-with-rdp-port/azuredeploy.json
@@ -52,7 +52,8 @@
     "subnet-id": "[concat(resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')),'/subnets/',variables('subnetName'))]",
     "imagePublisher": "MicrosoftWindowsServer",
     "imageOffer": "WindowsServer",
-    "imageSku": "2012-R2-Datacenter"
+    "imageSku": "2012-R2-Datacenter",
+    "networkSecurityGroupName": "[concat(Subnet, '-nsg')]"
   },
   "resources": [
     {
@@ -77,10 +78,21 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [Subnet]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {}
+    },
+    {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -91,7 +103,10 @@
           {
             "name": "Subnet",
             "properties": {
-              "addressPrefix": "[variables('subnetAddressRange')]"
+              "addressPrefix": "[variables('subnetAddressRange')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/101-vm-with-rdp-port/azuredeploy.json
+++ b/101-vm-with-rdp-port/azuredeploy.json
@@ -224,7 +224,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[concat('http://',variables('storageAccountName'),'.blob.core.windows.net')]"
+            "storageUri": "[reference(variables('storageAccountName'), '2018-02-01').primaryEndpoints.blob]"
           }
         }
       }

--- a/101-vm-with-rdp-port/metadata.json
+++ b/101-vm-with-rdp-port/metadata.json
@@ -5,7 +5,5 @@
   "description": "Creates a virtual machine and creates a NAT rule for RDP to the VM in load balancer",
   "summary": "Creates a virtual machine with RDP port",
   "githubUsername": "mmarch",
-  "dateUpdated": "2015-12-22"
+  "dateUpdated": "2020-03-02"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-vm-with-rdp-port

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [Subnet]:**

(No VMs with public IP in subnet.  Attached NSG will be empty.)

