### PR TITLE
Update Service Fabric certificate helper script from AzureRM->Az commands

### DIFF
--- a/service-fabric-secure-cluster-5-node-1-nodetype/New-ServiceFabricClusterCertificate.ps1
+++ b/service-fabric-secure-cluster-5-node-1-nodetype/New-ServiceFabricClusterCertificate.ps1
@@ -1,11 +1,11 @@
-#Requires -Module AzureRM.KeyVault
+#Requires -Module Az.KeyVault
 
 # Use this script to create a certificate that you can use to secure a Service Fabric Cluster
 # This script requires an existing KeyVault that is EnabledForDeployment.  The vault must be in the same region as the cluster.
 # To create a new vault and set the EnabledForDeployment property run:
 #
-# New-AzureRmResourceGroup -Name KeyVaults -Location WestUS
-# New-AzureRmKeyVault -VaultName $KeyVaultName -ResourceGroupName KeyVaults -Location WestUS -EnabledForDeployment
+# New-AzResourceGroup -Name KeyVaults -Location WestUS
+# New-AzKeyVault -VaultName $KeyVaultName -ResourceGroupName KeyVaults -Location WestUS -EnabledForDeployment
 #
 # Once the certificate is created and stored in the vault, the script will provide the parameter values needed for template deployment
 # 
@@ -36,9 +36,9 @@ $ContentBytes = [System.Text.Encoding]::UTF8.GetBytes($JSONBlob)
 $Content = [System.Convert]::ToBase64String($ContentBytes)
 
 $SecretValue = ConvertTo-SecureString -String $Content -AsPlainText -Force
-$NewSecret = Set-AzureKeyVaultSecret -VaultName $KeyVaultName -Name $KeyVaultSecretName -SecretValue $SecretValue -Verbose
+$NewSecret = Set-AzKeyVaultSecret -VaultName $KeyVaultName -Name $KeyVaultSecretName -SecretValue $SecretValue -Verbose
 
 Write-Host
-Write-Host "Source Vault Resource Id: "$(Get-AzureRmKeyVault -VaultName $KeyVaultName).ResourceId
+Write-Host "Source Vault Resource Id: "$(Get-AzKeyVault -VaultName $KeyVaultName).ResourceId
 Write-Host "Certificate URL : "$NewSecret.Id
 Write-Host "Certificate Thumbprint : "$NewCert.Thumbprint


### PR DESCRIPTION
# Best Practice Checklist

Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment.
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [ x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Updated the Service Fabric helper script for creating Key Vault cluster certificate to use Az commands (AzureRM commands are deprecated). No change to template or parameter files.
