### PR TITLE
Update vnet integration and default to route all enabled

### DIFF
--- a/quickstarts/microsoft.web/app-service-regional-vnet-integration/azuredeploy.json
+++ b/quickstarts/microsoft.web/app-service-regional-vnet-integration/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "4078227690523503856"
+      "version": "0.4.63.48766",
+      "templateHash": "7153102444456594205"
     }
   },
   "parameters": {
@@ -75,29 +75,22 @@
     },
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2021-01-01",
       "name": "[parameters('appName')]",
       "location": "[parameters('location')]",
       "kind": "app",
       "properties": {
-        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]"
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
+        "virtualNetworkSubnetId": "[reference(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))).subnets[0].id]",
+        "httpsOnly": true,
+        "siteConfig": {
+          "vnetRouteAllEnabled": true,
+          "http20Enabled": true
+        }
       },
       "dependsOn": [
         "[resourceId('Microsoft.Web/serverfarms', variables('appServicePlanName'))]",
         "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Web/sites/networkConfig",
-      "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', parameters('appName'), 'virtualNetwork')]",
-      "properties": {
-        "subnetResourceId": "[reference(resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))).subnets[0].id]",
-        "swiftSupported": true
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]",
-        "[resourceId('Microsoft.Web/sites', parameters('appName'))]"
       ]
     }
   ]

--- a/quickstarts/microsoft.web/app-service-regional-vnet-integration/main.bicep
+++ b/quickstarts/microsoft.web/app-service-regional-vnet-integration/main.bicep
@@ -48,23 +48,17 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
   }
 }
 
-resource webApp 'Microsoft.Web/sites@2020-06-01' = {
+resource webApp 'Microsoft.Web/sites@2021-01-01' = {
   name: appName
   location: location
   kind: 'app'
   properties: {
     serverFarmId: appServicePlan.id
-  }
-  dependsOn: [
-    vnet
-  ]
-}
-
-resource webappVnet 'Microsoft.Web/sites/networkConfig@2020-06-01' = {
-  parent: webApp
-  name: 'virtualNetwork'
-  properties: {
-    subnetResourceId: vnet.properties.subnets[0].id
-    swiftSupported: true
+    virtualNetworkSubnetId: vnet.properties.subnets[0].id
+    httpsOnly: true
+    siteConfig: {
+      vnetRouteAllEnabled: true
+      http20Enabled: true
+    }
   }
 }


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Change vnet integration to use new pre-join option (virtualNetworkSubnetId)
* Default vnet integration traffic routing to all traffic
