### PR TITLE
Migrate bicep example: 101/1vm-2nics-2subnets-1vnet

### DIFF
--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/README.md
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2F1vm-2nics-2subnets-1vnet%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2F1vm-2nics-2subnets-1vnet%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2F1vm-2nics-2subnets-1vnet%2Fazuredeploy.json)

--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/azuredeploy.json
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "14021489970797886746"
+      "templateHash": "4848305918507774483"
     }
   },
   "parameters": {
@@ -251,11 +251,5 @@
         ]
       }
     }
-  ],
-  "outputs": {
-    "asdf": {
-      "type": "object",
-      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName')), '2020-06-01', 'full')]"
-    }
-  }
+  ]
 }

--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/azuredeploy.json
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "16230829834163133202"
+      "templateHash": "14021489970797886746"
     }
   },
   "parameters": {
@@ -253,9 +253,9 @@
     }
   ],
   "outputs": {
-    "publicIp": {
-      "type": "string",
-      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).ipAddress]"
+    "asdf": {
+      "type": "object",
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName')), '2020-06-01', 'full')]"
     }
   }
 }

--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/azuredeploy.json
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "16230829834163133202"
+    }
+  },
   "parameters": {
     "virtualMachineSize": {
       "type": "string",
@@ -16,7 +23,7 @@
       }
     },
     "adminPassword": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Default Admin password"
       }
@@ -24,13 +31,13 @@
     "storageAccountType": {
       "type": "string",
       "defaultValue": "Standard_LRS",
-      "metadata": {
-        "description": "Storage Account type for the VM and VM diagnostic storage"
-      },
       "allowedValues": [
         "Standard_LRS",
         "Premium_LRS"
-      ]
+      ],
+      "metadata": {
+        "description": "Storage Account type for the VM and VM diagnostic storage"
+      }
     },
     "location": {
       "type": "string",
@@ -40,39 +47,32 @@
       }
     }
   },
+  "functions": [],
   "variables": {
     "virtualMachineName": "VM-MultiNic",
-    "nic1": "nic-1",
-    "nic2": "nic-2",
+    "nic1Name": "nic-1",
+    "nic2Name": "nic-2",
     "virtualNetworkName": "virtualNetwork",
     "subnet1Name": "subnet-1",
     "subnet2Name": "subnet-2",
     "publicIPAddressName": "publicIp",
-    "subnet1Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]",
-    "subnet2Ref": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet2Name'))]",
-    "diagStorageAccountName": "[concat('diags',uniqueString(resourceGroup().id))]",
+    "diagStorageAccountName": "[format('diags{0}', uniqueString(resourceGroup().id))]",
     "networkSecurityGroupName": "NSG",
-    "networkSecurityGroupName2": "[concat(variables('subnet2Name'), '-nsg')]"
+    "networkSecurityGroupName2": "[format('{0}-nsg', variables('subnet2Name'))]"
   },
   "resources": [
     {
-      "name": "[variables('virtualMachineName')]",
       "type": "Microsoft.Compute/virtualMachines",
-      "apiVersion": "2019-12-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('virtualMachineName')]",
       "location": "[parameters('location')]",
-      "comments": "This is the virtual machine that you're building.",
-      "dependsOn": [
-        "[variables('nic1')]",
-        "[variables('nic2')]",
-        "[variables('diagStorageAccountName')]"
-      ],
       "properties": {
         "osProfile": {
           "computerName": "[variables('virtualMachineName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "adminPassword": "[parameters('adminPassword')]",
           "windowsConfiguration": {
-            "provisionVmAgent": "true"
+            "provisionVMAgent": true
           }
         },
         "hardwareProfile": {
@@ -95,28 +95,33 @@
               "properties": {
                 "primary": true
               },
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1Name'))]"
             },
             {
               "properties": {
                 "primary": false
               },
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2'))]"
+              "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2Name'))]"
             }
           ]
         },
         "diagnosticsProfile": {
           "bootDiagnostics": {
             "enabled": true,
-            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('diagStorageAccountName')), '2019-06-01').primaryEndpoints['blob']]"
+            "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', variables('diagStorageAccountName'))).primaryEndpoints.blob]"
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('diagStorageAccountName'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('nic1Name'))]",
+        "[resourceId('Microsoft.Network/networkInterfaces', variables('nic2Name'))]"
+      ]
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('diagStorageAccountName')]",
       "apiVersion": "2019-06-01",
+      "name": "[variables('diagStorageAccountName')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('storageAccountType')]"
@@ -124,21 +129,16 @@
       "kind": "StorageV2"
     },
     {
-      "comments": "Simple Network Security Group for subnet [variables('subnet2Name')]",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
       "name": "[variables('networkSecurityGroupName2')]",
       "location": "[parameters('location')]"
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-06-01",
       "name": "[variables('virtualNetworkName')]",
-      "apiVersion": "2020-05-01",
       "location": "[parameters('location')]",
-      "comments": "This will build a Virtual Network.",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
-      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -162,30 +162,27 @@
             }
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName2'))]"
+      ]
     },
     {
-      "name": "[variables('nic1')]",
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('nic1Name')]",
       "location": "[parameters('location')]",
-      "comments": "This will be your Primary NIC",
-      "dependsOn": [
-        "[variables('publicIpAddressName')]",
-        "[variables('networkSecurityGroupName')]",
-        "[variables('virtualNetworkName')]"
-      ],
       "properties": {
         "ipConfigurations": [
           {
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[variables('subnet1Ref')]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet1Name'))]"
               },
               "privateIPAllocationMethod": "Dynamic",
-              "publicIpAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIpAddresses', variables('publicIpAddressName'))]"
+              "publicIPAddress": {
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               }
             }
           }
@@ -193,47 +190,49 @@
         "networkSecurityGroup": {
           "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]"
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+      ]
     },
     {
-      "name": "[variables('nic2')]",
       "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('nic2Name')]",
       "location": "[parameters('location')]",
-      "comments": "This will be your Secondary NIC",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-      ],
       "properties": {
         "ipConfigurations": [
           {
             "name": "ipconfig1",
             "properties": {
               "subnet": {
-                "id": "[variables('subnet2Ref')]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnet2Name'))]"
               },
               "privateIPAllocationMethod": "Dynamic"
             }
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+      ]
     },
     {
-      "name": "[variables('publicIpAddressName')]",
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('publicIPAddressName')]",
       "location": "[parameters('location')]",
-      "comments": "Public IP for your Primary NIC",
       "properties": {
         "publicIPAllocationMethod": "Dynamic"
       }
     },
     {
-      "name": "[variables('networkSecurityGroupName')]",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
+      "name": "[variables('networkSecurityGroupName')]",
       "location": "[parameters('location')]",
-      "comments": "Network Security Group (NSG) for your Primary NIC",
       "properties": {
         "securityRules": [
           {
@@ -252,5 +251,11 @@
         ]
       }
     }
-  ]
+  ],
+  "outputs": {
+    "publicIp": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))).ipAddress]"
+    }
+  }
 }

--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/main.bicep
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/main.bicep
@@ -202,4 +202,4 @@ resource nsg 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
   }
 }
 
-output publicIp string = pip.properties.ipAddress
+output asdf object = pip

--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/main.bicep
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/main.bicep
@@ -201,5 +201,3 @@ resource nsg 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
     ]
   }
 }
-
-output asdf object = pip

--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/main.bicep
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/main.bicep
@@ -1,0 +1,205 @@
+@description('Virtual machine size (has to be at least the size of Standard_A3 to support 2 NICs)')
+param virtualMachineSize string = 'Standard_DS1_v2'
+
+@description('Default Admin username')
+param adminUsername string
+
+@description('Default Admin password')
+@secure()
+param adminPassword string
+
+@description('Storage Account type for the VM and VM diagnostic storage')
+@allowed([
+  'Standard_LRS'
+  'Premium_LRS'
+])
+param storageAccountType string = 'Standard_LRS'
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+var virtualMachineName = 'VM-MultiNic'
+var nic1Name = 'nic-1'
+var nic2Name = 'nic-2'
+var virtualNetworkName = 'virtualNetwork'
+var subnet1Name = 'subnet-1'
+var subnet2Name = 'subnet-2'
+var publicIPAddressName = 'publicIp'
+var diagStorageAccountName = 'diags${uniqueString(resourceGroup().id)}'
+var networkSecurityGroupName = 'NSG'
+var networkSecurityGroupName2 = '${subnet2Name}-nsg'
+
+// This is the virtual machine that you're building.
+resource vm 'Microsoft.Compute/virtualMachines@2020-06-01' = {
+  name: virtualMachineName
+  location: location
+  properties: {
+    osProfile: {
+      computerName: virtualMachineName
+      adminUsername: adminUsername
+      adminPassword: adminPassword
+      windowsConfiguration: {
+        provisionVMAgent: true
+      }
+    }
+    hardwareProfile: {
+      vmSize: virtualMachineSize
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: 'MicrosoftWindowsServer'
+        offer: 'WindowsServer'
+        sku: '2019-Datacenter'
+        version: 'latest'
+      }
+      osDisk: {
+        createOption: 'FromImage'
+      }
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          properties: {
+            primary: true
+          }
+          id: nic1.id
+        }
+        {
+          properties: {
+            primary: false
+          }
+          id: nic2.id
+        }
+      ]
+    }
+    diagnosticsProfile: {
+      bootDiagnostics: {
+        enabled: true
+        storageUri: diagsAccount.properties.primaryEndpoints.blob
+      }
+    }
+  }
+}
+
+resource diagsAccount 'Microsoft.Storage/storageAccounts@2019-06-01' = {
+  name: diagStorageAccountName
+  location: location
+  sku: {
+    name: storageAccountType
+  }
+  kind: 'StorageV2'
+}
+
+// Simple Network Security Group for subnet2
+resource nsg2 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
+  name: networkSecurityGroupName2
+  location: location
+}
+
+// This will build a Virtual Network.
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/16'
+      ]
+    }
+    subnets: [
+      {
+        name: subnet1Name
+        properties: {
+          addressPrefix: '10.0.0.0/24'
+        }
+      }
+      {
+        name: subnet2Name
+        properties: {
+          addressPrefix: '10.0.1.0/24'
+          networkSecurityGroup: {
+            id: nsg2.id
+          }
+        }
+      }
+    ]
+  }
+}
+
+// This will be your Primary NIC
+resource nic1 'Microsoft.Network/networkInterfaces@2020-06-01' = {
+  name: nic1Name
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          subnet: {
+            id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, subnet1Name)
+          }
+          privateIPAllocationMethod: 'Dynamic'
+          publicIPAddress: {
+            id: pip.id
+          }
+        }
+      }
+    ]
+    networkSecurityGroup: {
+      id: nsg.id
+    }
+  }
+}
+
+// This will be your Secondary NIC
+resource nic2 'Microsoft.Network/networkInterfaces@2020-06-01' = {
+  name: nic2Name
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          subnet: {
+            id: resourceId('Microsoft.Network/virtualNetworks/subnets', vnet.name, subnet2Name)
+          }
+          privateIPAllocationMethod: 'Dynamic'
+        }
+      }
+    ]
+  }
+}
+
+// Public IP for your Primary NIC
+resource pip 'Microsoft.Network/publicIPAddresses@2020-06-01' = {
+  name: publicIPAddressName
+  location: location
+  properties: {
+    publicIPAllocationMethod: 'Dynamic'
+  }
+}
+
+// Network Security Group (NSG) for your Primary NIC
+resource nsg 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
+  name: networkSecurityGroupName
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'default-allow-rdp'
+        properties: {
+          priority: 1000
+          sourceAddressPrefix: '*'
+          protocol: 'Tcp'
+          destinationPortRange: '3389'
+          access: 'Allow'
+          direction: 'Inbound'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+        }
+      }
+    ]
+  }
+}
+
+output publicIp string = pip.properties.ipAddress

--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/metadata.json
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/metadata.json
@@ -5,5 +5,5 @@
   "description": "Creates a new VM with two NICs which connect to two different subnets within the same VNet.",
   "summary": "Creates a new VM with two NICs which connect to two different subnets within the same VNet.",
   "githubUsername": "lmoxiel",
-  "dateUpdated": "2021-06-11"
+  "dateUpdated": "2021-06-23"
 }

--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/metadata.json
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/metadata.json
@@ -5,5 +5,5 @@
   "description": "Creates a new VM with two NICs which connect to two different subnets within the same VNet.",
   "summary": "Creates a new VM with two NICs which connect to two different subnets within the same VNet.",
   "githubUsername": "lmoxiel",
-  "dateUpdated": "2021-06-23"
+  "dateUpdated": "2021-07-07"
 }

--- a/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/metadata.json
+++ b/quickstarts/microsoft.compute/1vm-2nics-2subnets-1vnet/metadata.json
@@ -5,5 +5,5 @@
   "description": "Creates a new VM with two NICs which connect to two different subnets within the same VNet.",
   "summary": "Creates a new VM with two NICs which connect to two different subnets within the same VNet.",
   "githubUsername": "lmoxiel",
-  "dateUpdated": "2021-04-21"
+  "dateUpdated": "2021-06-11"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/1vm-2nics-2subnets-1vnet

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3189