### PR TITLE
Adding Network Security Group to 201-vm-push-certificate-windows

### DIFF
--- a/201-vm-push-certificate-windows/azuredeploy.json
+++ b/201-vm-push-certificate-windows/azuredeploy.json
@@ -55,7 +55,8 @@
     "subnet1Name": "Subnet-1",
     "virtualNetworkName": "certVNET",
     "addressPrefix": "10.0.0.0/16",
-    "publicIPName": "certPublicIP"
+    "publicIPName": "certPublicIP",
+    "networkSecurityGroupName": "[concat(variables('subnet1Name'), '-nsg')]"
   },
   "resources": [
     {
@@ -68,10 +69,37 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('subnet1Name')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2019-06-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -82,7 +110,10 @@
           {
             "name": "[variables('subnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
+              "addressPrefix": "[variables('subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/201-vm-push-certificate-windows/metadata.json
+++ b/201-vm-push-certificate-windows/metadata.json
@@ -5,7 +5,5 @@
   "description": "Push a certificate onto a Windows VM. Create the Key Vault using the template at http://azure.microsoft.com/en-us/documentation/templates/101-create-key-vault",
   "summary": "Push a certificate onto a Windows VM",
   "githubUsername": "bmoore-msft",
-  "dateUpdated": "2019-10-05"
+  "dateUpdated": "2020-03-04"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vm-push-certificate-windows

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnet1Name')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
WindowsVm | Tcp | 3389 | True | Standard remote access

