### PR TITLE
Fix typo in EventHub SKU description

### DIFF
--- a/101-eventhubs-create-namespace-and-eventhub/azuredeploy.json
+++ b/101-eventhubs-create-namespace-and-eventhub/azuredeploy.json
@@ -20,7 +20,7 @@
       "allowedValues": [ "Basic", "Standard" ],
       "defaultValue": "Standard",
       "metadata": {
-        "description": "Specifies the messaging tier for service Bus namespace."
+        "description": "Specifies the messaging tier for Event Hub Namespace."
       }
     }
   },


### PR DESCRIPTION
This pull request fixes a typo in the quickstart template for EventHub that described the `eventHubSku` parameter as a Service Bus SKU which can lead to confusion for users with regards to our [ServiceBus](https://azure.microsoft.com/en-us/services/service-bus/) offering.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Change description of `eventHubSku` parameter
