### PR TITLE
add defaultValue for easier portal deployment

### DIFF
--- a/101-SQL-Injection-Attack-Prevention/azuredeploy.json
+++ b/101-SQL-Injection-Attack-Prevention/azuredeploy.json
@@ -67,8 +67,11 @@
     },
     "bacpacUri": {
       "type": "string",
+      "defaultValue": "[if(equals(environment().name, 'AzureUSGovernment'),
+                            'https://azbotstorageus.blob.core.usgovcloudapi.net/bacpacs/contosoclinic.bacpac',
+                            'https://azbotstorage.blob.core.windows.net/bacpacs/contosoclinic.bacpac')]",
       "metadata": {
-        "description": "The uri to the Contoso Clinic BacPac - must be hosted in Azure Storage"
+        "description": "The uri to the Contoso Clinic BacPac - must be hosted in Azure Storage, use the defaultValue if deploying from QuickStarts."
       }
     },
     "bacpacUriSasToken": {

--- a/101-SQL-Injection-Attack-Prevention/azuredeploy.parameters.json
+++ b/101-SQL-Injection-Attack-Prevention/azuredeploy.parameters.json
@@ -7,9 +7,6 @@
     },
     "sqlServerPassword": {
       "value": "GEN-PASSWORD"
-    },
-    "bacpacUri": {
-      "value": "GEN-CLINIC-BACPAC-URI"
     }
   }
 }


### PR DESCRIPTION
# Best Practice Checklist

Check these items before submitting a PR... See the Contribution Guide for the full detail: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md 

1. uri's compatible with all clouds (Stack, China, Government)
1. Staged artifacts use _artifactsLocation & _artifactsLocationSasToken
1. Use a parameter for resource locations with the defaultValue set to resourceGroup().location
1. Folder names for artifacts (nestedtemplates, scripts, DSC)
1. Use literal values for apiVersion (no variables)
1. Parameter files (GEN-UNIQUE for value generation and no "changemeplease" values)
1. $schema and other uris use https
1. Use uniqueString() whenever possible to generate names for resources.  While this is not required, it's one of the most common failure points in a deployment.
1. Update the metadata.json with the current date

For details: https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md

- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* added defaultValue for bacpac uri to make portal deployment easier
*
*
