### PR TITLE
Update azuredeploy.json to parse uri content

### DIFF
--- a/quickstarts/microsoft.compute/vm-virus-attack-prevention/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-virus-attack-prevention/azuredeploy.json
@@ -139,12 +139,12 @@
         "[concat(parameters('vmNamePrefix'),'-without-ep')]",
         "[concat(parameters('vmNamePrefix'),'-with-ep')]"
       ],
-      "omsTemplateUri": "[concat(parameters('_artifactsLocation'),'nested/microsoft.loganalytics/workspaces.json',parameters('_artifactsLocationSasToken'))]",
-      "vnetTemplateUri": "[concat(parameters('_artifactsLocation'),'nested/microsoft.network/virtualnetworks.json',parameters('_artifactsLocationSasToken'))]",
-      "nsgTemplateUri": "[concat(parameters('_artifactsLocation'),'nested/microsoft.network/nsg.json',parameters('_artifactsLocationSasToken'))]",
-      "pipTemplateUri": "[concat(parameters('_artifactsLocation'),'nested/microsoft.network/publicipaddress.json',parameters('_artifactsLocationSasToken'))]",
-      "nicTemplateUri": "[concat(parameters('_artifactsLocation'),'nested/microsoft.network/nic-with-pip.json',parameters('_artifactsLocationSasToken'))]",
-      "vmTemplateUri": "[concat(parameters('_artifactsLocation'),'nested/microsoft.compute/vm.windows.json',parameters('_artifactsLocationSasToken'))]"
+      "omsTemplateUri": "[concat(uri(parameters('_artifactsLocation'),'nested/microsoft.loganalytics/workspaces.json'),parameters('_artifactsLocationSasToken'))]",
+      "vnetTemplateUri": "[concat(uri(parameters('_artifactsLocation'),'nested/microsoft.network/virtualnetworks.json'),parameters('_artifactsLocationSasToken'))]",
+      "nsgTemplateUri": "[concat(uri(parameters('_artifactsLocation'),'nested/microsoft.network/nsg.json'),parameters('_artifactsLocationSasToken'))]",
+      "pipTemplateUri": "[concat(uri(parameters('_artifactsLocation'),'nested/microsoft.network/publicipaddress.json'),parameters('_artifactsLocationSasToken'))]",
+      "nicTemplateUri": "[concat(uri(parameters('_artifactsLocation'),'nested/microsoft.network/nic-with-pip.json'),parameters('_artifactsLocationSasToken'))]",
+      "vmTemplateUri": "[concat(uri(parameters('_artifactsLocation'),'nested/microsoft.compute/vm.windows.json'),parameters('_artifactsLocationSasToken'))]"
     },
     "resources": [
       {


### PR DESCRIPTION
For some reason the code is not converting the raw text into an uri format, and this might be causing troubles from Azure to download the ARM content

## Changelog

* Included uri conversion for variables including uri content #10442 
