### PR TITLE
Migrate bicep example: 101/aad-domainservices

### DIFF
--- a/quickstarts/microsoft.network/aad-domainservices/README.md
+++ b/quickstarts/microsoft.network/aad-domainservices/README.md
@@ -9,9 +9,12 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/aad-domainservices/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/aad-domainservices/CredScanResult.svg)
 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Faad-domainservices%2Fazuredeploy.json)  
-[![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)]( https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Faad-domainservices%2Fazuredeploy.json)
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/aad-domainservices/BicepVersion.svg)
+
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Faad-domainservices%2Fazuredeploy.json)
+[![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Faad-domainservices%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Faad-domainservices%2Fazuredeploy.json)
+
  
 
  
@@ -145,5 +148,3 @@ To remove this deployment simply remove the resource group that contains this sa
 2. Networking Considerations: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/active-directory-ds-networking
 3. Password Synchronization: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/active-directory-ds-getting-started-password-sync
 4. Troubleshooting Guide: https://docs.microsoft.com/en-us/azure/active-directory-domain-services/active-directory-ds-troubleshooting
-
-

--- a/quickstarts/microsoft.network/aad-domainservices/azuredeploy.json
+++ b/quickstarts/microsoft.network/aad-domainservices/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "16102777703905677431"
+    }
+  },
   "parameters": {
     "domainName": {
       "type": "string",
@@ -16,21 +23,21 @@
       }
     },
     "sku": {
-      "type": "String",
+      "type": "string",
       "defaultValue": "Enterprise",
       "metadata": {
         "description": "SKU of the AD Domain Service."
       }
     },
     "domainConfigurationType": {
-      "type": "String",
+      "type": "string",
       "defaultValue": "FullySynced",
       "metadata": {
         "description": "Domain Configuration Type."
       }
     },
     "filteredSync": {
-      "type": "String",
+      "type": "string",
       "defaultValue": "Disabled",
       "metadata": {
         "description": "Choose the filtered sync type."
@@ -65,21 +72,60 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "domainServicesNSGName": "[concat(parameters('domainServicesSubnetName'), '-nsg')]",
-    "nsgRefId": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]",
-    "subnetRefId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]",
+    "domainServicesNSGName": "[format('{0}-nsg', parameters('domainServicesSubnetName'))]",
+    "PSRemotingSlicePIPAddresses": [
+      "52.180.179.108",
+      "52.180.177.87",
+      "13.75.105.168",
+      "52.175.18.134",
+      "52.138.68.41",
+      "52.138.65.157",
+      "104.41.159.212",
+      "104.45.138.161",
+      "52.169.125.119",
+      "52.169.218.0",
+      "52.187.19.1",
+      "52.187.120.237",
+      "13.78.172.246",
+      "52.161.110.169",
+      "52.174.189.149",
+      "40.68.160.142",
+      "40.83.144.56",
+      "13.64.151.161"
+    ],
     "RDPIPAddresses": [
       "207.68.190.32/27",
       "13.106.78.32/27",
       "13.106.174.32/27",
       "13.106.4.96/27"
+    ],
+    "PSRemotingSliceTIPAddresses": [
+      "52.180.183.67",
+      "52.180.181.39",
+      "52.175.28.111",
+      "52.175.16.141",
+      "52.138.70.93",
+      "52.138.64.115",
+      "40.80.146.22",
+      "40.121.211.60",
+      "52.138.143.173",
+      "52.169.87.10",
+      "13.76.171.84",
+      "52.187.169.156",
+      "13.78.174.255",
+      "13.78.191.178",
+      "40.68.163.143",
+      "23.100.14.28",
+      "13.64.188.43",
+      "23.99.93.197"
     ]
   },
   "resources": [
     {
-      "apiVersion": "2020-11-01",
       "type": "Microsoft.Network/networkSecurityGroups",
+      "apiVersion": "2020-11-01",
       "name": "[variables('domainServicesNSGName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -90,7 +136,7 @@
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "5986",
-              "sourceAddressPrefix": "*",
+              "sourceAddressPrefixes": "[variables('PSRemotingSlicePIPAddresses')]",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 301,
@@ -129,7 +175,7 @@
               "protocol": "Tcp",
               "sourcePortRange": "*",
               "destinationPortRange": "5986",
-              "sourceAddressPrefix": "*",
+              "sourceAddressPrefixes": "[variables('PSRemotingSliceTIPAddresses')]",
               "destinationAddressPrefix": "*",
               "access": "Allow",
               "priority": 302,
@@ -140,51 +186,56 @@
       }
     },
     {
-      "apiVersion": "2020-11-01",
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-11-01",
       "name": "[parameters('domainServicesVnetName')]",
       "location": "[parameters('location')]",
-      "dependsOn": ["[variables('domainServicesNSGName')]"],
       "properties": {
         "addressSpace": {
-          "addressPrefixes": ["[parameters('domainServicesVnetAddressPrefix')]"]
+          "addressPrefixes": [
+            "[parameters('domainServicesVnetAddressPrefix')]"
+          ]
         }
       },
-      "resources": [
-        {
-          "apiVersion": "2020-11-01",
-          "type": "subnets",
-          "location": "[parameters('location')]",
-          "name": "[parameters('domainServicesSubnetName')]",
-          "dependsOn": ["[parameters('domainServicesVnetName')]"],
-          "properties": {
-            "addressPrefix": "[parameters('domainServicesSubnetAddressPrefix')]",
-            "networkSecurityGroup": {
-              "id": "[variables('nsgRefId')]"
-            }
-          }
-        }
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]"
       ]
     },
     {
-      "type": "Microsoft.AAD/DomainServices",
-      "name": "[parameters('domainName')]",
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-11-01",
+      "name": "[format('{0}/{1}', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('domainServicesSubnetAddressPrefix')]",
+        "networkSecurityGroup": {
+          "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('domainServicesVnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.AAD/domainServices",
       "apiVersion": "2020-01-01",
+      "name": "[parameters('domainName')]",
       "location": "[parameters('location')]",
-      "dependsOn": ["[parameters('domainServicesVnetName')]"],
       "properties": {
         "domainName": "[parameters('domainName')]",
         "filteredSync": "[parameters('filteredSync')]",
         "domainConfigurationType": "[parameters('domainConfigurationType')]",
         "replicaSets": [
-                    {
-                        "subnetId": "[variables('subnetRefId')]",
-                        "location": "[parameters('location')]"
-                    }
-                ],
+          {
+            "subnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]",
+            "location": "[parameters('location')]"
+          }
+        ],
         "sku": "[parameters('sku')]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('domainServicesVnetName'), parameters('domainServicesSubnetName'))]"
+      ]
     }
-  ],
-  "outputs": {}
+  ]
 }

--- a/quickstarts/microsoft.network/aad-domainservices/azuredeploy.json
+++ b/quickstarts/microsoft.network/aad-domainservices/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "16102777703905677431"
+      "templateHash": "15010615918273948230"
     }
   },
   "parameters": {
@@ -196,10 +196,7 @@
             "[parameters('domainServicesVnetAddressPrefix')]"
           ]
         }
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('domainServicesNSGName'))]"
-      ]
+      }
     },
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",

--- a/quickstarts/microsoft.network/aad-domainservices/main.bicep
+++ b/quickstarts/microsoft.network/aad-domainservices/main.bicep
@@ -1,0 +1,180 @@
+@description('Domain Name')
+param domainName string
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+@description('SKU of the AD Domain Service.')
+param sku string = 'Enterprise'
+
+@description('Domain Configuration Type.')
+param domainConfigurationType string = 'FullySynced'
+
+@description('Choose the filtered sync type.')
+param filteredSync string = 'Disabled'
+
+@description('Virtual Network Name')
+param domainServicesVnetName string = 'domain-services-vnet'
+
+@description('Address Prefix')
+param domainServicesVnetAddressPrefix string = '10.0.0.0/16'
+
+@description('Virtual Network Name')
+param domainServicesSubnetName string = 'domain-services-subnet'
+
+@description('Subnet prefix')
+param domainServicesSubnetAddressPrefix string = '10.0.0.0/24'
+
+var domainServicesNSGName = '${domainServicesSubnetName}-nsg'
+
+var PSRemotingSlicePIPAddresses = [
+  '52.180.179.108'
+  '52.180.177.87'
+  '13.75.105.168'
+  '52.175.18.134'
+  '52.138.68.41'
+  '52.138.65.157'
+  '104.41.159.212'
+  '104.45.138.161'
+  '52.169.125.119'
+  '52.169.218.0'
+  '52.187.19.1'
+  '52.187.120.237'
+  '13.78.172.246'
+  '52.161.110.169'
+  '52.174.189.149'
+  '40.68.160.142'
+  '40.83.144.56'
+  '13.64.151.161'
+]
+var RDPIPAddresses = [
+  '207.68.190.32/27'
+  '13.106.78.32/27'
+  '13.106.174.32/27'
+  '13.106.4.96/27'
+]
+
+var PSRemotingSliceTIPAddresses = [
+  '52.180.183.67'
+  '52.180.181.39'
+  '52.175.28.111'
+  '52.175.16.141'
+  '52.138.70.93'
+  '52.138.64.115'
+  '40.80.146.22'
+  '40.121.211.60'
+  '52.138.143.173'
+  '52.169.87.10'
+  '13.76.171.84'
+  '52.187.169.156'
+  '13.78.174.255'
+  '13.78.191.178'
+  '40.68.163.143'
+  '23.100.14.28'
+  '13.64.188.43'
+  '23.99.93.197'
+]
+
+resource nsg 'Microsoft.Network/networkSecurityGroups@2020-11-01' = {
+  name: domainServicesNSGName
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowPSRemotingSliceP'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '5986'
+          sourceAddressPrefixes: PSRemotingSlicePIPAddresses
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 301
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'AllowRDP'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '3389'
+          sourceAddressPrefixes: RDPIPAddresses
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 201
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'AllowSyncWithAzureAD'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 101
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'AllowPSRemotingSliceT'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '5986'
+          sourceAddressPrefixes: PSRemotingSliceTIPAddresses
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 302
+          direction: 'Inbound'
+        }
+      }
+    ]
+  }
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2020-11-01' = {
+  name: domainServicesVnetName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        domainServicesVnetAddressPrefix
+      ]
+    }
+  }
+  dependsOn: [
+    nsg
+  ]
+}
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = {
+  parent: vnet
+  name: domainServicesSubnetName
+  properties: {
+    addressPrefix: domainServicesSubnetAddressPrefix
+    networkSecurityGroup: {
+      id: nsg.id
+    }
+  }
+}
+
+resource domainServices 'Microsoft.AAD/DomainServices@2020-01-01' = {
+  name: domainName
+  location: location
+  properties: {
+    domainName: domainName
+    filteredSync: filteredSync
+    domainConfigurationType: domainConfigurationType
+    replicaSets: [
+      {
+        subnetId: subnet.id
+        location: location
+      }
+    ]
+    sku: sku
+  }
+}

--- a/quickstarts/microsoft.network/aad-domainservices/main.bicep
+++ b/quickstarts/microsoft.network/aad-domainservices/main.bicep
@@ -146,9 +146,6 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-11-01' = {
       ]
     }
   }
-  dependsOn: [
-    nsg
-  ]
 }
 
 resource subnet 'Microsoft.Network/virtualNetworks/subnets@2020-11-01' = {

--- a/quickstarts/microsoft.network/aad-domainservices/metadata.json
+++ b/quickstarts/microsoft.network/aad-domainservices/metadata.json
@@ -5,5 +5,6 @@
   "description": "This template deploys an Managed Azure Active Directory Domain Service with required VNet and NSG configurations.",
   "summary": "Deploy Managed AADDS with required VNet and NSG configurations",
   "githubUsername": "rahulkhengare",
-  "dateUpdated": "2021-06-11"
+  "dateUpdated": "2021-06-11",
+  "validationType": "Manual"
 }

--- a/quickstarts/microsoft.network/aad-domainservices/metadata.json
+++ b/quickstarts/microsoft.network/aad-domainservices/metadata.json
@@ -5,6 +5,6 @@
   "description": "This template deploys an Managed Azure Active Directory Domain Service with required VNet and NSG configurations.",
   "summary": "Deploy Managed AADDS with required VNet and NSG configurations",
   "githubUsername": "rahulkhengare",
-  "dateUpdated": "2021-06-11",
+  "dateUpdated": "2021-06-15",
   "validationType": "Manual"
 }

--- a/quickstarts/microsoft.network/aad-domainservices/metadata.json
+++ b/quickstarts/microsoft.network/aad-domainservices/metadata.json
@@ -5,6 +5,6 @@
   "description": "This template deploys an Managed Azure Active Directory Domain Service with required VNet and NSG configurations.",
   "summary": "Deploy Managed AADDS with required VNet and NSG configurations",
   "githubUsername": "rahulkhengare",
-  "dateUpdated": "2021-05-14",
+  "dateUpdated": "2021-06-11",
   "validationType": "Manual"
 }

--- a/quickstarts/microsoft.network/aad-domainservices/metadata.json
+++ b/quickstarts/microsoft.network/aad-domainservices/metadata.json
@@ -5,6 +5,5 @@
   "description": "This template deploys an Managed Azure Active Directory Domain Service with required VNet and NSG configurations.",
   "summary": "Deploy Managed AADDS with required VNet and NSG configurations",
   "githubUsername": "rahulkhengare",
-  "dateUpdated": "2021-06-11",
-  "validationType": "Manual"
+  "dateUpdated": "2021-06-11"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/aad-domainservices

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3190