### PR TITLE
Adding Network Security Group to sqlvm-provisioning-csp

### DIFF
--- a/sqlvm-provisioning-csp/azuredeploy.json
+++ b/sqlvm-provisioning-csp/azuredeploy.json
@@ -16,9 +16,10 @@
     },
     "sqlImageOffer": {
       "type": "string",
-      "defaultValue": "SQL2016-WS2012R2",
+      "defaultValue": "sql2019-ws2019",
       "allowedValues": [
-        "SQL2016-WS2012R2"
+        "sql2019-ws2019",
+        "sql2019-ws2016"
       ],
       "metadata": {
         "description": "SQL Server Gallery Image Offer"

--- a/sqlvm-provisioning-csp/azuredeploy.json
+++ b/sqlvm-provisioning-csp/azuredeploy.json
@@ -116,7 +116,8 @@
   "variables": {
     "vmnic": "[concat(parameters('vmName'), 'devnic')]",
     "vmosdisk": "[concat(parameters('vmName'), 'osdisk')]",
-    "vnetSubNetID": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]"
+    "vnetSubNetID": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetName'))]",
+    "networkSecurityGroupName": "[concat(parameters('subnetName'), '-nsg')]"
   },
   "resources": [
     {
@@ -141,10 +142,37 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [parameters('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2015-05-01-preview",
       "name": "[parameters('vnetName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -155,7 +183,10 @@
           {
             "name": "[parameters('subnetName')]",
             "properties": {
-              "addressPrefix": "[parameters('subnetAddressPrefix')]"
+              "addressPrefix": "[parameters('subnetAddressPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/sqlvm-provisioning-csp/azuredeploy.parameters.json
+++ b/sqlvm-provisioning-csp/azuredeploy.parameters.json
@@ -21,7 +21,7 @@
       "value": "GEN-VNET-NAME"
     },
     "subnetName": {
-      "value": "GEN-SUBNET1-NAME"
+      "value": "GEN-VNET-SUBNET1-NAME"
     },
     "publicDnsName": {
       "value": "GEN-UNIQUE"

--- a/sqlvm-provisioning-csp/metadata.json
+++ b/sqlvm-provisioning-csp/metadata.json
@@ -5,7 +5,5 @@
   "description": "Microsoft Azure has a new subscription offering, CSP Subscriptions. Some aspects of SQL VM deployment are not yet supported in CSP subscriptions. This includes the SQL IaaS Agent Extension, which is required for features such as SQL Automated Backup and SQL Automated Patching.",
   "summary": "Creates a SQL VM for CSP Subscriptions",
   "githubUsername": "ninarn",
-  "dateUpdated": "2018-08-13"
+  "dateUpdated": "2020-03-05"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to sqlvm-provisioning-csp

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [parameters('subnetName')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
GEN-UNIQUE-13 | Tcp | 3389 | True | Standard remote access

