### PR TITLE
Add Enforce HTTPS and Disable public storage blob access.

### DIFF
--- a/quickstarts/microsoft.sql/sql-logical-server/azuredeploy.json
+++ b/quickstarts/microsoft.sql/sql-logical-server/azuredeploy.json
@@ -141,7 +141,7 @@
             },
             "kind": "StorageV2",
             "properties": {
-                "minimumTlsVersion": "TLS1_2"
+                "minimumTlsVersion": "TLS1_2",
                 "supportsHttpsTrafficOnly": "true",
                 "allowBlobPublicAccess": "false"
             }

--- a/quickstarts/microsoft.sql/sql-logical-server/azuredeploy.json
+++ b/quickstarts/microsoft.sql/sql-logical-server/azuredeploy.json
@@ -142,6 +142,8 @@
             "kind": "StorageV2",
             "properties": {
                 "minimumTlsVersion": "TLS1_2"
+                "supportsHttpsTrafficOnly": "true",
+                "allowBlobPublicAccess": "false",
             }
         },
         {

--- a/quickstarts/microsoft.sql/sql-logical-server/azuredeploy.json
+++ b/quickstarts/microsoft.sql/sql-logical-server/azuredeploy.json
@@ -143,7 +143,7 @@
             "properties": {
                 "minimumTlsVersion": "TLS1_2"
                 "supportsHttpsTrafficOnly": "true",
-                "allowBlobPublicAccess": "false",
+                "allowBlobPublicAccess": "false"
             }
         },
         {


### PR DESCRIPTION
When the customer enables VA we create a new storage account for storing the VA scan results. 
We have new requirements that this new storage account will enforce HTTPS and disable public storage blob access.
We update the Storage resource and add new properties for those requirements.

I test this template by running it manually.
