### PR TITLE
Update ARM Template Files - Azure Attestation 

### DIFF
--- a/101-attestation-provider-create/azuredeploy.json
+++ b/101-attestation-provider-create/azuredeploy.json
@@ -17,8 +17,8 @@
       "defaultValue": "[resourceGroup().location]"
     },
     "tags": {
-      "type": "Object",
-      "defaultValue": {},
+      "type": "object",
+      "defaultValue": {}
     },
     "policySigningCertificates": {
       "type": "string",


### PR DESCRIPTION
default value for object has extra comma - fails on deploy when using the docs!

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Default value has an extra comma and fails on template deploy when following azure attestation documentation
* For the user this may result in confusion if they don't know where to find the template on the azure quickstart templates github
