### PR TITLE
added creation of system topic explicitly

### DIFF
--- a/101-event-grid-subscription-and-storage/azuredeploy.json
+++ b/101-event-grid-subscription-and-storage/azuredeploy.json
@@ -28,6 +28,13 @@
             "metadata": {
                 "description": "Provide the URL for the WebHook to receive events. Create your own endpoint for events."
             }
+        },
+		"systemTopicName": {
+			"type": "String",
+			"defaultValue": "mystoragesystemtopic",
+			"metadata": {
+				"description": "Provide a name for the system topic."
+			}
         }
     },
     "resources": [
@@ -45,29 +52,40 @@
                 "accessTier": "Hot"
             }
         },
-        {
-            "type": "Microsoft.Storage/storageAccounts/providers/eventSubscriptions",
-            "name": "[concat(parameters('storageName'), '/Microsoft.EventGrid/', parameters('eventSubName'))]",
-            "apiVersion": "2018-01-01",
-            "dependsOn": [
-                "[parameters('storageName')]"
-            ],
-            "properties": {
-                "destination": {
-                    "endpointType": "WebHook",
-                    "properties": {
-                        "endpointUrl": "[parameters('endpoint')]"
-                    }
-                },
-                "filter": {
-                    "subjectBeginsWith": "",
-                    "subjectEndsWith": "",
-                    "isSubjectCaseSensitive": false,
-                    "includedEventTypes": [
-                        "All"
-                    ]
-                }
-            }
+		{
+			"name": "[parameters('systemTopicName')]",
+			"type": "Microsoft.EventGrid/systemTopics",
+			"apiVersion": "2020-04-01-preview",
+			"location": "eastus",
+			"dependsOn": [
+				"[parameters('storageName')]"
+			],
+			"properties": {
+				"source": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageName'))]",
+				"topicType": "Microsoft.Storage.StorageAccounts"
+			}
+		},
+		{
+			"type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+			"apiVersion": "2020-04-01-preview",
+			"name": "[concat(parameters('systemTopicName'), '/', parameters('eventSubName'))]",
+			"dependsOn": [
+				"[resourceId('Microsoft.EventGrid/systemTopics', parameters('systemTopicName'))]"
+			],
+			"properties": {
+				"destination": {
+					"properties": {
+						"endpointUrl": "[parameters('endpoint')]"
+					},
+					"endpointType": "WebHook"
+				},
+				"filter": {
+					"includedEventTypes": [
+						"Microsoft.Storage.BlobCreated",
+						"Microsoft.Storage.BlobDeleted"
+					]
+				}
+			}
         }
     ]
 }

--- a/101-event-grid-subscription-and-storage/azuredeploy.json
+++ b/101-event-grid-subscription-and-storage/azuredeploy.json
@@ -56,7 +56,7 @@
 			"name": "[parameters('systemTopicName')]",
 			"type": "Microsoft.EventGrid/systemTopics",
 			"apiVersion": "2020-04-01-preview",
-			"location": "eastus",
+			"location": "[parameters('location')]",
 			"dependsOn": [
 				"[parameters('storageName')]"
 			],

--- a/101-event-grid-subscription-and-storage/metadata.json
+++ b/101-event-grid-subscription-and-storage/metadata.json
@@ -4,7 +4,7 @@
   "itemDisplayName": "Create Blob Storage and Event Grid subscription to the Blob",
   "description": "Creates Azure Blob Storage account and then creates an Event Grid subscription to that Blob.",
   "summary": "This template creates Azure Blob Storage account and then creates an Event Grid subscription to that Blob.",
-  "githubUsername": "tfitzmac",
-  "dateUpdated": "2018-08-13"
+  "githubUsername": "spelluru",
+  "dateUpdated": "2020-06-02"
 }
 


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

The system topic for the storage account is created automatically, but we recommend our customers to create system topic explicitly so that they can use the topic name to search for diagnostic logs. 

So, I added the creation of system topic resource and an event subscription for the resource. 
