### PR TITLE
groestlcoin: Remove groestlcoin-cli and groestlcoin-util from ppa

### DIFF
--- a/blockchain/scripts/groestlcoin.sh
+++ b/blockchain/scripts/groestlcoin.sh
@@ -49,7 +49,7 @@ else
 #################################################################
 sudo add-apt-repository -y ppa:groestlcoin/groestlcoin
 sudo apt-get update
-sudo apt-get install -y groestlcoind groestlcoin-cli groestlcoin-tx groestlcoin-wallet groestlcoin-util
+sudo apt-get install -y groestlcoind groestlcoin-tx groestlcoin-wallet
 
 fi
 


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Remove groestlcoin-cli (this is already part of groestlcoind  package) and groestlcoin-util (this might come in the future in the ppa) from ppa
