### PR TITLE
Migrate bicep example: 201/cloud-shell-vnet

### DIFF
--- a/demos/cloud-shell-vnet/README.md
+++ b/demos/cloud-shell-vnet/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/demos/cloud-shell-vnet/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/demos/cloud-shell-vnet/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/demos/cloud-shell-vnet/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fcloud-shell-vnet%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fcloud-shell-vnet%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fcloud-shell-vnet%2Fazuredeploy.json)
@@ -29,3 +31,4 @@ You can click the "Deploy to Azure" button at the beginning of this document or 
 After deploying this template and setting up storage, navigate to Cloud Shell in the Azure Portal or on shell.azure.com.
 If Cloud Shell has been used in the past, the existing clouddrive must be unmounted. To do this run `clouddrive unmount` from an active Cloud Shell session.
 Reconnect to Cloud Shell, you will be prompted with the first run experience. Select your preferred shell experience, then navigate to the advanced settings and select the show isolated VNET settings box. Fill in the fields with the desired resources create with this template.
+

--- a/demos/cloud-shell-vnet/azuredeploy.json
+++ b/demos/cloud-shell-vnet/azuredeploy.json
@@ -1,302 +1,289 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "existingVNETName": {
-            "type": "String",
-            "metadata": {
-                "description": "Name of the existing VNET to inject Cloud Shell into."
-            }
-        },
-        "relayNamespaceName": {
-            "type": "String",
-            "metadata": {
-                "description": "Name of Azure Relay Namespace."
-            }
-        },
-        "azureContainerInstanceOID": {
-            "type": "String",
-            "metadata": {
-                "description": "Object Id of Azure Container Instance Service Principal. We have to grant this permission to create hybrid connections in the Azure Relay you specify. To get it - Get-AzADServicePrincipal -DisplayNameBeginsWith 'Azure Container Instance'"
-            }
-        },
-        "containerSubnetName": {
-            "defaultValue": "cloudshellsubnet",
-            "type": "String",
-            "metadata": {
-                "description": "Name of the subnet to use for cloud shell containers."
-            }
-        },
-        "containerSubnetAddressPrefix": {
-            "type": "String",
-            "metadata": {
-                "description": "Address space of the subnet to add for cloud shell. e.g. 10.0.1.0/26"
-            }
-        },
-        "relaySubnetName": {
-            "defaultValue": "relaysubnet",
-            "type": "String",
-            "metadata": {
-                "description": "Name of the subnet to use for private link of relay namespace."
-            }
-        },
-        "relaySubnetAddressPrefix": {
-            "type": "String",
-            "metadata": {
-                "description": "Address space of the subnet to add for relay. e.g. 10.0.2.0/26"
-            }
-        },
-        "storageSubnetName": {
-            "defaultValue": "storagesubnet",
-            "type": "String",
-            "metadata": {
-                "description": "Name of the subnet to use for storage account."
-            }
-        },
-        "storageSubnetAddressPrefix": {
-            "type": "String",
-            "metadata": {
-                "description": "Address space of the subnet to add for storage. e.g. 10.0.3.0/26"
-            }
-        },
-        "privateEndpointName": {
-            "defaultValue": "cloudshellRelayEndpoint",
-            "type": "String",
-            "metadata": {
-                "description": "Name of Private Endpoint for Azure Relay."
-            }
-        },
-        "location": {
-            "defaultValue": "[resourceGroup().location]",
-            "type": "String",
-            "metadata": {
-                "description": "Location for all resources."
-            }
-        }
-    },
-    "variables": {
-        "networkProfileName": "[concat('aci-networkProfile-', parameters('location'))]",
-        "networkProfileRef": "[resourceId('Microsoft.Network/networkProfiles', variables('networkProfileName'))]",
-        "containerSubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]",
-        "relayNamespaceRef": "[resourceId('Microsoft.Relay/namespaces/', parameters('relayNamespaceName'))]",
-        "relaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]",
-        "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-        "networkRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
-        "privateDnsZoneName": "[if(equals(toLower(environment().name), 'azureusgovernment'), 'privatelink.servicebus.usgovcloudapi.net', 'privatelink.servicebus.windows.net')]",
-        "networkRef": "[resourceId('Microsoft.Network/virtualNetworks', parameters('existingVNETName'))]",
-        "privateEndpointRef": "[resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))]"
-    },
-    "resources": [
-        {
-            "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2020-04-01",
-            "name": "[concat(parameters('existingVNETName'), '/', parameters('containerSubnetName'))]",
-            "location": "[parameters('location')]",
-            "properties": {
-                "addressPrefix": "[parameters('containerSubnetAddressPrefix')]",
-                "serviceEndpoints": [
-                    {
-                        "service": "Microsoft.Storage",
-                        "locations": [
-                            "[parameters('location')]"
-                        ]
-                    }
-                ],
-                "delegations": [
-                    {
-                        "name": "CloudShellDelegation",
-                        "properties": {
-                            "serviceName": "Microsoft.ContainerInstance/containerGroups"
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/networkProfiles",
-            "apiVersion": "2019-11-01",
-            "name": "[variables('networkProfileName')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[variables('containerSubnetRef')]"
-            ],
-            "properties": {
-                "containerNetworkInterfaceConfigurations": [
-                    {
-                        "name": "[concat('eth-', parameters('containerSubnetName'))]",
-                        "properties": {
-                            "ipConfigurations": [
-                                {
-                                    "name": "[concat('ipconfig-', parameters('containerSubnetName'))]",
-                                    "properties": {
-                                        "subnet": {
-                                            "id": "[variables('containerSubnetRef')]"
-                                        }
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
-        },
-        {
-            "scope": "[format('Microsoft.Network/networkProfiles/{0}', variables('networkProfileName'))]",
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2020-04-01-preview",
-            "name": "[guid(variables('networkRoleDefinitionId'), parameters('azureContainerInstanceOID'), variables('networkProfileName'))]",
-            "dependsOn": [
-                "[variables('networkProfileRef')]"
-            ],
-            "properties": {
-                "roleDefinitionId": "[variables('networkRoleDefinitionId')]",
-                "principalId": "[parameters('azureContainerInstanceOID')]",
-                "scope": "[variables('networkProfileRef')]"
-            }
-        },
-        {
-            "type": "Microsoft.Relay/namespaces",
-            "apiVersion": "2018-01-01-preview",
-            "name": "[parameters('relayNamespaceName')]",
-            "location": "[parameters('location')]",
-            "sku": {
-                "name": "Standard",
-                "tier": "Standard"
-            }
-        },
-        {
-            "scope": "[format('Microsoft.Relay/namespaces/{0}', parameters('relayNamespaceName'))]",
-            "type": "Microsoft.Authorization/roleAssignments",
-            "apiVersion": "2020-04-01-preview",
-            "name": "[guid(variables('contributorRoleDefinitionId'), parameters('azureContainerInstanceOID'), parameters('relayNamespaceName'))]",
-            "dependsOn": [
-                "[variables('relayNamespaceRef')]"
-            ],
-            "properties": {
-                "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
-                "principalId": "[parameters('azureContainerInstanceOID')]",
-                "scope": "[variables('relayNamespaceRef')]"
-            }
-        },
-        {
-            "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2020-04-01",
-            "name": "[concat(parameters('existingVNETName'), '/', parameters('relaySubnetName'))]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[variables('containerSubnetRef')]"
-            ],
-            "properties": {
-                "addressPrefix": "[parameters('relaySubnetAddressPrefix')]",
-                "privateEndpointNetworkPolicies": "Disabled",
-                "privateLinkServiceNetworkPolicies": "Enabled"
-            }
-        },
-        {
-            "type": "Microsoft.Network/privateEndpoints",
-            "apiVersion": "2020-04-01",
-            "name": "[parameters('privateEndpointName')]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[variables('relaySubnetRef')]",
-                "[variables('relayNamespaceRef')]"
-            ],
-            "properties": {
-                "privateLinkServiceConnections": [
-                    {
-                        "name": "[parameters('privateEndpointName')]",
-                        "properties": {
-                            "privateLinkServiceId": "[variables('relayNamespaceRef')]",
-                            "groupIds": [
-                                "namespace"
-                            ]
-                        }
-                    }
-                ],
-                "subnet": {
-                    "id": "[variables('relaySubnetRef')]"
-                }
-            }
-        },
-        {
-            "type": "Microsoft.Network/virtualNetworks/subnets",
-            "apiVersion": "2020-04-01",
-            "name": "[concat(parameters('existingVNETName'), '/', parameters('storageSubnetName'))]",
-            "location": "[parameters('location')]",
-            "dependsOn": [
-                "[variables('relaySubnetRef')]"
-            ],
-            "properties": {
-                "addressPrefix": "[parameters('storageSubnetAddressPrefix')]",
-                "serviceEndpoints": [
-                    {
-                        "service": "Microsoft.Storage",
-                        "locations": [
-                            "[parameters('location')]"
-                        ]
-                    }
-                ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/privateDnsZones",
-            "apiVersion": "2020-01-01",
-            "name": "[variables('privateDnsZoneName')]",
-            "location": "global",
-            "properties": {
-                "maxNumberOfRecordSets": 25000,
-                "maxNumberOfVirtualNetworkLinks": 1000,
-                "maxNumberOfVirtualNetworkLinksWithRegistration": 100,
-                "numberOfRecordSets": 2,
-                "numberOfVirtualNetworkLinks": 1,
-                "numberOfVirtualNetworkLinksWithRegistration": 0
-            }
-        },
-        {
-            "type": "Microsoft.Network/privateDnsZones/A",
-            "apiVersion": "2020-01-01",
-            "name": "[concat(variables('privateDnsZoneName'),'/', parameters('relayNamespaceName'))]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
-                "[variables('privateEndpointRef')]"
-            ],
-            "properties": {
-                "ttl": 3600,
-                "aRecords": [
-                    {
-                        "ipv4Address": "[first(first(reference(parameters('privateEndpointName'),'2020-04-01','Full').properties.customDnsConfigs).ipAddresses)]"
-                    }
-                ]
-            }
-        },
-        {
-            "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-            "apiVersion": "2020-01-01",
-            "name": "[concat(variables('privateDnsZoneName'), '/', parameters('relayNamespaceName'))]",
-            "location": "global",
-            "dependsOn": [
-                "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
-            ],
-            "properties": {
-                "registrationEnabled": false,
-                "virtualNetwork": {
-                    "id": "[variables('networkRef')]"
-                }
-            }
-        }
-    ],
-    "outputs": {
-        "vnetName": {
-            "type": "String",
-            "value": "[parameters('existingVNETName')]"
-        },
-        "containerSubnetName": {
-            "type": "String",
-            "value": "[parameters('containerSubnetName')]"
-        },
-        "storageSubnetName": {
-            "type": "String",
-            "value": "[parameters('storageSubnetName')]"
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "2385262269927911863"
     }
+  },
+  "parameters": {
+    "existingVNETName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the existing VNET to inject Cloud Shell into."
+      }
+    },
+    "relayNamespaceName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of Azure Relay Namespace."
+      }
+    },
+    "azureContainerInstanceOID": {
+      "type": "string"
+    },
+    "containerSubnetName": {
+      "type": "string",
+      "defaultValue": "cloudshellsubnet",
+      "metadata": {
+        "description": "Name of the subnet to use for cloud shell containers."
+      }
+    },
+    "containerSubnetAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address space of the subnet to add for cloud shell. e.g. 10.0.1.0/26"
+      }
+    },
+    "relaySubnetName": {
+      "type": "string",
+      "defaultValue": "relaysubnet",
+      "metadata": {
+        "description": "Name of the subnet to use for private link of relay namespace."
+      }
+    },
+    "relaySubnetAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address space of the subnet to add for relay. e.g. 10.0.2.0/26"
+      }
+    },
+    "storageSubnetName": {
+      "type": "string",
+      "defaultValue": "storagesubnet",
+      "metadata": {
+        "description": "Name of the subnet to use for storage account."
+      }
+    },
+    "storageSubnetAddressPrefix": {
+      "type": "string",
+      "metadata": {
+        "description": "Address space of the subnet to add for storage. e.g. 10.0.3.0/26"
+      }
+    },
+    "privateEndpointName": {
+      "type": "string",
+      "defaultValue": "cloudshellRelayEndpoint",
+      "metadata": {
+        "description": "Name of Private Endpoint for Azure Relay."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for all resources."
+      }
+    }
+  },
+  "functions": [],
+  "variables": {
+    "networkProfileName": "[format('aci-networkProfile-{0}', parameters('location'))]",
+    "contributorRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+    "networkRoleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')]",
+    "privateDnsZoneName": "[if(equals(toLower(environment().name), 'azureusgovernment'), 'privatelink.servicebus.usgovcloudapi.net', 'privatelink.servicebus.windows.net')]",
+    "vnetResourceId": "[resourceId('Microsoft.Network/virtualNetworks', parameters('existingVNETName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-04-01",
+      "name": "[format('{0}/{1}', parameters('existingVNETName'), parameters('containerSubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('containerSubnetAddressPrefix')]",
+        "serviceEndpoints": [
+          {
+            "service": "Microsoft.Storage",
+            "locations": [
+              "[parameters('location')]"
+            ]
+          }
+        ],
+        "delegations": [
+          {
+            "name": "CloudShellDelegation",
+            "properties": {
+              "serviceName": "Microsoft.ContainerInstance/containerGroups"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/networkProfiles",
+      "apiVersion": "2019-11-01",
+      "name": "[variables('networkProfileName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "containerNetworkInterfaceConfigurations": [
+          {
+            "name": "[format('eth-{0}', parameters('containerSubnetName'))]",
+            "properties": {
+              "ipConfigurations": [
+                {
+                  "name": "[format('ipconfig-{0}', parameters('containerSubnetName'))]",
+                  "properties": {
+                    "subnet": {
+                      "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "scope": "[format('Microsoft.Network/networkProfiles/{0}', variables('networkProfileName'))]",
+      "name": "[guid(variables('networkRoleDefinitionId'), parameters('azureContainerInstanceOID'), variables('networkProfileName'))]",
+      "properties": {
+        "roleDefinitionId": "[variables('networkRoleDefinitionId')]",
+        "principalId": "[parameters('azureContainerInstanceOID')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/networkProfiles', variables('networkProfileName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Relay/namespaces",
+      "apiVersion": "2018-01-01-preview",
+      "name": "[parameters('relayNamespaceName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard",
+        "tier": "Standard"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "scope": "[format('Microsoft.Relay/namespaces/{0}', parameters('relayNamespaceName'))]",
+      "name": "[guid(variables('contributorRoleDefinitionId'), parameters('azureContainerInstanceOID'), parameters('relayNamespaceName'))]",
+      "properties": {
+        "roleDefinitionId": "[variables('contributorRoleDefinitionId')]",
+        "principalId": "[parameters('azureContainerInstanceOID')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-04-01",
+      "name": "[format('{0}/{1}', parameters('existingVNETName'), parameters('relaySubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('relaySubnetAddressPrefix')]",
+        "privateEndpointNetworkPolicies": "Disabled",
+        "privateLinkServiceNetworkPolicies": "Enabled"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateEndpoints",
+      "apiVersion": "2020-04-01",
+      "name": "[parameters('privateEndpointName')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "privateLinkServiceConnections": [
+          {
+            "name": "[parameters('privateEndpointName')]",
+            "properties": {
+              "privateLinkServiceId": "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]",
+              "groupIds": [
+                "namespace"
+              ]
+            }
+          }
+        ],
+        "subnet": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Relay/namespaces', parameters('relayNamespaceName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-04-01",
+      "name": "[format('{0}/{1}', parameters('existingVNETName'), parameters('storageSubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('storageSubnetAddressPrefix')]",
+        "serviceEndpoints": [
+          {
+            "service": "Microsoft.Storage",
+            "locations": [
+              "[parameters('location')]"
+            ]
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('relaySubnetName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones",
+      "apiVersion": "2020-01-01",
+      "name": "[variables('privateDnsZoneName')]",
+      "location": "global"
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones/A",
+      "apiVersion": "2020-01-01",
+      "name": "[format('{0}/{1}', variables('privateDnsZoneName'), parameters('relayNamespaceName'))]",
+      "properties": {
+        "ttl": 3600,
+        "aRecords": [
+          {
+            "ipv4Address": "[first(first(reference(resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))).customDnsConfigs).ipAddresses)]"
+          }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]",
+        "[resourceId('Microsoft.Network/privateEndpoints', parameters('privateEndpointName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+      "apiVersion": "2020-01-01",
+      "name": "[format('{0}/{1}', variables('privateDnsZoneName'), parameters('relayNamespaceName'))]",
+      "location": "global",
+      "properties": {
+        "registrationEnabled": false,
+        "virtualNetwork": {
+          "id": "[variables('vnetResourceId')]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/privateDnsZones', variables('privateDnsZoneName'))]"
+      ]
+    }
+  ],
+  "outputs": {
+    "vnetId": {
+      "type": "string",
+      "value": "[variables('vnetResourceId')]"
+    },
+    "containerSubnetId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('containerSubnetName'))]"
+    },
+    "storageSubnetId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('existingVNETName'), parameters('storageSubnetName'))]"
+    }
+  }
 }

--- a/demos/cloud-shell-vnet/main.bicep
+++ b/demos/cloud-shell-vnet/main.bicep
@@ -1,0 +1,205 @@
+@description('Name of the existing VNET to inject Cloud Shell into.')
+param existingVNETName string
+
+@description('Name of Azure Relay Namespace.')
+param relayNamespaceName string
+// Object Id of Azure Container Instance Service Principal. 
+// We have to grant this permission to create hybrid connections in the Azure Relay you specify.
+// To get it: Get-AzADServicePrincipal -DisplayNameBeginsWith \'Azure Container Instance\'
+param azureContainerInstanceOID string
+
+@description('Name of the subnet to use for cloud shell containers.')
+param containerSubnetName string = 'cloudshellsubnet'
+
+@description('Address space of the subnet to add for cloud shell. e.g. 10.0.1.0/26')
+param containerSubnetAddressPrefix string
+
+@description('Name of the subnet to use for private link of relay namespace.')
+param relaySubnetName string = 'relaysubnet'
+
+@description('Address space of the subnet to add for relay. e.g. 10.0.2.0/26')
+param relaySubnetAddressPrefix string
+
+@description('Name of the subnet to use for storage account.')
+param storageSubnetName string = 'storagesubnet'
+
+@description('Address space of the subnet to add for storage. e.g. 10.0.3.0/26')
+param storageSubnetAddressPrefix string
+
+@description('Name of Private Endpoint for Azure Relay.')
+param privateEndpointName string = 'cloudshellRelayEndpoint'
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+var networkProfileName = 'aci-networkProfile-${location}'
+var contributorRoleDefinitionId = resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+var networkRoleDefinitionId = resourceId('Microsoft.Authorization/roleDefinitions', '4d97b98b-1d4f-4787-a291-c67834d212e7')
+var privateDnsZoneName = ((toLower(environment().name) == 'azureusgovernment') ? 'privatelink.servicebus.usgovcloudapi.net' : 'privatelink.servicebus.windows.net')
+var vnetResourceId = resourceId('Microsoft.Network/virtualNetworks', existingVNETName)
+
+resource existingVNET 'Microsoft.Network/virtualNetworks@2020-04-01' existing = {
+  name: existingVNETName
+}
+
+resource containerSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-04-01' = {
+  parent: existingVNET
+  name: containerSubnetName
+  properties: {
+    addressPrefix: containerSubnetAddressPrefix
+    serviceEndpoints: [
+      {
+        service: 'Microsoft.Storage'
+        locations: [
+          location
+        ]
+      }
+    ]
+    delegations: [
+      {
+        name: 'CloudShellDelegation'
+        properties: {
+          serviceName: 'Microsoft.ContainerInstance/containerGroups'
+        }
+      }
+    ]
+  }
+}
+
+resource networkProfile 'Microsoft.Network/networkProfiles@2019-11-01' = {
+  name: networkProfileName
+  location: location
+  properties: {
+    containerNetworkInterfaceConfigurations: [
+      {
+        name: 'eth-${containerSubnetName}'
+        properties: {
+          ipConfigurations: [
+            {
+              name: 'ipconfig-${containerSubnetName}'
+              properties: {
+                subnet: {
+                  id: containerSubnet.id
+                }
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource networkProfile_roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  scope: networkProfile
+  name: guid(networkRoleDefinitionId, azureContainerInstanceOID, networkProfile.name)
+  properties: {
+    roleDefinitionId: networkRoleDefinitionId
+    principalId: azureContainerInstanceOID
+  }
+}
+
+resource relayNamespace 'Microsoft.Relay/namespaces@2018-01-01-preview' = {
+  name: relayNamespaceName
+  location: location
+  sku: {
+    name: 'Standard'
+    tier: 'Standard'
+  }
+}
+
+resource relayNamespace_roleAssignment 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  scope: relayNamespace
+  name: guid(contributorRoleDefinitionId, azureContainerInstanceOID, relayNamespace.name)
+  properties: {
+    roleDefinitionId: contributorRoleDefinitionId
+    principalId: azureContainerInstanceOID
+  }
+}
+
+resource relaySubnet 'Microsoft.Network/virtualNetworks/subnets@2020-04-01' = {
+  parent: existingVNET
+  name: relaySubnetName
+  properties: {
+    addressPrefix: relaySubnetAddressPrefix
+    privateEndpointNetworkPolicies: 'Disabled'
+    privateLinkServiceNetworkPolicies: 'Enabled'
+  }
+  dependsOn: [
+    containerSubnet
+  ]
+}
+
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2020-04-01' = {
+  name: privateEndpointName
+  location: location
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        name: privateEndpointName
+        properties: {
+          privateLinkServiceId: relayNamespace.id
+          groupIds: [
+            'namespace'
+          ]
+        }
+      }
+    ]
+    subnet: {
+      id: relaySubnet.id
+    }
+  }
+}
+
+resource storageSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-04-01' = {
+  parent: existingVNET
+  name: storageSubnetName
+  properties: {
+    addressPrefix: storageSubnetAddressPrefix
+    serviceEndpoints: [
+      {
+        service: 'Microsoft.Storage'
+        locations: [
+          location
+        ]
+      }
+    ]
+  }
+  dependsOn: [
+    relaySubnet
+  ]
+}
+
+resource privateDnsZone 'Microsoft.Network/privateDnsZones@2020-01-01' = {
+  name: privateDnsZoneName
+  location: 'global'
+}
+
+resource privateDnsZoneARecord 'Microsoft.Network/privateDnsZones/A@2020-01-01' = {
+  parent: privateDnsZone
+  name: relayNamespaceName
+  properties: {
+    ttl: 3600
+    aRecords: [
+      {
+        ipv4Address: first(first(privateEndpoint.properties.customDnsConfigs).ipAddresses)
+      }
+    ]
+  }
+}
+
+resource privateDnsZoneVnetLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-01-01' = {
+  parent: privateDnsZone
+  name: relayNamespaceName
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetResourceId
+    }
+  }
+}
+
+output vnetId string = vnetResourceId
+output containerSubnetId string = containerSubnet.id
+output storageSubnetId string = storageSubnet.id

--- a/demos/cloud-shell-vnet/metadata.json
+++ b/demos/cloud-shell-vnet/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template deploys Azure Cloud Shell resources into an Azure virtual network.",
   "summary": "This template demonstrates how to create Cloud Shell resources in a VNet. For more information, please view our documentation: https://aka.ms/cloudshell/docs/vnet ",
   "githubUsername": "maertendMSFT",
-  "dateUpdated": "2021-05-12"
+  "dateUpdated": "2021-06-21"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/cloud-shell-vnet

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3309