### PR TITLE
Adding Network Security Group to 201-vmss-internal-loadbalancer

### DIFF
--- a/201-vmss-internal-loadbalancer/azuredeploy.json
+++ b/201-vmss-internal-loadbalancer/azuredeploy.json
@@ -109,14 +109,42 @@
           }
         ]
       }
-    }
+    },
+    "networkSecurityGroupName": "[concat(variables('subnetName'), '-nsg')]"
   },
   "resources": [
+    {
+      "comments": "Simple Network Security Group for subnet [variables('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-22",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "22",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
     {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
       "apiVersion": "2018-04-01",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -127,7 +155,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/201-vmss-internal-loadbalancer/azuredeploy.json
+++ b/201-vmss-internal-loadbalancer/azuredeploy.json
@@ -249,7 +249,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference(parameters('jumpBoxSAName'), '2018-02-01').primaryEndpoints.blob]"
+            "storageUri": "[reference(variables('jumpBoxSAName'), '2018-02-01').primaryEndpoints.blob]"
           }
         }
       }

--- a/201-vmss-internal-loadbalancer/azuredeploy.json
+++ b/201-vmss-internal-loadbalancer/azuredeploy.json
@@ -249,7 +249,7 @@
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[concat('http://',variables('jumpBoxSAName'),'.blob.core.windows.net')]"
+            "storageUri": "[reference(parameters('jumpBoxSAName'), '2018-02-01').primaryEndpoints.blob]"
           }
         }
       }

--- a/201-vmss-internal-loadbalancer/metadata.json
+++ b/201-vmss-internal-loadbalancer/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to deploy a VM Scale Set of Linux VMs using the latest patched version of Ubuntu Linux 15.10 or 14.04.4-LTS. These VMs are behind an internal load balancer with NAT rules for ssh connections.",
   "summary": "This template deploys a VM Scale Set of Linux VMs behind an internal load balancer with NAT rules for ssh connections.",
   "githubUsername": "gatneil",
-  "dateUpdated": "2019-07-08"
+  "dateUpdated": "2020-03-04"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 201-vmss-internal-loadbalancer

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnetName')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
gen-uniqujbox | Tcp | 22 | True | Standard remote access

