### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/101-automation/scripts/AzureAutomationTutorialPython2.py
+++ b/101-automation/scripts/AzureAutomationTutorialPython2.py
@@ -6,6 +6,7 @@ Azure Python SDK documentation : https://aka.ms/azure-python-sdk
 
 This tutorial runbook demonstrate how to authenticate against Azure using the Azure automation service principal and then lists the resource groups present in the specified subscription.
 """
+from __future__ import print_function
 import azure.mgmt.resource
 import automationassets
 from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
@@ -54,4 +55,4 @@ resource_client = azure.mgmt.resource.ResourceManagementClient(
 # Get list of resource groups and print them out
 groups = resource_client.resource_groups.list()
 for group in groups:
-    print group.name.encode('utf-8')
+    print(group.name.encode('utf-8'))

--- a/bosh-cf-crossregion/scripts/setup_env.py
+++ b/bosh-cf-crossregion/scripts/setup_env.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import json
 import netaddr
 import os
@@ -202,7 +203,7 @@ def main():
     prepare_storage(settings)
 
     bosh_director_ip = render_bosh_manifest(settings)
-    print bosh_director_ip
+    print(bosh_director_ip)
 
     render_cloud_foundry_manifest(settings)
     render_cloud_foundry_deployment_cmd(settings)

--- a/cloudera-director-on-centos/scripts/director_user_passwd.py
+++ b/cloudera-director-on-centos/scripts/director_user_passwd.py
@@ -56,7 +56,7 @@ def prepare_user(username, password):
                               roles=["ROLE_ADMIN", "ROLE_READONLY"]))
 
         logging.info('Successfully created new admin user %s.' % dirUsername)
-    except HTTPError, e:
+    except HTTPError as e:
         logging.error("Failed to create user '%s'. %s" % (username, e.msg))
         return ExitCodes.ERROR
 
@@ -70,7 +70,7 @@ def prepare_user(username, password):
 
         logging.info("Successfully deleted default user 'admin'")
         return ExitCodes.OK
-    except HTTPError, e:
+    except HTTPError as e:
         logging.error("Failed to delete default user 'admin'. %s" % e.msg)
         return ExitCodes.ERROR
 

--- a/cloudera-director-on-centos/scripts/setup-default.py
+++ b/cloudera-director-on-centos/scripts/setup-default.py
@@ -17,6 +17,7 @@
 # Simple script that shows how to use the Cloudera Director API to initialize
 # the environment and instance templates
 
+from __future__ import print_function
 import argparse
 import ConfigParser
 import sys
@@ -96,11 +97,11 @@ def create_environment(client, config, provider_type, cloud_provider_metadata):
 
     except HTTPError as e:
         if e.code == 302:
-            print "Warning: an environment with the same name already exists"
+            print("Warning: an environment with the same name already exists")
         else:
             raise e
 
-    print "Environments: %s" % api.list()
+    print("Environments: %s" % api.list())
     return env.name
 
 
@@ -157,7 +158,7 @@ def configure_provider(merged_provider_config, provider_type, cloud_provider_met
     provider = InstanceProviderConfig()
     provider.type = provider_type
     if debug:
-        print "merged_provider_config: %s" % merged_provider_config
+        print("merged_provider_config: %s" % merged_provider_config)
     provider.config = {}
 
     provider.config.update(get_configuration_property_values(merged_provider_config, cloud_provider_metadata.credentialsProperties))
@@ -166,8 +167,8 @@ def configure_provider(merged_provider_config, provider_type, cloud_provider_met
         provider.config.update(get_configuration_property_values(merged_provider_config, resource_provider_metadata.configurationProperties))
 
     if debug:
-        print "provider.config: %s" % provider.config
-        print "Unknown keys: %s" % (merged_provider_config.viewkeys() - provider.config.viewkeys())
+        print("provider.config: %s" % provider.config)
+        print("Unknown keys: %s" % (merged_provider_config.viewkeys() - provider.config.viewkeys()))
 
     return provider
 
@@ -197,16 +198,16 @@ def create_instance_templates(client, config, environment_name, provider_type, c
             instance_provider_metadata = resource_provider_metadata
             break
     if instance_provider_metadata is None:
-        print "Warning: there is no compute instance provider for provider type: %s" % provider_type
+        print("Warning: there is no compute instance provider for provider type: %s" % provider_type)
     else:
         template_configs_by_template_name = config.get_config('instances')
         for template_name in template_configs_by_template_name.viewkeys():
             template_config = template_configs_by_template_name.get_config(template_name)
             merged_template_config = merge_configs([merged_provider_config, template_config])
             if debug:
-                print "template %s: %s" % (template_name, merged_template_config)
+                print("template %s: %s" % (template_name, merged_template_config))
             template = configure_instance_template(merged_template_config, template_name, instance_provider_metadata)
-            print "Creating a new instance template: %s ..." % template_name
+            print("Creating a new instance template: %s ..." % template_name)
             create_instance_template(client, environment_name, template)
             template_names.append(template_name)
 
@@ -268,10 +269,10 @@ def configure_instance_template(merged_template_config, template_name, instance_
     template.config.update(get_configuration_property_values(merged_template_config, instance_provider_metadata.templateProperties))
 
     if debug:
-        print "name: %s, type: %s, image: %s, sshUsername: %s, normalizeInstance: %s, bootstrapScript: %s, tags: %s" % \
-            (template.name, template.type, template.image, template.sshUsername, template.normalizeInstance, template.bootstrapScript, template.tags)
-        print "template.config: %s" % template.config
-        print "Unknown keys: %s" % (merged_template_config.viewkeys() - template.config.viewkeys())
+        print("name: %s, type: %s, image: %s, sshUsername: %s, normalizeInstance: %s, bootstrapScript: %s, tags: %s" % \
+            (template.name, template.type, template.image, template.sshUsername, template.normalizeInstance, template.bootstrapScript, template.tags))
+        print("template.config: %s" % template.config)
+        print("Unknown keys: %s" % (merged_template_config.viewkeys() - template.config.viewkeys()))
 
     return template
 
@@ -294,7 +295,7 @@ def create_instance_template(client, environment_name, template):
 
     except HTTPError as e:
         if e.code == 302:
-            print "Warning: an instance template with the same name already exists"
+            print("Warning: an instance template with the same name already exists")
         else:
             raise e
 
@@ -323,14 +324,14 @@ def add_existing_external_db_servers(client, config, environment_name):
         if is_existing_db_server(db_config):
             merged_db_config = merge_configs([merged_provider_config, db_config])
             if debug:
-                print "external db %s: %s" % (db_name, merged_db_config)
+                print("external db %s: %s" % (db_name, merged_db_config))
             db_server_template = configure_external_db_server(merged_db_config, db_name)
-            print "Adding an existing external DB server: %s ..." % db_name
+            print("Adding an existing external DB server: %s ..." % db_name)
             create_external_db_server(client, environment_name, db_server_template)
             db_server_names.append(db_name)
         else:
-            print "External DB server config template %s is not referring to an existing server" \
-                  % db_name
+            print("External DB server config template %s is not referring to an existing server" \
+                  % db_name)
 
     return db_server_names
 
@@ -379,9 +380,9 @@ def configure_external_db_server(db_server_config, db_name):
         db_server_template.type = config_value.upper()
 
     if debug:
-        print "name: %s, hostname: %s, port: %s, username: %s, type: %s" % \
+        print("name: %s, hostname: %s, port: %s, username: %s, type: %s" % \
             (db_name, db_server_template.hostname, db_server_template.port,
-             db_server_template.username, db_server_template.type)
+             db_server_template.username, db_server_template.type))
 
     return db_server_template
 
@@ -401,7 +402,7 @@ def create_external_db_server(client, environment_name, db_server):
 
     except HTTPError as e:
         if e.code == 302:
-            print "Warning: an database server with the same name already exists"
+            print("Warning: an database server with the same name already exists")
         else:
             raise e
 
@@ -425,7 +426,7 @@ def get_cloud_provider_metadata(client, provider_type):
 
     except HTTPError as e:
         if e.code == 404:
-            print "Error: no such provider type: %s" % provider_type
+            print("Error: no such provider type: %s" % provider_type)
         raise e
 
     return cloud_provider_metadata
@@ -488,7 +489,7 @@ def set_configuration_property_value(values_by_config_key, config_key, config_va
 
     if config_value:
         if debug:
-            print "setting %s: %s" % (config_key, config_value)
+            print("setting %s: %s" % (config_key, config_value))
         if config_type == 'BOOLEAN':
             config_value = config_value.lower()
         values_by_config_key[config_key] = config_value
@@ -514,7 +515,7 @@ def load_config(config_file, fallback_config_files):
             if isfile(fallback_config_file):
                 config = config.with_fallback(fallback_config_file)
             else:
-                print 'Warn: "%s" not found or not a file' % fallback_config_file
+                print('Warn: "%s" not found or not a file' % fallback_config_file)
 
     return config
 
@@ -544,7 +545,7 @@ def main():
         urllib2.install_opener(opener)
 
     if not isfile(args.config_file):
-        print 'Error: "%s" not found or not a file' % args.config_file
+        print('Error: "%s" not found or not a file' % args.config_file)
         return -1
 
     script_path = dirname(realpath(__file__))
@@ -558,13 +559,13 @@ def main():
     providerType = config.get_string('provider.type')
     cloudProviderMetadata = get_cloud_provider_metadata(client, providerType)
 
-    print "Creating a new environment ..."
+    print("Creating a new environment ...")
     environment_name = create_environment(client, config, providerType, cloudProviderMetadata)
 
-    print "Creating new instance templates ..."
+    print("Creating new instance templates ...")
     create_instance_templates(client, config, environment_name, providerType, cloudProviderMetadata)
 
-    print "Adding existing external database servers ..."
+    print("Adding existing external database servers ...")
     add_existing_external_db_servers(client, config, environment_name)
 
     return 0
@@ -575,5 +576,5 @@ if __name__ == '__main__':
         sys.exit(main())
 
     except HTTPError as e:
-        print e.read()
+        print(e.read())
         raise e

--- a/cloudera-on-centos/scripts/cmxDeployOnIbiza.py
+++ b/cloudera-on-centos/scripts/cmxDeployOnIbiza.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # 
+from __future__ import print_function
 __version__ = '0.11.2803'
 
 import socket
@@ -81,11 +82,11 @@ def init_cluster():
     cm.update_config({"REMOTE_PARCEL_REPO_URLS": "http://archive.cloudera.com/cdh5/parcels/{latest_supported}",
                       "PHONE_HOME": False, "PARCEL_DISTRIBUTE_RATE_LIMIT_KBS_PER_SECOND": "1024000"})
 
-    print "> Initialise Cluster"
+    print("> Initialise Cluster")
     if cmx.cluster_name in [x.name for x in api.get_all_clusters()]:
-        print "Cluster name: '%s' already exists" % cmx.cluster_name
+        print("Cluster name: '%s' already exists" % cmx.cluster_name)
     else:
-        print "Creating cluster name '%s'" % cmx.cluster_name
+        print("Creating cluster name '%s'" % cmx.cluster_name)
         api.create_cluster(name=cmx.cluster_name, version=cmx.cluster_version)
 
 
@@ -94,7 +95,7 @@ def add_hosts_to_cluster():
     Add hosts to cluster
     :return:
     """
-    print "> Add hosts to Cluster: %s" % cmx.cluster_name
+    print("> Add hosts to Cluster: %s" % cmx.cluster_name)
     api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
     cluster = api.get_cluster(cmx.cluster_name)
     cm = api.get_cloudera_manager()
@@ -105,30 +106,30 @@ def add_hosts_to_cluster():
     if host_list:
         cmd = cm.host_install(user_name=cmx.ssh_root_user, host_names=host_list,
                               password=cmx.ssh_root_password, private_key=cmx.ssh_private_key)
-        print "Installing host(s) to cluster '%s' - [ http://%s:7180/cmf/command/%s/details ]" % \
-              (socket.getfqdn(cmx.cm_server), cmx.cm_server, cmd.id)
+        print("Installing host(s) to cluster '%s' - [ http://%s:7180/cmf/command/%s/details ]" % \
+              (socket.getfqdn(cmx.cm_server), cmx.cm_server, cmd.id))
         #check.status_for_command("Hosts: %s " % host_list, cmd)
-        print "Installing hosts. This might take a while."
+        print("Installing hosts. This might take a while.")
         while cmd.success == None:
             sleep(20)
             cmd = cmd.fetch()
-            print "Installing hosts... Checking"
+            print("Installing hosts... Checking")
 
         if cmd.success != True:
-            print "cm_host_install failed: " + cmd.resultMessage
+            print("cm_host_install failed: " + cmd.resultMessage)
             exit(1)
 
-    print "Host install finish, agents installed"
+    print("Host install finish, agents installed")
     hosts = []
     for host in api.get_all_hosts():
         if host.hostId not in [x.hostId for x in cluster.list_hosts()]:
-            print "Adding {'ip': '%s', 'hostname': '%s', 'hostId': '%s'}" % (host.ipAddress, host.hostname, host.hostId)
+            print("Adding {'ip': '%s', 'hostname': '%s', 'hostId': '%s'}" % (host.ipAddress, host.hostname, host.hostId))
             hosts.append(host.hostId)
 
-    print "adding new hosts to cluster"
+    print("adding new hosts to cluster")
     if hosts:
-        print "Adding hostId(s) to '%s'" % cmx.cluster_name
-        print "%s" % hosts
+        print("Adding hostId(s) to '%s'" % cmx.cluster_name)
+        print("%s" % hosts)
         cluster.add_hosts(hosts)
 
 
@@ -138,7 +139,7 @@ def host_rack():
     :return:
     """
     # TODO: Add host to rack
-    print "> Add host to rack"
+    print("> Add host to rack")
     api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
     cluster = api.get_cluster(cmx.cluster_name)
     hosts = []
@@ -161,7 +162,7 @@ def deploy_parcel(parcel_product, parcel_version):
     cluster = api.get_cluster(cmx.cluster_name)
     parcel = cluster.get_parcel(parcel_product, parcel_version)
     if parcel.stage != 'ACTIVATED':
-        print "> Deploying parcel: [ %s-%s ]" % (parcel_product, parcel_version)
+        print("> Deploying parcel: [ %s-%s ]" % (parcel_product, parcel_version))
         parcel.start_download()
         # unlike other commands, check progress by looking at parcel stage and status
         while True:
@@ -174,8 +175,8 @@ def deploy_parcel(parcel_product, parcel_version):
             sys.stdout.write(msg + " " * (78 - len(msg)) + "\r")
             sys.stdout.flush()
 
-        print ""
-        print "1. Parcel Stage: %s" % parcel.stage
+        print("")
+        print("1. Parcel Stage: %s" % parcel.stage)
         parcel.start_distribution()
 
         while True:
@@ -188,7 +189,7 @@ def deploy_parcel(parcel_product, parcel_version):
             sys.stdout.write(msg + " " * (78 - len(msg)) + "\r")
             sys.stdout.flush()
 
-        print "2. Parcel Stage: %s" % parcel.stage
+        print("2. Parcel Stage: %s" % parcel.stage)
         if parcel.stage == 'DISTRIBUTED':
             parcel.activate()
 
@@ -201,7 +202,7 @@ def deploy_parcel(parcel_product, parcel_version):
            # elif parcel.state.errors:
              #   raise Exception(str(parcel.state.errors))
             else:
-                print "3. Parcel Stage: %s" % parcel.stage
+                print("3. Parcel Stage: %s" % parcel.stage)
                 break
 
 
@@ -216,9 +217,9 @@ def setup_zookeeper(HA):
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "ZOOKEEPER"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "zookeeper"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         
@@ -240,9 +241,9 @@ def setup_zookeeper(HA):
                 # Pick 3 hosts and deploy Zookeeper Server role for Zookeeper HA
                 # mingrui change install on primary, secondary, and CM
                 if HA:
-                    print cmhost
-                    print [x for x in hosts if x.id == 0 ][0]
-                    print [x for x in hosts if x.id == 1 ][0]
+                    print(cmhost)
+                    print([x for x in hosts if x.id == 0 ][0])
+                    print([x for x in hosts if x.id == 1 ][0])
                     cdh.create_service_role(service, rcg.roleType, cmhost)
                     cdh.create_service_role(service, rcg.roleType, [x for x in hosts if x.id == 0 ][0])
                     cdh.create_service_role(service, rcg.roleType, [x for x in hosts if x.id == 1 ][0])
@@ -269,9 +270,9 @@ def setup_hdfs(HA):
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "HDFS"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "hdfs"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -386,9 +387,9 @@ def setup_hbase():
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "HBASE"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "hbase"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -435,9 +436,9 @@ def setup_solr():
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "SOLR"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "solr"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -474,9 +475,9 @@ def setup_ks_indexer():
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "KS_INDEXER"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "ks_indexer"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -507,9 +508,9 @@ def setup_spark_on_yarn():
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "SPARK_ON_YARN"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "spark_on_yarn"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -552,9 +553,9 @@ def setup_yarn(HA):
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "YARN"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "yarn"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -642,9 +643,9 @@ def setup_mapreduce(HA):
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "MAPREDUCE"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "mapreduce"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -695,9 +696,9 @@ def setup_hive():
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "HIVE"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "hive"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -750,9 +751,9 @@ def setup_sqoop():
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "SQOOP"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "sqoop"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -779,9 +780,9 @@ def setup_sqoop_client():
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "SQOOP_CLIENT"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "sqoop_client"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         # hosts = get_cluster_hosts()
@@ -813,15 +814,15 @@ def setup_impala(HA):
         max_count=int(diskcount)-1
         if x < max_count:
           impala_dir_list+=","
-          print "x is %d. Adding comma" % (x)
+          print("x is %d. Adding comma" % (x))
 
     api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "IMPALA"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "impala"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         service_config = {"impala_cmd_args_safety_valve": "-scratch_dirs=%s" % (impala_dir_list) }
@@ -878,9 +879,9 @@ def setup_oozie():
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "OOZIE"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "oozie"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -913,9 +914,9 @@ def setup_hue():
     cluster = api.get_cluster(cmx.cluster_name)
     service_type = "HUE"
     if cdh.get_service_type(service_type) is None:
-        print "> %s" % service_type
+        print("> %s" % service_type)
         service_name = "hue"
-        print "Create %s service" % service_name
+        print("Create %s service" % service_name)
         cluster.create_service(service_name, service_type)
         service = cluster.get_service(service_name)
         hosts = management.get_hosts()
@@ -961,7 +962,7 @@ def setup_hdfs_ha():
     # api = ApiResource(cmx.cm_server, username=cmx.username, password=cmx.password, version=6)
     # cluster = api.get_cluster(cmx.cluster_name)
     try:
-        print "> Setup HDFS-HA"
+        print("> Setup HDFS-HA")
         hdfs = cdh.get_service_type('HDFS')
         zookeeper = cdh.get_service_type('ZOOKEEPER')
 
@@ -1014,7 +1015,7 @@ def setup_hdfs_ha():
             cdh('HDFS').start()
 
     except ApiException as err:
-        print " ERROR: %s" % err.message
+        print(" ERROR: %s" % err.message)
 
 
 def setup_yarn_ha():
@@ -1024,7 +1025,7 @@ def setup_yarn_ha():
     """
     # api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
     # cluster = api.get_cluster(cmx.cluster_name)
-    print "> Setup YARN-HA"
+    print("> Setup YARN-HA")
     yarn = cdh.get_service_type('YARN')
     zookeeper = cdh.get_service_type('ZOOKEEPER')
     hosts = management.get_hosts()
@@ -1045,7 +1046,7 @@ def setup_kerberos():
     """
     # api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
     # cluster = api.get_cluster(cmx.cluster_name)
-    print "> Setup Kerberos"
+    print("> Setup Kerberos")
     hdfs = cdh.get_service_type('HDFS')
     zookeeper = cdh.get_service_type('ZOOKEEPER')
     hue = cdh.get_service_type('HUE')
@@ -1109,7 +1110,7 @@ def setup_easy():
     """
     api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
     cluster = api.get_cluster(cmx.cluster_name)
-    print "> Easy setup for cluster: %s" % cmx.cluster_name
+    print("> Easy setup for cluster: %s" % cmx.cluster_name)
     # Do not install these services
     do_not_install = ['KEYTRUSTEE', 'KMS', 'KS_INDEXER', 'ISILON', 'FLUME', 'MAPREDUCE', 'ACCUMULO',
                       'ACCUMULO16', 'SPARK_ON_YARN', 'SPARK', 'SOLR', 'SENTRY']
@@ -1144,23 +1145,23 @@ def teardown(keep_cluster=True):
     try:
         cluster = api.get_cluster(cmx.cluster_name)
         service_list = cluster.get_all_services()
-        print "> Teardown Cluster: %s Services and keep_cluster: %s" % (cmx.cluster_name, keep_cluster)
+        print("> Teardown Cluster: %s Services and keep_cluster: %s" % (cmx.cluster_name, keep_cluster))
         check.status_for_command("Stop %s" % cmx.cluster_name, cluster.stop())
 
         for service in service_list[:None:-1]:
             try:
                 check.status_for_command("Stop Service %s" % service.name, service.stop())
             except ApiException as err:
-                print " ERROR: %s" % err.message
+                print(" ERROR: %s" % err.message)
 
-            print "Processing service %s" % service.name
+            print("Processing service %s" % service.name)
             for role in service.get_all_roles():
-                print " Delete role %s" % role.name
+                print(" Delete role %s" % role.name)
                 service.delete_role(role.name)
 
             cluster.delete_service(service.name)
     except ApiException as err:
-        print err.message
+        print(err.message)
         exit(1)
 
     # Delete Management Services
@@ -1169,20 +1170,20 @@ def teardown(keep_cluster=True):
         check.status_for_command("Stop Management services", mgmt.get_service().stop())
         mgmt.delete_mgmt_service()
     except ApiException as err:
-        print " ERROR: %s" % err.message
+        print(" ERROR: %s" % err.message)
 
     # cluster.remove_all_hosts()
     if not keep_cluster:
         # Remove CDH Parcel and GPL Extras Parcel
         for x in cmx.parcel:
-            print "Removing parcel: [ %s-%s ]" % (x['product'], x['version'])
+            print("Removing parcel: [ %s-%s ]" % (x['product'], x['version']))
             parcel_product = x['product']
             parcel_version = x['version']
 
             while True:
                 parcel = cluster.get_parcel(parcel_product, parcel_version)
                 if parcel.stage == 'ACTIVATED':
-                    print "Deactivating parcel"
+                    print("Deactivating parcel")
                     parcel.deactivate()
                 else:
                     break
@@ -1190,9 +1191,9 @@ def teardown(keep_cluster=True):
             while True:
                 parcel = cluster.get_parcel(parcel_product, parcel_version)
                 if parcel.stage == 'DISTRIBUTED':
-                    print "Executing parcel.start_removal_of_distribution()"
+                    print("Executing parcel.start_removal_of_distribution()")
                     parcel.start_removal_of_distribution()
-                    print "Executing parcel.remove_download()"
+                    print("Executing parcel.remove_download()")
                     parcel.remove_download()
                 elif parcel.stage == 'UNDISTRIBUTING':
                     msg = " [%s: %s / %s]" % (parcel.stage, parcel.state.progress, parcel.state.totalProgress)
@@ -1201,7 +1202,7 @@ def teardown(keep_cluster=True):
                 else:
                     break
 
-        print "Deleting cluster: %s" % cmx.cluster_name
+        print("Deleting cluster: %s" % cmx.cluster_name)
         api.delete_cluster(cmx.cluster_name)
 
 
@@ -1247,7 +1248,7 @@ class ManagementActions:
         :return:
         """
         # api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
-        print "> Setup Management Services"
+        print("> Setup Management Services")
         self._cm.update_config({"TSQUERY_STREAMS_LIMIT": 1000})
         hosts = management.get_hosts(include_cm_host=True)
         # pick hostId that match the ipAddress of cm_server
@@ -1260,12 +1261,12 @@ class ManagementActions:
         for role_type in [x for x in self._service.get_role_types() if x in self._role_list]:
             try:
                 if not [x for x in self._service.get_all_roles() if x.type == role_type]:
-                    print "Creating Management Role %s " % role_type
+                    print("Creating Management Role %s " % role_type)
                     role_name = "mgmt-%s-%s" % (role_type, mgmt_host.md5host)
                     for cmd in self._service.create_role(role_name, role_type, mgmt_host.hostId).get_commands():
                         check.status_for_command("Creating %s" % role_name, cmd)
             except ApiException as err:
-                print "ERROR: %s " % err.message
+                print("ERROR: %s " % err.message)
 
         # now configure each role
         for group in [x for x in self._service.get_all_role_config_groups() if x.roleType in self._role_list]:
@@ -1331,10 +1332,10 @@ class ManagementActions:
         api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
         cm = api.get_cloudera_manager()
         if cmx.license_file and not management.licensed():
-            print "Upload license"
+            print("Upload license")
             with open(cmx.license_file, 'r') as f:
                 license_contents = f.read()
-                print "Upload CM License: \n %s " % license_contents
+                print("Upload CM License: \n %s " % license_contents)
                 cm.update_license(license_contents)
                 # REPORTSMANAGER required after applying license
                 management("REPORTSMANAGER").setup()
@@ -1347,7 +1348,7 @@ class ManagementActions:
         :return:
         """
         api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
-        print "def begin_trial"
+        print("def begin_trial")
         if not management.licensed():
             try:
                 api.post("/cm/trial/begin")
@@ -1355,7 +1356,7 @@ class ManagementActions:
                 management("REPORTSMANAGER").setup()
                 management("REPORTSMANAGER").start()
             except ApiException as err:
-                print err.message
+                print(err.message)
 
     @classmethod
     def get_mgmt_password(cls, role_type):
@@ -1373,7 +1374,7 @@ class ManagementActions:
                 with open(file_path) as f:
                     contents = f.readlines()
             except IOError:
-                print "Unable to open file %s." % file_path
+                print("Unable to open file %s." % file_path)
 
         # role_type expected to be in
         # ACTIVITYMONITOR, REPORTSMANAGER, NAVIGATOR, OOZIE, HIVEMETASTORESERVER
@@ -1516,8 +1517,8 @@ class ServiceActions:
         if isinstance(obj, str) or isinstance(obj, unicode):
             for role_name in [x.roleName for x in api.get_host(obj).roleRefs if 'GATEWAY' in x.roleName]:
                 service = cdh.get_service_type('GATEWAY')
-                print "Deploying client config for service: %s - host: [%s]" % \
-                      (service.type, api.get_host(obj).hostname)
+                print("Deploying client config for service: %s - host: [%s]" % \
+                      (service.type, api.get_host(obj).hostname))
                 check.status_for_command("Deploy client config for role %s" %
                                          role_name, service.deploy_client_config(role_name))
         elif isinstance(obj, ApiService):
@@ -1535,7 +1536,7 @@ class ServiceActions:
             if len(role_type) > 24 else service.name
 
         role_name = "-".join([service_name, role_type, host.md5host])[:64]
-        print "Creating role: %s on host: [%s]" % (role_name, host.hostname)
+        print("Creating role: %s on host: [%s]" % (role_name, host.hostname))
         for cmd in service.create_role(role_name, role_type, host.hostId).get_commands():
             check.status_for_command("Creating role: %s on host: [%s]" % (role_name, host.hostname), cmd)
 
@@ -1547,7 +1548,7 @@ class ServiceActions:
         """
         api = ApiResource(server_host=cmx.cm_server, username=cmx.username, password=cmx.password)
         cluster = api.get_cluster(cmx.cluster_name)
-        print "Restart cluster: %s" % cmx.cluster_name
+        print("Restart cluster: %s" % cmx.cluster_name)
         check.status_for_command("Stop %s" % cmx.cluster_name, cluster.stop())
         check.status_for_command("Start %s" % cmx.cluster_name, cluster.start())
         # Example deploying cluster wide Client Config
@@ -1637,7 +1638,7 @@ class ActiveCommands:
                     _state = 0
                 time.sleep(2)
             else:
-                print "\n [%s] %s" % (command.id, self._api.get("/commands/%s" % command.id)['resultMessage'])
+                print("\n [%s] %s" % (command.id, self._api.get("/commands/%s" % command.id)['resultMessage']))
                 self._child_cmd(self._api.get("/commands/%s" % command.id)['children']['items'])
                 break
 
@@ -1648,11 +1649,11 @@ class ActiveCommands:
         :return:
         """
         if len(cmd) != 0:
-            print " Sub tasks result(s):"
+            print(" Sub tasks result(s):")
             for resMsg in cmd:
                 if resMsg.get('resultMessage'):
-                    print "  [%s] %s" % (resMsg['id'], resMsg['resultMessage']) if not resMsg.get('roleRef') \
-                        else "  [%s] %s - %s" % (resMsg['id'], resMsg['resultMessage'], resMsg['roleRef']['roleName'])
+                    print("  [%s] %s" % (resMsg['id'], resMsg['resultMessage']) if not resMsg.get('roleRef') \
+                        else "  [%s] %s - %s" % (resMsg['id'], resMsg['resultMessage'], resMsg['roleRef']['roleName']))
                 self._child_cmd(self._api.get("/commands/%s" % resMsg['id'])['children']['items'])
 
 def display_eula():
@@ -1686,14 +1687,14 @@ def parse_options():
 
     def cmx_args(option, opt_str, value, *args, **kwargs):
         if option.dest == 'host_names':
-            print "switch %s value check: %s" % (opt_str, value)
+            print("switch %s value check: %s" % (opt_str, value))
             for host in value.split(','):
                 if not hostname_resolves(host):
                     exit(1)
             else:
                 cmx_config_options[option.dest] = [socket.gethostbyname(x) for x in value.split(',')]
         elif option.dest == 'cm_server':
-            print "switch %s value check: %s" % (opt_str, value)
+            print("switch %s value check: %s" % (opt_str, value))
 
             cmx_config_options[option.dest] = socket.gethostbyname(value) if \
                 hostname_resolves(value) else exit(1)
@@ -1701,14 +1702,14 @@ def parse_options():
             while retry_count > 0:
                 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 if not s.connect_ex((socket.gethostbyname(value), 7180)) == 0:
-                    print "Cloudera Manager Server is not started on %s " % value
+                    print("Cloudera Manager Server is not started on %s " % value)
                     s.close()
                     sleep(60)
                 else:
                     break
                 retry_count -= 1
             if retry_count == 0:
-                print "Couldn't connect to Cloudera Manager after 5 minutes, exiting"
+                print("Couldn't connect to Cloudera Manager after 5 minutes, exiting")
                 exit(1)
         elif option.dest == 'ssh_private_key':
             with open(value, 'r') as f:
@@ -1725,15 +1726,15 @@ def parse_options():
         """
         try:
             if socket.gethostbyname(hostname) == '0.0.0.0':
-                print "Error [{'host': '%s', 'fqdn': '%s'}]" % \
-                      (socket.gethostbyname(hostname), socket.getfqdn(hostname))
+                print("Error [{'host': '%s', 'fqdn': '%s'}]" % \
+                      (socket.gethostbyname(hostname), socket.getfqdn(hostname)))
                 return False
             else:
-                print "Success [{'host': '%s', 'fqdn': '%s'}]" % \
-                      (socket.gethostbyname(hostname), socket.getfqdn(hostname))
+                print("Success [{'host': '%s', 'fqdn': '%s'}]" % \
+                      (socket.gethostbyname(hostname), socket.getfqdn(hostname)))
                 return True
         except socket.error:
-            print "Error 'host': '%s'" % hostname
+            print("Error 'host': '%s'" % hostname)
             return False
 
     def manifest_to_dict(manifest_json):
@@ -1842,10 +1843,10 @@ def parse_options():
     if cmx_config_options['cm_server'] and options.teardown:
         if options.teardown.lower() in ['remove_cluster', 'keep_cluster']:
             teardown(keep_cluster=(options.teardown.lower() == 'keep_cluster'))
-            print "Bye!"
+            print("Bye!")
             exit(0)
         else:
-            print 'Teardown Cloudera Manager Cluster. Required arguments "keep_cluster" or "remove_cluster".'
+            print('Teardown Cloudera Manager Cluster. Required arguments "keep_cluster" or "remove_cluster".')
             exit(1)
 
     # Uncomment here to see cmx configuration options
@@ -1853,7 +1854,7 @@ def parse_options():
     return options
 
 def log(msg):
-    print time.strftime("%X") + ": " + msg
+    print(time.strftime("%X") + ": " + msg)
 
 def postEulaInfo(firstName, lastName, emailAddress, company,jobRole, jobFunction, businessPhone):
     elqFormName='Cloudera_Azure_EULA'
@@ -1966,13 +1967,13 @@ def main():
     # setup_kerberos()
     # setup_sentry()
 
-    print "Enjoy!"
+    print("Enjoy!")
 
 
 if __name__ == "__main__":
-    print "%s" % '- ' * 20
-    print "Version: %s" % __version__
-    print "%s" % '- ' * 20
+    print("%s" % '- ' * 20)
+    print("Version: %s" % __version__)
+    print("%s" % '- ' * 20)
     main()
 
     #   def setup_template():

--- a/cloudera-on-centos/scripts/cmxDeployOnIbiza.py
+++ b/cloudera-on-centos/scripts/cmxDeployOnIbiza.py
@@ -1882,7 +1882,7 @@ def main():
     options = parse_options()
     global diskcount
     diskcount= getDataDiskCount()
-    log("data_disk_count"+`diskcount`)
+    log("data_disk_count" + str(diskcount))
     if(cmx.do_post):
         postEulaInfo(cmx.fname, cmx.lname, cmx.email, cmx.company,
                      cmx.jobrole, cmx.jobfunction, cmx.phone)

--- a/cloudera-tableau/scripts/cmxDeployOnIbiza.py
+++ b/cloudera-tableau/scripts/cmxDeployOnIbiza.py
@@ -1881,7 +1881,7 @@ def main():
     options = parse_options()
     global diskcount
     diskcount= getDataDiskCount()
-    log("data_disk_count"+`diskcount`)
+    log("data_disk_count" + str(diskcount))
     if(cmx.do_post):
         postEulaInfo(cmx.fname, cmx.lname, cmx.email, cmx.company,
                      cmx.jobrole, cmx.jobfunction, cmx.phone)

--- a/elasticsearch-centos-3node/elasticinstall.py
+++ b/elasticsearch-centos-3node/elasticinstall.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import subprocess
 import socket
 import sys
@@ -9,21 +10,21 @@ number_nodes = sys.argv[2]
 accountname = sys.argv[3] 
 accountkey =  sys.argv[4]
 
-print"inputs:\n"
-print "clustername = " + clustername 
-print "accontname = " + accountname 
-print "accountkey = " + accountkey 
+print("inputs:\n")
+print("clustername = " + clustername) 
+print("accontname = " + accountname) 
+print("accountkey = " + accountkey) 
 
 hostname = socket.gethostname()
-print "hostname: " + hostname
+print("hostname: " + hostname)
 
 hostbase = "10.0.2.1"
-print "hostbase: " + hostbase
+print("hostbase: " + hostbase)
 
 
 def RunCommand(cmd):
 	ret = subprocess.check_output(cmd, shell=True)
-	print ret
+	print(ret)
 	return
 
 
@@ -35,11 +36,11 @@ cmds = ["yum -y install nano",
 	"/usr/share/elasticsearch/bin/plugin -install royrusso/elasticsearch-HQ",
 	"/usr/share/elasticsearch/bin/plugin -install elasticsearch/elasticsearch-cloud-azure/2.8.2"]
 
-print "start running installs"
+print("start running installs")
 for cmd in cmds:
 	RunCommand(cmd)
 
-print "prep data disk for use"
+print("prep data disk for use")
 cmds=["sfdisk /dev/sdc < sdc.layout",
 	"mkfs -t ext4 /dev/sdc1",
 	"mkdir /data",
@@ -54,7 +55,7 @@ uuid = temp[17:53]
 with open("/etc/fstab", "a") as fstab:
     fstab.write("UUID="+uuid+"\t/data\text4\tdefaults\t1\t2\n")
 
-print RunCommand("chmod go+w /data")
+print(RunCommand("chmod go+w /data"))
 
 datapath = "/data/elastic"
 
@@ -74,7 +75,7 @@ sysconfig.truncate()
 sysconfig.write("ES_HEAP_SIZE=" + heapsize + "\n")
 sysconfig.close()
 
-print "start writing elastic config"
+print("start writing elastic config")
 
 # write config
 hosts=""
@@ -101,9 +102,9 @@ config.write("       account: " + accountname + "\n")
 config.write("       key: " + accountkey + "\n")
 config.close()
 
-print "finished writing config file" 
+print("finished writing config file") 
 
 
 RunCommand("systemctl start elasticsearch")
-print "elastic install script finished"
+print("elastic install script finished")
 

--- a/thinkbox-deadline/repo-autoconf.py
+++ b/thinkbox-deadline/repo-autoconf.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import subprocess
 import os
 import re
@@ -10,9 +11,9 @@ def change_line(src, pattern, sub, dest=None, verbose=False):
     lines = []
 
     if verbose:
-        print 'Editing:', src
-        print 'Searching for:', pattern
-        print 'Replacing with:', sub
+        print('Editing:', src)
+        print('Searching for:', pattern)
+        print('Replacing with:', sub)
 
     with open(src, 'r') as f:
         lines = f.readlines()
@@ -20,8 +21,8 @@ def change_line(src, pattern, sub, dest=None, verbose=False):
     with open(dest, 'w') as f:
         for line in lines:
             if verbose and re.search(pattern, line):
-                print '\tBefore:', line
-                print '\tAfter:', re.sub(pattern, sub, line)
+                print('\tBefore:', line)
+                print('\tAfter:', re.sub(pattern, sub, line))
             f.write(re.sub(pattern, sub, line))
 
 


### PR DESCRIPTION
Legacy __print__ statements and old-style exceptions are syntax errors in Python 3 but __print()__ function and new-style exceptions work as expected in both Python 2 and Python 3.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Use print() function in both Python 2 and Python 3
* Old-style exceptions -> new-style for Python 3
* Backticks for `repr()` were removed in Python 3
