### PR TITLE
Adding Network Security Group to 201-vm-vmss-orchestrator

### DIFF
--- a/201-vm-vmss-orchestrator/azuredeploy.json
+++ b/201-vm-vmss-orchestrator/azuredeploy.json
@@ -125,7 +125,7 @@
       }
     },
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('myVNETName'),  variables('myVNETSubnet1Name'))]",
-    "noZoneObj" : {
+    "noZoneObj": {
       "none": null
     },
     "fdCountOptions": {
@@ -133,14 +133,42 @@
       "nonzonal": 2
     },
     "selectedZone": "[if(equals(parameters('virtualMachineScaleSetAvailabilityZone'), 'none'), variables('noZoneObj').none, array(parameters('virtualMachineScaleSetAvailabilityZone')))]",
-    "virtualMachineScaleSetPlatformFaultDomainCount": "[if(equals(parameters('virtualMachineScaleSetAvailabilityZone'), 'none'), variables('fdCountOptions').nonzonal, variables('fdCountOptions').zonal)]"
+    "virtualMachineScaleSetPlatformFaultDomainCount": "[if(equals(parameters('virtualMachineScaleSetAvailabilityZone'), 'none'), variables('fdCountOptions').nonzonal, variables('fdCountOptions').zonal)]",
+    "networkSecurityGroupName": "[concat(variables('myVNETSubnet1Name'), '-nsg')]"
   },
   "resources": [
+    {
+      "comments": "Simple Network Security Group for subnet [variables('myVNETSubnet1Name')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-22",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "22",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
     {
       "name": "[variables('myVNETName')]",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[parameters('location')]",
       "apiVersion": "2019-04-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "tags": {
         "displayName": "[variables('myVNETName')]"
       },
@@ -154,7 +182,10 @@
           {
             "name": "[variables('myVNETSubnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('myVNETSubnet1Prefix')]"
+              "addressPrefix": "[variables('myVNETSubnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/201-vm-vmss-orchestrator/metadata.json
+++ b/201-vm-vmss-orchestrator/metadata.json
@@ -5,6 +5,5 @@
   "description": "This template will create N number of VM's with managed disks, public IPs and network interfaces. It will create the VMs in a Virtula Machine Scale Set. They will be provisioned in a Virtual Network which will also be created as part of the deployment ",
   "summary": "This template will create N number of VM's with managed disks, public IPs and network interfaces.",
   "githubUsername": "fitzgeraldsteele",
-  "dateUpdated": "2019-10-31"
+  "dateUpdated": "2020-03-04"
 }
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vm-vmss-orchestrator

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('myVNETSubnet1Name')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
MyVM01 | Tcp | 22 | True | Standard remote access

