### PR TITLE
Adding Network Security Group to 101-vm-with-standardssd-disk

### DIFF
--- a/101-vm-with-standardssd-disk/azuredeploy.json
+++ b/101-vm-with-standardssd-disk/azuredeploy.json
@@ -61,10 +61,10 @@
     }
   },
   "variables": {
-    "dataDiskSize":1024,
-    "dataDisksCount":5,
-    "virtualNetworkName":"[concat(toLower(parameters('virtualMachineName')),'-vnet')]",
-    "subnetName":"[concat(toLower(parameters('virtualMachineName')),'-subnet')]",
+    "dataDiskSize": 1024,
+    "dataDisksCount": 5,
+    "virtualNetworkName": "[concat(toLower(parameters('virtualMachineName')),'-vnet')]",
+    "subnetName": "[concat(toLower(parameters('virtualMachineName')),'-subnet')]",
     "imagePublisher": "MicrosoftWindowsServer",
     "imageOffer": "WindowsServer",
     "OSDiskName": "[concat(toLower(parameters('virtualMachineName')),'OSDisk')]",
@@ -73,7 +73,8 @@
     "publicIPAddressType": "Dynamic",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
     "networkInterfaceName": "[toLower(parameters('virtualMachineName'))]",
-    "publicIpAddressName": "[concat(toLower(parameters('virtualMachineName')),'-ip')]"
+    "publicIpAddressName": "[concat(toLower(parameters('virtualMachineName')),'-ip')]",
+    "networkSecurityGroupName": "[concat(variables('subnetName'), '-nsg')]"
   },
   "resources": [
     {
@@ -91,10 +92,37 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2018-02-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -105,7 +133,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/101-vm-with-standardssd-disk/azuredeploy.parameters.json
+++ b/101-vm-with-standardssd-disk/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "virtualMachineName": {
-            "value": "GEN-UNIQUE"
+            "value": "GEN-UNIQUE-15"
         },
         "adminUsername": {
             "value": "GEN-UNIQUE"

--- a/101-vm-with-standardssd-disk/metadata.json
+++ b/101-vm-with-standardssd-disk/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template allows you to create a Windows Virtual Machine from a specified image. It also attaches multiple empty StandardSSD data disks by default. Note that you can specify the size and the Storage type (Standard_LRS, StandardSSD_LRS and Premium_LRS) of the empty data disks.",
   "summary": "Create a VM from a Windows Image with N Empty Data Disks",
   "githubUsername": "ramankumarlive",
-  "dateUpdated": "2018-06-04"
+  "dateUpdated": "2020-03-04"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 101-vm-with-standardssd-disk

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnetName')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
GEN-UNIQUE | Tcp | 3389 | True | Standard remote access

