### PR TITLE
Update metadata date validation

### DIFF
--- a/test/ci-scripts/Validate-Metadata.ps1
+++ b/test/ci-scripts/Validate-Metadata.ps1
@@ -26,8 +26,9 @@ if ($ENV:BUILD_REASON -eq "PullRequest") {
     Catch {
         Write-Error "dateUpdate is not in the correct format: $rawDate must be in yyyy-MM-dd format."
     }
-    if ($dateUpdated -gt (Get-Date)) {
-        Write-Error "dateUpdated in metadata.json must not be in the future -- $dateUpdated is later than $(Get-Date)"
+    # Provide one day grace in the future since half the planet is ahead of UTC
+    if ($dateUpdated -gt (Get-Date).AddDays(1)) {
+        Write-Error "dateUpdated in metadata.json must not be in the future -- $dateUpdated is later than $((Get-Date).AddDays(1))"
     }
     $oldDate = (Get-Date).AddDays(-60)
     if ($dateUpdated -lt $oldDate) {


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Update the `metadata.json` validation to allow for dates to be future-dated by up to one day. This is because the agents that perform this check are running in UTC, but many countries are ahead of UTC and therefore appear to be one day in the future.