### PR TITLE
Removed deny nsg rule and added rule for 8808 and 5701

### DIFF
--- a/101-azure-bastion-nsg/azuredeploy.json
+++ b/101-azure-bastion-nsg/azuredeploy.json
@@ -92,10 +92,7 @@
                             "protocol": "Tcp",
                             "sourcePortRange": "*",
                             "sourceAddressPrefix": "GatewayManager",
-                            "destinationPortRanges": [
-                                "443",
-                                "4443"
-                            ],
+                            "destinationPortRange": "443",
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
                             "priority": 120,
@@ -103,15 +100,18 @@
                         }
                     },
                     {
-                        "name": "bastion-in-deny",
+                        "name": "bastion-in-host",
                         "properties": {
                             "protocol": "*",
                             "sourcePortRange": "*",
-                            "destinationPortRange": "*",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Deny",
-                            "priority": 900,
+                            "destinationPortRanges": [
+                                "8080",
+                                "5701"
+                            ],
+                            "sourceAddressPrefix": "VirtualNetwork",
+                            "destinationAddressPrefix": "VirtualNetwork",
+                            "access": "Allow",
+                            "priority": 130,
                             "direction": "Inbound"
                         }
                     },
@@ -141,6 +141,22 @@
                             "destinationAddressPrefix": "AzureCloud",
                             "access": "Allow",
                             "priority": 120,
+                            "direction": "Outbound"
+                        }
+                    },
+                    {
+                        "name": "bastion-out-host",
+                        "properties": {
+                            "protocol": "*",
+                            "sourcePortRange": "*",
+                            "destinationPortRanges": [
+                                "8080",
+                                "5701"
+                            ],
+                            "sourceAddressPrefix": "VirtualNetwork",
+                            "destinationAddressPrefix": "VirtualNetwork",
+                            "access": "Allow",
+                            "priority": 130,
                             "direction": "Outbound"
                         }
                     }
@@ -219,4 +235,3 @@
         }
     ]
 }
-


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Removed deny nsg rule, this is redundant over what is deployed by default.
* Added rule for port 8080 and 5701 as per [bastion docs](https://docs.microsoft.com/en-us/azure/bastion/bastion-nsg#apply) and discussion with bastion team.

Fixes: https://github.com/Azure/azure-quickstart-templates/issues/8655