### PR TITLE
FIX-TEMPLATE:  logic-app-correlation-using-servicebus - fix API ID

### DIFF
--- a/quickstarts/microsoft.logic/logic-app-correlation-using-servicebus/azuredeploy.json
+++ b/quickstarts/microsoft.logic/logic-app-correlation-using-servicebus/azuredeploy.json
@@ -560,7 +560,7 @@
         "displayName": "Router",
         "customParameterValues": {},
         "api": {
-          "id": "[concat('/subscriptions/',  subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('location') , '/managedApis/', parameters('serviceBusConnection'))]"
+          "id": "[concat('/subscriptions/',  subscription().subscriptionId, '/providers/Microsoft.Web/locations/', parameters('location') , '/managedApis/servicebus')]"
         },
         "parameterValues": {
           "connectionString": "[listKeys(resourceId('Microsoft.ServiceBus/namespaces/authorizationRules', parameters('serviceBusNamespace'), 'RootManageSharedAccessKey'), '2015-08-01').primaryConnectionString]"

--- a/quickstarts/microsoft.logic/logic-app-correlation-using-servicebus/metadata.json
+++ b/quickstarts/microsoft.logic/logic-app-correlation-using-servicebus/metadata.json
@@ -5,5 +5,5 @@
   "description": "which shows how we can correlate messages over Logic Apps using Azure Service Bus",
   "summary": "which shows how we can correlate messages over Logic Apps using Azure Service Bus",
   "githubUsername": "EldertGrootenboer",
-  "dateUpdated": "2021-04-29"
+  "dateUpdated": "2021-05-20"
 }


### PR DESCRIPTION
The API ID is specified with ending `...'/managedApis/', parameters('serviceBusConnection'))]"`
However, the last part should not be variable - it should be always set to `servicebus`
Currently the default value of `serviceBusConnection` parameter is `servicebus`, but if you change this parameter name to anything else it will fail

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Fixed `logic-app-correlation-using-servicebus` API ID
