### PR TITLE
[ros-vm-windows] Adding GitHub Runner option

### DIFF
--- a/ros-vm-windows/InstallGitHubAgent.ps1
+++ b/ros-vm-windows/InstallGitHubAgent.ps1
@@ -1,0 +1,89 @@
+# Downloads the Visual Studio Team Services Build Agent and installs on the new machine
+# and registers with the Visual Studio Team Services account and build agent pool
+
+# Enable -Verbose option
+[CmdletBinding()]
+Param(
+    [Parameter(Mandatory = $true)]$GitHubRepo,
+    [Parameter(Mandatory = $true)]$GitHubToken,
+    [Parameter(Mandatory = $true)]$AgentName
+)
+
+Write-Verbose "Entering InstallGitHubAgent.ps1" -verbose
+
+$currentLocation = Split-Path -parent $MyInvocation.MyCommand.Definition
+Write-Verbose "Current folder: $currentLocation" -verbose
+
+#Create a temporary directory where to download from VSTS the agent package (vsts-agent.zip) and then launch the configuration.
+$agentTempFolderName = Join-Path $env:temp ([System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Force -Path $agentTempFolderName
+Write-Verbose "Temporary Agent download folder: $agentTempFolderName" -verbose
+
+$serverUrl = "https://github.com/$GitHubRepo"
+Write-Verbose "Server URL: $serverUrl" -verbose
+
+$retryCount = 3
+$retries = 1
+Write-Verbose "Downloading Agent install files" -verbose
+do {
+    try {
+        Write-Verbose "Trying to get download URL for latest GitHub agent release..."
+        $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/actions/runner/releases"
+        $latestRelease = $latestRelease | Where-Object assets -ne $null | Sort-Object created_at -Descending | Select-Object -First 1
+        $assetsURL = ($latestRelease.assets).browser_download_url
+        $latestReleaseDownloadUrl = ((Invoke-RestMethod -Uri $assetsURL) -match 'win-x64').downloadurl
+        Invoke-WebRequest -Uri $latestReleaseDownloadUrl -Method Get -OutFile "$agentTempFolderName\agent.zip"
+        Write-Verbose "Downloaded agent successfully on attempt $retries" -verbose
+        break
+    }
+    catch {
+        $exceptionText = ($_ | Out-String).Trim()
+        Write-Verbose "Exception occured downloading agent: $exceptionText in try number $retries" -verbose
+        $retries++
+        Start-Sleep -Seconds 30 
+    }
+} 
+while ($retries -le $retryCount)
+
+# Construct the agent folder under the main (hardcoded) C: drive.
+$agentInstallationPath = Join-Path "C:" $AgentName 
+# Create the directory for this agent.
+New-Item -ItemType Directory -Force -Path $agentInstallationPath 
+
+# Create a folder for the build work
+New-Item -ItemType Directory -Force -Path (Join-Path $agentInstallationPath $WorkFolder)
+
+Write-Verbose "Extracting the zip file for the agent" -verbose
+$destShellFolder = (new-object -com shell.application).namespace("$agentInstallationPath")
+$destShellFolder.CopyHere((new-object -com shell.application).namespace("$agentTempFolderName\agent.zip").Items(), 16)
+
+# Removing the ZoneIdentifier from files downloaded from the internet so the plugins can be loaded
+# Don't recurse down _work or _diag, those files are not blocked and cause the process to take much longer
+Write-Verbose "Unblocking files" -verbose
+Get-ChildItem -Recurse -Path $agentInstallationPath | Unblock-File | out-null
+
+# Retrieve the path to the config.cmd file.
+$agentConfigPath = [System.IO.Path]::Combine($agentInstallationPath, 'config.cmd')
+Write-Verbose "Agent Location = $agentConfigPath" -Verbose
+if (![System.IO.File]::Exists($agentConfigPath)) {
+    Write-Error "File not found: $agentConfigPath" -Verbose
+    return
+}
+
+# Call the agent with the configure command and all the options (this creates the settings file) without prompting
+# the user or blocking the cmd execution
+
+Write-Verbose "Configuring agent" -Verbose
+
+# Set the current directory to the agent dedicated one previously created.
+Push-Location -Path $agentInstallationPath
+
+# Setup the agent as a service
+.\config.cmd --unattended --url $serverUrl --token $GitHubToken --runasservice
+
+Pop-Location
+
+Write-Verbose "Agent install output: $LASTEXITCODE" -Verbose
+
+Write-Verbose "Exiting InstallGitHubAgent.ps1" -Verbose
+

--- a/ros-vm-windows/InstallGitHubAgent.ps1
+++ b/ros-vm-windows/InstallGitHubAgent.ps1
@@ -31,7 +31,7 @@ do {
         $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/actions/runner/releases"
         $latestRelease = $latestRelease | Where-Object assets -ne $null | Sort-Object created_at -Descending | Select-Object -First 1
         $assetsURL = ($latestRelease.assets).browser_download_url
-        $latestReleaseDownloadUrl = ((Invoke-RestMethod -Uri $assetsURL) -match 'win-x64').downloadurl
+        $latestReleaseDownloadUrl = $assetsURL -match 'win-x64' | Select-Object -First 1
         Invoke-WebRequest -Uri $latestReleaseDownloadUrl -Method Get -OutFile "$agentTempFolderName\agent.zip"
         Write-Verbose "Downloaded agent successfully on attempt $retries" -verbose
         break

--- a/ros-vm-windows/azuredeploy.json
+++ b/ros-vm-windows/azuredeploy.json
@@ -53,6 +53,18 @@
                 "description": "Password for the Virtual Machine."
             }
         },
+        "pipelineProvider": {
+            "type": "string",
+            "defaultValue": "None",
+            "allowedValues": [
+                "None",
+                "AzurePipelines",
+                "GitHubRunner"
+            ],
+            "metadata": {
+                "description": "The continuous integration provider to register."
+            }
+        },
         "vstsAccount": {
             "type": "string",
             "metadata": {
@@ -80,6 +92,20 @@
             "metadata": {
               "description": "Enable autologon to run the build agent in interactive mode that can sustain machine reboots.<br>Set this to true if the agents will be used to run UI tests."
             }
+        },
+        "githubRepo": {
+            "type": "string",
+            "metadata": {
+                "description": "The github account and repo alias."
+            },
+            "defaultValue": ""
+        },
+        "githubRunnerToken": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The token to register GitHub runner."
+            },
+            "defaultValue": ""
         },
         "_artifactsLocation": {
             "type": "string",
@@ -166,9 +192,11 @@
         "osDiskType": "StandardSSD_LRS",
         "rosScriptFileUri": "[uri(parameters('_artifactsLocation'), concat('InstallROS.ps1', parameters('_artifactsLocationSasToken')))]",
         "vstsScriptFileUri": "[uri(parameters('_artifactsLocation'), concat('InstallVstsAgent.ps1', parameters('_artifactsLocationSasToken')))]",
+        "githubScriptFileUri": "[uri(parameters('_artifactsLocation'), concat('InstallGitHubAgent.ps1', parameters('_artifactsLocationSasToken')))]",
         "nvidiaGpuDriverWindowsUri": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/nvidiaGpuDriverWindows.json', parameters('_artifactsLocationSasToken')))]",
         "extensionUrl": "[uri(parameters('_artifactsLocation'), concat('nestedtemplates/customScriptExtension.json', parameters('_artifactsLocationSasToken')))]",
-        "vstsParameters": "[concat('-vstsAccount ', parameters('vstsAccount'), ' -personalAccessToken ', parameters('vstsPersonalAccessToken'), ' -AgentName ', concat(parameters('projectName'), '-vsts'),' -PoolName ', parameters('vstsPoolName'), ' -runAsAutoLogon ', parameters('enableAutologon'), ' -vmAdminUserName ', parameters('adminUsername'), ' -vmAdminPassword ', parameters('adminPassword'))]"
+        "vstsParameters": "[concat('-vstsAccount ', parameters('vstsAccount'), ' -personalAccessToken ', parameters('vstsPersonalAccessToken'), ' -AgentName ', concat(parameters('projectName'), '-vsts'),' -PoolName ', parameters('vstsPoolName'), ' -runAsAutoLogon ', parameters('enableAutologon'), ' -vmAdminUserName ', parameters('adminUsername'), ' -vmAdminPassword ', parameters('adminPassword'))]",
+        "githubParameters": "[concat('-GitHubRepo ', parameters('githubRepo'), ' -GitHubToken ', parameters('githubRunnerToken'), ' -AgentName ', concat(parameters('projectName'), '-github'))]"
     },
     "resources": [
         {
@@ -327,7 +355,7 @@
             }
         },
         {
-            "condition": "[not(empty(parameters('vstsPersonalAccessToken')))]",
+            "condition": "[contains(parameters('pipelineProvider'), 'AzurePipelines')]",
             "name": "[concat(variables('virtualMachineName'), '-VSTSAgentInstall')]",
             "type": "Microsoft.Resources/deployments",
             "apiVersion": "2018-05-01",
@@ -357,6 +385,41 @@
                     },
                     "commandToExecute": {
                         "value": "[concat('powershell.exe -ExecutionPolicy Unrestricted -Command \"& {', './', 'InstallVstsAgent.ps1', ' ', variables('vstsParameters'), '}\"')]"
+                    }
+                }
+            }
+        },
+        {
+            "condition": "[contains(parameters('pipelineProvider'), 'GitHubRunner')]",
+            "name": "[concat(variables('virtualMachineName'), '-GitHubAgentInstall')]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Resources/deployments', concat(variables('virtualMachineName'), '-ROSInstall'))]"
+            ],
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "[variables('extensionUrl')]",
+                    "contentVersion": "1.0.0.0"
+                },
+                "parameters": {
+                    "location": {
+                        "value": "[variables('location')]"
+                    },
+                    "extensionName": {
+                        "value": "cse"
+                    },
+                    "vmName": {
+                        "value": "[variables('virtualMachineName')]"
+                    },
+                    "fileUris": {
+                        "value": [
+                            "[variables('githubScriptFileUri')]"
+                        ]
+                    },
+                    "commandToExecute": {
+                        "value": "[concat('powershell.exe -ExecutionPolicy Unrestricted -Command \"& {', './', 'InstallGitHubAgent.ps1', ' ', variables('githubParameters'), '}\"')]"
                     }
                 }
             }


### PR DESCRIPTION
# Best Practice Checklist

Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment.
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Adding GitHub runner as an option for CI registration.
*
*
