### PR TITLE
Bypass SharePoint template validation error in portal

### DIFF
--- a/sharepoint-adfs/CHANGELOG.md
+++ b/sharepoint-adfs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for Azure template SharePoint-ADFS
 
+## Enhancements & bug-fixes - Published in October 5, 2020
+
+* Implement workaround to the template validation error when it is deployed from the portal and parameter numberOfAdditionalFrontEnd is set to 0
+
 ## Enhancements & bug-fixes - Published in October 2, 2020
 
 * Replace parameter addFrontEndToFarm with numberOfAdditionalFrontEnd

--- a/sharepoint-adfs/azuredeploy.json
+++ b/sharepoint-adfs/azuredeploy.json
@@ -209,6 +209,7 @@
     }
   },
   "variables": {
+    "copyCountVarToWorkaroundTemplateValidationBugInPortal": "[if(equals(parameters('numberOfAdditionalFrontEnd'), 0), 1, parameters('numberOfAdditionalFrontEnd'))]",
     "generalSettings": {
       "vmDCName": "DC",
       "vmSQLName": "SQL",
@@ -927,7 +928,7 @@
       },
       "copy": {
           "name": "frontendPublicIPAddresses",
-          "count": "[parameters('numberOfAdditionalFrontEnd')]"
+          "count": "[variables('copyCountVarToWorkaroundTemplateValidationBugInPortal')]"
       },
       "sku": {
         "name": "Basic",
@@ -955,7 +956,7 @@
       },
       "copy": {
           "name": "frontendNetworkInterfaces",
-          "count": "[parameters('numberOfAdditionalFrontEnd')]"
+          "count": "[variables('copyCountVarToWorkaroundTemplateValidationBugInPortal')]"
       },
       "properties": {
         "ipConfigurations": [
@@ -988,7 +989,7 @@
       },
       "copy": {
           "name": "frontendVirtualMachines",
-          "count": "[parameters('numberOfAdditionalFrontEnd')]"
+          "count": "[variables('copyCountVarToWorkaroundTemplateValidationBugInPortal')]"
       },
       "properties": {
         "hardwareProfile": {
@@ -1047,7 +1048,7 @@
       },
        "copy": {
           "name": "frontendVirtualMachineExtensions",
-          "count": "[parameters('numberOfAdditionalFrontEnd')]"
+          "count": "[variables('copyCountVarToWorkaroundTemplateValidationBugInPortal')]"
       },
       "properties": {
         "publisher": "Microsoft.Powershell",
@@ -1179,7 +1180,7 @@
       ],
       "copy": {
           "name": "frontendAutoShutdowns",
-          "count": "[parameters('numberOfAdditionalFrontEnd')]"
+          "count": "[variables('copyCountVarToWorkaroundTemplateValidationBugInPortal')]"
       },
       "properties": {
         "status": "Enabled",

--- a/sharepoint-adfs/metadata.json
+++ b/sharepoint-adfs/metadata.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
   "type": "QuickStart",
-  "itemDisplayName": "SharePoint 2019 / 2016 / 2013 with a broad configuration",
+  "itemDisplayName": "SharePoint 2019 / 2016 / 2013 fully configured",
   "description": "Create a SharePoint 2019 / 2016 / 2013 farm with a web application set with Windows and ADFS authentication, and some path based and host-named site collections. It also provisions User Profiles and Apps service applications and installs claims provider LDAPCP.",
   "summary": "Create a SharePoint farm with a web application set with Windows and ADFS, some path based and host-named site collections, User Pprofiles and Apps services, and install claims provider LDAPCP.",
   "githubUsername": "Yvand",
-  "dateUpdated": "2020-10-02"
+  "dateUpdated": "2020-10-05"
 }


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Implement a workaround to the template validation error when it is deployed from the portal and parameter numberOfAdditionalFrontEnd is set to 0 (default value)
It's a bug that occurs only when it's deployed from the portal (which is why I missed it), the template is actually valid
