### PR TITLE
Added slash to end of keyVaultSecretId

### DIFF
--- a/quickstarts/microsoft.network/azurefirewall-premium/azuredeploy.json
+++ b/quickstarts/microsoft.network/azurefirewall-premium/azuredeploy.json
@@ -313,7 +313,7 @@
                 "transportSecurity": {
                     "certificateAuthority": {
                         "name": "[variables('keyVaultCASecretName')]",
-                        "keyVaultSecretId": "[concat(reference(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), '2019-09-01').vaultUri, 'secrets/', variables('keyVaultCASecretName'))]"
+                        "keyVaultSecretId": "[concat(reference(resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName')), '2019-09-01').vaultUri, 'secrets/', variables('keyVaultCASecretName'), '/')]"
                     }
                 },
                 "intrusionDetection": {


### PR DESCRIPTION
In order to get the latest version of the secret the URL should end with a /.

The current deploy result is: https://kv-xxxxx.vault.azure.net/secrets/XXXX
When you look in the interface you will see that no certificate is selected at TLS inspection.

Correct result should be: https://kv-xxxxx.vault.azure.net/secrets/XXXX/
And now when you look in the interface the certificate is selected correctly.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

In order to get the latest version of the secret the URL should end with a /.

The current deploy result is: https://kv-xxxxx.vault.azure.net/secrets/XXXX
When you look in the interface you will see that no certificate is selected at TLS inspection.

Correct result should be: https://kv-xxxxx.vault.azure.net/secrets/XXXX/
And now when you look in the interface the certificate is selected correctly.
