### PR TITLE
101-azure-bastion-nsg: Narrow Inbound NSG down further and upgrade API versions

### DIFF
--- a/101-azure-bastion-nsg/azuredeploy.json
+++ b/101-azure-bastion-nsg/azuredeploy.json
@@ -55,7 +55,7 @@
     },
     "resources": [
         {
-            "apiVersion": "2019-02-01",
+            "apiVersion": "2019-11-01",
             "type": "Microsoft.Network/publicIpAddresses",
             "name": "[variables('public-ip-address-name')]",
             "location": "[parameters('location')]",
@@ -67,7 +67,7 @@
             }
         },
         {
-            "apiVersion": "2019-02-01",
+            "apiVersion": "2019-11-01",
             "type": "Microsoft.Network/networkSecurityGroups",
             "name": "[variables('nsg-name')]",
             "location": "[parameters('location')]",
@@ -78,7 +78,7 @@
                         "properties": {
                             "protocol": "Tcp",
                             "sourcePortRange": "*",
-                            "sourceAddressPrefix": "*",
+                            "sourceAddressPrefix": "Internet",
                             "destinationPortRange": "443",
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
@@ -149,7 +149,7 @@
         },
         {
             "condition": "[equals(parameters('vnet-new-or-existing'), 'new')]",
-            "apiVersion": "2019-02-01",
+            "apiVersion": "2019-11-01",
             "name": "[parameters('vnet-name')]",
             "type": "Microsoft.Network/virtualNetworks",
             "location": "[parameters('location')]",
@@ -177,7 +177,7 @@
         },
         {
             "condition": "[equals(parameters('vnet-new-or-existing'), 'existing')]",
-            "apiVersion": "2019-02-01",
+            "apiVersion": "2019-11-01",
             "type": "Microsoft.Network/virtualNetworks/subnets",
             "name": "[concat(parameters('vnet-name'), '/', variables('bastion-subnet-name'))]",
             "location": "[parameters('location')]",

--- a/101-azure-bastion-nsg/azuredeploy.parameters.json
+++ b/101-azure-bastion-nsg/azuredeploy.parameters.json
@@ -4,9 +4,6 @@
   "parameters": {
       "bastion-host-name": {
         "value": "GEN-UNIQUE-8"
-    },
-      "location": {
-        "value": "southcentralus"
     }
   }
 }


### PR DESCRIPTION
Existing NSG is unnecessarily permissive.
This has been tested and been recommended by Azure support engineer R. Franco
Failure in government cloud is due to region being hard-coded in parameter file, rather than using the default value that is resource group inferred, so nothing new but is that something we can/should change as well? I'd propose to remove the value in the parameters file.
https://github.com/Azure/azure-quickstart-templates/blob/cdac53335b1e09b11ae87fec3775e120f6b350e0/101-azure-bastion-nsg/azuredeploy.parameters.json#L9

### Best Practice Checklist
Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment. 
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

### Changelog

* Narrow done Inbound bastion NSG rule from Any to just Internet inbound traffic
* Upgrade ARM api version

