### PR TITLE
101-vnet-two-subnets: Switch to subnet properties

### DIFF
--- a/101-vnet-two-subnets/azuredeploy.json
+++ b/101-vnet-two-subnets/azuredeploy.json
@@ -64,35 +64,22 @@
           "addressPrefixes": [
             "[parameters('vnetAddressPrefix')]"
           ]
-        }
-      },
-      "resources": [
-        {
-          "apiVersion": "2018-10-01",
-          "type": "subnets",
-          "location": "[parameters('location')]",
-          "name": "[parameters('subnet1Name')]",
-          "dependsOn": [
-            "[parameters('vnetName')]"
-          ],
-          "properties": {
-            "addressPrefix": "[parameters('subnet1Prefix')]"
-          }
         },
-        {
-          "apiVersion": "2018-10-01",
-          "type": "subnets",
-          "location": "[parameters('location')]",
-          "name": "[parameters('subnet2Name')]",
-          "dependsOn": [
-            "[parameters('vnetName')]",
-            "[parameters('subnet1Name')]"
-          ],
-          "properties": {
-            "addressPrefix": "[parameters('subnet2Prefix')]"
+        "subnets": [
+          {
+            "name": "[parameters('subnet1Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet1Prefix')]"
+            }
+          },
+          {
+            "name": "[parameters('subnet2Name')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnet2Prefix')]"
+            }
           }
-        }
-      ]
+        ]
+      }
     }
   ]
 }

--- a/101-vnet-two-subnets/metadata.json
+++ b/101-vnet-two-subnets/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to create a Virtual Network with two subnets.",
   "summary": "Create a Virtual Network with two Subnets",
   "githubUsername": "telmosampaio",
-  "dateUpdated": "2019-10-11"
+  "dateUpdated": "2020-04-14"
 }


### PR DESCRIPTION
Declaring subnets as a child resource or separate resource can cause issues when rerunning deployments, as noted in #3317

# Best Practice Checklist

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.
