### PR TITLE
Missing opening square bracket in value

### DIFF
--- a/webapp-keyvault-ssl/azuredeploy.json
+++ b/webapp-keyvault-ssl/azuredeploy.json
@@ -110,7 +110,7 @@
             "[concat('Microsoft.Web/sites/', parameters('webAppName'))]"
           ],
           "properties": {
-            "siteName": "[parameters('webAppName'))]",
+            "siteName": "[parameters('webAppName')]",
             "domainId": null,
             "hostNameType": "Verified"
           }

--- a/webapp-keyvault-ssl/azuredeploy.json
+++ b/webapp-keyvault-ssl/azuredeploy.json
@@ -110,7 +110,7 @@
             "[concat('Microsoft.Web/sites/', parameters('webAppName'))]"
           ],
           "properties": {
-            "siteName": "parameters('webAppName'))]",
+            "siteName": "[parameters('webAppName'))]",
             "domainId": null,
             "hostNameType": "Verified"
           }

--- a/webapp-keyvault-ssl/azuredeploy.json
+++ b/webapp-keyvault-ssl/azuredeploy.json
@@ -131,7 +131,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(parameters('_artifactsLocation'), '/', variables('nestedTemplateFolder'), '/', variables('nestedTemplateFileName'), parameters('_artifactsLocationSasToken'))]",
+          "uri": "[uri(parameters('_artifactsLocation'), concat(variables('nestedTemplateFolder'), '/', variables('nestedTemplateFileName'), parameters('_artifactsLocationSasToken')))]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {


### PR DESCRIPTION
# Best Practice Checklist

Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment.
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*Missing opening square bracket in value:
"siteName": "parameters('webAppName'))]", should be "siteName": "[parameters('webAppName'))]",

