### PR TITLE
Migrate bicep example: 201/servicebus-create-queue (IGNORE BEST PRACTICE FAILURES)

### DIFF
--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/README.md
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/README.md
@@ -9,8 +9,11 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.servicebus/servicebus-create-queue/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.servicebus/servicebus-create-queue/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.servicebus/servicebus-create-queue/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.servicebus%2Fservicebus-create-queue%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.servicebus%2Fservicebus-create-queue%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.servicebus%2Fservicebus-create-queue%2Fazuredeploy.json)
 
 For information about using this template, see [Quickstart: Create a Service Bus namespace and a queue using an ARM template](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-resource-manager-namespace-queue).
+

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "16254364616677220399"
+      "templateHash": "2783991400666652465"
     }
   },
   "parameters": {
@@ -33,7 +33,7 @@
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2021-01-01-preview",
       "name": "[parameters('serviceBusNamespaceName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -43,7 +43,7 @@
     },
     {
       "type": "Microsoft.ServiceBus/namespaces/queues",
-      "apiVersion": "2017-04-01",
+      "apiVersion": "2021-06-01-preview",
       "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('serviceBusQueueName'))]",
       "properties": {
         "lockDuration": "PT5M",

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "6331353568702595225"
+      "templateHash": "15029864625336203587"
     }
   },
   "parameters": {
@@ -33,7 +33,7 @@
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",
-      "apiVersion": "2021-01-01-preview",
+      "apiVersion": "2017-04-01",
       "name": "[parameters('serviceBusNamespaceName')]",
       "location": "[parameters('location')]",
       "sku": {

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "7737296610134797264"
+      "version": "0.4.412.5873",
+      "templateHash": "16254364616677220399"
     }
   },
   "parameters": {
@@ -33,7 +33,7 @@
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",
-      "apiVersion": "2021-01-01-preview",
+      "apiVersion": "2017-04-01",
       "name": "[parameters('serviceBusNamespaceName')]",
       "location": "[parameters('location')]",
       "sku": {

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "15029864625336203587"
+      "templateHash": "16254364616677220399"
     }
   },
   "parameters": {
@@ -43,7 +43,7 @@
     },
     {
       "type": "Microsoft.ServiceBus/namespaces/queues",
-      "apiVersion": "2021-01-01-preview",
+      "apiVersion": "2017-04-01",
       "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('serviceBusQueueName'))]",
       "properties": {
         "lockDuration": "PT5M",

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "4888852670688853493"
+    }
+  },
   "parameters": {
     "serviceBusNamespaceName": {
       "type": "string",
@@ -22,6 +29,7 @@
       }
     }
   },
+  "functions": [],
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",
@@ -31,29 +39,27 @@
       "sku": {
         "name": "Standard"
       },
-      "properties": {},
-      "resources": [
-        {
-          "type": "Queues",
-          "apiVersion": "2017-04-01",
-          "name": "[parameters('serviceBusQueueName')]",
-          "dependsOn": [
-            "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]"
-          ],
-          "properties": {
-            "lockDuration": "PT5M",
-            "maxSizeInMegabytes": 1024,
-            "requiresDuplicateDetection": false,
-            "requiresSession": false,
-            "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
-            "deadLetteringOnMessageExpiration": false,
-            "duplicateDetectionHistoryTimeWindow": "PT10M",
-            "maxDeliveryCount": 10,
-            "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
-            "enablePartitioning": false,
-            "enableExpress": false
-          }
-        }
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.ServiceBus/namespaces/queues",
+      "apiVersion": "2017-04-01",
+      "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('serviceBusQueueName'))]",
+      "properties": {
+        "lockDuration": "PT5M",
+        "maxSizeInMegabytes": 1024,
+        "requiresDuplicateDetection": false,
+        "requiresSession": false,
+        "defaultMessageTimeToLive": "P10675199DT2H48M5.4775807S",
+        "deadLetteringOnMessageExpiration": false,
+        "duplicateDetectionHistoryTimeWindow": "PT10M",
+        "maxDeliveryCount": 10,
+        "autoDeleteOnIdle": "P10675199DT2H48M5.4775807S",
+        "enablePartitioning": false,
+        "enableExpress": false
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]"
       ]
     }
   ]

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "2783991400666652465"
+      "templateHash": "6331353568702595225"
     }
   },
   "parameters": {
@@ -43,7 +43,7 @@
     },
     {
       "type": "Microsoft.ServiceBus/namespaces/queues",
-      "apiVersion": "2021-06-01-preview",
+      "apiVersion": "2021-01-01-preview",
       "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('serviceBusQueueName'))]",
       "properties": {
         "lockDuration": "PT5M",

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "4888852670688853493"
+      "templateHash": "7737296610134797264"
     }
   },
   "parameters": {
@@ -33,7 +33,7 @@
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",
-      "apiVersion": "2018-01-01-preview",
+      "apiVersion": "2021-01-01-preview",
       "name": "[parameters('serviceBusNamespaceName')]",
       "location": "[parameters('location')]",
       "sku": {

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
@@ -7,7 +7,7 @@ param serviceBusQueueName string
 @description('Location for all resources.')
 param location string = resourceGroup().location
 
-resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-01-01-preview' = {
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
   name: serviceBusNamespaceName
   location: location
   sku: {

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
@@ -16,7 +16,7 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-01-01-preview
   properties: {}
 }
 
-resource serviceBusQueue 'Microsoft.ServiceBus/namespaces/queues@2021-06-01-preview' = {
+resource serviceBusQueue 'Microsoft.ServiceBus/namespaces/queues@2021-01-01-preview' = {
   parent: serviceBusNamespace
   name: serviceBusQueueName
   properties: {

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
@@ -7,7 +7,7 @@ param serviceBusQueueName string
 @description('Location for all resources.')
 param location string = resourceGroup().location
 
-resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-01-01-preview' = {
   name: serviceBusNamespaceName
   location: location
   sku: {
@@ -16,7 +16,7 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
   properties: {}
 }
 
-resource serviceBusQueue 'Microsoft.ServiceBus/namespaces/queues@2017-04-01' = {
+resource serviceBusQueue 'Microsoft.ServiceBus/namespaces/queues@2021-06-01-preview' = {
   parent: serviceBusNamespace
   name: serviceBusQueueName
   properties: {

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
@@ -1,0 +1,35 @@
+@description('Name of the Service Bus namespace')
+param serviceBusNamespaceName string
+
+@description('Name of the Queue')
+param serviceBusQueueName string
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
+  name: serviceBusNamespaceName
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {}
+}
+
+resource serviceBusQueue 'Microsoft.ServiceBus/namespaces/queues@2017-04-01' = {
+  parent: serviceBusNamespace
+  name: serviceBusQueueName
+  properties: {
+    lockDuration: 'PT5M'
+    maxSizeInMegabytes: 1024
+    requiresDuplicateDetection: false
+    requiresSession: false
+    defaultMessageTimeToLive: 'P10675199DT2H48M5.4775807S'
+    deadLetteringOnMessageExpiration: false
+    duplicateDetectionHistoryTimeWindow: 'PT10M'
+    maxDeliveryCount: 10
+    autoDeleteOnIdle: 'P10675199DT2H48M5.4775807S'
+    enablePartitioning: false
+    enableExpress: false
+  }
+}

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
@@ -7,7 +7,7 @@ param serviceBusQueueName string
 @description('Location for all resources.')
 param location string = resourceGroup().location
 
-resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2021-01-01-preview' = {
   name: serviceBusNamespaceName
   location: location
   sku: {

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/main.bicep
@@ -16,7 +16,7 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
   properties: {}
 }
 
-resource serviceBusQueue 'Microsoft.ServiceBus/namespaces/queues@2021-01-01-preview' = {
+resource serviceBusQueue 'Microsoft.ServiceBus/namespaces/queues@2017-04-01' = {
   parent: serviceBusNamespace
   name: serviceBusQueueName
   properties: {

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/metadata.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/metadata.json
@@ -6,5 +6,5 @@
   "summary": "This template creates a Service Bus namespace and a queue.",
   "githubUsername": "v-ajnava",
   "docOwner": "spelluru",
-  "dateUpdated": "2021-06-22"
+  "dateUpdated": "2021-07-09"
 }

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/metadata.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/metadata.json
@@ -6,5 +6,5 @@
   "summary": "This template creates a Service Bus namespace and a queue.",
   "githubUsername": "v-ajnava",
   "docOwner": "spelluru",
-  "dateUpdated": "2021-06-21"
+  "dateUpdated": "2021-06-22"
 }

--- a/quickstarts/microsoft.servicebus/servicebus-create-queue/metadata.json
+++ b/quickstarts/microsoft.servicebus/servicebus-create-queue/metadata.json
@@ -6,5 +6,5 @@
   "summary": "This template creates a Service Bus namespace and a queue.",
   "githubUsername": "v-ajnava",
   "docOwner": "spelluru",
-  "dateUpdated": "2021-04-29"
+  "dateUpdated": "2021-06-21"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/servicebus-create-queue

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3317