### PR TITLE
fix enum value for scheduled builds

### DIFF
--- a/test/ci-scripts/Validate-Metadata.ps1
+++ b/test/ci-scripts/Validate-Metadata.ps1
@@ -18,7 +18,7 @@ $metadata | Test-Json -Schema $schema.content
 $rawDate = ($metadata | convertfrom-json).dateUpdated
 $dateUpdated = (Get-Date $rawDate)
 
-if (!($ENV:BUILD_REASON -eq "Scheduled")) {
+if (!($ENV:BUILD_REASON -eq "Schedule")) {
     #When running the scheduled tests, we don't want to check the date
     try {
         [DateTime]::ParseExact($rawDate, 'yyyy-MM-dd', $(Get-Culture))


### PR DESCRIPTION
# Best Practice Checklist

Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment.
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
