### PR TITLE
Fix isBicep check false case

### DIFF
--- a/az-group-deploy.sh
+++ b/az-group-deploy.sh
@@ -53,7 +53,7 @@ then
     templateFile="$artifactsStagingDirectory$defaultTemplateFile"
 fi
 
-if [[ $isBicep ]]
+if [[ $isBicep = true ]]
 then
     bicep build $templateFile
     # after building the script will work with the json file


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-quickstart-templates/issues/8925

Without this change, the isBicep check always evaluates to True.

Tested on:
MacOS GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin19)
CentOS 8 GNU bash, version 4.4.19(1)-release (x86_64-redhat-linux-gnu)

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
