### PR TITLE
Adding Network Security Group to zabbix-monitoring-cluster

### DIFF
--- a/zabbix-monitoring-cluster/azuredeploy.json
+++ b/zabbix-monitoring-cluster/azuredeploy.json
@@ -104,6 +104,13 @@
       },
       "defaultValue": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/zabbix-monitoring-cluster"
     },
+    "_artifactsLocationSasToken": {
+      "type": "secureString",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated. Use the defaultValue if the staging location is not secured."
+      }
+    },
     "location": {
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
@@ -123,7 +130,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('_artifactsLocation'), '/nested/clusterNodes.json')]",
+          "uri": "[uri(parameters('_artifactsLocation'), concat('nested/clusterNodes.json', parameters('_artifactsLocationSasToken)))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -149,7 +156,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('_artifactsLocation'), '/nested/monitoringSolution.json')]",
+          "uri": "[uri(parameters('_artifactsLocation'), concat('nested/monitoringSolution.json', parameters('_artifactsLocationSasToken')))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {

--- a/zabbix-monitoring-cluster/metadata.json
+++ b/zabbix-monitoring-cluster/metadata.json
@@ -5,7 +5,5 @@
   "description": "This template creates a cluster and sets up a zabbix monitoring server for cluster monitoring.",
   "summary": "Create a cluster and a zabbix monitor server for cluster monitoring.",
   "githubUsername": "karataliu",
-  "dateUpdated": "2018-08-16"
+  "dateUpdated": "2020-03-05"
 }
-
-

--- a/zabbix-monitoring-cluster/nested/clusterNodes.json
+++ b/zabbix-monitoring-cluster/nested/clusterNodes.json
@@ -67,14 +67,42 @@
     "vmSize": "Standard_D2_v2",
     "storageAccountType": "Standard_LRS",
     "VMCount": "[parameters('vmCount')]",
-    "VMStart": 1
+    "VMStart": 1,
+    "networkSecurityGroupName": "[concat(variables('subnetName'), '-nsg')]"
   },
   "resources": [
+    {
+      "comments": "Simple Network Security Group for subnet [variables('subnetName')]",
+      "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2019-08-01",
+      "name": "[variables('networkSecurityGroupName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "securityRules": [
+          {
+            "name": "default-allow-22",
+            "properties": {
+              "priority": 1000,
+              "access": "Allow",
+              "direction": "Inbound",
+              "destinationPortRange": "22",
+              "protocol": "Tcp",
+              "sourceAddressPrefix": "*",
+              "sourcePortRange": "*",
+              "destinationAddressPrefix": "*"
+            }
+          }
+        ]
+      }
+    },
     {
       "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -85,7 +113,10 @@
           {
             "name": "[variables('subnetName')]",
             "properties": {
-              "addressPrefix": "[variables('subnetPrefix')]"
+              "addressPrefix": "[variables('subnetPrefix')]",
+              "networkSecurityGroup": {
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
+              }
             }
           }
         ]
@@ -185,7 +216,7 @@
       "type": "string",
       "value": "[resourceGroup().name]"
     },
-      "virtualNetworkName": {
+    "virtualNetworkName": {
       "type": "string",
       "value": "[variables('virtualNetworkName')]"
     }


### PR DESCRIPTION
### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Adding Network Security Group to zabbix-monitoring-cluster

The following subnets were identified as missing NSGs.  An NSG was created for each to allow traffic based on the VMs they contained.

**Subnet [variables('subnetName')]:**

VM | Protocol | Port | Allowed through NSG | Reason
--- | --- | --- | --- | ---
GEN-Uvm1 | Tcp | 22 | True | Standard remote access

