### PR TITLE
Migrate bicep example: 201/aci-wordpress

### DIFF
--- a/application-workloads/wordpress/aci-wordpress/README.md
+++ b/application-workloads/wordpress/aci-wordpress/README.md
@@ -9,11 +9,13 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/application-workloads/wordpress/aci-wordpress/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/application-workloads/wordpress/aci-wordpress/CredScanResult.svg)
 
-Create a WordPress site (and its MySQL database) on a Container Instance
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/application-workloads/wordpress/aci-wordpress/BicepVersion.svg)
 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fapplication-workloads%2Fwordpress%2Faci-wordpress%2Fazuredeploy.json)  
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fapplication-workloads%2Fwordpress%2Faci-wordpress%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fapplication-workloads%2Fwordpress%2Faci-wordpress%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fapplication-workloads%2Fwordpress%2Faci-wordpress%2Fazuredeploy.json)
+
+Create a WordPress site (and its MySQL database) on a Container Instance
 
 This template creates a WordPress website and its MySQL database on a Container Instance. The WordPress site content and MySQL database are persistently stored on an Azure Storage File Share.
 
@@ -45,5 +47,3 @@ Use browser to access the site FQDN from deployment output. WordPress will guide
 
 ## Notes
 Azure Container Instance is available in selected [locations](https://docs.microsoft.com/en-us/azure/container-instances/container-instances-quotas#region-availability). Please use one of the available location for Azure Container Instance resource.
-
-

--- a/application-workloads/wordpress/aci-wordpress/azuredeploy.json
+++ b/application-workloads/wordpress/aci-wordpress/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "13415595626799563787"
+      "templateHash": "4316775323044759329"
     }
   },
   "parameters": {
@@ -60,9 +60,8 @@
     "identityName": "scratch",
     "roleDefinitionId": "[resourceId('microsoft.authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
     "roleAssignmentName": "[guid(variables('identityName'), variables('roleDefinitionId'), resourceGroup().id)]",
-    "uamiId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
-    "wpScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('wordpressShareName'))]",
-    "sqlScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('mysqlShareName'))]"
+    "sqlScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('mysqlShareName'))]",
+    "wpScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('wordpressShareName'))]"
   },
   "resources": [
     {
@@ -106,7 +105,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[variables('uamiId')]": {}
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": {}
         }
       },
       "properties": {
@@ -134,7 +133,7 @@
       "identity": {
         "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[variables('uamiId')]": {}
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": {}
         }
       },
       "properties": {

--- a/application-workloads/wordpress/aci-wordpress/azuredeploy.json
+++ b/application-workloads/wordpress/aci-wordpress/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "13415595626799563787"
+    }
+  },
   "parameters": {
     "storageAccountType": {
       "type": "string",
@@ -16,20 +23,20 @@
     },
     "storageAccountName": {
       "type": "string",
-      "defaultValue": "[uniquestring(resourceGroup().id)]",
+      "defaultValue": "[uniqueString(resourceGroup().id)]",
       "metadata": {
         "description": "Storage Account Name"
       }
     },
     "siteName": {
       "type": "string",
-      "defaultValue": "[uniquestring(resourceGroup().id)]",
+      "defaultValue": "[parameters('storageAccountName')]",
       "metadata": {
         "description": "WordPress Site Name"
       }
     },
-    "mysqlPassword": {
-      "type": "securestring",
+    "mySqlPassword": {
+      "type": "secureString",
       "metadata": {
         "description": "MySQL database password"
       }
@@ -42,6 +49,7 @@
       }
     }
   },
+  "functions": [],
   "variables": {
     "cpuCores": "0.5",
     "memoryInGb": "0.7",
@@ -50,118 +58,106 @@
     "mysqlShareName": "mysql-share",
     "scriptName": "createFileShare",
     "identityName": "scratch",
-    "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
-    "roleDefinitionName": "[guid(variables('identityName'), variables('roleDefinitionId'), resourceGroup().id)]"
+    "roleDefinitionId": "[resourceId('microsoft.authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+    "roleAssignmentName": "[guid(variables('identityName'), variables('roleDefinitionId'), resourceGroup().id)]",
+    "uamiId": "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
+    "wpScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('wordpressShareName'))]",
+    "sqlScriptToExecute": "[format('Get-AzStorageAccount -StorageAccountName {0} -ResourceGroupName {1} | New-AzStorageShare -Name {2}', parameters('storageAccountName'), resourceGroup().name, variables('mysqlShareName'))]"
   },
   "resources": [
     {
       "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
-      "name": "[variables('identityName')]",
       "apiVersion": "2018-11-30",
+      "name": "[variables('identityName')]",
       "location": "[parameters('location')]"
     },
     {
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-04-01-preview",
-      "name": "[variables('roleDefinitionName')]",
-      "dependsOn": [
-        "[variables('identityName')]"
-      ],
+      "name": "[variables('roleAssignmentName')]",
       "properties": {
         "roleDefinitionId": "[variables('roleDefinitionId')]",
-        "principalId": "[reference(variables('identityName')).principalId]",
-        "scope": "[resourceGroup().id]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))).principalId]",
         "principalType": "ServicePrincipal"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
+      ]
     },
     {
       "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2021-04-01",
       "name": "[parameters('storageAccountName')]",
-      "apiVersion": "2019-06-01",
       "location": "[parameters('location')]",
       "sku": {
         "name": "[parameters('storageAccountType')]"
       },
       "kind": "StorageV2",
       "dependsOn": [
-        "[variables('roleDefinitionName')]" // need to create a slight delay for the roleAssignment to replicate before the deployment script can run
+        "[resourceId('Microsoft.Authorization/roleAssignments', variables('roleAssignmentName'))]"
       ]
     },
     {
       "type": "Microsoft.Resources/deploymentScripts",
       "apiVersion": "2020-10-01",
-      "name": "[concat(variables('scriptName'), '-', variables('wordpressShareName'))]",
+      "name": "[format('{0}-{1}', variables('scriptName'), variables('wordpressShareName'))]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[parameters('storageAccountName')]"
-      ],
       "kind": "AzurePowerShell",
       "identity": {
-        "type": "userAssigned",
+        "type": "UserAssigned",
         "userAssignedIdentities": {
-          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": { /*ttk bug*/
-          }
+          "[variables('uamiId')]": {}
         }
       },
       "properties": {
-        "forceUpdateTag": "1",
         "azPowerShellVersion": "3.0",
-        "arguments": "[format(' -storageAccountName {0} -fileShareName {1} -resourceGroupName {2}', parameters('storageAccountName'), variables('wordpressShareName'), resourceGroup().name)]",
-        "scriptContent": "
-                param(
-                    [string] $storageAccountName,
-                    [string] $fileShareName,
-                    [string] $resourceGroupName
-                )
-                Get-AzStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName | New-AzStorageShare -Name $fileShareName
-                ",
-        "timeout": "PT5M",
+        "storageAccountSettings": {
+          "storageAccountName": "[parameters('storageAccountName')]",
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2021-04-01').keys[0].value]"
+        },
+        "scriptContent": "[variables('wpScriptToExecute')]",
         "cleanupPreference": "OnSuccess",
-        "retentionInterval": "P1D"
-      }
-    },
-        {
-      "type": "Microsoft.Resources/deploymentScripts",
-      "apiVersion": "2020-10-01",
-      "name": "[concat(variables('scriptName'), '-', variables('mysqlShareName'))]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[parameters('storageAccountName')]"
-      ],
-      "kind": "AzurePowerShell",
-      "identity": {
-        "type": "userAssigned",
-        "userAssignedIdentities": {
-          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]": { /*ttk bug*/
-          }
-        }
+        "retentionInterval": "P1D",
+        "timeout": "PT5M"
       },
-      "properties": {
-        "forceUpdateTag": "1",
-        "azPowerShellVersion": "3.0",
-        "arguments": "[format(' -storageAccountName {0} -fileShareName {1} -resourceGroupName {2}', parameters('storageAccountName'), variables('mysqlShareName'), resourceGroup().name)]",
-        "scriptContent": "
-                param(
-                    [string] $storageAccountName,
-                    [string] $fileShareName,
-                    [string] $resourceGroupName
-                )
-                Get-AzStorageAccount -StorageAccountName $storageAccountName -ResourceGroupName $resourceGroupName | New-AzStorageShare -Name $fileShareName
-                ",
-        "timeout": "PT5M",
-        "cleanupPreference": "OnSuccess",
-        "retentionInterval": "P1D"
-      }
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
     },
     {
-      "name": "[variables('wordpresscontainerGroupName')]",
+      "type": "Microsoft.Resources/deploymentScripts",
+      "apiVersion": "2020-10-01",
+      "name": "[format('{0}-{1}', variables('scriptName'), variables('mysqlShareName'))]",
+      "location": "[parameters('location')]",
+      "kind": "AzurePowerShell",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[variables('uamiId')]": {}
+        }
+      },
+      "properties": {
+        "azPowerShellVersion": "3.0",
+        "storageAccountSettings": {
+          "storageAccountName": "[parameters('storageAccountName')]",
+          "storageAccountKey": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2021-04-01').keys[0].value]"
+        },
+        "scriptContent": "[variables('sqlScriptToExecute')]",
+        "cleanupPreference": "OnSuccess",
+        "retentionInterval": "P1D",
+        "timeout": "PT5M"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
+    },
+    {
       "type": "Microsoft.ContainerInstance/containerGroups",
       "apiVersion": "2019-12-01",
+      "name": "[variables('wordpressContainerGroupName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Resources/deploymentScripts', concat(variables('scriptName'), '-', variables('wordpressShareName')))]",
-        "[resourceId('Microsoft.Resources/deploymentScripts', concat(variables('scriptName'), '-', variables('mysqlShareName')))]"
-      ],
       "properties": {
         "containers": [
           {
@@ -170,7 +166,7 @@
               "image": "wordpress:4.9-apache",
               "ports": [
                 {
-                  "protocol": "Tcp",
+                  "protocol": "TCP",
                   "port": 80
                 }
               ],
@@ -181,7 +177,7 @@
                 },
                 {
                   "name": "WORDPRESS_DB_PASSWORD",
-                  "value": "[parameters('mysqlPassword')]"
+                  "value": "[parameters('mySqlPassword')]"
                 }
               ],
               "volumeMounts": [
@@ -193,7 +189,7 @@
               "resources": {
                 "requests": {
                   "cpu": "[variables('cpuCores')]",
-                  "memoryInGb": "[variables('memoryInGb')]"
+                  "memoryInGB": "[variables('memoryInGb')]"
                 }
               }
             }
@@ -204,14 +200,14 @@
               "image": "mysql:5.6",
               "ports": [
                 {
-                  "protocol": "Tcp",
+                  "protocol": "TCP",
                   "port": 3306
                 }
               ],
               "environmentVariables": [
                 {
                   "name": "MYSQL_ROOT_PASSWORD",
-                  "value": "[parameters('mysqlPassword')]"
+                  "value": "[parameters('mySqlPassword')]"
                 }
               ],
               "volumeMounts": [
@@ -223,7 +219,7 @@
               "resources": {
                 "requests": {
                   "cpu": "[variables('cpuCores')]",
-                  "memoryInGb": "[variables('memoryInGb')]"
+                  "memoryInGB": "[variables('memoryInGb')]"
                 }
               }
             }
@@ -233,7 +229,7 @@
           {
             "azureFile": {
               "shareName": "[variables('wordpressShareName')]",
-              "storageAccountKey": "[listKeys(parameters('storageAccountName'),'2019-06-01').keys[0].value]",
+              "storageAccountKey": "[listKeys(parameters('storageAccountName'), '2021-04-01').keys[0].value]",
               "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "wordpressfile"
@@ -241,7 +237,7 @@
           {
             "azureFile": {
               "shareName": "[variables('mysqlShareName')]",
-              "storageAccountKey": "[listKeys(parameters('storageAccountName'),'2019-06-01').keys[0].value]",
+              "storageAccountKey": "[listKeys(parameters('storageAccountName'), '2021-04-01').keys[0].value]",
               "storageAccountName": "[parameters('storageAccountName')]"
             },
             "name": "mysqlfile"
@@ -250,7 +246,7 @@
         "ipAddress": {
           "ports": [
             {
-              "protocol": "Tcp",
+              "protocol": "TCP",
               "port": 80
             }
           ],
@@ -258,13 +254,18 @@
           "dnsNameLabel": "[parameters('siteName')]"
         },
         "osType": "Linux"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-{1}', variables('scriptName'), variables('mysqlShareName')))]",
+        "[resourceId('Microsoft.Resources/deploymentScripts', format('{0}-{1}', variables('scriptName'), variables('wordpressShareName')))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+      ]
     }
   ],
   "outputs": {
     "siteFQDN": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups/', variables('wordpresscontainerGroupName'))).ipAddress.fqdn]"
+      "value": "[reference(resourceId('Microsoft.ContainerInstance/containerGroups', variables('wordpressContainerGroupName'))).ipAddress.fqdn]"
     }
   }
 }

--- a/application-workloads/wordpress/aci-wordpress/main.bicep
+++ b/application-workloads/wordpress/aci-wordpress/main.bicep
@@ -175,8 +175,8 @@ resource wpAci 'Microsoft.ContainerInstance/containerGroups@2019-12-01' = {
           ]
           resources: {
             requests: {
-              cpu: cpuCores
-              memoryInGB: memoryInGb
+              cpu: any(cpuCores)
+              memoryInGB: any(memoryInGb)
             }
           }
         }

--- a/application-workloads/wordpress/aci-wordpress/main.bicep
+++ b/application-workloads/wordpress/aci-wordpress/main.bicep
@@ -1,0 +1,217 @@
+@description('Storage Account type')
+@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+  'Standard_ZRS'
+])
+param storageAccountType string = 'Standard_LRS'
+
+@description('Storage Account Name')
+param storageAccountName string = uniqueString(resourceGroup().id)
+
+@description('WordPress Site Name')
+param siteName string = storageAccountName
+
+@description('MySQL database password')
+@secure()
+param mySqlPassword string
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+var cpuCores = '0.5'
+var memoryInGb = '0.7'
+var wordpressContainerGroupName = 'wordpress-containerinstance'
+var wordpressShareName = 'wordpress-share'
+var mysqlShareName = 'mysql-share'
+var scriptName = 'createFileShare'
+var identityName = 'scratch'
+
+resource mi 'Microsoft.ManagedIdentity/userAssignedIdentities@2018-11-30' = {
+  name: identityName
+  location: location
+}
+
+var roleDefinitionId = resourceId('microsoft.authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+var roleAssignmentName = guid(mi.name, roleDefinitionId, resourceGroup().id)
+
+resource miRoleAssign 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
+  name: roleAssignmentName
+  properties: {
+    roleDefinitionId: roleDefinitionId
+    principalId: mi.properties.principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+var uamiId = resourceId(mi.type, mi.name)
+
+resource stg 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: storageAccountType
+  }
+  kind: 'StorageV2'
+  dependsOn: [
+    miRoleAssign
+  ]
+}
+
+// create file share for wordpress
+var wpScriptToExecute = 'Get-AzStorageAccount -StorageAccountName ${storageAccountName} -ResourceGroupName ${resourceGroup().name} | New-AzStorageShare -Name ${wordpressShareName}'
+resource dScriptWp 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: '${scriptName}-${wordpressShareName}'
+  location: location
+  kind: 'AzurePowerShell'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${uamiId}': {}
+    }
+  }
+  properties: {
+    azPowerShellVersion: '3.0'
+    storageAccountSettings: {
+      storageAccountName: stg.name
+      storageAccountKey: listKeys(stg.id, stg.apiVersion).keys[0].value
+    }
+    scriptContent: wpScriptToExecute
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+    timeout: 'PT5M'
+  }
+}
+
+// create second file share for sql
+var sqlScriptToExecute = 'Get-AzStorageAccount -StorageAccountName ${storageAccountName} -ResourceGroupName ${resourceGroup().name} | New-AzStorageShare -Name ${mysqlShareName}'
+resource dScriptSql 'Microsoft.Resources/deploymentScripts@2020-10-01' = {
+  name: '${scriptName}-${mysqlShareName}'
+  location: location
+  kind: 'AzurePowerShell'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${uamiId}': {}
+    }
+  }
+  properties: {
+    azPowerShellVersion: '3.0'
+    storageAccountSettings: {
+      storageAccountName: stg.name
+      storageAccountKey: listKeys(stg.id, stg.apiVersion).keys[0].value
+    }
+    scriptContent: sqlScriptToExecute
+    cleanupPreference: 'OnSuccess'
+    retentionInterval: 'P1D'
+    timeout: 'PT5M'
+  }
+}
+
+resource wpAci 'Microsoft.ContainerInstance/containerGroups@2019-12-01' = {
+  name: wordpressContainerGroupName
+  location: location
+  dependsOn: [
+    dScriptSql
+    dScriptWp
+  ]
+  properties: {
+    containers: [
+      {
+        name: 'wordpress'
+        properties: {
+          image: 'wordpress:4.9-apache'
+          ports: [
+            {
+              protocol: 'TCP'
+              port: 80
+            }
+          ]
+          environmentVariables: [
+            {
+              name: 'WORDPRESS_DB_HOST'
+              value: '127.0.0.1:3306'
+            }
+            {
+              name: 'WORDPRESS_DB_PASSWORD'
+              value: mySqlPassword
+            }
+          ]
+          volumeMounts: [
+            {
+              mountPath: '/var/www/html'
+              name: 'wordpressfile'
+            }
+          ]
+          resources: {
+            requests: {
+              cpu: any(cpuCores)
+              memoryInGB: any(memoryInGb)
+            }
+          }
+        }
+      }
+      {
+        name: 'mysql'
+        properties: {
+          image: 'mysql:5.6'
+          ports: [
+            {
+              protocol: 'TCP'
+              port: 3306
+            }
+          ]
+          environmentVariables: [
+            {
+              name: 'MYSQL_ROOT_PASSWORD'
+              value: mySqlPassword
+            }
+          ]
+          volumeMounts: [
+            {
+              mountPath: '/var/lib/mysql'
+              name: 'mysqlfile'
+            }
+          ]
+          resources: {
+            requests: {
+              cpu: cpuCores
+              memoryInGB: memoryInGb
+            }
+          }
+        }
+      }
+    ]
+    volumes: [
+      {
+        azureFile: {
+          shareName: wordpressShareName
+          storageAccountKey: listKeys(stg.name, stg.apiVersion).keys[0].value
+          storageAccountName: stg.name
+        }
+        name: 'wordpressfile'
+      }
+      {
+        azureFile: {
+          shareName: mysqlShareName
+          storageAccountKey: listKeys(stg.name, stg.apiVersion).keys[0].value
+          storageAccountName: stg.name
+        }
+        name: 'mysqlfile'
+      }
+    ]
+    ipAddress: {
+      ports: [
+        {
+          protocol: 'TCP'
+          port: 80
+        }
+      ]
+      type: 'Public'
+      dnsNameLabel: siteName
+    }
+    osType: 'Linux'
+  }
+}
+
+output siteFQDN string = wpAci.properties.ipAddress.fqdn

--- a/application-workloads/wordpress/aci-wordpress/metadata.json
+++ b/application-workloads/wordpress/aci-wordpress/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template creates a WordPress site on Container Instance",
   "summary": "Create a WordPress site on Container Instance",
   "githubUsername": "wenwu449",
-  "dateUpdated": "2021-06-21"
+  "dateUpdated": "2021-07-14"
 }

--- a/application-workloads/wordpress/aci-wordpress/metadata.json
+++ b/application-workloads/wordpress/aci-wordpress/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template creates a WordPress site on Container Instance",
   "summary": "Create a WordPress site on Container Instance",
   "githubUsername": "wenwu449",
-  "dateUpdated": "2021-05-18"
+  "dateUpdated": "2021-06-21"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/aci-wordpress

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3310