### PR TITLE
GloballyRedundant -> GeoRedundant

### DIFF
--- a/101-recovery-services-vault-create/azuredeploy.json
+++ b/101-recovery-services-vault-create/azuredeploy.json
@@ -17,10 +17,10 @@
     },
     "vaultStorageType": {
       "type": "string",
-      "defaultValue": "GloballyRedundant",
+      "defaultValue": "GeoRedundant",
       "allowedValues": [
         "LocallyRedundant",
-        "GloballyRedundant"
+        "GeoRedundant"
       ],
       "metadata": {
         "description": "Change Vault Storage Type (not allowed if the vault has registered backups)"


### PR DESCRIPTION
I don't know if it changed recently, but now it works for me only if I replace _GloballyRedundant_ with _GeoRedundant_.

In the GUI it's called _GeoRedundant_ as well.

Regards

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* 
*
*
