### PR TITLE
Adding Network Security Group to vod-aspera-wowza-azuremediaservices

### DIFF
--- a/vod-aspera-wowza-azuremediaservices/desktop/desktop.json
+++ b/vod-aspera-wowza-azuremediaservices/desktop/desktop.json
@@ -47,7 +47,8 @@
     "virtualNetworkName": "MyVNET",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
     "storageAccountName": "[concat(uniqueString(resourceGroup().id),'winrmsa')]",
-    "FQDN": "[concat(variables('dnsLabelPrefix'),'.',parameters('location'),'.cloudapp.azure.com')]"
+    "FQDN": "[concat(variables('dnsLabelPrefix'),'.',parameters('location'),'.cloudapp.azure.com')]",
+    "networkSecurityGroupName": "[concat(variables('subnetName'), '-nsg')]"
   },
   "resources": [
     {
@@ -72,10 +73,37 @@
       }
     },
     {
+      "comments": "Simple Network Security Group for subnet [variables('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-3389",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "3389",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
+    {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -86,7 +114,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]
@@ -144,7 +175,7 @@
             "version": "latest"
           },
           "osDisk": {
-            "name":  "[concat(variables('vmName'),'_OSDisk')]",
+            "name": "[concat(variables('vmName'),'_OSDisk')]",
             "caching": "ReadWrite",
             "createOption": "FromImage"
           }

--- a/vod-aspera-wowza-azuremediaservices/metadata.json
+++ b/vod-aspera-wowza-azuremediaservices/metadata.json
@@ -5,5 +5,5 @@
   "description": "Wowza end to end Solution template launches a stack which includes a End User Desktop, Aspera Transfer server, Storage Account, Azure Media Services, and Wowza Streaming Server",
   "summary": "Wowza Solution Stack involves high-speed Transfer of video files optimally, Transcode the video files to various formats, Video On Demand Streaming",
   "githubUsername": "vcherukuri",
-  "dateUpdated": "2019-12-19"
+  "dateUpdated": "2020-03-05"
 }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to vod-aspera-wowza-azuremediaservices

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnetName')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
GEN-UNIQUEdesktop | Tcp | 3389 | True | Standard remote access

