### PR TITLE
Adding Network Security Group to 201-encrypt-running-linux-vm-without-aad

### DIFF
--- a/201-encrypt-running-linux-vm-without-aad/metadata.json
+++ b/201-encrypt-running-linux-vm-without-aad/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template enables encryption on a running Linux VM without needing AAD application details",
   "summary": "This template enables encryption on a running Linux VM",
   "githubUsername": "azure",
-  "dateUpdated": "2019-11-15"
+  "dateUpdated": "2020-03-04"
 }

--- a/201-encrypt-running-linux-vm-without-aad/prereqs/.settings.json
+++ b/201-encrypt-running-linux-vm-without-aad/prereqs/.settings.json
@@ -1,0 +1,4 @@
+{
+    "comment": "If prereqs need to be deployed to the same resourceGroup as the rest of the sample set the PrereqResourceGroupNameSuffix property to an empty string - otherwise you can omit this file",
+    "PrereqResourceGroupNameSuffix": "" 
+}

--- a/201-encrypt-running-linux-vm-without-aad/prereqs/prereq.azuredeploy.json
+++ b/201-encrypt-running-linux-vm-without-aad/prereqs/prereq.azuredeploy.json
@@ -120,7 +120,7 @@
       ],
       "properties": {
         "hardwareProfile": {
-          "vmSize": "Standard_A1"
+          "vmSize": "Standard_A4_v2"
         },
         "osProfile": {
           "computerName": "[variables('vmName')]",

--- a/201-encrypt-running-linux-vm-without-aad/prereqs/prereq.azuredeploy.json
+++ b/201-encrypt-running-linux-vm-without-aad/prereqs/prereq.azuredeploy.json
@@ -132,7 +132,7 @@
           "imageReference": {
             "publisher": "Canonical",
             "offer": "UbuntuServer",
-            "sku": "14.04.5-DAILY-LTS",
+            "sku": "18.04-LTS",
             "version": "latest"
           },
           "osDisk": {

--- a/201-encrypt-running-linux-vm-without-aad/prereqs/prereq.azuredeploy.json
+++ b/201-encrypt-running-linux-vm-without-aad/prereqs/prereq.azuredeploy.json
@@ -49,14 +49,26 @@
           }
         ]
       }
-    }
+    },
+    "networkSecurityGroupName": "[concat(variables('subnetName'), '-nsg')]"
   },
   "resources": [
+    {
+      "comments": "Simple Network Security Group for subnet [variables('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {}
+    },
     {
       "apiVersion": "2017-04-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -67,7 +79,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "10.0.0.0/24"
+              "addressPrefix": "10.0.0.0/24",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-encrypt-running-linux-vm-without-aad

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnetName')]:**

(No VMs with public IP in subnet.  Attached NSG will be empty.)

