### PR TITLE
Adding Network Security Group to deis-cluster-coreos

### DIFF
--- a/deis-cluster-coreos/azuredeploy.json
+++ b/deis-cluster-coreos/azuredeploy.json
@@ -112,7 +112,8 @@
     "lbIPConfig": "[concat(variables('lbID'),'/frontendIPConfigurations/',variables('loadBalancerIPConfigName'))]",
     "apiProbeID": "[concat(variables('lbID'),'/probes/',variables('apiProbeName'))]",
     "builderProbeID": "[concat(variables('lbID'),'/probes/',variables('builderProbeName'))]",
-    "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/',variables('lbBackendAddressPoolName'))]"
+    "lbPoolID": "[concat(variables('lbID'),'/backendAddressPools/',variables('lbBackendAddressPoolName'))]",
+    "networkSecurityGroupName": "[concat(variables('subnet1Name'), '-nsg')]"
   },
   "resources": [
     {
@@ -122,11 +123,11 @@
       "location": "[resourceGroup().location]",
       "sku": {
         "name": "Aligned"
-          },
-        "properties": { 
-            "platformFaultDomainCount": 2,
-            "platformUpdateDomainCount": 5
-        }
+      },
+      "properties": {
+        "platformFaultDomainCount": 2,
+        "platformUpdateDomainCount": 5
+      }
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
@@ -254,10 +255,21 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('subnet1Name')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[resourceGroup().location]",
+      "properties": {}
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[resourceGroup().location]",
       "apiVersion": "2015-05-01-preview",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -268,7 +280,10 @@
           {
             "name": "[variables('subnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('subnet1Prefix')]"
+              "addressPrefix": "[variables('subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/deis-cluster-coreos/azuredeploy.json
+++ b/deis-cluster-coreos/azuredeploy.json
@@ -16,30 +16,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_A1",
-      "allowedValues": [
-        "Standard_A0",
-        "Standard_A1",
-        "Standard_A2",
-        "Standard_A3",
-        "Standard_A4",
-        "Standard_D1",
-        "Standard_DS1",
-        "Standard_D2",
-        "Standard_DS2",
-        "Standard_D3",
-        "Standard_DS3",
-        "Standard_D4",
-        "Standard_DS4",
-        "Standard_D11",
-        "Standard_DS11",
-        "Standard_D12",
-        "Standard_DS12",
-        "Standard_D13",
-        "Standard_DS13",
-        "Standard_D14",
-        "Standard_DS14"
-      ],
+      "defaultValue": "Standard_A2_v2",
       "metadata": {
         "description": "Instance size for the VMs"
       }

--- a/deis-cluster-coreos/azuredeploy.parameters.json
+++ b/deis-cluster-coreos/azuredeploy.parameters.json
@@ -27,7 +27,7 @@
       "value": 100
     },
     "coreosVersion": {
-      "value": "latest"
+      "value": "2135.5.0"
     }
   }
 }

--- a/deis-cluster-coreos/azuredeploy.parameters.json
+++ b/deis-cluster-coreos/azuredeploy.parameters.json
@@ -27,7 +27,7 @@
       "value": 100
     },
     "coreosVersion": {
-      "value": "2135.5.0"
+      "value": "1122.3.0"
     }
   }
 }

--- a/deis-cluster-coreos/azuredeploy.parameters.json
+++ b/deis-cluster-coreos/azuredeploy.parameters.json
@@ -9,7 +9,7 @@
       "value": "GEN-UNIQUE-8"
     },
     "vmSize": {
-      "value": "Standard_A1"
+      "value": "Standard_A2_v2"
     },
     "adminUsername": {
       "value": "GEN-UNIQUE"
@@ -27,7 +27,7 @@
       "value": 100
     },
     "coreosVersion": {
-      "value": "1122.3.0"
+      "value": "899.17.0"
     }
   }
 }

--- a/deis-cluster-coreos/azuredeploy.parameters.json
+++ b/deis-cluster-coreos/azuredeploy.parameters.json
@@ -27,7 +27,7 @@
       "value": 100
     },
     "coreosVersion": {
-      "value": "899.17.0"
+      "value": "latest"
     }
   }
 }

--- a/deis-cluster-coreos/metadata.json
+++ b/deis-cluster-coreos/metadata.json
@@ -5,7 +5,5 @@
   "description": "Template spins up a Deis cluster.",
   "githubUsername": "haishibai",
   "summary": "Deis cluster",
-  "dateUpdated": "2015-05-15"
+  "dateUpdated": "2020-03-05"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to deis-cluster-coreos

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnet1Name')]:**

(No VMs with public IP in subnet.  Attached NSG will be empty.)

