### PR TITLE
Migrate bicep example: 101/sqlmi-new-vnet

### DIFF
--- a/quickstarts/microsoft.sql/sqlmi-new-vnet/README.md
+++ b/quickstarts/microsoft.sql/sqlmi-new-vnet/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.sql/sqlmi-new-vnet/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.sql/sqlmi-new-vnet/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.sql/sqlmi-new-vnet/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.sql%2Fsqlmi-new-vnet%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.sql%2Fsqlmi-new-vnet%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.sql%2Fsqlmi-new-vnet%2Fazuredeploy.json)

--- a/quickstarts/microsoft.sql/sqlmi-new-vnet/azuredeploy.json
+++ b/quickstarts/microsoft.sql/sqlmi-new-vnet/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.1",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "6566447512027820895"
+    }
+  },
   "parameters": {
     "managedInstanceName": {
       "type": "string",
@@ -15,7 +22,7 @@
       }
     },
     "administratorLoginPassword": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Enter password."
       }
@@ -85,8 +92,8 @@
     "storageSizeInGB": {
       "type": "int",
       "defaultValue": 256,
-      "minValue": 32,
       "maxValue": 8192,
+      "minValue": 32,
       "metadata": {
         "description": "Enter storage size."
       }
@@ -103,9 +110,10 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "networkSecurityGroupName": "[concat('SQLMI-', parameters('managedInstanceName'), '-NSG')]",
-    "routeTableName": "[concat('SQLMI-', parameters('managedInstanceName'), '-Route-Table')]"
+    "networkSecurityGroupName": "[format('SQLMI-{0}-NSG', parameters('managedInstanceName'))]",
+    "routeTableName": "[format('SQLMI-{0}-Route-Table', parameters('managedInstanceName'))]"
   },
   "resources": [
     {
@@ -188,10 +196,6 @@
       "apiVersion": "2020-06-01",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('routeTableName')]",
-        "[variables('networkSecurityGroupName')]"
-      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -211,7 +215,7 @@
               },
               "delegations": [
                 {
-                  "name": "miDelegation",
+                  "name": "managedInstanceDelegation",
                   "properties": {
                     "serviceName": "Microsoft.Sql/managedInstances"
                   }
@@ -220,7 +224,11 @@
             }
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
+        "[resourceId('Microsoft.Network/routeTables', variables('routeTableName'))]"
+      ]
     },
     {
       "type": "Microsoft.Sql/managedInstances",
@@ -233,9 +241,6 @@
       "identity": {
         "type": "SystemAssigned"
       },
-      "dependsOn": [
-        "[parameters('virtualNetworkName')]"
-      ],
       "properties": {
         "administratorLogin": "[parameters('administratorLogin')]",
         "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
@@ -243,7 +248,10 @@
         "storageSizeInGB": "[parameters('storageSizeInGB')]",
         "vCores": "[parameters('vCores')]",
         "licenseType": "[parameters('licenseType')]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
     }
   ]
 }

--- a/quickstarts/microsoft.sql/sqlmi-new-vnet/azuredeploy.json
+++ b/quickstarts/microsoft.sql/sqlmi-new-vnet/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "6566447512027820895"
+      "version": "0.4.412.5873",
+      "templateHash": "12536359447865472095"
     }
   },
   "parameters": {

--- a/quickstarts/microsoft.sql/sqlmi-new-vnet/main.bicep
+++ b/quickstarts/microsoft.sql/sqlmi-new-vnet/main.bicep
@@ -1,0 +1,187 @@
+@description('Enter managed instance name.')
+param managedInstanceName string
+
+@description('Enter user name.')
+param administratorLogin string
+
+@description('Enter password.')
+@secure()
+param administratorLoginPassword string
+
+@description('Enter location. If you leave this field blank resource group location would be used.')
+param location string = resourceGroup().location
+
+@description('Enter virtual network name. If you leave this field blank name will be created by the template.')
+param virtualNetworkName string = 'SQLMI-VNET'
+
+@description('Enter virtual network address prefix.')
+param addressPrefix string = '10.0.0.0/16'
+
+@description('Enter subnet name.')
+param subnetName string = 'ManagedInstance'
+
+@description('Enter subnet address prefix.')
+param subnetPrefix string = '10.0.0.0/24'
+
+@description('Enter sku name.')
+@allowed([
+  'GP_Gen5'
+  'BC_Gen5'
+])
+param skuName string = 'GP_Gen5'
+
+@description('Enter number of vCores.')
+@allowed([
+  8
+  16
+  24
+  32
+  40
+  64
+  80
+])
+param vCores int = 16
+
+@description('Enter storage size.')
+@minValue(32)
+@maxValue(8192)
+param storageSizeInGB int = 256
+
+@description('Enter license type.')
+@allowed([
+  'BasePrice'
+  'LicenseIncluded'
+])
+param licenseType string = 'LicenseIncluded'
+
+var networkSecurityGroupName = 'SQLMI-${managedInstanceName}-NSG'
+var routeTableName = 'SQLMI-${managedInstanceName}-Route-Table'
+
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2020-06-01' = {
+  name: networkSecurityGroupName
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'allow_tds_inbound'
+        properties: {
+          description: 'Allow access to data'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '1433'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 1000
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'allow_redirect_inbound'
+        properties: {
+          description: 'Allow inbound redirect traffic to Managed Instance inside the virtual network'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '11000-11999'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 1100
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'deny_all_inbound'
+        properties: {
+          description: 'Deny all other inbound traffic'
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: '*'
+          access: 'Deny'
+          priority: 4096
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'deny_all_outbound'
+        properties: {
+          description: 'Deny all other outbound traffic'
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: '*'
+          access: 'Deny'
+          priority: 4096
+          direction: 'Outbound'
+        }
+      }
+    ]
+  }
+}
+
+resource routeTable 'Microsoft.Network/routeTables@2020-06-01' = {
+  name: routeTableName
+  location: location
+  properties: {
+    disableBgpRoutePropagation: false
+  }
+}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        addressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: subnetName
+        properties: {
+          addressPrefix: subnetPrefix
+          routeTable: {
+            id: routeTable.id
+          }
+          networkSecurityGroup: {
+            id: networkSecurityGroup.id
+          }
+          delegations: [
+            {
+              name: 'managedInstanceDelegation'
+              properties: {
+                serviceName: 'Microsoft.Sql/managedInstances'
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource managedInstanceName_resource 'Microsoft.Sql/managedInstances@2020-02-02-preview' = {
+  name: managedInstanceName
+  location: location
+  sku: {
+    name: skuName
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+  properties: {
+    administratorLogin: administratorLogin
+    administratorLoginPassword: administratorLoginPassword
+    subnetId: resourceId('Microsoft.Network/virtualNetworks/subnets', virtualNetworkName, subnetName)
+    storageSizeInGB: storageSizeInGB
+    vCores: vCores
+    licenseType: licenseType
+  }
+  dependsOn: [
+    virtualNetwork
+  ]
+}

--- a/quickstarts/microsoft.sql/sqlmi-new-vnet/main.bicep
+++ b/quickstarts/microsoft.sql/sqlmi-new-vnet/main.bicep
@@ -164,7 +164,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2020-06-01' = {
   }
 }
 
-resource managedInstanceName_resource 'Microsoft.Sql/managedInstances@2020-02-02-preview' = {
+resource managedInstance 'Microsoft.Sql/managedInstances@2020-02-02-preview' = {
   name: managedInstanceName
   location: location
   sku: {

--- a/quickstarts/microsoft.sql/sqlmi-new-vnet/main.bicep
+++ b/quickstarts/microsoft.sql/sqlmi-new-vnet/main.bicep
@@ -173,6 +173,9 @@ resource managedInstance 'Microsoft.Sql/managedInstances@2020-02-02-preview' = {
   identity: {
     type: 'SystemAssigned'
   }
+  dependsOn: [
+    virtualNetwork
+  ]
   properties: {
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorLoginPassword
@@ -181,7 +184,4 @@ resource managedInstance 'Microsoft.Sql/managedInstances@2020-02-02-preview' = {
     vCores: vCores
     licenseType: licenseType
   }
-  dependsOn: [
-    virtualNetwork
-  ]
 }

--- a/quickstarts/microsoft.sql/sqlmi-new-vnet/metadata.json
+++ b/quickstarts/microsoft.sql/sqlmi-new-vnet/metadata.json
@@ -6,5 +6,5 @@
   "summary": "Deploy Azure Sql Database Managed Instance (SQL MI) inside new Virtual Network",
   "githubUsername": "srdan-bozovic-msft",
   "docOwner": "stevestein",
-  "dateUpdated": "2021-06-16"
+  "dateUpdated": "2021-08-18"
 }

--- a/quickstarts/microsoft.sql/sqlmi-new-vnet/metadata.json
+++ b/quickstarts/microsoft.sql/sqlmi-new-vnet/metadata.json
@@ -6,5 +6,5 @@
   "summary": "Deploy Azure Sql Database Managed Instance (SQL MI) inside new Virtual Network",
   "githubUsername": "srdan-bozovic-msft",
   "docOwner": "stevestein",
-  "dateUpdated": "2021-04-29"
+  "dateUpdated": "2021-06-16"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/sqlmi-new-vnet

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3244