### PR TITLE
Adding Network Security Group to visual-studio-dev-vm

### DIFF
--- a/visual-studio-dev-vm/azuredeploy.json
+++ b/visual-studio-dev-vm/azuredeploy.json
@@ -16,24 +16,18 @@
     },
     "vmVisualStudioVersion": {
       "type": "string",
-      "defaultValue": "VS-2015-Ent-VSU3-AzureSDK-29-Win10-N",
+      "defaultValue": "VS-2017-Ent-Latest-WS2016",
       "allowedValues": [
-        "VS-2013-Comm-VSU5-AzureSDK-295-WS2012R2",
-        "VS-2013-Prem-VSU5-AzureSDK-295-WS2012R2",
-        "VS-2013-Ult-VSU5-AzureSDK-295-WS2012R2",
-        "VS-2015-Comm-AzureSDK-2.9-W10T-Win10-N",
-        "VS-2015-Comm-AzureSDK-2.9-WS2012R2",
-        "VS-2015-Comm-VSU3-AzureSDK-29-Win10-N",
-        "VS-2015-Comm-VSU3-AzureSDK-291-Win10-N",
+        "VS-2015-Comm-VSU3-AzureSDK-29-WS2012R2",
         "VS-2015-Comm-VSU3-AzureSDK-291-WS2012R2",
-        "VS-2015-Ent-AzureSDK-2.9-WS2012R2",
-        "VS-2015-Ent-AzureSDK-29-W10T-Win10-N",
-        "VS-2015-Ent-VSU3-AzureSDK-29-Win10-N",
-        "VS-2015-Ent-VSU3-AzureSDK-291-WS2012R2",
-        "VS-2017-RC1-Comm-Win10-N",
-        "VS-2017-RC1-Comm-WS2012R2",
-        "VS-2017-RC1-Ent-Win10-N",
-        "VS-2017-RC1-Ent-WS2012R2"
+        "VS-2015-Ent-VSU3-AzureSDK-29-WS2012R2",
+        "VS-2017-Comm-Latest-Preview-WS2016",
+        "VS-2017-Comm-Latest-WS2016",
+        "VS-2017-Comm-WS2016",
+        "VS-2017-Ent-Latest-Preview-WS2016",
+        "VS-2017-Ent-Latest-WS2016",
+        "VS-2017-Ent-WS2016",
+        "vs-2019-preview-ws2016"
       ],
       "metadata": {
         "description": "Which version of Visual Studio you would like to deploy"

--- a/visual-studio-dev-vm/azuredeploy.json
+++ b/visual-studio-dev-vm/azuredeploy.json
@@ -182,7 +182,7 @@
             "caching": "ReadWrite",
             "createOption": "FromImage",
             "managedDisk": {
-              "storageAccountType": "Standard_SSD"
+              "storageAccountType": "StandardSSD_LRS"
             }
           }
         },

--- a/visual-studio-dev-vm/azuredeploy.json
+++ b/visual-studio-dev-vm/azuredeploy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.2",
   "parameters": {
     "vmAdminUserName": {
@@ -45,39 +45,29 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_D2s_v3",
+      "metadata": {
+        "description": "VM Size"
+      }
     }
   },
   "variables": {
-    "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'visstudiovm')]",
-    "storageType": "Premium_LRS",
-    "vmSize": "Standard_D2s_v3",
     "vmName": "[concat(substring(parameters('vmVisualStudioVersion'),0,8), 'vm')]",
     "vnet01Prefix": "10.0.0.0/16",
     "vnet01Subnet1Name": "Subnet-1",
+    "vnetName": "vnet",
     "vnet01Subnet1Prefix": "10.0.0.0/24",
     "vmImagePublisher": "MicrosoftVisualStudio",
     "vmImageOffer": "VisualStudio",
-    "vmOSDiskName": "VMOSDisk",
-    "vmSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'Vnet01', variables('Vnet01Subnet1Name'))]",
-    "vmStorageAccountContainerName": "vhds",
+    "vmSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('Vnet01Subnet1Name'))]",
     "vmNicName": "[concat(variables('vmName'), '-nic')]",
     "vmIP01Name": "VMIP01",
     "networkSecurityGroupName": "[concat(variables('vnet01Subnet1Name'), '-nsg')]"
   },
   "resources": [
-    {
-      "name": "[variables('storageAccountName')]",
-      "type": "Microsoft.Storage/storageAccounts",
-      "location": "[parameters('location')]",
-      "apiVersion": "2015-06-15",
-      "dependsOn": [],
-      "tags": {
-        "displayName": "Storage01"
-      },
-      "properties": {
-        "accountType": "[variables('storageType')]"
-      }
-    },
     {
       "comments": "Simple Network Security Group for subnet [variables('vnet01Subnet1Name')]",
       "type": "Microsoft.Network/networkSecurityGroups",
@@ -103,10 +93,10 @@
       }
     },
     {
-      "name": "VNet01",
+      "name": "[variables('vnetName')]",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[parameters('location')]",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2019-11-01",
       "dependsOn": [
         "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
       ],
@@ -136,10 +126,10 @@
       "name": "[variables('vmNicName')]",
       "type": "Microsoft.Network/networkInterfaces",
       "location": "[parameters('location')]",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2020-03-01",
       "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworks/', 'Vnet01')]",
-        "[concat('Microsoft.Network/publicIPAddresses/', variables('vmIP01Name'))]"
+        "[variables('vnetName')]",
+        "[variables('vmIP01Name')]"
       ],
       "tags": {
         "displayName": "VMNic01"
@@ -165,17 +155,16 @@
       "name": "[variables('vmName')]",
       "type": "Microsoft.Compute/virtualMachines",
       "location": "[parameters('location')]",
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2019-12-01",
       "dependsOn": [
-        "[concat('Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
-        "[concat('Microsoft.Network/networkInterfaces/', variables('vmNicName'))]"
+        "[variables('vmNicName')]"
       ],
       "tags": {
         "displayName": "VM01"
       },
       "properties": {
         "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
+          "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
           "computerName": "[variables('vmName')]",
@@ -190,12 +179,11 @@
             "version": "latest"
           },
           "osDisk": {
-            "name": "VMOSDisk",
-            "vhd": {
-              "uri": "[concat('http://', variables('storageAccountName'), '.blob.core.windows.net/', variables('vmStorageAccountContainerName'), '/', variables('vmOSDiskName'), '.vhd')]"
-            },
             "caching": "ReadWrite",
-            "createOption": "FromImage"
+            "createOption": "FromImage",
+            "managedDisk": {
+              "storageAccountType": "Standard_SSD"
+            }
           }
         },
         "networkProfile": {
@@ -206,14 +194,14 @@
           ]
         }
       },
-      "resources": []
+      "resources": [
+      ]
     },
     {
       "name": "[variables('vmIP01Name')]",
       "type": "Microsoft.Network/publicIPAddresses",
       "location": "[parameters('location')]",
-      "apiVersion": "2015-06-15",
-      "dependsOn": [],
+      "apiVersion": "2020-03-01",
       "tags": {
         "displayName": "VMIP01"
       },

--- a/visual-studio-dev-vm/azuredeploy.json
+++ b/visual-studio-dev-vm/azuredeploy.json
@@ -67,7 +67,8 @@
     "vmSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', 'Vnet01', variables('Vnet01Subnet1Name'))]",
     "vmStorageAccountContainerName": "vhds",
     "vmNicName": "[concat(variables('vmName'), '-nic')]",
-    "vmIP01Name": "VMIP01"
+    "vmIP01Name": "VMIP01",
+    "networkSecurityGroupName": "[concat(variables('vnet01Subnet1Name'), '-nsg')]"
   },
   "resources": [
     {
@@ -84,11 +85,37 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('vnet01Subnet1Name')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "name": "VNet01",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[parameters('location')]",
       "apiVersion": "2015-06-15",
-      "dependsOn": [],
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "tags": {
         "displayName": "VNet01"
       },
@@ -102,7 +129,10 @@
           {
             "name": "[variables('vnet01Subnet1Name')]",
             "properties": {
-              "addressPrefix": "[variables('vnet01Subnet1Prefix')]"
+              "addressPrefix": "[variables('vnet01Subnet1Prefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]

--- a/visual-studio-dev-vm/azuredeploy.json
+++ b/visual-studio-dev-vm/azuredeploy.json
@@ -50,7 +50,7 @@
   "variables": {
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'visstudiovm')]",
     "storageType": "Premium_LRS",
-    "vmSize": "Standard_DS2",
+    "vmSize": "Standard_D2s_v3",
     "vmName": "[concat(substring(parameters('vmVisualStudioVersion'),0,8), 'vm')]",
     "vnet01Prefix": "10.0.0.0/16",
     "vnet01Subnet1Name": "Subnet-1",

--- a/visual-studio-dev-vm/metadata.json
+++ b/visual-studio-dev-vm/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template creates a Visual Studio 2015 or Dev15 VM from the base gallery VM images available.  It creates the VM in a new vnet, storage account, nic, and public ip with the new compute stack.",
   "summary": "Creates a Visual Studio 2015 or Dev15 VM from the base gallery VM images available with the new compute stack.",
   "githubUsername": "dtzar",
-  "dateUpdated": "2016-08-05"
+  "dateUpdated": "2020-03-05"
 }
-
-


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to visual-studio-dev-vm

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('vnet01Subnet1Name')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
VS-2015-vm | Tcp | 3389 | True | Standard remote access

