### PR TITLE
Adding parameters to allow for VS2019 based Agent on WS2019 as well as the previous default VS2017 on WS2016

### DIFF
--- a/201-vm-vsts-agent/azuredeploy.json
+++ b/201-vm-vsts-agent/azuredeploy.json
@@ -123,7 +123,7 @@
       },
       "allowedValues": [
         "VisualStudio",
-        "VisualStudio2019"
+        "visualstudio2019"
       ],
       "defaultValue": "VisualStudio"
     },

--- a/201-vm-vsts-agent/azuredeploy.json
+++ b/201-vm-vsts-agent/azuredeploy.json
@@ -108,6 +108,35 @@
       "metadata": {
         "description": "Location for all resources."
       }
+    },
+    "imagePublisher": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifiy the publisher of the vm image"
+      },
+      "defaultValue": "MicrosoftVisualStudio"
+    },
+    "imageOffer": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifiy the Offer of the vm image"
+      },
+      "allowedValues": [
+        "VisualStudio",
+        "VisualStudio2019"
+      ],
+      "defaultValue": "VisualStudio"
+    },
+    "imageSKU": {
+      "type": "string",
+      "metadata": {
+        "description": "Specifiy the Offer of the vm image"
+      },
+      "allowedValues": [
+        "VS-2017-Ent-WS2016",
+        "vs-2019-ent-ws2019"
+      ],
+      "defaultValue": "VS-2017-Ent-WS2016"
     }
   },
   "variables": {
@@ -292,9 +321,9 @@
         },
         "storageProfile": {
           "imageReference": {
-            "publisher": "MicrosoftVisualStudio",
-            "offer": "VisualStudio",
-            "sku": "VS-2017-Ent-WS2016",
+            "publisher": "[parameters('imagePublisher')]",
+            "offer": "[parameters('imageOffer')]",
+            "sku": "[parameters('imageSku')]",
             "version": "latest"
           },
           "osDisk": {


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Adding parameters and allowable values for image publisher, sku and offer. Defaults kept as previous values to keep existing consumers unaffected by this change, new clients can provide parameters to get latest VS2019 image on WS2019.

