### PR TITLE
workaround for AzDO bug

### DIFF
--- a/test/ci-gen-setup/Create-GEN-Artifacts.ps1
+++ b/test/ci-gen-setup/Create-GEN-Artifacts.ps1
@@ -146,11 +146,11 @@ if($ServicePrincipalObjectId){
 # Assign the Azure ML SP perms to the subscription - this needs contributor at the moment, hopefully the fix that later
 # Display Name = "Azure Machine Learning" (this substring is not unique)
 # Service Principal Name = 0736f41a-0425-4b46-bdb5-1563eff02385
-$mlsp = Get-AzureRmADServicePrincipal -ServicePrincipalName '0736f41a-0425-4b46-bdb5-1563eff02385'
+$mlsp = Get-AzureRmADServicePrincipal -ServicePrincipalName '0736f41a-0425-4b46-bdb5-1563eff02385' #-DisplayName "Azure Machine Learning"
 $roleDef = Get-AzureRmRoleDefinition -Name 'Contributor'
 New-AzureRMRoleAssignment -RoleDefinitionId $roleDef.id -ObjectId $mlsp.id -Scope "/subscriptions/$((Get-AzureRMContext).Subscription.Id)" -Verbose
 
-$cosmossp = Get-AzureRmADServicePrincipal -ServicePrincipalName "a232010e-820c-4083-83bb-3ace5fc29d0b"
+$cosmossp = Get-AzureRmADServicePrincipal -ServicePrincipalName "a232010e-820c-4083-83bb-3ace5fc29d0b" # -DisplayName "Azure Cosmos DB"
 Set-AzureRMKeyVaultAccessPolicy -VaultName $KeyVaultName -ObjectId $cosmossp.id -PermissionsToKeys get,unwrapKey,wrapKey 
 
 

--- a/test/ci-scripts/Validate-Metadata.ps1
+++ b/test/ci-scripts/Validate-Metadata.ps1
@@ -4,6 +4,8 @@ param(
     [string] $BuildReason = $ENV:BUILD_REASON
 )
 
+$ErrorView = "NormalView" # this is working around a bug in Azure DevOps with PS Core and inline scripts https://github.com/microsoft/azure-pipelines-agent/issues/2853
+
 #get the file content
 Write-Output "Testing file: $SampleFolder\metadata.json"
 $metadata = Get-Content -Path "$SampleFolder\metadata.json" -Raw 

--- a/test/ci-scripts/Validate-ReadMe.ps1
+++ b/test/ci-scripts/Validate-ReadMe.ps1
@@ -4,6 +4,8 @@ param(
     [string] $ReadMeFileName = "README.md"
 )
 
+$ErrorView = "NormalView" # this is working around a bug in Azure DevOps with PS Core and inline scripts https://github.com/microsoft/azure-pipelines-agent/issues/2853
+
 <#
 TODO linting - is there a pipeline tool for this ?
 #>


### PR DESCRIPTION
## Changelog

* AzDO has a bug in handling/detecting errors for pwsh core tasks, this is a workaround for that bug
* added ci gen setup for AML CMK scenarios
*
