### PR TITLE
Adding Network Security Group to 201-encrypt-running-windows-vm-without-aad

### DIFF
--- a/201-encrypt-running-windows-vm-without-aad/metadata.json
+++ b/201-encrypt-running-windows-vm-without-aad/metadata.json
@@ -1,11 +1,9 @@
 {
   "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
   "type": "QuickStart",
-    "itemDisplayName": "Enable encryption on a running Windows VM without AAD",
-    "description": "This template enables encryption on a running windows VM without needing AAD application details",
-    "summary": "This template enables encryption on a running windows VM",
-    "githubUsername": "sudhakarareddyevuri",
-    "dateUpdated": "2018-04-24"
+  "itemDisplayName": "Enable encryption on a running Windows VM without AAD",
+  "description": "This template enables encryption on a running windows VM without needing AAD application details",
+  "summary": "This template enables encryption on a running windows VM",
+  "githubUsername": "sudhakarareddyevuri",
+  "dateUpdated": "2020-03-04"
 }
-
-

--- a/201-encrypt-running-windows-vm-without-aad/prereqs/.settings.json
+++ b/201-encrypt-running-windows-vm-without-aad/prereqs/.settings.json
@@ -1,0 +1,4 @@
+{
+    "comment": "If prereqs need to be deployed to the same resourceGroup as the rest of the sample set the PrereqResourceGroupNameSuffix property to an empty string - otherwise you can omit this file",
+    "PrereqResourceGroupNameSuffix": "" 
+}

--- a/201-encrypt-running-windows-vm-without-aad/prereqs/prereq.azuredeploy.json
+++ b/201-encrypt-running-windows-vm-without-aad/prereqs/prereq.azuredeploy.json
@@ -117,7 +117,7 @@
           },
           "dataDisks": [
             {
-              "diskSizeGB": "1023",
+              "diskSizeGB": "32",
               "lun": 0,
               "createOption": "Empty"
             }

--- a/201-encrypt-running-windows-vm-without-aad/prereqs/prereq.azuredeploy.json
+++ b/201-encrypt-running-windows-vm-without-aad/prereqs/prereq.azuredeploy.json
@@ -117,7 +117,7 @@
           },
           "dataDisks": [
             {
-              "diskSizeGB": "32",
+              "diskSizeGB": "1023",
               "lun": 0,
               "createOption": "Empty"
             }

--- a/201-encrypt-running-windows-vm-without-aad/prereqs/prereq.azuredeploy.json
+++ b/201-encrypt-running-windows-vm-without-aad/prereqs/prereq.azuredeploy.json
@@ -27,14 +27,26 @@
     "subnetName": "Subnet",
     "vmName": "MyWindowsVM",
     "virtualNetworkName": "MyVNET",
-    "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', variables('virtualNetworkName'), variables('subnetName'))]"
+    "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', variables('virtualNetworkName'), variables('subnetName'))]",
+    "networkSecurityGroupName": "[concat(variables('subnetName'), '-nsg')]"
   },
   "resources": [
+    {
+      "comments": "Simple Network Security Group for subnet [variables('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {}
+    },
     {
       "apiVersion": "2017-04-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -45,7 +57,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "10.0.0.0/24"
+              "addressPrefix": "10.0.0.0/24",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-encrypt-running-windows-vm-without-aad

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnetName')]:**

(No VMs with public IP in subnet.  Attached NSG will be empty.)

