### PR TITLE
Migrate bicep example: 101/webapp-privateendpoint-vnet-injection

### DIFF
--- a/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/README.md
+++ b/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.web%2Fwebapp-privateendpoint-vnet-injection%2Fazuredeploy.json)
 
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.web%2Fwebapp-privateendpoint-vnet-injection%2Fazuredeploy.json)
@@ -27,3 +29,4 @@ If you are new to template deployment, see:
 [Azure Resource Manager documentation](https://docs.microsoft.com/azure/azure-resource-manager/)
 
 `Tags: appServices`
+

--- a/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/azuredeploy.json
+++ b/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/azuredeploy.json
@@ -1,372 +1,367 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "virtualNetwork_name": {
-            "type": "String",
-            "defaultValue": "vnet1",
-            "metadata":{
-                "description": "Name of the VNet"
-            }
-        },
-        "serverFarm_name": {
-            "type": "String",
-            "defaultValue": "serverfarm",
-            "metadata":{
-                "description": "Name of the Web Farm"
-            }
-        },
-        "site1_name": {
-            "type": "String",
-            "defaultValue": "[concat('webapp1', uniqueString(resourceGroup().id))]", 
-            "metadata":{
-                "description": "Web App 1 name must be unique DNS name worldwide"
-            }
-        },
-        "site2_name": {
-            "type": "String",
-            "defaultValue": "[concat('webapp2', uniqueString(resourceGroup().id))]",
-            "metadata":{
-                "description": "Web App 2 name must be unique DNS name worldwide"
-            }
-        },
-        "virtualNetwork_CIDR": {
-            "type": "String",
-            "defaultValue": "10.200.0.0/16",
-            "metadata":{
-                "description": "CIDR of your VNet"
-            }
-        },
-        "subnet1_name": {
-            "type": "String",
-            "defaultValue": "Subnet1",
-            "metadata":{
-                "description": "Name of the subnet"
-            }
-        },
-        "subnet2_name": {
-            "type": "String",
-            "defaultValue": "Subnet2",
-            "metadata":{
-                "description": "Name of the subnet"
-            }
-        },
-        "subnet1_CIDR": {
-            "type": "String",
-            "defaultValue": "10.200.1.0/24",
-            "metadata":{
-                "description": "CIDR of your subnet"
-            }
-        },
-        "subnet2_CIDR": {
-            "type": "String",
-            "defaultValue": "10.200.2.0/24",
-            "metadata":{
-                "description": "CIDR of your subnet"
-            }
-        },
-        "location": {
-            "type": "string",
-            "defaultValue": "[resourceGroup().location]",
-            "metadata":{
-                "description": "Location for all resources."
-            }
-        },
-        "SKU_name": {
-            "type": "String",
-            "defaultValue": "P1v2",
-            "allowedValues": [
-                "P1v2",
-                "P2v2",
-                "P3v2"
-                ],
-            "metadata":{
-                "description": "SKU name, must be minimum P1v2"
-            }
-        },
-        "SKU_size": {
-            "type": "String",
-            "defaultValue": "P1v2",
-            "allowedValues": [
-                "P1v2",
-                "P2v2",
-                "P3v2"
-                ],
-            "metadata":{
-                "description": "SKU size, must be minimum P1v2"
-            }
-        },
-        "SKU_family": {
-            "type": "String",
-            "defaultValue": "P1v2",
-            "allowedValues": [
-                "P1v2",
-                "P2v2",
-                "P3v2"
-                ],
-            "metadata":{
-                "description": "SKU family, must be minimum P1v2"
-            }
-        },
-        "privateEndpoint_name": {
-            "type": "string",
-            "defaultValue": "PrivateEndpoint1",
-            "metadata":{
-                "description": "Name of your Private Endpoint"
-            }
-        },
-        "privateLinkConnection_name": {
-            "type": "string",
-            "defaultValue": "PrivateEndpointLink1",
-            "metadata":{
-                "description": "Link name between your Private Endpoint and your Web App"
-            }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "1915532474745147129"
+    }
+  },
+  "parameters": {
+    "virtualNetworkName": {
+      "type": "string",
+      "defaultValue": "vnet1",
+      "metadata": {
+        "description": "Name of the VNet"
+      }
+    },
+    "serverFarmName": {
+      "type": "string",
+      "defaultValue": "serverfarm",
+      "metadata": {
+        "description": "Name of the Web Farm"
+      }
+    },
+    "site1_Name": {
+      "type": "string",
+      "defaultValue": "[format('webapp1-{0}', uniqueString(resourceGroup().id))]",
+      "metadata": {
+        "description": "Web App 1 name must be unique DNS name worldwide"
+      }
+    },
+    "site2_Name": {
+      "type": "string",
+      "defaultValue": "[format('webapp2-{0}', uniqueString(resourceGroup().id))]",
+      "metadata": {
+        "description": "Web App 2 name must be unique DNS name worldwide"
+      }
+    },
+    "virtualNetwork_CIDR": {
+      "type": "string",
+      "defaultValue": "10.200.0.0/16",
+      "metadata": {
+        "description": "CIDR of your VNet"
+      }
+    },
+    "subnet1Name": {
+      "type": "string",
+      "defaultValue": "Subnet1",
+      "metadata": {
+        "description": "Name of the subnet"
+      }
+    },
+    "subnet2Name": {
+      "type": "string",
+      "defaultValue": "Subnet2",
+      "metadata": {
+        "description": "Name of the subnet"
+      }
+    },
+    "subnet1_CIDR": {
+      "type": "string",
+      "defaultValue": "10.200.1.0/24",
+      "metadata": {
+        "description": "CIDR of your subnet"
+      }
+    },
+    "subnet2_CIDR": {
+      "type": "string",
+      "defaultValue": "10.200.2.0/24",
+      "metadata": {
+        "description": "CIDR of your subnet"
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    },
+    "skuName": {
+      "type": "string",
+      "defaultValue": "P1v2",
+      "allowedValues": [
+        "P1v2",
+        "P2v2",
+        "P3v2"
+      ],
+      "metadata": {
+        "description": "SKU name, must be minimum P1v2"
+      }
+    },
+    "skuSize": {
+      "type": "string",
+      "defaultValue": "P1v2",
+      "allowedValues": [
+        "P1v2",
+        "P2v2",
+        "P3v2"
+      ],
+      "metadata": {
+        "description": "SKU size, must be minimum P1v2"
+      }
+    },
+    "skuFamily": {
+      "type": "string",
+      "defaultValue": "P1v2",
+      "allowedValues": [
+        "P1v2",
+        "P2v2",
+        "P3v2"
+      ],
+      "metadata": {
+        "description": "SKU family, must be minimum P1v2"
+      }
+    },
+    "privateEndpointName": {
+      "type": "string",
+      "defaultValue": "PrivateEndpoint1",
+      "metadata": {
+        "description": "Name of your Private Endpoint"
+      }
+    },
+    "privateLinkConnectionName": {
+      "type": "string",
+      "defaultValue": "PrivateEndpointLink1",
+      "metadata": {
+        "description": "Link name between your Private Endpoint and your Web App"
+      }
+    }
+  },
+  "functions": [],
+  "variables": {
+    "webapp_dns_name": ".azurewebsites.net",
+    "privateDNSZoneName": "privatelink.azurewebsites.net",
+    "SKU_tier": "PremiumV2"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('virtualNetworkName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[parameters('virtualNetwork_CIDR')]"
+          ]
         }
+      }
     },
-    "variables": {
-        "webapp_dns_name": ".azurewebsites.net",
-        "privateDNSZone_name": "privatelink.azurewebsites.net",
-        "SKU_tier": "PremiumV2"
-        
-
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnet1Name'))]",
+      "properties": {
+        "addressPrefix": "[parameters('subnet1_CIDR')]",
+        "privateEndpointNetworkPolicies": "Disabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
     },
-    "resources": [
-        {
-            "type": "Microsoft.Network/virtualNetworks",
-            "apiVersion": "2020-04-01",
-            "name": "[parameters('virtualNetwork_name')]",
-            "location": "[parameters('location')]",
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnet2Name'))]",
+      "properties": {
+        "addressPrefix": "[parameters('subnet2_CIDR')]",
+        "delegations": [
+          {
+            "name": "delegation",
             "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[parameters('virtualNetwork_CIDR')]"
-                    ]
-                }
+              "serviceName": "Microsoft.Web/serverfarms"
             }
-        },
-        {
-            "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2020-04-01",
-            "name": "[concat(parameters('virtualNetwork_name'),'/', parameters('subnet1_name'))]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetwork_name'))]"
-            ],
-            "properties": {
-                "addressPrefix": "[parameters('subnet1_CIDR')]",
-                "privateEndpointNetworkPolicies": "Disabled"
-            }
-        },
-        {
-            "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2020-04-01",
-            "name": "[concat(parameters('virtualNetwork_name'),'/', parameters('subnet2_name'))]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetwork_name'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetwork_name'), parameters('subnet1_name'))]"
-            ],
-            "properties": {
-                "addressPrefix": "[parameters('subnet2_CIDR')]",
-                "delegations": [
-                                {
-                                    "name": "delegation",
-                                    "properties": {
-                                        "serviceName": "Microsoft.Web/serverfarms"
-                                    }
-                                }
-                            ],
-                "privateEndpointNetworkPolicies": "Enabled"
-            }
-        },
-        {
-            "type": "Microsoft.Web/serverfarms",
-            "apiVersion": "2019-08-01",
-            "name": "[parameters('serverFarm_name')]",
-            "location": "[parameters('location')]",
-            "sku": {
-                "name": "[parameters('SKU_name')]",
-                "tier": "[variables('SKU_tier')]",
-                "size": "[parameters('SKU_size')]",
-                "family": "[parameters('SKU_family')]",
-                "capacity": 1
-            },
-            "kind": "app"
-
-        },
-        {
-            "type": "Microsoft.Web/sites",
-            "apiVersion": "2019-08-01",
-            "name": "[parameters('site1_name')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarm_name'))]"
-            ],
-            "kind": "app",
-            "properties": {
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarm_name'))]"
-            }
-        },
-        {
-            "type": "Microsoft.Web/sites",
-            "apiVersion": "2019-08-01",
-            "name": "[parameters('site2_name')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarm_name'))]"
-            ],
-            "kind": "app",
-            "properties": {
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarm_name'))]"
-            },
-            "resources":[
-                {
-                    "name": "appsettings",
-                    "type": "config",
-                    "apiVersion": "2018-11-01",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/sites', parameters('site2_name'))]"
-                    ],
-                    "properties": {
-                        "WEBSITE_DNS_SERVER": "168.63.129.16",
-                        "WEBSITE_VNET_ROUTE_ALL": "1"
-                    }
-                }
-            ]
-        },
-        {
-            "type": "Microsoft.Web/sites/config",
-            "apiVersion": "2019-08-01",
-            "name": "[concat(parameters('site1_name'), '/web')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('site1_name'))]"
-            ],
-            "properties": {
-                "ftpsState": "AllAllowed"
-            }
-        },
-                {
-            "type": "Microsoft.Web/sites/config",
-            "apiVersion": "2019-08-01",
-            "name": "[concat(parameters('site2_name'), '/web')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('site2_name'))]"
-            ],
-            "properties": {
-                "ftpsState": "AllAllowed"
-            }
-        },
-        {
-            "type": "Microsoft.Web/sites/hostNameBindings",
-            "apiVersion": "2019-08-01",
-            "name": "[concat(parameters('site1_name'), '/', parameters('site1_name'), variables('webapp_dns_name'))]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('site1_name'))]"
-            ],
-            "properties": {
-                "siteName": "[parameters('site1_name')]",
-                "hostNameType": "Verified"
-            }
-        },
-        {
-            "type": "Microsoft.Web/sites/hostNameBindings",
-            "apiVersion": "2019-08-01",
-            "name": "[concat(parameters('site2_name'), '/', parameters('site2_name'), variables('webapp_dns_name'))]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('site2_name'))]"
-            ],
-            "properties": {
-                "siteName": "[parameters('site2_name')]",
-                "hostNameType": "Verified"
-            }
-        },
-        {
-            "type": "Microsoft.Web/sites/networkConfig",
-            "apiVersion": "2019-08-01",
-            "name": "[concat(parameters('site2_name'), '/VirtualNetwork')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetwork_name'), parameters('subnet2_name'))]",
-                "[resourceId('Microsoft.Web/sites', parameters('site2_name'))]"
-            ],
-          "properties": {
-            "subnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetwork_name'), parameters('subnet2_name'))]"
-
           }
+        ],
+        "privateEndpointNetworkPolicies": "Enabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnet1Name'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('serverFarmName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[parameters('skuName')]",
+        "tier": "[variables('SKU_tier')]",
+        "size": "[parameters('skuSize')]",
+        "family": "[parameters('skuFamily')]",
+        "capacity": 1
+      },
+      "kind": "app"
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('site1_Name')]",
+      "location": "[parameters('location')]",
+      "kind": "app",
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarmName'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarmName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('site2_Name')]",
+      "location": "[parameters('location')]",
+      "kind": "app",
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarmName'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', parameters('serverFarmName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('site2_Name'), 'appsettings')]",
+      "properties": {
+        "WEBSITE_DNS_SERVER": "168.63.129.16",
+        "WEBSITE_VNET_ROUTE_ALL": "1"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('site2_Name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('site1_Name'), 'web')]",
+      "properties": {
+        "ftpsState": "AllAllowed"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('site1_Name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/config",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('site2_Name'), 'web')]",
+      "properties": {
+        "ftpsState": "AllAllowed"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('site2_Name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/hostNameBindings",
+      "apiVersion": "2019-08-01",
+      "name": "[format('{0}/{1}', parameters('site1_Name'), format('{0}{1}', parameters('site1_Name'), variables('webapp_dns_name')))]",
+      "properties": {
+        "siteName": "[parameters('site1_Name')]",
+        "hostNameType": "Verified"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('site1_Name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/hostNameBindings",
+      "apiVersion": "2019-08-01",
+      "name": "[format('{0}/{1}', parameters('site2_Name'), format('{0}{1}', parameters('site2_Name'), variables('webapp_dns_name')))]",
+      "properties": {
+        "siteName": "[parameters('site2_Name')]",
+        "hostNameType": "Verified"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('site2_Name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/networkConfig",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('site2_Name'), 'virtualNetwork')]",
+      "properties": {
+        "subnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnet2Name'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnet2Name'))]",
+        "[resourceId('Microsoft.Web/sites', parameters('site2_Name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateEndpoints",
+      "apiVersion": "2020-06-01",
+      "name": "[parameters('privateEndpointName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "subnet": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnet1Name'))]"
         },
-        {
-            "type": "Microsoft.Network/privateEndpoints",
-            "apiVersion": "2020-05-01",
-            "name": "[parameters('privateEndpoint_name')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/sites', parameters('site1_name'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetwork_name'), parameters('subnet1_name'))]"
-            ],
+        "privateLinkServiceConnections": [
+          {
+            "name": "[parameters('privateLinkConnectionName')]",
             "properties": {
-                "subnet": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetwork_name'), parameters('subnet1_name'))]"
-                },
-                "privateLinkServiceConnections": [
-                    {
-                        "name": "[parameters('privateLinkConnection_name')]",
-                        "properties": {
-                            "privateLinkServiceId": "[resourceId('Microsoft.Web/sites', parameters('site1_name'))]",
-                            "groupIds": [
-                                "sites"
-                            ]
-                        }
-                    }
-                ]
-            } 
-        },
-        {
-            "type": "Microsoft.Network/privateDnsZones",
-            "apiVersion": "2018-09-01",
-            "name": "[variables('privateDNSZone_name')]",
-            "location": "global",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetwork_name'))]"
-            ] 
-        },
-        {
-            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-            "apiVersion": "2018-09-01",
-            "name": "[concat(variables('privateDNSZone_name'), '/', variables('privateDNSZone_name'), '-link')]",
-            "location": "global",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDNSZone_name'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetwork_name'))]"
-            ],
-            "properties": {
-                "registrationEnabled": false,
-                "virtualNetwork": {
-                    "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetwork_name'))]"
-                }
+              "privateLinkServiceId": "[resourceId('Microsoft.Web/sites', parameters('site1_Name'))]",
+              "groupIds": [
+                "sites"
+              ]
             }
-        },
-        {
-            "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-            "apiVersion": "2020-03-01",
-            "name": "[concat(parameters('privateEndpoint_name'),'/dnsgroupname')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-               "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDNSZone_name'))]",
-               "[resourceId('Microsoft.Network/privateEndpoints' , parameters('privateEndpoint_name'))]"
-             ],
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('subnet1Name'))]",
+        "[resourceId('Microsoft.Web/sites', parameters('site1_Name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones",
+      "apiVersion": "2018-09-01",
+      "name": "[variables('privateDNSZoneName')]",
+      "location": "global",
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+      "apiVersion": "2018-09-01",
+      "name": "[format('{0}/{1}', variables('privateDNSZoneName'), format('{0}-link', variables('privateDNSZoneName')))]",
+      "location": "global",
+      "properties": {
+        "registrationEnabled": false,
+        "virtualNetwork": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDNSZoneName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+      "apiVersion": "2020-03-01",
+      "name": "[format('{0}/{1}', parameters('privateEndpointName'), 'dnsgroupname')]",
+      "properties": {
+        "privateDnsZoneConfigs": [
+          {
+            "name": "config1",
             "properties": {
-                "privateDnsZoneConfigs": [
-                    {
-                        "name": "config1",
-                        "properties": {
-                             "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDNSZone_name'))]"
-                        }
-                    }
-                ]
+              "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDNSZoneName'))]"
             }
-        } 
-       
-    ]
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDNSZoneName'))]",
+        "[resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))]"
+      ]
+    }
+  ]
 }

--- a/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/main.bicep
+++ b/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/main.bicep
@@ -86,6 +86,9 @@ resource subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
 resource subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
   parent: virtualNetwork
   name: subnet2Name
+  dependsOn: [
+    subnet1
+  ]
   properties: {
     addressPrefix: subnet2_CIDR
     delegations: [
@@ -98,9 +101,6 @@ resource subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
     ]
     privateEndpointNetworkPolicies: 'Enabled'
   }
-  dependsOn: [
-    subnet1
-  ]
 }
 
 resource serverFarm 'Microsoft.Web/serverfarms@2020-06-01' = {

--- a/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/main.bicep
+++ b/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/main.bicep
@@ -1,0 +1,242 @@
+@description('Name of the VNet')
+param virtualNetworkName string = 'vnet1'
+
+@description('Name of the Web Farm')
+param serverFarmName string = 'serverfarm'
+
+@description('Web App 1 name must be unique DNS name worldwide')
+param site1_Name string = 'webapp1-${uniqueString(resourceGroup().id)}'
+
+@description('Web App 2 name must be unique DNS name worldwide')
+param site2_Name string = 'webapp2-${uniqueString(resourceGroup().id)}'
+
+@description('CIDR of your VNet')
+param virtualNetwork_CIDR string = '10.200.0.0/16'
+
+@description('Name of the subnet')
+param subnet1Name string = 'Subnet1'
+
+@description('Name of the subnet')
+param subnet2Name string = 'Subnet2'
+
+@description('CIDR of your subnet')
+param subnet1_CIDR string = '10.200.1.0/24'
+
+@description('CIDR of your subnet')
+param subnet2_CIDR string = '10.200.2.0/24'
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+@description('SKU name, must be minimum P1v2')
+@allowed([
+  'P1v2'
+  'P2v2'
+  'P3v2'
+])
+param skuName string = 'P1v2'
+
+@description('SKU size, must be minimum P1v2')
+@allowed([
+  'P1v2'
+  'P2v2'
+  'P3v2'
+])
+param skuSize string = 'P1v2'
+
+@description('SKU family, must be minimum P1v2')
+@allowed([
+  'P1v2'
+  'P2v2'
+  'P3v2'
+])
+param skuFamily string = 'P1v2'
+
+@description('Name of your Private Endpoint')
+param privateEndpointName string = 'PrivateEndpoint1'
+
+@description('Link name between your Private Endpoint and your Web App')
+param privateLinkConnectionName string = 'PrivateEndpointLink1'
+
+var webapp_dns_name = '.azurewebsites.net'
+var privateDNSZoneName = 'privatelink.azurewebsites.net'
+var SKU_tier = 'PremiumV2'
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2020-06-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        virtualNetwork_CIDR
+      ]
+    }
+  }
+}
+
+resource subnet1 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+  parent: virtualNetwork
+  name: subnet1Name
+  properties: {
+    addressPrefix: subnet1_CIDR
+    privateEndpointNetworkPolicies: 'Disabled'
+  }
+}
+
+resource subnet2 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+  parent: virtualNetwork
+  name: subnet2Name
+  properties: {
+    addressPrefix: subnet2_CIDR
+    delegations: [
+      {
+        name: 'delegation'
+        properties: {
+          serviceName: 'Microsoft.Web/serverfarms'
+        }
+      }
+    ]
+    privateEndpointNetworkPolicies: 'Enabled'
+  }
+  dependsOn: [
+    subnet1
+  ]
+}
+
+resource serverFarm 'Microsoft.Web/serverfarms@2020-06-01' = {
+  name: serverFarmName
+  location: location
+  sku: {
+    name: skuName
+    tier: SKU_tier
+    size: skuSize
+    family: skuFamily
+    capacity: 1
+  }
+  kind: 'app'
+}
+
+resource webApp1 'Microsoft.Web/sites@2020-06-01' = {
+  name: site1_Name
+  location: location
+  kind: 'app'
+  properties: {
+    serverFarmId: serverFarm.id
+  }
+}
+
+resource webApp2 'Microsoft.Web/sites@2020-06-01' = {
+  name: site2_Name
+  location: location
+  kind: 'app'
+  properties: {
+    serverFarmId: serverFarm.id
+  }
+}
+
+resource webApp2AppSettings 'Microsoft.Web/sites/config@2020-06-01' = {
+  parent: webApp2
+  name: 'appsettings'
+  properties: {
+    WEBSITE_DNS_SERVER: '168.63.129.16'
+    WEBSITE_VNET_ROUTE_ALL: '1'
+  }
+}
+
+resource webApp1Config 'Microsoft.Web/sites/config@2020-06-01' = {
+  parent: webApp1
+  name: 'web'
+  properties: {
+    ftpsState: 'AllAllowed'
+  }
+}
+
+resource webApp2Config 'Microsoft.Web/sites/config@2020-06-01' = {
+  parent: webApp2
+  name: 'web'
+  properties: {
+    ftpsState: 'AllAllowed'
+  }
+}
+
+resource webApp1Binding 'Microsoft.Web/sites/hostNameBindings@2019-08-01' = {
+  parent: webApp1
+  name: '${webApp1.name}${webapp_dns_name}'
+  properties: {
+    siteName: webApp1.name
+    hostNameType: 'Verified'
+  }
+}
+
+resource webApp2Binding 'Microsoft.Web/sites/hostNameBindings@2019-08-01' = {
+  parent: webApp2
+  name: '${webApp2.name}${webapp_dns_name}'
+  properties: {
+    siteName: webApp2.name
+    hostNameType: 'Verified'
+  }
+}
+
+resource webApp2NetworkConfig 'Microsoft.Web/sites/networkConfig@2020-06-01' = {
+  parent: webApp2
+  name: 'virtualNetwork'
+  properties: {
+    subnetResourceId: subnet2.id
+  }
+}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2020-06-01' = {
+  name: privateEndpointName
+  location: location
+  properties: {
+    subnet: {
+      id: subnet1.id
+    }
+    privateLinkServiceConnections: [
+      {
+        name: privateLinkConnectionName
+        properties: {
+          privateLinkServiceId: webApp1.id
+          groupIds: [
+            'sites'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource privateDnsZones 'Microsoft.Network/privateDnsZones@2018-09-01' = {
+  name: privateDNSZoneName
+  location: 'global'
+  dependsOn: [
+    virtualNetwork
+  ]
+}
+
+resource privateDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2018-09-01' = {
+  parent: privateDnsZones
+  name: '${privateDnsZones.name}-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: virtualNetwork.id
+    }
+  }
+}
+
+resource privateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-03-01' = {
+  parent: privateEndpoint
+  name: 'dnsgroupname'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'config1'
+        properties: {
+          privateDnsZoneId: privateDnsZones.id
+        }
+      }
+    ]
+  }
+}

--- a/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/metadata.json
+++ b/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/metadata.json
@@ -4,7 +4,7 @@
   "description": "This template allows you to create a secure end to end solution with two web apps, front end and back end, front end will consume securely the back through VNet injection and Private Endpoint",
   "summary": "Deploy two web apps and connect it securely with Private Endpoint and VNet injection",
   "githubUsername": "ericgre",
-  "dateUpdated": "2021-06-21",
+  "dateUpdated": "2021-07-09",
   "type": "QuickStart",
   "environments": [
     "AzureCloud"

--- a/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/metadata.json
+++ b/quickstarts/microsoft.web/webapp-privateendpoint-vnet-injection/metadata.json
@@ -4,7 +4,7 @@
   "description": "This template allows you to create a secure end to end solution with two web apps, front end and back end, front end will consume securely the back through VNet injection and Private Endpoint",
   "summary": "Deploy two web apps and connect it securely with Private Endpoint and VNet injection",
   "githubUsername": "ericgre",
-  "dateUpdated": "2021-05-11",
+  "dateUpdated": "2021-06-21",
   "type": "QuickStart",
   "environments": [
     "AzureCloud"


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/webapp-privateendpoint-vnet-injection

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3292