### PR TITLE
Migrate bicep example: 101/databricks-all-in-one-template-for-vnet-injection

### DIFF
--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/README.md
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.databricks%2Fdatabricks-all-in-one-template-for-vnet-injection%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.databricks%2Fdatabricks-all-in-one-template-for-vnet-injection%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.databricks%2Fdatabricks-all-in-one-template-for-vnet-injection%2Fazuredeploy.json)
@@ -36,5 +38,3 @@ DataBricks Premium
 ### Microsoft Learn Modules
 
 [Data Bricks Microsoft Learn Modules](https://docs.microsoft.com/en-us/learn/browse/?term=Databricks)
-
-

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "4954400551878579026"
+      "templateHash": "5825894836913271378"
     }
   },
   "parameters": {
@@ -33,20 +33,20 @@
     "pricingTier": {
       "type": "string",
       "defaultValue": "premium",
-      "metadata": {
-        "description": "The pricing tier of workspace."
-      },
       "allowedValues": [
         "trial",
         "standard",
         "premium"
-      ]
+      ],
+      "metadata": {
+        "description": "The pricing tier of workspace."
+      }
     },
     "privateSubnetCidr": {
       "type": "string",
       "defaultValue": "10.179.0.0/18",
       "metadata": {
-        "description": "Cidr range for the private subnet."
+        "description": "CIDR range for the private subnet."
       }
     },
     "privateSubnetName": {
@@ -60,7 +60,7 @@
       "type": "string",
       "defaultValue": "10.179.64.0/18",
       "metadata": {
-        "description": "Cidr range for the public subnet.."
+        "description": "CIDR range for the public subnet.."
       }
     },
     "publicSubnetName": {
@@ -74,7 +74,7 @@
       "type": "string",
       "defaultValue": "10.179.0.0/16",
       "metadata": {
-        "description": "Cidr range for the vnet."
+        "description": "CIDR range for the vnet."
       }
     },
     "vnetName": {

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "5814833397059804677"
+    }
+  },
   "parameters": {
     "disablePublicIp": {
       "type": "bool",
@@ -17,62 +24,62 @@
       }
     },
     "nsgName": {
-      "defaultValue": "databricks-nsg",
       "type": "string",
+      "defaultValue": "databricks-nsg",
       "metadata": {
         "description": "The name of the network security group to create."
       }
     },
     "pricingTier": {
+      "type": "string",
       "defaultValue": "premium",
+      "metadata": {
+        "description": "The pricing tier of workspace."
+      },
       "allowedValues": [
         "trial",
         "standard",
         "premium"
-      ],
-      "type": "string",
-      "metadata": {
-        "description": "The pricing tier of workspace."
-      }
+      ]
     },
     "privateSubnetCidr": {
-      "defaultValue": "10.179.0.0/18",
       "type": "string",
+      "defaultValue": "10.179.0.0/18",
       "metadata": {
         "description": "Cidr range for the private subnet."
       }
     },
     "privateSubnetName": {
-      "defaultValue": "private-subnet",
       "type": "string",
+      "defaultValue": "private-subnet",
       "metadata": {
         "description": "The name of the private subnet to create."
       }
     },
     "publicSubnetCidr": {
-      "defaultValue": "10.179.64.0/18",
       "type": "string",
+      "defaultValue": "10.179.64.0/18",
       "metadata": {
         "description": "Cidr range for the public subnet.."
       }
     },
     "publicSubnetName": {
-      "defaultValue": "public-subnet",
       "type": "string",
+      "defaultValue": "public-subnet",
       "metadata": {
         "description": "The name of the public subnet to create."
       }
     },
     "vnetCidr": {
-      "defaultValue": "10.179.0.0/16",
       "type": "string",
+      "defaultValue": "10.179.0.0/16",
       "metadata": {
         "description": "Cidr range for the vnet."
       }
     },
     "vnetName": {
-      "defaultValue": "databricks-vnet",
       "type": "string",
+      "defaultValue": "databricks-vnet",
       "metadata": {
         "description": "The name of the virtual network to create."
       }
@@ -84,18 +91,17 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "managedResourceGroupName": "[concat('databricks-rg-', parameters('workspaceName'), '-', uniqueString(parameters('workspaceName'), resourceGroup().id))]",
-    "managedResourceGroupId": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('managedResourceGroupName'))]",
-    "nsgId": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]",
-    "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
+    "managedResourceGroupName": "[format('databricks-rg-{0}-{1}', parameters('workspaceName'), uniqueString(parameters('workspaceName'), resourceGroup().id))]",
+    "managedResourceGroupId": "[format('{0}/resourceGroups/{1}', subscription().id, variables('managedResourceGroupName'))]"
   },
   "resources": [
     {
-      "apiVersion": "2020-05-01",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "location": "[parameters('location')]",
+      "apiVersion": "2020-05-01",
       "name": "[parameters('nsgName')]",
+      "location": "[parameters('location')]",
       "properties": {
         "securityRules": [
           {
@@ -116,7 +122,7 @@
             "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-databricks-webapp",
             "properties": {
               "description": "Required for workers communication with Databricks Webapp.",
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "443",
               "sourceAddressPrefix": "VirtualNetwork",
@@ -130,7 +136,7 @@
             "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-sql",
             "properties": {
               "description": "Required for workers communication with Azure SQL services.",
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "3306",
               "sourceAddressPrefix": "VirtualNetwork",
@@ -144,7 +150,7 @@
             "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-storage",
             "properties": {
               "description": "Required for workers communication with Azure Storage services.",
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "443",
               "sourceAddressPrefix": "VirtualNetwork",
@@ -172,7 +178,7 @@
             "name": "Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-eventhub",
             "properties": {
               "description": "Required for worker communication with Azure Eventhub services.",
-              "protocol": "tcp",
+              "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "9093",
               "sourceAddressPrefix": "VirtualNetwork",
@@ -186,13 +192,10 @@
       }
     },
     {
-      "apiVersion": "2020-05-01",
       "type": "Microsoft.Network/virtualNetworks",
-      "location": "[parameters('location')]",
+      "apiVersion": "2020-05-01",
       "name": "[parameters('vnetName')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups/', parameters('nsgName'))]"
-      ],
+      "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -205,7 +208,7 @@
             "properties": {
               "addressPrefix": "[parameters('publicSubnetCidr')]",
               "networkSecurityGroup": {
-                "id": "[variables('nsgId')]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
               },
               "delegations": [
                 {
@@ -222,7 +225,7 @@
             "properties": {
               "addressPrefix": "[parameters('privateSubnetCidr')]",
               "networkSecurityGroup": {
-                "id": "[variables('nsgId')]"
+                "id": "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
               },
               "delegations": [
                 {
@@ -235,26 +238,24 @@
             }
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]"
+      ]
     },
     {
-      "apiVersion": "2018-04-01",
       "type": "Microsoft.Databricks/workspaces",
-      "location": "[parameters('location')]",
+      "apiVersion": "2018-04-01",
       "name": "[parameters('workspaceName')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups/', parameters('nsgName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vnetName'))]"
-      ],
+      "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('pricingTier')]"
       },
-      "comments": "The managed resource group specified will be locked after deployment.",
       "properties": {
-        "ManagedResourceGroupId": "[variables('managedResourceGroupId')]",
+        "managedResourceGroupId": "[variables('managedResourceGroupId')]",
         "parameters": {
           "customVirtualNetworkId": {
-            "value": "[variables('vnetId')]"
+            "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
           },
           "customPublicSubnetName": {
             "value": "[parameters('publicSubnetName')]"
@@ -266,7 +267,11 @@
             "value": "[parameters('disablePublicIp')]"
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
+      ]
     }
   ]
 }

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "5825894836913271378"
+      "templateHash": "3247823006110740501"
     }
   },
   "parameters": {
@@ -268,7 +268,6 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', parameters('nsgName'))]",
         "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
       ]
     }

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "5814833397059804677"
+      "templateHash": "4954400551878579026"
     }
   },
   "parameters": {
@@ -93,8 +93,7 @@
   },
   "functions": [],
   "variables": {
-    "managedResourceGroupName": "[format('databricks-rg-{0}-{1}', parameters('workspaceName'), uniqueString(parameters('workspaceName'), resourceGroup().id))]",
-    "managedResourceGroupId": "[format('{0}/resourceGroups/{1}', subscription().id, variables('managedResourceGroupName'))]"
+    "managedResourceGroupName": "[format('databricks-rg-{0}-{1}', parameters('workspaceName'), uniqueString(parameters('workspaceName'), resourceGroup().id))]"
   },
   "resources": [
     {
@@ -252,7 +251,7 @@
         "name": "[parameters('pricingTier')]"
       },
       "properties": {
-        "managedResourceGroupId": "[variables('managedResourceGroupId')]",
+        "managedResourceGroupId": "[subscriptionResourceId('Microsoft.Resources/resourceGroups', variables('managedResourceGroupName'))]",
         "parameters": {
           "customVirtualNetworkId": {
             "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/main.bicep
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/main.bicep
@@ -7,27 +7,27 @@ param location string = resourceGroup().location
 @description('The name of the network security group to create.')
 param nsgName string = 'databricks-nsg'
 
+@description('The pricing tier of workspace.')
 @allowed([
   'trial'
   'standard'
   'premium'
 ])
-@description('The pricing tier of workspace.')
 param pricingTier string = 'premium'
 
-@description('Cidr range for the private subnet.')
+@description('CIDR range for the private subnet.')
 param privateSubnetCidr string = '10.179.0.0/18'
 
 @description('The name of the private subnet to create.')
 param privateSubnetName string = 'private-subnet'
 
-@description('Cidr range for the public subnet..')
+@description('CIDR range for the public subnet..')
 param publicSubnetCidr string = '10.179.64.0/18'
 
 @description('The name of the public subnet to create.')
 param publicSubnetName string = 'public-subnet'
 
-@description('Cidr range for the vnet.')
+@description('CIDR range for the vnet.')
 param vnetCidr string = '10.179.0.0/16'
 
 @description('The name of the virtual network to create.')
@@ -37,6 +37,11 @@ param vnetName string = 'databricks-vnet'
 param workspaceName string
 
 var managedResourceGroupName = 'databricks-rg-${workspaceName}-${uniqueString(workspaceName, resourceGroup().id)}'
+
+resource managedResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' existing = {
+  scope: subscription()
+  name: managedResourceGroupName
+}
 
 resource nsg 'Microsoft.Network/networkSecurityGroups@2020-05-01' = {
   location: location
@@ -205,9 +210,4 @@ resource ws 'Microsoft.Databricks/workspaces@2018-04-01' = {
   dependsOn: [
     nsg
   ]
-}
-
-resource managedResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' existing = {
-  scope: subscription()
-  name: managedResourceGroupName
 }

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/main.bicep
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/main.bicep
@@ -37,7 +37,6 @@ param vnetName string = 'databricks-vnet'
 param workspaceName string
 
 var managedResourceGroupName = 'databricks-rg-${workspaceName}-${uniqueString(workspaceName, resourceGroup().id)}'
-var managedResourceGroupId = '${subscription().id}/resourceGroups/${managedResourceGroupName}'
 
 resource nsg 'Microsoft.Network/networkSecurityGroups@2020-05-01' = {
   location: location
@@ -187,8 +186,7 @@ resource ws 'Microsoft.Databricks/workspaces@2018-04-01' = {
     name: pricingTier
   }
   properties: {
-    // TODO: improve once we have scoping functions
-    managedResourceGroupId: managedResourceGroupId
+    managedResourceGroupId: managedResourceGroup.id
     parameters: {
       customVirtualNetworkId: {
         value: vnet.id
@@ -207,4 +205,9 @@ resource ws 'Microsoft.Databricks/workspaces@2018-04-01' = {
   dependsOn: [
     nsg
   ]
+}
+
+resource managedResourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' existing = {
+  scope: subscription()
+  name: managedResourceGroupName
 }

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/main.bicep
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/main.bicep
@@ -207,7 +207,4 @@ resource ws 'Microsoft.Databricks/workspaces@2018-04-01' = {
       }
     }
   }
-  dependsOn: [
-    nsg
-  ]
 }

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/main.bicep
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/main.bicep
@@ -1,0 +1,210 @@
+@description('Specifies whether to deploy Azure Databricks workspace with secure cluster connectivity (SCC) enabled or not (No Public IP)')
+param disablePublicIp bool = false
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+@description('The name of the network security group to create.')
+param nsgName string = 'databricks-nsg'
+
+@allowed([
+  'trial'
+  'standard'
+  'premium'
+])
+@description('The pricing tier of workspace.')
+param pricingTier string = 'premium'
+
+@description('Cidr range for the private subnet.')
+param privateSubnetCidr string = '10.179.0.0/18'
+
+@description('The name of the private subnet to create.')
+param privateSubnetName string = 'private-subnet'
+
+@description('Cidr range for the public subnet..')
+param publicSubnetCidr string = '10.179.64.0/18'
+
+@description('The name of the public subnet to create.')
+param publicSubnetName string = 'public-subnet'
+
+@description('Cidr range for the vnet.')
+param vnetCidr string = '10.179.0.0/16'
+
+@description('The name of the virtual network to create.')
+param vnetName string = 'databricks-vnet'
+
+@description('The name of the Azure Databricks workspace to create.')
+param workspaceName string
+
+var managedResourceGroupName = 'databricks-rg-${workspaceName}-${uniqueString(workspaceName, resourceGroup().id)}'
+var managedResourceGroupId = '${subscription().id}/resourceGroups/${managedResourceGroupName}'
+
+resource nsg 'Microsoft.Network/networkSecurityGroups@2020-05-01' = {
+  location: location
+  name: nsgName
+  properties: {
+    securityRules: [
+      {
+        name: 'Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-worker-inbound'
+        properties: {
+          description: 'Required for worker nodes communication within a cluster.'
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'VirtualNetwork'
+          access: 'Allow'
+          priority: 100
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-databricks-webapp'
+        properties: {
+          description: 'Required for workers communication with Databricks Webapp.'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'AzureDatabricks'
+          access: 'Allow'
+          priority: 100
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-sql'
+        properties: {
+          description: 'Required for workers communication with Azure SQL services.'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '3306'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'Sql'
+          access: 'Allow'
+          priority: 101
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-storage'
+        properties: {
+          description: 'Required for workers communication with Azure Storage services.'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'Storage'
+          access: 'Allow'
+          priority: 102
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-worker-outbound'
+        properties: {
+          description: 'Required for worker nodes communication within a cluster.'
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'VirtualNetwork'
+          access: 'Allow'
+          priority: 103
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'Microsoft.Databricks-workspaces_UseOnly_databricks-worker-to-eventhub'
+        properties: {
+          description: 'Required for worker communication with Azure Eventhub services.'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '9093'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: 'EventHub'
+          access: 'Allow'
+          priority: 104
+          direction: 'Outbound'
+        }
+      }
+    ]
+  }
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2020-05-01' = {
+  location: location
+  name: vnetName
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetCidr
+      ]
+    }
+    subnets: [
+      {
+        name: publicSubnetName
+        properties: {
+          addressPrefix: publicSubnetCidr
+          networkSecurityGroup: {
+            id: nsg.id
+          }
+          delegations: [
+            {
+              name: 'databricks-del-public'
+              properties: {
+                serviceName: 'Microsoft.Databricks/workspaces'
+              }
+            }
+          ]
+        }
+      }
+      {
+        name: privateSubnetName
+        properties: {
+          addressPrefix: privateSubnetCidr
+          networkSecurityGroup: {
+            id: nsg.id
+          }
+          delegations: [
+            {
+              name: 'databricks-del-private'
+              properties: {
+                serviceName: 'Microsoft.Databricks/workspaces'
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource ws 'Microsoft.Databricks/workspaces@2018-04-01' = {
+  name: workspaceName
+  location: location
+  sku: {
+    name: pricingTier
+  }
+  properties: {
+    // TODO: improve once we have scoping functions
+    managedResourceGroupId: managedResourceGroupId
+    parameters: {
+      customVirtualNetworkId: {
+        value: vnet.id
+      }
+      customPublicSubnetName: {
+        value: publicSubnetName
+      }
+      customPrivateSubnetName: {
+        value: privateSubnetName
+      }
+      enableNoPublicIp: {
+        value: disablePublicIp
+      }
+    }
+  }
+  dependsOn: [
+    nsg
+  ]
+}

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/metadata.json
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template allows you to create a network security group, a virtual network and an Azure Databricks workspace with the virtual network.",
   "summary": "Deploy a Network Security Group, a Virtual Network and an Azure Databricks Workspace with the Virtual Network.",
   "githubUsername": "sunainakrishnamoorthy",
-  "dateUpdated": "2021-06-10",
+  "dateUpdated": "2021-06-11",
   "tags": {
     "subscriptionType": "Azure4Student",
     "cost": "$$$",

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/metadata.json
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template allows you to create a network security group, a virtual network and an Azure Databricks workspace with the virtual network.",
   "summary": "Deploy a Network Security Group, a Virtual Network and an Azure Databricks Workspace with the Virtual Network.",
   "githubUsername": "sunainakrishnamoorthy",
-  "dateUpdated": "2021-06-09",
+  "dateUpdated": "2021-06-10",
   "tags": {
     "subscriptionType": "Azure4Student",
     "cost": "$$$",

--- a/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/metadata.json
+++ b/quickstarts/microsoft.databricks/databricks-all-in-one-template-for-vnet-injection/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template allows you to create a network security group, a virtual network and an Azure Databricks workspace with the virtual network.",
   "summary": "Deploy a Network Security Group, a Virtual Network and an Azure Databricks Workspace with the Virtual Network.",
   "githubUsername": "sunainakrishnamoorthy",
-  "dateUpdated": "2021-05-12",
+  "dateUpdated": "2021-06-09",
   "tags": {
     "subscriptionType": "Azure4Student",
     "cost": "$$$",


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/databricks-all-in-one-template-for-vnet-injection

https://github.com/Azure/bicep/pull/3151