### PR TITLE
Removes hard coded application insights location

### DIFF
--- a/101-function-app-create-dynamic/azuredeploy.json
+++ b/101-function-app-create-dynamic/azuredeploy.json
@@ -28,6 +28,12 @@
         "description": "Location for all resources."
       }
     },
+    "appInsightsLocation": {
+      "type": "string",
+      "metadata": {
+        "description": "Location for Application Insights"
+      }
+    },
     "runtime": {
       "type": "string",
       "defaultValue": "node",
@@ -123,7 +129,7 @@
       "type": "microsoft.insights/components",
       "apiVersion": "2020-02-02-preview",
       "name": "[variables('applicationInsightsName')]",
-      "location": "[parameters('location')]",
+      "location": "[parameters('appInsightsLocation')]",
       "tags": {
         "[concat('hidden-link:', resourceId('Microsoft.Web/sites', variables('applicationInsightsName')))]": "Resource"
       },

--- a/101-function-app-create-dynamic/azuredeploy.json
+++ b/101-function-app-create-dynamic/azuredeploy.json
@@ -46,11 +46,7 @@
     "hostingPlanName": "[parameters('appName')]",
     "applicationInsightsName": "[parameters('appName')]",
     "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]",
-    "functionWorkerRuntime": "[parameters('runtime')]",
-    "insightsLocation": {
-      "AzureCloud": "eastus",
-      "AzureUSGovernment": "usgovvirginia"
-    }
+    "functionWorkerRuntime": "[parameters('runtime')]"
   },
   "resources": [
     {
@@ -127,7 +123,7 @@
       "type": "microsoft.insights/components",
       "apiVersion": "2020-02-02-preview",
       "name": "[variables('applicationInsightsName')]",
-      "location": "[variables('insightsLocation')[environment().name]]",
+      "location": "[parameters('location')]",
       "tags": {
         "[concat('hidden-link:', resourceId('Microsoft.Web/sites', variables('applicationInsightsName')))]": "Resource"
       },

--- a/101-function-app-create-dynamic/azuredeploy.parameters.us.json
+++ b/101-function-app-create-dynamic/azuredeploy.parameters.us.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
       "appInsightsLocation": {
-          "value": "eastus"
+          "value": "usgovvirginia"
       }
     }
 }


### PR DESCRIPTION
Allows Application Insights to be deployed to the same location as the other resources. Existing code appears to be from when App Insights was not widely available

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
