### PR TITLE
Adding Network Security Group to 301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd

### DIFF
--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
@@ -100,8 +100,8 @@
     "imageOffer": "UbuntuServer",
     "imageSku": "14.04.2-LTS",
     "SQLimagePublisher": "MicrosoftSQLServer",
-    "SQLimageOffer": "SQL2014SP1-WS2012R2",
-    "SQLimageSku": "Web",
+    "SQLimageOffer": "sql2019-ws2019",
+    "SQLimageSku": "Standard",
     "networkSecurityGroupName": "Subnet-nsg"
   },
   "resources": [

--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
@@ -63,7 +63,7 @@
         "subnet-id": "[resourceId('Microsoft.Network/virtualNetworks/subnets','VNET',variables('subnetName'))]",
         "imagePublisher": "Canonical",
         "imageOffer": "UbuntuServer",
-        "imageSku": "14.04.5-LTS",
+        "imageSku": "14.04.2-LTS",
         "SQLimagePublisher": "MicrosoftSQLServer",
         "SQLimageOffer": "sql2019-ws2019",
         "SQLimageSku": "Standard",
@@ -71,7 +71,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2015-06-15",
+            "apiVersion": "2019-08-01",
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "publicIp",
             "location": "[parameters('location')]",
@@ -83,7 +83,7 @@
             }
         },
         {
-            "apiVersion": "2015-06-15",
+            "apiVersion": "2019-08-01",
             "type": "Microsoft.Network/publicIPAddresses",
             "name": "vmsqlIp",
             "location": "[parameters('location')]",
@@ -94,21 +94,24 @@
         {
             "type": "Microsoft.Compute/availabilitySets",
             "name": "myavlset",
-            "apiVersion": "2016-04-30-preview",
+            "apiVersion": "2019-12-01",
             "location": "[parameters('location')]",
+            "sku": {
+                "name": "Aligned"
+            },
             "properties": {
                 "platformFaultDomainCount": 2,
-                "platformUpdateDomainCount": 2,
-                "managed": true
+                "platformUpdateDomainCount": 2
             }
         },
         {
-            "apiVersion": "2015-06-15",
+            "apiVersion": "2019-06-01",
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountNameDiag')]",
             "location": "[parameters('location')]",
-            "properties": {
-                "accountType": "Standard_LRS"
+            "kind": "StorageV2",
+            "sku": {
+                "name": "Standard_LRS"
             }
         },
         {
@@ -121,7 +124,7 @@
             }
         },
         {
-            "apiVersion": "2015-06-15",
+            "apiVersion": "2019-08-01",
             "type": "Microsoft.Network/virtualNetworks",
             "name": "VNET",
             "location": "[parameters('location')]",
@@ -153,7 +156,7 @@
             "type": "Microsoft.Network/loadBalancers",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "Microsoft.Network/publicIPAddresses/publicIp"
+                "publicIp"
             ],
             "properties": {
                 "frontendIpConfigurations": [
@@ -231,7 +234,7 @@
             }
         },
         {
-            "apiVersion": "2015-06-15",
+            "apiVersion": "2019-08-01",
             "type": "Microsoft.Network/networkSecurityGroups",
             "name": "vmsql",
             "location": "[parameters('location')]",
@@ -255,7 +258,7 @@
             }
         },
         {
-            "apiVersion": "2015-06-15",
+            "apiVersion": "2019-08-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[concat(variables('vmName'),copyindex())]",
             "copy": {
@@ -264,8 +267,8 @@
             },
             "location": "[parameters('location')]",
             "dependsOn": [
-                "Microsoft.Network/virtualNetworks/VNET",
-                "Microsoft.Network/loadBalancers/loadBalancer"
+                "VNET",
+                "loadBalancer"
             ],
             "properties": {
                 "ipConfigurations": [
@@ -292,13 +295,13 @@
             }
         },
         {
-            "apiVersion": "2015-06-15",
+            "apiVersion": "2019-08-01",
             "type": "Microsoft.Network/networkInterfaces",
             "name": "[variables('nicsql')]",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "Microsoft.Network/virtualNetworks/VNET",
-                "Microsoft.Network/networkSecurityGroups/vmsql"
+                "VNET",
+                "vmsql"
             ],
             "properties": {
                 "networkSecurityGroup": {
@@ -321,7 +324,7 @@
             }
         },
         {
-            "apiVersion": "2016-04-30-preview",
+            "apiVersion": "2019-12-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "[concat(variables('vmName'), copyindex())]",
             "copy": {
@@ -367,13 +370,13 @@
                 "diagnosticsProfile": {
                     "bootDiagnostics": {
                         "enabled": true,
-                        "storageUri": "[reference(variables('storageAccountNameDiag'), '2018-02-01').primaryEndpoints.blob]"
+                        "storageUri": "[reference(variables('storageAccountNameDiag'), '2019-06-01').primaryEndpoints.blob]"
                     }
                 }
             }
         },
         {
-            "apiVersion": "2016-04-30-preview",
+            "apiVersion": "2019-12-01",
             "type": "Microsoft.Compute/virtualMachines",
             "name": "vmsql",
             "location": "[parameters('location')]",
@@ -424,7 +427,7 @@
                 "diagnosticsProfile": {
                     "bootDiagnostics": {
                         "enabled": true,
-                        "storageUri": "[reference(variables('storageAccountNameDiag'), '2018-02-01').primaryEndpoints.blob]"
+                        "storageUri": "[reference(variables('storageAccountNameDiag'), '2019-06-01').primaryEndpoints.blob]"
                     }
                 }
             }

--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
@@ -301,7 +301,7 @@
             "location": "[parameters('location')]",
             "dependsOn": [
                 "VNET",
-                "vmsql"
+                "[resourceId('Microsoft.Network/networkSecurityGroups', 'vmsql')]"
             ],
             "properties": {
                 "networkSecurityGroup": {

--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
@@ -101,7 +101,8 @@
     "imageSku": "14.04.2-LTS",
     "SQLimagePublisher": "MicrosoftSQLServer",
     "SQLimageOffer": "SQL2014SP1-WS2012R2",
-    "SQLimageSku": "Web"
+    "SQLimageSku": "Web",
+    "networkSecurityGroupName": "Subnet-nsg"
   },
   "resources": [
     {
@@ -146,10 +147,21 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [Subnet]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {}
+    },
+    {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "VNET",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -160,7 +172,10 @@
           {
             "name": "Subnet",
             "properties": {
-              "addressPrefix": "[variables('subnetAddressRange')]"
+              "addressPrefix": "[variables('subnetAddressRange')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
@@ -1,467 +1,433 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.0",
-  "parameters": {
-    "publicDnsName": {
-      "type": "string",
-      "metadata": {
-        "description": "Unique public DNS prefix for the deployment. The fqdn will look something like '<dnsname>.westus.cloudapp.azure.com'. Up to 62 chars, digits or dashes, lowercase, should start with a letter: must conform to '^[a-z][a-z0-9-]{1,61}[a-z0-9]$'."
-      }
-    },
-    "adminUsername": {
-      "type": "string",
-      "metadata": {
-        "description": "The name of the administrator of the new VM. Exclusion list: 'admin','administrator'"
-      }
-    },
-    "adminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "The password for the administrator account of the new VM"
-      }
-    },
-    "storageType": {
-      "type": "string",
-      "allowedValues": [
-        "Premium_LRS",
-        "Standard_LRS"
-      ],
-      "metadata": {
-        "description": "Type of storage:Premium (SSD) or Standard"
-      }
-    },
-    "sizeOfDiskInGB": {
-      "type": "string",
-      "metadata": {
-        "description": "Size of data disk in GB 128-1024"
-      }
-    },
-    "vmSizeFE": {
-      "type": "string",
-      "allowedValues": [
-        "Standard_DS1",
-        "Standard_DS2",
-        "Standard_DS3",
-        "Standard_DS4",
-        "Standard_DS11",
-        "Standard_DS12",
-        "Standard_DS13",
-        "Standard_DS14",
-        "Standard_GS1",
-        "Standard_GS2",
-        "Standard_GS3",
-        "Standard_GS4",
-        "Standard_GS5"
-      ],
-      "metadata": {
-        "description": "VM size allowed for Front End"
-      }
-    },
-    "vmSizeSQL": {
-      "type": "string",
-      "allowedValues": [
-        "Standard_DS1",
-        "Standard_DS2",
-        "Standard_DS3",
-        "Standard_DS4",
-        "Standard_DS11",
-        "Standard_DS12",
-        "Standard_DS13",
-        "Standard_DS14",
-        "Standard_GS1",
-        "Standard_GS2",
-        "Standard_GS3",
-        "Standard_GS4",
-        "Standard_GS5"
-      ],
-      "metadata": {
-        "description": "VM size allowed for SQL Server Back End"
-      }
-    },
-    "location": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]",
-      "metadata": {
-        "description": "Location for all resources."
-      }
-    }
-  },
-  "variables": {
-    "vnetAddressRange": "10.0.0.0/16",
-    "subnetAddressRange": "10.0.0.0/24",
-    "subnetName": "Subnet",
-    "numberOfInstances": 2,
-    "availabilitySetName": "myavlset",
-    "vmName": "vm",
-    "nicsql": "[concat(variables('vmName'),'sql')]",
-    "storageAccountNameDiag": "[concat('diag',uniqueString(resourceGroup().id))]",
-    "subnet-id": "[concat(resourceId('Microsoft.Network/virtualNetworks','VNET'),'/subnets/',variables('subnetName'))]",
-    "imagePublisher": "Canonical",
-    "imageOffer": "UbuntuServer",
-    "imageSku": "14.04.2-LTS",
-    "SQLimagePublisher": "MicrosoftSQLServer",
-    "SQLimageOffer": "sql2019-ws2019",
-    "SQLimageSku": "Standard",
-    "networkSecurityGroupName": "Subnet-nsg"
-  },
-  "resources": [
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "publicIp",
-      "location": "[parameters('location')]",
-      "properties": {
-        "publicIPAllocationMethod": "Dynamic",
-        "dnsSettings": {
-          "domainNameLabel": "[parameters('publicDnsName')]"
-        }
-      }
-    },
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "vmsqlIp",
-      "location": "[parameters('location')]",
-      "properties": {
-        "publicIPAllocationMethod": "Dynamic"
-      }
-    },
-    {
-      "type": "Microsoft.Compute/availabilitySets",
-      "name": "myavlset",
-      "apiVersion": "2016-04-30-preview",
-      "location": "[parameters('location')]",
-      "properties": {
-        "platformFaultDomainCount": 2,
-        "platformUpdateDomainCount": 2,
-        "managed": true
-      }
-    },
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountNameDiag')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "accountType": "Standard_LRS"
-      }
-    },
-    {
-      "comments": "Simple Network Security Group for subnet [Subnet]",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2019-08-01",
-      "name": "[variables('networkSecurityGroupName')]",
-      "location": "[parameters('location')]",
-      "properties": {}
-    },
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/virtualNetworks",
-      "name": "VNET",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
-      ],
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[variables('vnetAddressRange')]"
-          ]
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "publicDnsName": {
+            "type": "string",
+            "metadata": {
+                "description": "Unique public DNS prefix for the deployment. Up to 62 chars, digits or dashes, lowercase, should start with a letter: must conform to '^[a-z][a-z0-9-]{1,61}[a-z0-9]$'."
+            }
         },
-        "subnets": [
-          {
-            "name": "Subnet",
-            "properties": {
-              "addressPrefix": "[variables('subnetAddressRange')]",
-              "networkSecurityGroup": {
-                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
-              }
+        "adminUsername": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the administrator of the new VM. Exclusion list: 'admin','administrator'"
             }
-          }
-        ]
-      }
+        },
+        "adminPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The password for the administrator account of the new VM"
+            }
+        },
+        "sizeOfDiskInGB": {
+            "type": "int",
+            "defaultValue": 128,
+            "minValue": 128,
+            "maxValue": 1024,
+            "metadata": {
+                "description": "Size of data disk in GB 128-1024"
+            }
+        },
+        "vmSizeFE": {
+            "type": "string",
+            "defaultValue": "Standard_D2s_v3",
+            "metadata": {
+                "description": "VM size allowed for Front End"
+            }
+        },
+        "vmSizeSQL": {
+            "type": "string",
+            "defaultValue": "Standard_D2s_v3",
+            "metadata": {
+                "description": "VM size allowed for SQL Server Back End"
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        }
     },
-    {
-      "apiVersion": "2018-10-01",
-      "name": "loadBalancer",
-      "type": "Microsoft.Network/loadBalancers",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "Microsoft.Network/publicIPAddresses/publicIp"
-      ],
-      "properties": {
-        "frontendIpConfigurations": [
-          {
-            "name": "LBFE",
-            "properties": {
-              "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses','publicIp')]"
-              }
-            }
-          }
-        ],
-        "backendAddressPools": [
-          {
-            "name": "LBBAP"
-          }
-        ],
-        "inboundNatRules": [
-          {
-            "name": "[concat('rdp','0')]",
-            "properties": {
-              "frontendIPConfiguration": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/frontendIPConfigurations/LBFE')]"
-              },
-              "protocol": "Tcp",
-              "frontendPort": 6001,
-              "backendPort": 22,
-              "enableFloatingIP": false
-            }
-          },
-          {
-            "name": "[concat('rdp','1')]",
-            "properties": {
-              "frontendIPConfiguration": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/frontendIPConfigurations/LBFE')]"
-              },
-              "protocol": "Tcp",
-              "frontendPort": 6002,
-              "backendPort": 22,
-              "enableFloatingIP": false
-            }
-          }
-        ],
-        "loadBalancingRules": [
-          {
-            "properties": {
-              "frontendIPConfiguration": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', 'loadBalancer'), '/frontendIpConfigurations/LBFE')]"
-              },
-              "backendAddressPool": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', 'loadBalancer'), '/backendAddressPools/LBBAP')]"
-              },
-              "probe": {
-                "id": "[concat(resourceId('Microsoft.Network/loadBalancers', 'loadBalancer'), '/probes/lbprobe')]"
-              },
-              "protocol": "Tcp",
-              "frontendPort": 80,
-              "backendPort": 80,
-              "idleTimeoutInMinutes": 15
-            },
-            "name": "lbrule"
-          }
-        ],
-        "probes": [
-          {
-            "properties": {
-              "protocol": "Tcp",
-              "port": 80,
-              "intervalInSeconds": 15,
-              "numberOfProbes": 2
-            },
-            "name": "lbprobe"
-          }
-        ]
-      }
+    "variables": {
+        "vnetAddressRange": "10.0.0.0/16",
+        "subnetAddressRange": "10.0.0.0/24",
+        "subnetName": "Subnet",
+        "numberOfInstances": 2,
+        "availabilitySetName": "myavlset",
+        "vmName": "vm",
+        "nicsql": "[concat(variables('vmName'),'sql')]",
+        "storageAccountNameDiag": "[concat('diag',uniqueString(resourceGroup().id))]",
+        "subnet-id": "[resourceId('Microsoft.Network/virtualNetworks/subnets','VNET',variables('subnetName'))]",
+        "imagePublisher": "Canonical",
+        "imageOffer": "UbuntuServer",
+        "imageSku": "14.04.2-LTS",
+        "SQLimagePublisher": "MicrosoftSQLServer",
+        "SQLimageOffer": "sql2019-ws2019",
+        "SQLimageSku": "Standard",
+        "networkSecurityGroupName": "Subnet-nsg"
     },
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "vmsql",
-      "location": "[parameters('location')]",
-      "properties": {
-        "securityRules": [
-          {
-            "name": "default-allow-rdp",
+    "resources": [
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "publicIp",
+            "location": "[parameters('location')]",
             "properties": {
-              "description": "Allow RDP",
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "3389",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 1000,
-              "direction": "Inbound"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[concat(variables('vmName'),copyindex())]",
-      "copy": {
-        "name": "netIntLoop",
-        "count": "[variables('numberOfInstances')]"
-      },
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "Microsoft.Network/virtualNetworks/VNET",
-        "Microsoft.Network/loadBalancers/loadBalancer"
-      ],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig",
-            "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "subnet": {
-                "id": "[variables('subnet-id')]"
-              },
-              "loadBalancerBackendAddressPools": [
-                {
-                  "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/backendAddressPools/LBBAP')]"
+                "publicIPAllocationMethod": "Dynamic",
+                "dnsSettings": {
+                    "domainNameLabel": "[parameters('publicDnsName')]"
                 }
-              ],
-              "loadBalancerInboundNatRules": [
-                {
-                  "id": "[concat(resourceId('Microsoft.Network/loadBalancers','loadBalancer'),'/inboundNatRules/rdp', copyindex())]"
-                }
-              ]
             }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2015-06-15",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('nicsql')]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "Microsoft.Network/virtualNetworks/VNET",
-        "Microsoft.Network/networkSecurityGroups/vmsql"
-      ],
-      "properties": {
-        "networkSecurityGroup": {
-          "id": "[resourceId('Microsoft.Network/networkSecurityGroups','vmsql')]"
         },
-        "ipConfigurations": [
-          {
-            "name": "ipconfig1",
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Network/publicIPAddresses",
+            "name": "vmsqlIp",
+            "location": "[parameters('location')]",
             "properties": {
-              "privateIPAllocationMethod": "Dynamic",
-              "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'vmsqlIp')]"
-              },
-              "subnet": {
-                "id": "[variables('subnet-id')]"
-              }
+                "publicIPAllocationMethod": "Dynamic"
             }
-          }
-        ]
-      }
-    },
-    {
-      "apiVersion": "2016-04-30-preview",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[concat(variables('vmName'), copyindex())]",
-      "copy": {
-        "name": "virtualMachineLoop",
-        "count": "[variables('numberOfInstances')]"
-      },
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountNameDiag'))]",
-        "[concat('Microsoft.Network/networkInterfaces/',variables('vmName'),copyindex())]",
-        "[concat('Microsoft.Compute/availabilitySets/', variables('availabilitySetName'))]"
-      ],
-      "properties": {
-        "availabilitySet": {
-          "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
         },
-        "hardwareProfile": {
-          "vmSize": "[parameters('vmSizeFE')]"
-        },
-        "osProfile": {
-          "computerName": "[concat(variables('vmName'), copyindex())]",
-          "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "publisher": "[variables('imagePublisher')]",
-            "offer": "[variables('imageOffer')]",
-            "sku": "[variables('imageSku')]",
-            "version": "latest"
-          },
-          "osDisk": {
-            "createOption": "FromImage"
-          }
-        },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmName'),copyindex()))]"
+        {
+            "type": "Microsoft.Compute/availabilitySets",
+            "name": "myavlset",
+            "apiVersion": "2016-04-30-preview",
+            "location": "[parameters('location')]",
+            "properties": {
+                "platformFaultDomainCount": 2,
+                "platformUpdateDomainCount": 2,
+                "managed": true
             }
-          ]
         },
-        "diagnosticsProfile": {
-          "bootDiagnostics": {
-            "enabled": true,
-            "storageUri": "[concat('http://',variables('storageAccountNameDiag'),'.blob.core.windows.net')]"
-          }
-        }
-      }
-    },
-    {
-      "apiVersion": "2016-04-30-preview",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "vmsql",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Storage/storageAccounts',variables('storageAccountNameDiag'))]",
-        "[concat('Microsoft.Network/networkInterfaces/',variables('nicsql'))]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[parameters('vmSizeSQL')]"
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[variables('storageAccountNameDiag')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "accountType": "Standard_LRS"
+            }
         },
-        "osProfile": {
-          "computerName": "[concat(variables('vmName'), 'sql')]",
-          "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]"
+        {
+            "comments": "Simple Network Security Group for subnet [Subnet]",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "apiVersion": "2019-08-01",
+            "name": "[variables('networkSecurityGroupName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+            }
         },
-        "storageProfile": {
-          "imageReference": {
-            "publisher": "[variables('SQLimagePublisher')]",
-            "offer": "[variables('SQLimageOffer')]",
-            "sku": "[variables('SQLimageSku')]",
-            "version": "latest"
-          },
-          "osDisk": {
-            "createOption": "FromImage"
-          },
-          "dataDisks": [
-            {
-              "diskSizeGB": "[parameters('sizeOfDiskInGB')]",
-              "lun": 0,
-              "caching": "ReadOnly",
-              "createOption": "Empty"
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Network/virtualNetworks",
+            "name": "VNET",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+            ],
+            "properties": {
+                "addressSpace": {
+                    "addressPrefixes": [
+                        "[variables('vnetAddressRange')]"
+                    ]
+                },
+                "subnets": [
+                    {
+                        "name": "Subnet",
+                        "properties": {
+                            "addressPrefix": "[variables('subnetAddressRange')]",
+                            "networkSecurityGroup": {
+                                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2018-10-01",
+            "name": "loadBalancer",
+            "type": "Microsoft.Network/loadBalancers",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "Microsoft.Network/publicIPAddresses/publicIp"
+            ],
+            "properties": {
+                "frontendIpConfigurations": [
+                    {
+                        "name": "LBFE",
+                        "properties": {
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses','publicIp')]"
+                            }
+                        }
+                    }
+                ],
+                "backendAddressPools": [
+                    {
+                        "name": "LBBAP"
+                    }
+                ],
+                "inboundNatRules": [
+                    {
+                        "name": "[concat('rdp','0')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations','loadBalancer','LBFE')]"
+                            },
+                            "protocol": "Tcp",
+                            "frontendPort": 6001,
+                            "backendPort": 22,
+                            "enableFloatingIP": false
+                        }
+                    },
+                    {
+                        "name": "[concat('rdp','1')]",
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations','loadBalancer', 'LBFE')]"
+                            },
+                            "protocol": "Tcp",
+                            "frontendPort": 6002,
+                            "backendPort": 22,
+                            "enableFloatingIP": false
+                        }
+                    }
+                ],
+                "loadBalancingRules": [
+                    {
+                        "properties": {
+                            "frontendIPConfiguration": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', 'loadBalancer', 'LBFE')]"
+                            },
+                            "backendAddressPool": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'loadBalancer', 'LBBAP')]"
+                            },
+                            "probe": {
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'loadBalancer', 'lbprobe')]"
+                            },
+                            "protocol": "Tcp",
+                            "frontendPort": 80,
+                            "backendPort": 80,
+                            "idleTimeoutInMinutes": 15
+                        },
+                        "name": "lbrule"
+                    }
+                ],
+                "probes": [
+                    {
+                        "properties": {
+                            "protocol": "Tcp",
+                            "port": 80,
+                            "intervalInSeconds": 15,
+                            "numberOfProbes": 2
+                        },
+                        "name": "lbprobe"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Network/networkSecurityGroups",
+            "name": "vmsql",
+            "location": "[parameters('location')]",
+            "properties": {
+                "securityRules": [
+                    {
+                        "name": "default-allow-rdp",
+                        "properties": {
+                            "description": "Allow RDP",
+                            "protocol": "Tcp",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "3389",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 1000,
+                            "direction": "Inbound"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[concat(variables('vmName'),copyindex())]",
+            "copy": {
+                "name": "netIntLoop",
+                "count": "[variables('numberOfInstances')]"
             },
-            {
-              "diskSizeGB": "[parameters('sizeOfDiskInGB')]",
-              "lun": 1,
-              "createOption": "Empty"
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "Microsoft.Network/virtualNetworks/VNET",
+                "Microsoft.Network/loadBalancers/loadBalancer"
+            ],
+            "properties": {
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "subnet": {
+                                "id": "[variables('subnet-id')]"
+                            },
+                            "loadBalancerBackendAddressPools": [
+                                {
+                                    "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools','loadBalancer','LBBAP')]"
+                                }
+                            ],
+                            "loadBalancerInboundNatRules": [
+                                {
+                                    "id": "[resourceId('Microsoft.Network/loadBalancers/inboundNatRules','loadBalancer', concat('rdp', copyindex()))]"
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
-          ]
         },
-        "networkProfile": {
-          "networkInterfaces": [
-            {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicsql'))]"
+        {
+            "apiVersion": "2015-06-15",
+            "type": "Microsoft.Network/networkInterfaces",
+            "name": "[variables('nicsql')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "Microsoft.Network/virtualNetworks/VNET",
+                "Microsoft.Network/networkSecurityGroups/vmsql"
+            ],
+            "properties": {
+                "networkSecurityGroup": {
+                    "id": "[resourceId('Microsoft.Network/networkSecurityGroups','vmsql')]"
+                },
+                "ipConfigurations": [
+                    {
+                        "name": "ipconfig1",
+                        "properties": {
+                            "privateIPAllocationMethod": "Dynamic",
+                            "publicIPAddress": {
+                                "id": "[resourceId('Microsoft.Network/publicIPAddresses', 'vmsqlIp')]"
+                            },
+                            "subnet": {
+                                "id": "[variables('subnet-id')]"
+                            }
+                        }
+                    }
+                ]
             }
-          ]
         },
-        "diagnosticsProfile": {
-          "bootDiagnostics": {
-            "enabled": true,
-            "storageUri": "[concat('http://',variables('storageAccountNameDiag'),'.blob.core.windows.net')]"
-          }
+        {
+            "apiVersion": "2016-04-30-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "[concat(variables('vmName'), copyindex())]",
+            "copy": {
+                "name": "virtualMachineLoop",
+                "count": "[variables('numberOfInstances')]"
+            },
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameDiag'))]",
+                "[resourceId('Microsoft.Network/networkInterfaces', concat(variables('vmName'),copyindex()))]",
+                "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+            ],
+            "properties": {
+                "availabilitySet": {
+                    "id": "[resourceId('Microsoft.Compute/availabilitySets', variables('availabilitySetName'))]"
+                },
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSizeFE')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('vmName'), copyindex())]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('imagePublisher')]",
+                        "offer": "[variables('imageOffer')]",
+                        "sku": "[variables('imageSku')]",
+                        "version": "latest"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage"
+                    }
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',concat(variables('vmName'),copyindex()))]"
+                        }
+                    ]
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": true,
+                        "storageUri": "[reference(variables('storageAccountNameDiag'), '2018-02-01').primaryEndpoints.blob]"
+                    }
+                }
+            }
+        },
+        {
+            "apiVersion": "2016-04-30-preview",
+            "type": "Microsoft.Compute/virtualMachines",
+            "name": "vmsql",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountNameDiag'))]",
+                "[resourceId('Microsoft.Network/networkInterfaces', variables('nicsql'))]"
+            ],
+            "properties": {
+                "hardwareProfile": {
+                    "vmSize": "[parameters('vmSizeSQL')]"
+                },
+                "osProfile": {
+                    "computerName": "[concat(variables('vmName'), 'sql')]",
+                    "adminUsername": "[parameters('adminUsername')]",
+                    "adminPassword": "[parameters('adminPassword')]"
+                },
+                "storageProfile": {
+                    "imageReference": {
+                        "publisher": "[variables('SQLimagePublisher')]",
+                        "offer": "[variables('SQLimageOffer')]",
+                        "sku": "[variables('SQLimageSku')]",
+                        "version": "latest"
+                    },
+                    "osDisk": {
+                        "createOption": "FromImage"
+                    },
+                    "dataDisks": [
+                        {
+                            "diskSizeGB": "[parameters('sizeOfDiskInGB')]",
+                            "lun": 0,
+                            "caching": "ReadOnly",
+                            "createOption": "Empty"
+                        },
+                        {
+                            "diskSizeGB": "[parameters('sizeOfDiskInGB')]",
+                            "lun": 1,
+                            "createOption": "Empty"
+                        }
+                    ]
+                },
+                "networkProfile": {
+                    "networkInterfaces": [
+                        {
+                            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('nicsql'))]"
+                        }
+                    ]
+                },
+                "diagnosticsProfile": {
+                    "bootDiagnostics": {
+                        "enabled": true,
+                        "storageUri": "[reference(variables('storageAccountNameDiag'), '2018-02-01').primaryEndpoints.blob]"
+                    }
+                }
+            }
         }
-      }
-    }
-  ]
+    ]
 }

--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
@@ -63,7 +63,7 @@
         "subnet-id": "[resourceId('Microsoft.Network/virtualNetworks/subnets','VNET',variables('subnetName'))]",
         "imagePublisher": "Canonical",
         "imageOffer": "UbuntuServer",
-        "imageSku": "14.04.2-LTS",
+        "imageSku": "14.04.5-LTS",
         "SQLimagePublisher": "MicrosoftSQLServer",
         "SQLimageOffer": "sql2019-ws2019",
         "SQLimageSku": "Standard",

--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.json
@@ -207,7 +207,7 @@
                                 "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'loadBalancer', 'LBBAP')]"
                             },
                             "probe": {
-                                "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', 'loadBalancer', 'lbprobe')]"
+                                "id": "[resourceId('Microsoft.Network/loadBalancers/probes', 'loadBalancer', 'lbprobe')]"
                             },
                             "protocol": "Tcp",
                             "frontendPort": 80,

--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.parameters.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/azuredeploy.parameters.json
@@ -6,22 +6,10 @@
       "value": "GEN-UNIQUE"
     },
     "adminUsername": {
-      "value": "pietro"
+      "value": "GEN-UNIQUE"
     },
     "adminPassword": {
       "value": "GEN-PASSWORD"
-    },
-     "sizeOfDiskInGB": {
-      "value": "128"
-    },
-    "vmSizeFE": {
-      "value": "Standard_DS1"
-    },
-    "vmSizeSQL": {
-      "value": "Standard_DS1"
-    },
-    "storageType": {
-      "value": "Premium_LRS"
     }
   }
 }

--- a/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/metadata.json
+++ b/301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template creates 2 Linux VMs (that can be used as web FE) with in an Availability Set and a Load Balancer with port 80 open. The two VMs can be reached using SSH on port 6001 and 6002. This template also create a SQL Server 2014 VM that can be reached via RDP connection defined in a Network Security Group. All VMs storage can use Premium Storage (SSD) and you can choose to creare VMs with all DS sizes",
   "summary": "This template creates 2 VMs Linux as Front End and SQL Server VM as backend.",
   "githubUsername": "pietrobr",
-  "dateUpdated": "2015-10-16"
+  "dateUpdated": "2020-03-05"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to 301-2fe-linux-lb80-ssh-1be-win-nsg-rdp-datadisk-ssd

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [Subnet]:**

(No VMs with public IP in subnet.  Attached NSG will be empty.)

