### PR TITLE
Update API version on 101-sql-vm-new-storage-ultrassd

### DIFF
--- a/101-sql-vm-new-storage-ultrassd/README.md
+++ b/101-sql-vm-new-storage-ultrassd/README.md
@@ -14,10 +14,8 @@ Before deploying the template you must have the following
 1. **Virtual Network** and **Subnet** in same location
 2. Follow this [this documentation](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-enable-ultra-ssd) to **determine your availability zone**.
 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-sql-vm-new-storage-ultrassd%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-sql-vm-new-storage-ultrassd%2Fazuredeploy.json)
-    <img src="http://azuredeploy.net/deploybutton.png"/>
-
-    <img src="http://armviz.io/visualizebutton.png"/>
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-sql-vm-new-storage-ultrassd%2Fazuredeploy.json)  
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2F101-sql-vm-new-storage-ultrassd%2Fazuredeploy.json)
 
 `Tags: Azure, SQL, VirtualMachine, Performance, StorageConfiguration, UltraSSD`
 

--- a/101-sql-vm-new-storage-ultrassd/azuredeploy.json
+++ b/101-sql-vm-new-storage-ultrassd/azuredeploy.json
@@ -12,22 +12,6 @@
     "virtualMachineSize": {
       "type": "String",
       "defaultValue": "Standard_D8s_v3",
-      "allowedValues": [
-        "Standard_D2s_v3",
-        "Standard_D4s_v3",
-        "Standard_D8s_v3",
-        "Standard_D16s_v3",
-        "Standard_D32s_v3",
-        "Standard_D64s_v3",
-        "Standard_E2s_v3",
-        "Standard_E4s_v3",
-        "Standard_E8s_v3",
-        "Standard_E16s_v3",
-        "Standard_E32s_v3",
-        "Standard_E64s_v3",
-        "Standard_E64is_v3",
-        "Experimental_E64-40s_v3"
-      ],
       "metadata": {
         "description": "The virtual machine size."
       }
@@ -54,13 +38,15 @@
     "imageOffer": {
       "type": "String",
       "allowedValues": [
+        "sql2019-ws2019",
+        "sql2017-ws2019",
         "SQL2017-WS2016",
         "SQL2016SP1-WS2016",
         "SQL2016SP2-WS2016",
         "SQL2014SP3-WS2012R2",
         "SQL2014SP2-WS2012R2"
       ],
-      "defaultValue": "SQL2017-WS2016",
+      "defaultValue": "sql2019-ws2019",
       "metadata": {
         "description": "Windows Server and SQL Offer"
       }
@@ -209,7 +195,7 @@
   "resources": [
     {
       "type": "Microsoft.Compute/disks",
-      "apiVersion": "2018-06-01",
+      "apiVersion": "2019-11-01",
       "name": "[concat(parameters('virtualMachineName'),'-dataDisk-UltraSSD-',copyIndex())]",
       "location": "[parameters('location')]",
       "sku": {
@@ -233,7 +219,7 @@
     },
     {
       "type": "Microsoft.Compute/disks",
-      "apiVersion": "2018-06-01",
+      "apiVersion": "2019-11-01",
       "name": "[concat(parameters('virtualMachineName'),'-dataDisk-',copyIndex())]",
       "location": "[parameters('location')]",
       "sku": {
@@ -255,7 +241,7 @@
     },
     {
       "type": "Microsoft.Network/publicIpAddresses",
-      "apiVersion": "2019-02-01",
+      "apiVersion": "2020-05-01",
       "name": "[variables('publicIpAddressName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -270,7 +256,7 @@
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2019-02-01",
+      "apiVersion": "2020-05-01",
       "name": "[variables('networkSecurityGroupName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -279,12 +265,12 @@
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2018-10-01",
+      "apiVersion": "2020-05-01",
       "name": "[variables('networkInterfaceName')]",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkSecurityGroups/', variables('networkSecurityGroupName'))]",
-        "[concat('Microsoft.Network/publicIpAddresses/', variables('publicIpAddressName'))]"
+        "[resourceId('Microsoft.Network/networkSecurityGroups/', variables('networkSecurityGroupName'))]",
+        "[resourceId('Microsoft.Network/publicIpAddresses/', variables('publicIpAddressName'))]"
       ],
       "properties": {
         "ipConfigurations": [
@@ -309,11 +295,11 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines",
-      "apiVersion": "2018-10-01",
+      "apiVersion": "2019-12-01",
       "name": "[parameters('virtualMachineName')]",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Network/networkInterfaces/', variables('networkInterfaceName'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces/', variables('networkInterfaceName'))]",
         "UltraSSDLoop",
         "PremiumSSDLoop"
       ],

--- a/101-sql-vm-new-storage-ultrassd/metadata.json
+++ b/101-sql-vm-new-storage-ultrassd/metadata.json
@@ -5,5 +5,8 @@
   "description": "Create a SQL Server Virtual Machine with performance optimized storage settings, using UltraSSD for SQL Log files",
   "summary": "Create a SQL Server Virtual Machine with performance optimized storage settings, using UltraSSD for SQL Log files",
   "githubUsername": "sam0227",
-  "dateUpdated": "2019-09-26"
+  "dateUpdated": "2020-09-19",
+  "environments": [
+    "AzureCloud"
+  ]
 }

--- a/101-sql-vm-new-storage-ultrassd/prereqs/prereq.azuredeploy.json
+++ b/101-sql-vm-new-storage-ultrassd/prereqs/prereq.azuredeploy.json
@@ -22,7 +22,7 @@
       "name": "[variables('firstVNETName')]",
       "type": "Microsoft.Network/virtualNetworks",
       "location": "[variables('firstVNETLocation')]",
-      "apiVersion": "2018-04-01",
+      "apiVersion": "2020-05-01",
       "tags": {
         "displayName": "firstVNET"
       },

--- a/101-sql-vm-new-storage-ultrassd/prereqs/prereq.azuredeploy.json
+++ b/101-sql-vm-new-storage-ultrassd/prereqs/prereq.azuredeploy.json
@@ -7,12 +7,11 @@
       "metadata": {
         "description": "Location for all resources."
       },
-      "defaultValue": "East US 2"
+      "defaultValue": "[resourceGroup().location]"
     }
   },
   "variables": {
-    "firstVNETName": "vnet-01",
-    "firstVNETLocation": "[parameters('location')]",
+    "firstVNETName": "[concat('vnet-', uniqueString(resourceGroup().id, deployment().name))]",
     "firstVNETPrefix": "10.0.0.0/16",
     "firstVNETFESubnetName": "subnet01",
     "firstVNETFESubnetPrefix": "10.0.1.0/24"
@@ -21,7 +20,7 @@
     {
       "name": "[variables('firstVNETName')]",
       "type": "Microsoft.Network/virtualNetworks",
-      "location": "[variables('firstVNETLocation')]",
+      "location": "[parameters('location')]",
       "apiVersion": "2020-05-01",
       "tags": {
         "displayName": "firstVNET"

--- a/101-sql-vm-new-storage-ultrassd/prereqs/prereq.azuredeploy.parameters.json
+++ b/101-sql-vm-new-storage-ultrassd/prereqs/prereq.azuredeploy.parameters.json
@@ -2,5 +2,8 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "location": {
+      "value": "eastus2"
+    }
   }
 }


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Update API version
* Remove fixed list of VM sizes
* Move default image to SQL 2019
* Remove US Gov support because of the use of AZs
* Minor fixes