### PR TITLE
Migrate bicep example: 101/nat-gateway-vnet

### DIFF
--- a/quickstarts/microsoft.network/nat-gateway-vnet/README.md
+++ b/quickstarts/microsoft.network/nat-gateway-vnet/README.md
@@ -5,14 +5,15 @@
 
 ![Azure US Gov Last Test Date](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/nat-gateway-vnet/FairfaxLastTestDate.svg)
 ![Azure US Gov Last Test Result](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/nat-gateway-vnet/FairfaxDeployment.svg)
-    
+
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/nat-gateway-vnet/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/nat-gateway-vnet/CredScanResult.svg)
-    
-    
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fnat-gateway-vnet%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fnat-gateway-vnet%2Fazuredeploy.json)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/nat-gateway-vnet/BicepVersion.svg)
 
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fnat-gateway-vnet%2Fazuredeploy.json)
+
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fnat-gateway-vnet%2Fazuredeploy.json)
 
 This template deploys a **NAT gateway** and virtual network with a single subnet and public IP resource for the NAT gateway.
 
@@ -38,5 +39,3 @@ Description
   + **subnets**: Subnet for virtual network for NAT gateway.
 
 `Tags: virtual network, vnet, nat, nat gateway`
-
-

--- a/quickstarts/microsoft.network/nat-gateway-vnet/azuredeploy.json
+++ b/quickstarts/microsoft.network/nat-gateway-vnet/azuredeploy.json
@@ -1,69 +1,77 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "6383707689748214284"
+    }
+  },
   "parameters": {
-    "vnetname": {
+    "vnetName": {
+      "type": "string",
       "defaultValue": "myVnet",
-      "type": "String",
       "metadata": {
         "description": "Name of the virtual network"
       }
     },
-    "subnetname": {
+    "subnetName": {
+      "type": "string",
       "defaultValue": "mySubnet",
-      "type": "String",
       "metadata": {
         "description": "Name of the subnet for virtual network"
       }
     },
-    "vnetaddressspace": {
+    "vnetAddressSpace": {
+      "type": "string",
       "defaultValue": "192.168.0.0/16",
-      "type": "String",
       "metadata": {
         "description": "Address space for virtual network"
       }
     },
-    "vnetsubnetprefix": {
+    "vnetSubnetPrefix": {
+      "type": "string",
       "defaultValue": "192.168.0.0/24",
-      "type": "String",
       "metadata": {
         "description": "Subnet prefix for virtual network"
       }
     },
-    "natgatewayname": {
+    "natGatewayName": {
+      "type": "string",
       "defaultValue": "myNATgateway",
-      "type": "String",
       "metadata": {
         "description": "Name of the NAT gateway resource"
       }
     },
-    "publicipdns": {
-      "defaultValue": "[concat('gw-', uniqueString(resourceGroup().id))]",
-      "type": "String",
+    "publicIpDns": {
+      "type": "string",
+      "defaultValue": "[format('gw-{0}', uniqueString(resourceGroup().id))]",
       "metadata": {
         "description": "dns of the public ip address, leave blank for no dns"
       }
     },
     "location": {
+      "type": "string",
       "defaultValue": "[resourceGroup().location]",
-      "type": "String",
       "metadata": {
         "description": "Location of resources"
       }
     }
   },
+  "functions": [],
   "variables": {
-    "publicIpName": "[concat(parameters('natgatewayname'), 'ip')]",
+    "publicIpName": "[format('{0}-ip', parameters('natGatewayName'))]",
     "publicIpAddresses": [
       {
-        "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicipname'))]"
+        "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
       }
     ]
   },
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2019-11-01",
+      "apiVersion": "2020-06-01",
       "name": "[variables('publicIpName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -74,47 +82,44 @@
         "publicIPAllocationMethod": "Static",
         "idleTimeoutInMinutes": 4,
         "dnsSettings": {
-          "domainNameLabel": "[parameters('publicipdns')]"
+          "domainNameLabel": "[parameters('publicIpDns')]"
         }
       }
     },
     {
       "type": "Microsoft.Network/natGateways",
-      "apiVersion": "2019-11-01",
-      "name": "[parameters('natgatewayname')]",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('natGatewayName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicipname'))]"
-      ],
       "sku": {
         "name": "Standard"
       },
       "properties": {
         "idleTimeoutInMinutes": 4,
-        "publicIpAddresses": "[if(not(empty(parameters('publicipdns'))), variables('publicIpAddresses'), json('null'))]"
-      }
+        "publicIpAddresses": "[if(not(empty(parameters('publicIpDns'))), variables('publicIpAddresses'), null())]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIpName'))]"
+      ]
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2019-11-01",
-      "name": "[parameters('vnetname')]",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('vnetName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
-      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('vnetaddressspace')]"
+            "[parameters('vnetAddressSpace')]"
           ]
         },
         "subnets": [
           {
-            "name": "[parameters('subnetname')]",
+            "name": "[parameters('subnetName')]",
             "properties": {
-              "addressPrefix": "[parameters('vnetsubnetprefix')]",
+              "addressPrefix": "[parameters('vnetSubnetPrefix')]",
               "natGateway": {
-                "id": "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
+                "id": "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
               },
               "privateEndpointNetworkPolicies": "Enabled",
               "privateLinkServiceNetworkPolicies": "Enabled"
@@ -123,24 +128,27 @@
         ],
         "enableDdosProtection": false,
         "enableVmProtection": false
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
+      ]
     },
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2019-11-01",
-      "name": "[concat(parameters('vnetname'), '/mySubnet')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetname'))]",
-        "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
-      ],
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('vnetName'), 'mySubnet')]",
       "properties": {
-        "addressPrefix": "[parameters('vnetsubnetprefix')]",
+        "addressPrefix": "[parameters('vnetSubnetPrefix')]",
         "natGateway": {
-          "id": "[resourceId('Microsoft.Network/natGateways', parameters('natgatewayname'))]"
+          "id": "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]"
         },
         "privateEndpointNetworkPolicies": "Enabled",
         "privateLinkServiceNetworkPolicies": "Enabled"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/natGateways', parameters('natGatewayName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
+      ]
     }
   ]
 }

--- a/quickstarts/microsoft.network/nat-gateway-vnet/main.bicep
+++ b/quickstarts/microsoft.network/nat-gateway-vnet/main.bicep
@@ -1,0 +1,95 @@
+@description('Name of the virtual network')
+param vnetName string = 'myVnet'
+
+@description('Name of the subnet for virtual network')
+param subnetName string = 'mySubnet'
+
+@description('Address space for virtual network')
+param vnetAddressSpace string = '192.168.0.0/16'
+
+@description('Subnet prefix for virtual network')
+param vnetSubnetPrefix string = '192.168.0.0/24'
+
+@description('Name of the NAT gateway resource')
+param natGatewayName string = 'myNATgateway'
+
+@description('dns of the public ip address, leave blank for no dns')
+param publicIpDns string = 'gw-${uniqueString(resourceGroup().id)}'
+
+@description('Location of resources')
+param location string = resourceGroup().location
+
+var publicIpName = '${natGatewayName}-ip'
+var publicIpAddresses = [
+  {
+    id: publicIp.id
+  }
+]
+
+resource publicIp 'Microsoft.Network/publicIPAddresses@2020-06-01' = {
+  name: publicIpName
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAddressVersion: 'IPv4'
+    publicIPAllocationMethod: 'Static'
+    idleTimeoutInMinutes: 4
+    dnsSettings: {
+      domainNameLabel: publicIpDns
+    }
+  }
+}
+
+resource natGateway 'Microsoft.Network/natGateways@2020-06-01' = {
+  name: natGatewayName
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    idleTimeoutInMinutes: 4
+    publicIpAddresses: !empty(publicIpDns) ? publicIpAddresses : null
+  }
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+  name: vnetName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressSpace
+      ]
+    }
+    subnets: [
+      {
+        name: subnetName
+        properties: {
+          addressPrefix: vnetSubnetPrefix
+          natGateway: {
+            id: natGateway.id
+          }
+          privateEndpointNetworkPolicies: 'Enabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+    ]
+    enableDdosProtection: false
+    enableVmProtection: false
+  }
+}
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+  parent: vnet
+  name: 'mySubnet'
+  properties: {
+    addressPrefix: vnetSubnetPrefix
+    natGateway: {
+      id: natGateway.id
+    }
+    privateEndpointNetworkPolicies: 'Enabled'
+    privateLinkServiceNetworkPolicies: 'Enabled'
+  }
+}

--- a/quickstarts/microsoft.network/nat-gateway-vnet/metadata.json
+++ b/quickstarts/microsoft.network/nat-gateway-vnet/metadata.json
@@ -5,7 +5,7 @@
   "description": "Deploy a NAT gateway and virtual network",
   "summary": "Deploy a NAT gateway and virtual network.  The NAT gateway resource will be associated with the single subnet in the virtual network",
   "githubUsername": "asudbring",
-  "dateUpdated": "2021-05-12",
+  "dateUpdated": "2021-06-15",
   "environments": [
     "AzureCloud"
   ]


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/nat-gateway-vnet

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3236