### PR TITLE
Adding Network Security Group to 201-vm-winrm-keyvault-windows

### DIFF
--- a/201-vm-winrm-keyvault-windows/azuredeploy.json
+++ b/201-vm-winrm-keyvault-windows/azuredeploy.json
@@ -76,7 +76,8 @@
     "publicIPAddressType": "Dynamic",
     "virtualNetworkName": "myVNET",
     "nicName": "myNIC",
-    "subnet1Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]"
+    "subnet1Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]",
+    "networkSecurityGroupName": "[concat(variables('subnet1Name'), '-nsg')]"
   },
   "resources": [
     {
@@ -92,10 +93,37 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('subnet1Name')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2017-09-01",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -106,7 +134,10 @@
           {
             "name": "[variables('subnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
+              "addressPrefix": "[variables('subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/201-vm-winrm-keyvault-windows/azuredeploy.json
+++ b/201-vm-winrm-keyvault-windows/azuredeploy.json
@@ -171,7 +171,7 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines",
-      "apiVersion": "2017-03-30",
+      "apiVersion": "2019-07-01",
       "name": "[parameters('vmName')]",
       "location": "[resourceGroup().location]",
       "dependsOn": [

--- a/201-vm-winrm-keyvault-windows/azuredeploy.parameters.json
+++ b/201-vm-winrm-keyvault-windows/azuredeploy.parameters.json
@@ -15,7 +15,7 @@
             "value": "GEN-KEYVAULT-RESOURCE-ID"
         },
         "certificateUrl": {
-            "value": "GEN-KEYVAULT-SSL-SECRET-URI"
+            "value": "GEN-SF-CERT-URL"
         }
     }
 }

--- a/201-vm-winrm-keyvault-windows/metadata.json
+++ b/201-vm-winrm-keyvault-windows/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template installs a certificate from Azure Key Vault on a Virtual Machine and opens up WinRM HTTP and HTTPS listeners. Prerequisite: A certificate uploaded to Azure Key Vault. Create the Key Vault using the template at http://azure.microsoft.com/en-us/documentation/templates/101-create-key-vault",
   "summary": "Enable WinRM on a Windows VM",
   "githubUsername": "singhkays",
-  "dateUpdated": "2015-05-03"
+  "dateUpdated": "2020-03-04"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vm-winrm-keyvault-windows

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnet1Name')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
WinRmVm | Tcp | 3389 | True | Standard remote access

