### PR TITLE
Fix 101-app-function

### DIFF
--- a/101-app-function/azuredeploy.json
+++ b/101-app-function/azuredeploy.json
@@ -9,10 +9,10 @@
                 "description": "The name of you Web Site."
             }
         },
-		"storageAccountName": {
-			"type": "String",
-			"defaultValue": "[concat('store', uniqueString(resourceGroup().id))]"
-		},
+        "storageAccountName": {
+            "type": "String",
+            "defaultValue": "[concat('store', uniqueString(resourceGroup().id))]"
+        },
         "location": {
             "type": "string",
             "defaultValue": "[resourceGroup().location]",
@@ -23,7 +23,7 @@
     },
     "variables": {
         "hostingPlanName": "[concat('hpn-', resourceGroup().name)]",
-		"storageAccountid": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+        "storageAccountid": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
     },
     "resources": [
         {
@@ -34,7 +34,7 @@
             "location": "[parameters('location')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-				"[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
             ],
             "properties": {
                 "name": "[parameters('siteName')]",
@@ -48,10 +48,10 @@
                             "name": "FUNCTIONS_EXTENSION_VERSION",
                             "value": "~2"
                         },
-						{
-							"name": "AzureWebJobsStorage",
-							"value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
-						}
+                        {
+                            "name": "AzureWebJobsStorage",
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
+                        }
                     ]
                 },
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
@@ -72,15 +72,15 @@
                 "Name": "Y1"
             }
         },
-		{
-			"type": "Microsoft.Storage/storageAccounts",
-			"name": "[parameters('storageAccountName')]",
-			"apiVersion": "2019-06-01",
-			"location": "[parameters('location')]",
-			"kind": "StorageV2",
-			"sku": {
-				"name": "Standard_LRS"
-			}
-		}
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "name": "[parameters('storageAccountName')]",
+            "apiVersion": "2019-06-01",
+            "location": "[parameters('location')]",
+            "kind": "StorageV2",
+            "sku": {
+                "name": "Standard_LRS"
+            }
+        }
     ]
 }

--- a/101-app-function/azuredeploy.json
+++ b/101-app-function/azuredeploy.json
@@ -23,12 +23,12 @@
     },
     "variables": {
         "hostingPlanName": "[concat('hpn-', resourceGroup().name)]",
-		"storageAccountid": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]"
+		"storageAccountid": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
     },
     "resources": [
         {
             "type": "Microsoft.Web/sites",
-            "apiVersion": "2018-02-01",
+            "apiVersion": "2019-08-01",
             "name": "[parameters('siteName')]",
             "kind": "functionapp,linux",
             "location": "[parameters('location')]",
@@ -60,7 +60,7 @@
         },
         {
             "type": "Microsoft.Web/serverfarms",
-            "apiVersion": "2018-02-01",
+            "apiVersion": "2019-08-01",
             "name": "[variables('hostingPlanName')]",
             "location": "[parameters('location')]",
             "kind": "linux",
@@ -75,8 +75,8 @@
 		{
 			"type": "Microsoft.Storage/storageAccounts",
 			"name": "[parameters('storageAccountName')]",
-			"apiVersion": "2019-04-01",
-			"location": "[resourceGroup().location]",
+			"apiVersion": "2019-06-01",
+			"location": "[parameters('location')]",
 			"kind": "StorageV2",
 			"sku": {
 				"name": "Standard_LRS"

--- a/101-app-function/azuredeploy.json
+++ b/101-app-function/azuredeploy.json
@@ -9,16 +9,21 @@
                 "description": "The name of you Web Site."
             }
         },
+		"storageAccountName": {
+			"type": "String",
+			"defaultValue": "[concat('store', uniqueString(resourceGroup().id))]"
+		},
         "location": {
-        "type": "string",
-        "defaultValue": "[resourceGroup().location]",
-        "metadata": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
                 "description": "Location for all resources."
             }
         }
     },
-     "variables": {
-        "hostingPlanName": "[concat('hpn-', resourceGroup().name)]"
+    "variables": {
+        "hostingPlanName": "[concat('hpn-', resourceGroup().name)]",
+		"storageAccountid": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', parameters('storageAccountName'))]"
     },
     "resources": [
         {
@@ -28,12 +33,13 @@
             "kind": "functionapp,linux",
             "location": "[parameters('location')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
+                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+				"[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
             ],
             "properties": {
                 "name": "[parameters('siteName')]",
                 "siteConfig": {
-                     "appSettings": [
+                    "appSettings": [
                         {
                             "name": "FUNCTIONS_WORKER_RUNTIME",
                             "value": "python"
@@ -41,7 +47,11 @@
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
                             "value": "~2"
-                        }
+                        },
+						{
+							"name": "AzureWebJobsStorage",
+							"value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
+						}
                     ]
                 },
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
@@ -54,13 +64,23 @@
             "name": "[variables('hostingPlanName')]",
             "location": "[parameters('location')]",
             "kind": "linux",
-            "properties":{
+            "properties": {
                 "reserved": true
             },
             "sku": {
                 "Tier": "Dynamic",
                 "Name": "Y1"
             }
-        }
+        },
+		{
+			"type": "Microsoft.Storage/storageAccounts",
+			"name": "[parameters('storageAccountName')]",
+			"apiVersion": "2019-04-01",
+			"location": "[resourceGroup().location]",
+			"kind": "StorageV2",
+			"sku": {
+				"name": "Standard_LRS"
+			}
+		}
     ]
 }

--- a/101-app-function/azuredeploy.json
+++ b/101-app-function/azuredeploy.json
@@ -55,7 +55,7 @@
             "location": "[parameters('location')]",
             "kind": "linux",
             "properties":{
-                "reserved": false
+                "reserved": true
             },
             "sku": {
                 "Tier": "Dynamic",

--- a/101-app-function/azuredeploy.json
+++ b/101-app-function/azuredeploy.json
@@ -50,7 +50,7 @@
                         },
                         {
                             "name": "AzureWebJobsStorage",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', parameters('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2019-06-01').keys[0].value)]"
                         }
                     ]
                 },

--- a/101-app-function/azuredeploy.parameters.json
+++ b/101-app-function/azuredeploy.parameters.json
@@ -4,6 +4,9 @@
     "parameters": {
         "siteName": {
 			"value": "GEN-UNIQUE"
-		}
+        },
+        "storageAccountName": {
+            "value": "GEN-UNIQUE"
+        }
     }
 }

--- a/101-app-function/metadata.json
+++ b/101-app-function/metadata.json
@@ -4,7 +4,7 @@
   "description": "This template deploy an empty Function App and a hosting plan.",
   "summary": "This template deploys an empty Function App and a hosting plan.",
   "githubUsername": "leestott",
-  "dateUpdated": "2019-11-06",
+  "dateUpdated": "2020-05-11",
   "type": "QuickStart",
   "tags": {
       "subscriptiontype": "Azure4Student",

--- a/101-app-function/metadata.json
+++ b/101-app-function/metadata.json
@@ -12,5 +12,8 @@
       "os": "serverless",
       "level": "Begginer",
       "cost": "$0"
-  }
+  },
+  "environmnents": [
+    "AzureCloud"
+  ]
 }

--- a/101-app-function/metadata.json
+++ b/101-app-function/metadata.json
@@ -13,7 +13,7 @@
       "level": "Begginer",
       "cost": "$0"
   },
-  "environmnents": [
+  "environments": [
     "AzureCloud"
   ]
 }


### PR DESCRIPTION
## Background
No Python function can be deployed as it's set as Linux App Service Plan and no storage account for the function app.


## Changelog
* Set the app service plan as Linux. 
* Add and attach a storage account for the Function Apps
* Update azuredeploy.parameters.json and metadata.json accordingly

I have tested on my own and successfully deployed a sample Python function to it.


## Reason
* Linux is required for Python runtime. The function app must have the reserved property set to true to enable Linux. [See the 'reserved' definition of AppServicePlanProperties object](https://docs.microsoft.com/en-us/azure/templates/microsoft.web/2018-02-01/serverfarms#appserviceplanproperties-object)
* An Azure storage account is required for a function app. [See more details](https://docs.microsoft.com/en-us/azure/azure-functions/storage-considerations#storage-account-requirements)


## Other
* There are some discussions about updating this sample templates in the Feedback of [this documentation](https://docs.microsoft.com/en-us/azure/azure-functions/functions-infrastructure-as-code#next-steps)
---
- [ ] Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.
