### PR TITLE
Migrate bicep example: 101/mg-policy

### DIFF
--- a/managementgroup-deployments/mg-policy/README.md
+++ b/managementgroup-deployments/mg-policy/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/managementgroup-deployments/mg-policy/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/managementgroup-deployments/mg-policy/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/managementgroup-deployments/mg-policy/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fmanagementgroup-deployments%2Fmg-policy%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fmanagementgroup-deployments%2Fmg-policy%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fmanagementgroup-deployments%2Fmg-policy%2Fazuredeploy.json)

--- a/managementgroup-deployments/mg-policy/azuredeploy.json
+++ b/managementgroup-deployments/mg-policy/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "2350252618174097128"
+    }
+  },
   "parameters": {
     "targetMG": {
       "type": "string",
@@ -20,20 +27,20 @@
       }
     }
   },
+  "functions": [],
   "variables": {
     "mgScope": "[tenantResourceId('Microsoft.Management/managementGroups', parameters('targetMG'))]",
-    "policyDefinition": "LocationRestriction"
+    "policyDefinitionName": "LocationRestriction"
   },
   "resources": [
     {
       "type": "Microsoft.Authorization/policyDefinitions",
-      "name": "[variables('policyDefinition')]",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2020-03-01",
+      "name": "[variables('policyDefinitionName')]",
       "properties": {
         "policyType": "Custom",
         "mode": "All",
-        "parameters": {
-        },
+        "parameters": {},
         "policyRule": {
           "if": {
             "not": {
@@ -49,15 +56,15 @@
     },
     {
       "type": "Microsoft.Authorization/policyAssignments",
+      "apiVersion": "2020-03-01",
       "name": "location-lock",
-      "apiVersion": "2019-09-01",
-      "dependsOn": [
-        "[variables('policyDefinition')]"
-      ],
       "properties": {
         "scope": "[variables('mgScope')]",
-        "policyDefinitionId": "[extensionResourceId(variables('mgScope'), 'Microsoft.Authorization/policyDefinitions', variables('policyDefinition'))]"
-      }
+        "policyDefinitionId": "[extensionResourceId(variables('mgScope'), 'Microsoft.Authorization/policyDefinitions', variables('policyDefinitionName'))]"
+      },
+      "dependsOn": [
+        "[format('Microsoft.Authorization/policyDefinitions/{0}', variables('policyDefinitionName'))]"
+      ]
     }
   ]
 }

--- a/managementgroup-deployments/mg-policy/main.bicep
+++ b/managementgroup-deployments/mg-policy/main.bicep
@@ -1,0 +1,42 @@
+targetScope = 'managementGroup'
+
+@description('Target Management Group')
+param targetMG string
+
+@description('An array of the allowed locations, all other locations will be denied by the created policy.')
+param allowedLocations array = [
+  'australiaeast'
+  'australiasoutheast'
+  'australiacentral'
+]
+
+var mgScope = tenantResourceId('Microsoft.Management/managementGroups', targetMG)
+var policyDefinitionName = 'LocationRestriction'
+
+resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2020-03-01' = {
+  name: policyDefinitionName
+  properties: {
+    policyType: 'Custom'
+    mode: 'All'
+    parameters: {}
+    policyRule: {
+      if: {
+        not: {
+          field: 'location'
+          in: allowedLocations
+        }
+      }
+      then: {
+        effect: 'deny'
+      }
+    }
+  }
+}
+
+resource policyAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {
+  name: 'location-lock'
+  properties: {
+    scope: mgScope
+    policyDefinitionId: extensionResourceId(mgScope, 'Microsoft.Authorization/policyDefinitions', policyDefinition.name)
+  }
+}

--- a/managementgroup-deployments/mg-policy/metadata.json
+++ b/managementgroup-deployments/mg-policy/metadata.json
@@ -6,6 +6,5 @@
     "type": "ManagementGroupDeployment",
     "validationType": "Manual",
     "githubUsername": "bmoore-msft",
-    "dateUpdated": "2020-11-03"
+    "dateUpdated": "2021-06-12"
 }
-


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/mg-policy

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3194