### PR TITLE
fix password reference in outputs, portainer version bump

### DIFF
--- a/docker-portainer-traefik-windows-vm/configs/docker-compose.yml.template
+++ b/docker-portainer-traefik-windows-vm/configs/docker-compose.yml.template
@@ -33,7 +33,7 @@ services:
       - traefik.http.services.api.loadBalancer.server.port=8080
 
   portainer:
-    image: portainer/portainer-ce:2.1.1
+    image: portainer/portainer-ce:latest
     container_name: portainer
     command: --admin-password-file c:/data/passwordfile
     restart: always

--- a/docker-portainer-traefik-windows-vm/configs/docker-compose.yml.template
+++ b/docker-portainer-traefik-windows-vm/configs/docker-compose.yml.template
@@ -33,7 +33,7 @@ services:
       - traefik.http.services.api.loadBalancer.server.port=8080
 
   portainer:
-    image: portainer/portainer-ce:2.0.0
+    image: portainer/portainer-ce:2.1.1
     container_name: portainer
     command: --admin-password-file c:/data/passwordfile
     restart: always

--- a/docker-portainer-traefik-windows-vm/createUiDefinition.json
+++ b/docker-portainer-traefik-windows-vm/createUiDefinition.json
@@ -116,7 +116,7 @@
         ],
         "outputs": {
             "adminUser": "[steps('vmParameters').adminUser]",
-            "adminPassword": "[steps('vmParameters').adminPassword]",
+            "adminPassword": "[steps('vmParameters').adminPassword.password]",
             "email": "[basics('email')]",
             "diskSizeGB": "[steps('vmParameters').diskSizeGB]",
             "vmSize": "[steps('vmParameters').vmSection.vmSize]",


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Fixed the password reference in the outputs because `[steps('vmParameters').adminPassword]` returns an object while I need only the password, which is returned by `[steps('vmParameters').adminPassword.password]`
* Bump portainer version from 2.0.0 to 2.1.1