### PR TITLE
feat(nsg): include default nsg enabling idempotency for template. Resolves #6670

### DIFF
--- a/101-databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
+++ b/101-databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
@@ -96,7 +96,118 @@
       "type": "Microsoft.Network/networkSecurityGroups",
       "location": "[parameters('location')]",
       "name": "[parameters('nsgName')]",
-      "properties": {}
+      "properties": {
+        "securityRules": [
+          {
+            "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-worker-inbound",
+            "properties": {
+              "description": "Required for worker nodes communication within a cluster.",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "VirtualNetwork",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Inbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-databricks-webapp",
+            "properties": {
+              "description": "Required for workers communication with Databricks Webapp.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "AzureDatabricks",
+              "access": "Allow",
+              "priority": 100,
+              "direction": "Outbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-sql",
+            "properties": {
+              "description": "Required for workers communication with Azure SQL services.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "3306",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "Sql",
+              "access": "Allow",
+              "priority": 101,
+              "direction": "Outbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-storage",
+            "properties": {
+              "description": "Required for workers communication with Azure Storage services.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "443",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "Storage",
+              "access": "Allow",
+              "priority": 102,
+              "direction": "Outbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-worker-outbound",
+            "properties": {
+              "description": "Required for worker nodes communication within a cluster.",
+              "protocol": "*",
+              "sourcePortRange": "*",
+              "destinationPortRange": "*",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "VirtualNetwork",
+              "access": "Allow",
+              "priority": 103,
+              "direction": "Outbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          },
+          {
+            "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-eventhub",
+            "properties": {
+              "description": "Required for worker communication with Azure Eventhub services.",
+              "protocol": "tcp",
+              "sourcePortRange": "*",
+              "destinationPortRange": "9093",
+              "sourceAddressPrefix": "VirtualNetwork",
+              "destinationAddressPrefix": "EventHub",
+              "access": "Allow",
+              "priority": 104,
+              "direction": "Outbound",
+              "sourcePortRanges": [],
+              "destinationPortRanges": [],
+              "sourceAddressPrefixes": [],
+              "destinationAddressPrefixes": []
+            }
+          }
+        ]
+      }
     },
     {
       "apiVersion": "2020-05-01",

--- a/101-databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
+++ b/101-databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
@@ -109,11 +109,7 @@
               "destinationAddressPrefix": "VirtualNetwork",
               "access": "Allow",
               "priority": 100,
-              "direction": "Inbound",
-              "sourcePortRanges": [],
-              "destinationPortRanges": [],
-              "sourceAddressPrefixes": [],
-              "destinationAddressPrefixes": []
+              "direction": "Inbound"
             }
           },
           {
@@ -127,11 +123,7 @@
               "destinationAddressPrefix": "AzureDatabricks",
               "access": "Allow",
               "priority": 100,
-              "direction": "Outbound",
-              "sourcePortRanges": [],
-              "destinationPortRanges": [],
-              "sourceAddressPrefixes": [],
-              "destinationAddressPrefixes": []
+              "direction": "Outbound"
             }
           },
           {
@@ -145,11 +137,7 @@
               "destinationAddressPrefix": "Sql",
               "access": "Allow",
               "priority": 101,
-              "direction": "Outbound",
-              "sourcePortRanges": [],
-              "destinationPortRanges": [],
-              "sourceAddressPrefixes": [],
-              "destinationAddressPrefixes": []
+              "direction": "Outbound"
             }
           },
           {
@@ -163,11 +151,7 @@
               "destinationAddressPrefix": "Storage",
               "access": "Allow",
               "priority": 102,
-              "direction": "Outbound",
-              "sourcePortRanges": [],
-              "destinationPortRanges": [],
-              "sourceAddressPrefixes": [],
-              "destinationAddressPrefixes": []
+              "direction": "Outbound"
             }
           },
           {
@@ -181,11 +165,7 @@
               "destinationAddressPrefix": "VirtualNetwork",
               "access": "Allow",
               "priority": 103,
-              "direction": "Outbound",
-              "sourcePortRanges": [],
-              "destinationPortRanges": [],
-              "sourceAddressPrefixes": [],
-              "destinationAddressPrefixes": []
+              "direction": "Outbound"
             }
           },
           {
@@ -199,11 +179,7 @@
               "destinationAddressPrefix": "EventHub",
               "access": "Allow",
               "priority": 104,
-              "direction": "Outbound",
-              "sourcePortRanges": [],
-              "destinationPortRanges": [],
-              "sourceAddressPrefixes": [],
-              "destinationAddressPrefixes": []
+              "direction": "Outbound"
             }
           }
         ]


### PR DESCRIPTION
# PR Checklist

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Solves idempotency issue when trying to re deploy template
* Include default nsg rules created by ADB when creating a vnet injection
* NSG Rules:
  * Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-worker-inbound
  * Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-databricks-webapp
  * Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-sql
  * Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-storage
  * Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-worker-outbound
  * Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-eventhub 

resolves #6670 
