### PR TITLE
Removes hard coded App Insights location

### DIFF
--- a/101-function-premium-vnet-integration/azuredeploy.json
+++ b/101-function-premium-vnet-integration/azuredeploy.json
@@ -13,7 +13,7 @@
             "type": "string",
             "defaultValue": "",
             "metadata": {
-                "description": "Location for Application Insights"
+                "description": "Location for Application Insights. Leave empty for auto-selection."
             }
         },
         "appInsightsDefaultLocation": {

--- a/101-function-premium-vnet-integration/azuredeploy.json
+++ b/101-function-premium-vnet-integration/azuredeploy.json
@@ -12,7 +12,7 @@
         "appInsightsLocation": {
             "type": "string",
             "metadata": {
-                "description": "Location for Application Insights."
+                "description": "Location for Application Insights." 
             }
         },
         "runtime": {

--- a/101-function-premium-vnet-integration/azuredeploy.json
+++ b/101-function-premium-vnet-integration/azuredeploy.json
@@ -61,10 +61,6 @@
         "applicationInsightsName": "[parameters('appName')]",
         "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]",
         "functionWorkerRuntime": "[parameters('runtime')]",
-        "insightsLocation": {
-            "AzureCloud": "eastus",
-            "AzureUSGovernment": "usgovvirginia"
-        },
         "appInsightsResourceId": "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]"
     },
     "resources": [
@@ -113,7 +109,7 @@
         {
             "type": "Microsoft.Insights/components",
             "apiVersion": "2018-05-01-preview",
-            "location": "[variables('insightsLocation')[environment().name]]",
+            "location": "[parameters('location')]",
             "name": "[variables('applicationInsightsName')]",
             "kind": "web",
             "properties": {

--- a/101-function-premium-vnet-integration/azuredeploy.json
+++ b/101-function-premium-vnet-integration/azuredeploy.json
@@ -11,9 +11,21 @@
         },
         "appInsightsLocation": {
             "type": "string",
-            "defaultValue": "[resourceGroup().location]",
+            "defaultValue": "",
             "metadata": {
                 "description": "Location for Application Insights"
+            }
+        },
+        "appInsightsDefaultLocation": {
+            "type": "string",
+            "metadata": {
+                "description": "Default value for Application Insights. Should be provided in cloud-specific parameter file."
+            }
+        },
+        "appInsightsAllowedLocations": {
+            "type": "array",
+            "metadata": {
+                "description": "Regions allowing deployment of Application Insights. Should be provided in cloud-specific parameter file."
             }
         },
         "runtime": {
@@ -68,7 +80,8 @@
         "applicationInsightsName": "[parameters('appName')]",
         "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]",
         "functionWorkerRuntime": "[parameters('runtime')]",
-        "appInsightsResourceId": "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]"
+        "appInsightsResourceId": "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]",
+        "appInsightsCalculatedLocation":  "[coalesce(if(empty(parameters('appInsightsLocation')), null(), parameters('appInsightsLocation')),if(contains(parameters('appInsightsAllowedLocations'), parameters('location')), parameters('location'), null()), parameters('appInsightsDefaultLocation'))]"
     },
     "resources": [
         {
@@ -116,7 +129,7 @@
         {
             "type": "Microsoft.Insights/components",
             "apiVersion": "2018-05-01-preview",
-            "location": "[parameters('appInsightsLocation')]",
+            "location": "[variables('appInsightsCalculatedLocation')]",
             "name": "[variables('applicationInsightsName')]",
             "kind": "web",
             "properties": {

--- a/101-function-premium-vnet-integration/azuredeploy.json
+++ b/101-function-premium-vnet-integration/azuredeploy.json
@@ -6,7 +6,14 @@
             "type": "string",
             "defaultValue": "[resourceGroup().location]",
             "metadata": {
-                "description": "Location for all resources."
+                "description": "Location for all resources except Application Insights."
+            }
+        },
+        "appInsightsLocation": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for Application Insights"
             }
         },
         "runtime": {
@@ -109,7 +116,7 @@
         {
             "type": "Microsoft.Insights/components",
             "apiVersion": "2018-05-01-preview",
-            "location": "[parameters('location')]",
+            "location": "[parameters('appInsightsLocation')]",
             "name": "[variables('applicationInsightsName')]",
             "kind": "web",
             "properties": {

--- a/101-function-premium-vnet-integration/azuredeploy.parameters.json
+++ b/101-function-premium-vnet-integration/azuredeploy.parameters.json
@@ -7,6 +7,36 @@
         },
         "subnetName": {
             "value": "GEN-VNET-SUBNET1-NAME"
+        },
+        "appInsightsDefaultLocation" : {
+            "value": "eastus"
+        },
+        "appInsightsAllowedLocations": {
+            "value": [
+                "southafricanorth",
+                "australiaeast",
+                "australiasoutheast",
+                "centralindia",
+                "eastasia",
+                "japaneast",
+                "koreacentral",
+                "southeastasia",
+                "canadacentral",
+                "francecentral",
+                "northeurope",
+                "switzerlandnorth",
+                "uksouth",
+                "ukwest",
+                "westeurope",
+                "brazilsouth",
+                "centralus",
+                "eastus",
+                "eastus2",
+                "northcentralus",
+                "southcentralus",
+                "westus",
+                "westus2"
+            ]
         }
     }
 }

--- a/101-function-premium-vnet-integration/azuredeploy.parameters.us.json
+++ b/101-function-premium-vnet-integration/azuredeploy.parameters.us.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "vnetName": {
+            "value": "GEN-VNET-NAME"
+        },
+        "subnetName": {
+            "value": "GEN-VNET-SUBNET1-NAME"
+        },
+        "appInsightsDefaultLocation" : {
+            "value": "usgovvirginia"
+        },
+        "appInsightsAllowedLocations": {
+            "value": [
+                "usgovvirginia",
+                "usgovarizona"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
Allows Application Insights to be deployed to the same location as the other resources. Existing code appears to be from when App Insights was not widely available

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
