### PR TITLE
Migrate bicep example: 101/vnet-two-subnets

### DIFF
--- a/quickstarts/microsoft.network/vnet-two-subnets/README.md
+++ b/quickstarts/microsoft.network/vnet-two-subnets/README.md
@@ -9,8 +9,11 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/vnet-two-subnets/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/vnet-two-subnets/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/vnet-two-subnets/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fvnet-two-subnets%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fvnet-two-subnets%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fvnet-two-subnets%2Fazuredeploy.json)
 
 This template allows you to create a Virtual Network with two subnets.
+

--- a/quickstarts/microsoft.network/vnet-two-subnets/azuredeploy.json
+++ b/quickstarts/microsoft.network/vnet-two-subnets/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "5667812852678460186"
+      "version": "0.4.451.19169",
+      "templateHash": "12158665104972174025"
     }
   },
   "parameters": {
@@ -93,6 +93,7 @@
         "addressPrefix": "[parameters('subnet2Prefix')]"
       },
       "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnet1Name'))]",
         "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
       ]
     }

--- a/quickstarts/microsoft.network/vnet-two-subnets/azuredeploy.json
+++ b/quickstarts/microsoft.network/vnet-two-subnets/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.451.19169",
-      "templateHash": "12158665104972174025"
+      "version": "0.4.412.5873",
+      "templateHash": "17421496824516967129"
     }
   },
   "parameters": {
@@ -62,19 +62,6 @@
   "functions": [],
   "resources": [
     {
-      "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-06-01",
-      "name": "[parameters('vnetName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[parameters('vnetAddressPrefix')]"
-          ]
-        }
-      }
-    },
-    {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2020-06-01",
       "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnet1Name'))]",
@@ -96,6 +83,19 @@
         "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnet1Name'))]",
         "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
       ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('vnetName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('vnetAddressPrefix')]"
+          ]
+        }
+      }
     }
   ]
 }

--- a/quickstarts/microsoft.network/vnet-two-subnets/azuredeploy.json
+++ b/quickstarts/microsoft.network/vnet-two-subnets/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "5667812852678460186"
+    }
+  },
   "parameters": {
     "vnetName": {
       "type": "string",
@@ -52,11 +59,11 @@
       }
     }
   },
-  "variables": {},
+  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-05-01",
+      "apiVersion": "2020-06-01",
       "name": "[parameters('vnetName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -65,33 +72,28 @@
             "[parameters('vnetAddressPrefix')]"
           ]
         }
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnet1Name'))]",
+      "properties": {
+        "addressPrefix": "[parameters('subnet1Prefix')]"
       },
-      "resources": [
-        {
-          "type": "subnets",
-          "apiVersion": "2020-05-01",
-          "location": "[parameters('location')]",
-          "name": "[parameters('subnet1Name')]",
-          "dependsOn": [
-            "[parameters('vnetName')]"
-          ],
-          "properties": {
-            "addressPrefix": "[parameters('subnet1Prefix')]"
-          }
-        },
-        {
-          "type": "subnets",
-          "apiVersion": "2020-05-01",
-          "location": "[parameters('location')]",
-          "name": "[parameters('subnet2Name')]",
-          "dependsOn": [
-            "[parameters('vnetName')]",
-            "[parameters('subnet1Name')]"
-          ],
-          "properties": {
-            "addressPrefix": "[parameters('subnet2Prefix')]"
-          }
-        }
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('vnetName'), parameters('subnet2Name'))]",
+      "properties": {
+        "addressPrefix": "[parameters('subnet2Prefix')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnetName'))]"
       ]
     }
   ]

--- a/quickstarts/microsoft.network/vnet-two-subnets/main.bicep
+++ b/quickstarts/microsoft.network/vnet-two-subnets/main.bicep
@@ -39,12 +39,12 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
 
   resource subnet2 'subnets' = {
     name: subnet2Name
-    properties: {
-      addressPrefix: subnet2Prefix
-    }
     dependsOn: [
       // This ensures only one subnets is created at a time (so they're not both trying to modify the vnet at the same)
       subnet1
     ]
+    properties: {
+      addressPrefix: subnet2Prefix
+    }
   }
 }

--- a/quickstarts/microsoft.network/vnet-two-subnets/main.bicep
+++ b/quickstarts/microsoft.network/vnet-two-subnets/main.bicep
@@ -29,23 +29,22 @@ resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
       ]
     }
   }
-}
 
-resource subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-  parent: vnet
-  name: subnet1Name
-  properties: {
-    addressPrefix: subnet1Prefix
+  resource subnet1 'subnets' = {
+    name: subnet1Name
+    properties: {
+      addressPrefix: subnet1Prefix
+    }
   }
-}
 
-resource subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
-  parent: vnet
-  name: subnet2Name
-  properties: {
-    addressPrefix: subnet2Prefix
+  resource subnet2 'subnets' = {
+    name: subnet2Name
+    properties: {
+      addressPrefix: subnet2Prefix
+    }
+    dependsOn: [
+      // This ensures only one subnets is created at a time (so they're not both trying to modify the vnet at the same)
+      subnet1
+    ]
   }
-  dependsOn: [
-    subnet1
-  ]
 }

--- a/quickstarts/microsoft.network/vnet-two-subnets/main.bicep
+++ b/quickstarts/microsoft.network/vnet-two-subnets/main.bicep
@@ -45,4 +45,7 @@ resource subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
   properties: {
     addressPrefix: subnet2Prefix
   }
+  dependsOn: [
+    subnet1
+  ]
 }

--- a/quickstarts/microsoft.network/vnet-two-subnets/main.bicep
+++ b/quickstarts/microsoft.network/vnet-two-subnets/main.bicep
@@ -1,0 +1,48 @@
+@description('VNet name')
+param vnetName string = 'VNet1'
+
+@description('Address prefix')
+param vnetAddressPrefix string = '10.0.0.0/16'
+
+@description('Subnet 1 Prefix')
+param subnet1Prefix string = '10.0.0.0/24'
+
+@description('Subnet 1 Name')
+param subnet1Name string = 'Subnet1'
+
+@description('Subnet 2 Prefix')
+param subnet2Prefix string = '10.0.1.0/24'
+
+@description('Subnet 2 Name')
+param subnet2Name string = 'Subnet2'
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+resource vnet 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+  name: vnetName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+  }
+}
+
+resource subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+  parent: vnet
+  name: subnet1Name
+  properties: {
+    addressPrefix: subnet1Prefix
+  }
+}
+
+resource subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+  parent: vnet
+  name: subnet2Name
+  properties: {
+    addressPrefix: subnet2Prefix
+  }
+}

--- a/quickstarts/microsoft.network/vnet-two-subnets/metadata.json
+++ b/quickstarts/microsoft.network/vnet-two-subnets/metadata.json
@@ -6,5 +6,5 @@
   "summary": "Create a Virtual Network with two Subnets",
   "githubUsername": "telmosampaio",
   "docOwner": "KumudD",
-  "dateUpdated": "2021-05-11"
+  "dateUpdated": "2021-06-21"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/vnet-two-subnets

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3291