### PR TITLE
Migrate bicep example: 101/aci-linuxcontainer-public-ip

### DIFF
--- a/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/README.md
+++ b/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.containerinstance%2Faci-linuxcontainer-public-ip%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.containerinstance%2Faci-linuxcontainer-public-ip%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.containerinstance%2Faci-linuxcontainer-public-ip%2Fazuredeploy.json)

--- a/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/azuredeploy.json
+++ b/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "12367894147709986470"
+    }
+  },
   "parameters": {
     "name": {
       "type": "string",
@@ -17,24 +24,36 @@
       }
     },
     "port": {
-      "type": "string",
-      "defaultValue": "80",
+      "type": "int",
+      "defaultValue": 80,
       "metadata": {
         "description": "Port to open on the container and the public IP address."
       }
     },
     "cpuCores": {
-      "type": "string",
-      "defaultValue": "1.0",
+      "type": "int",
+      "defaultValue": 1,
       "metadata": {
         "description": "The number of CPU cores to allocate to the container."
       }
     },
     "memoryInGb": {
-      "type": "string",
-      "defaultValue": "1.5",
+      "type": "int",
+      "defaultValue": 2,
       "metadata": {
         "description": "The amount of memory to allocate to the container in gigabytes."
+      }
+    },
+    "restartPolicy": {
+      "type": "string",
+      "defaultValue": "Always",
+      "allowedValues": [
+        "Always",
+        "Never",
+        "OnFailure"
+      ],
+      "metadata": {
+        "description": "The behavior of Azure runtime if container has stopped."
       }
     },
     "location": {
@@ -43,20 +62,9 @@
       "metadata": {
         "description": "Location for all resources."
       }
-    },
-    "restartPolicy": {
-      "type": "string",
-      "defaultValue": "always",
-      "allowedValues": [
-        "never",
-        "always",
-        "onfailure"
-      ],
-      "metadata": {
-        "description": "The behavior of Azure runtime if container has stopped."
-      }
     }
   },
+  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ContainerInstance/containerGroups",
@@ -71,13 +79,14 @@
               "image": "[parameters('image')]",
               "ports": [
                 {
-                  "port": "[parameters('port')]"
+                  "port": "[parameters('port')]",
+                  "protocol": "TCP"
                 }
               ],
               "resources": {
                 "requests": {
                   "cpu": "[parameters('cpuCores')]",
-                  "memoryInGb": "[parameters('memoryInGb')]"
+                  "memoryInGB": "[parameters('memoryInGb')]"
                 }
               }
             }
@@ -89,8 +98,8 @@
           "type": "Public",
           "ports": [
             {
-              "protocol": "Tcp",
-              "port": "[parameters('port')]"
+              "port": "[parameters('port')]",
+              "protocol": "TCP"
             }
           ]
         }
@@ -100,7 +109,7 @@
   "outputs": {
     "containerIPv4Address": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups/', parameters('name'))).ipAddress.ip]"
+      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups', parameters('name'))).ipAddress.ip]"
     }
   }
 }

--- a/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/main.bicep
+++ b/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/main.bicep
@@ -1,0 +1,65 @@
+@description('Name for the container group')
+param name string = 'acilinuxpublicipcontainergroup'
+
+@description('Container image to deploy. Should be of the form repoName/imagename:tag for images stored in public Docker Hub, or a fully qualified URI for other registries. Images from private registries require additional registry credentials.')
+param image string = 'mcr.microsoft.com/azuredocs/aci-helloworld'
+
+@description('Port to open on the container and the public IP address.')
+param port int = 80
+
+@description('The number of CPU cores to allocate to the container.')
+param cpuCores int = 1
+
+@description('The amount of memory to allocate to the container in gigabytes.')
+param memoryInGb int = 2
+
+@description('The behavior of Azure runtime if container has stopped.')
+@allowed([
+  'Always'
+  'Never'
+  'OnFailure'
+])
+param restartPolicy string = 'Always'
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+resource containerGroup 'Microsoft.ContainerInstance/containerGroups@2019-12-01' = {
+  name: name
+  location: location
+  properties: {
+    containers: [
+      {
+        name: name
+        properties: {
+          image: image
+          ports: [
+            {
+              port: port
+              protocol: 'TCP'
+            }
+          ]
+          resources: {
+            requests: {
+              cpu: cpuCores
+              memoryInGB: memoryInGb
+            }
+          }
+        }
+      }
+    ]
+    osType: 'Linux'
+    restartPolicy: restartPolicy
+    ipAddress: {
+      type: 'Public'
+      ports: [
+        {
+          port: port
+          protocol: 'TCP'
+        }
+      ]
+    }
+  }
+}
+
+output containerIPv4Address string = containerGroup.properties.ipAddress.ip

--- a/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/metadata.json
+++ b/quickstarts/microsoft.containerinstance/aci-linuxcontainer-public-ip/metadata.json
@@ -6,5 +6,5 @@
   "summary": "This template demonstrates how to create a container group with a single Linux container and a public IP address using Azure Container Instances.",
   "githubUsername": "seanmck",
   "docOwner": "macolso",
-  "dateUpdated": "2021-04-21"
+  "dateUpdated": "2021-06-11"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/aci-linuxcontainer-public-ip

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3191