### PR TITLE
Update parameters reference to KeyVault for 101-vm-secure-password

### DIFF
--- a/101-vm-secure-password/azuredeploy.parameters.json
+++ b/101-vm-secure-password/azuredeploy.parameters.json
@@ -6,7 +6,12 @@
       "value": "GEN-UNIQUE"
     },
     "adminPassword": {
-      "reference": "GEN-KEYVAULT-PASSWORD-REFERENCE"
+      "reference": {
+        "keyVault": {
+          "id": "GEN-KEYVAULT-RESOURCE-ID"
+        },
+        "secretName": "GEN-KEYVAULT-PASSWORD-SECRET-NAME"
+      }
     }
   }
 }

--- a/101-vm-secure-password/metadata.json
+++ b/101-vm-secure-password/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to deploy a simple Windows VM by retrieving the password that is stored in a Key Vault. Therefore the password is never put in plain text in the template parameter file",
   "summary": "This template takes deploys a VM by retrieving the password securely from a Key Vault",
   "githubUsername": "bmoore-msft",
-  "dateUpdated": "2020-04-16"
+  "dateUpdated": "2020-07-01"
 }


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Expanded the parameters reference to KeyVault to bring back the sample's intended demonstration of referencing a KeyVault to retrieve a password for deployment.
