### PR TITLE
fixing vnet integration resource type

### DIFF
--- a/101-app-service-regional-vnet-integration/azuredeploy.json
+++ b/101-app-service-regional-vnet-integration/azuredeploy.json
@@ -87,7 +87,7 @@
             "resources": [
                 {
                     "name": "virtualNetwork",
-                    "type": "networkConfig",
+                    "type": "config",
                     "apiVersion": "2019-08-01",
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', parameters('appName'))]"


### PR DESCRIPTION
"networkConfig" is invalid. "config" is the correct resource type.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
