### PR TITLE
Migrate bicep example: 201/traffic-manager-webapp

### DIFF
--- a/quickstarts/microsoft.network/traffic-manager-webapp/README.md
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/README.md
@@ -9,9 +9,12 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/traffic-manager-webapp/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/traffic-manager-webapp/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/traffic-manager-webapp/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Ftraffic-manager-webapp%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Ftraffic-manager-webapp%2Fazuredeploy.json)
-[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Ftraffic-manager-webapp%2Fazuredeploy.json)  
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Ftraffic-manager-webapp%2Fazuredeploy.json)
+
 This template shows how to create an Azure Traffic Manager profile with an App Service Behind It
 
 The accompanying PowerShell script shows how to create a resource group from the template and read back the Traffic Manager profile details.  Before running the script, edit *azuredeploy.parameters.json* and replace the values marked with *'#####'*.
@@ -24,3 +27,4 @@ See also:
 
 
 `Tags: Azure, Traffic Manager`
+

--- a/quickstarts/microsoft.network/traffic-manager-webapp/azuredeploy.json
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "17990398772472211751"
+      "templateHash": "795783065741135908"
     }
   },
   "parameters": {
@@ -42,7 +42,7 @@
   "resources": [
     {
       "type": "Microsoft.Web/serverfarms",
-      "apiVersion": "2021-01-01",
+      "apiVersion": "2020-12-01",
       "name": "[parameters('appServicePlanName')]",
       "location": "[parameters('location')]",
       "sku": {

--- a/quickstarts/microsoft.network/traffic-manager-webapp/azuredeploy.json
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1.14562",
-      "templateHash": "795783065741135908"
+      "templateHash": "2507546902898660526"
     }
   },
   "parameters": {
@@ -52,7 +52,7 @@
     },
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2021-01-01",
+      "apiVersion": "2020-12-01",
       "name": "[parameters('uniqueDnsNameForWebApp')]",
       "location": "[parameters('location')]",
       "properties": {

--- a/quickstarts/microsoft.network/traffic-manager-webapp/azuredeploy.json
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "17990398772472211751"
+    }
+  },
   "parameters": {
     "uniqueDnsName": {
       "type": "string",
@@ -14,7 +21,7 @@
         "description": "Relative DNS name for the WebApps, must be globally unique.  An index will be appended for each Web App."
       }
     },
-    "webServerName": {
+    "appServicePlanName": {
       "type": "string",
       "metadata": {
         "description": "Name of the App Service Plan that is being created"
@@ -31,14 +38,12 @@
       }
     }
   },
-
-  "variables": {},
-
+  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Web/serverfarms",
-      "apiVersion": "2019-08-01",
-      "name": "[parameters('webServerName')]",
+      "apiVersion": "2021-01-01",
+      "name": "[parameters('appServicePlanName')]",
       "location": "[parameters('location')]",
       "sku": {
         "name": "S1",
@@ -47,19 +52,18 @@
     },
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2019-08-01",
+      "apiVersion": "2021-01-01",
       "name": "[parameters('uniqueDnsNameForWebApp')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Web/serverfarms/',parameters('webServerName'))]"
-
-      ],
       "properties": {
-        "serverFarmId": "[parameters('webServerName')]"
-      }
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]"
+      ]
     },
     {
-      "type": "Microsoft.Network/trafficManagerProfiles",
+      "type": "Microsoft.Network/trafficmanagerprofiles",
       "apiVersion": "2018-08-01",
       "name": "[parameters('trafficManagerName')]",
       "location": "global",
@@ -74,22 +78,21 @@
           "protocol": "HTTPS",
           "port": 443,
           "path": "/"
-        }
-      }
-    },
-    {
-      "type": "Microsoft.Network/trafficManagerProfiles/azureEndpoints",
-      "apiVersion": "2018-08-01",
-      "name": "[concat(parameters('trafficManagerName'),'/',parameters('uniqueDnsNameForWebApp'))]",
-      "location": "global",
+        },
+        "endpoints": [
+          {
+            "name": "[parameters('uniqueDnsNameForWebApp')]",
+            "type": "Microsoft.Network/trafficManagerProfiles/azureEndpoints",
+            "properties": {
+              "targetResourceId": "[resourceId('Microsoft.Web/sites', parameters('uniqueDnsNameForWebApp'))]",
+              "endpointStatus": "Enabled"
+            }
+          }
+        ]
+      },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/trafficManagerProfiles/',parameters('trafficManagerName'))]",
-        "[resourceId('Microsoft.Web/sites/',parameters('uniqueDnsNameForWebApp'))]"
-      ],
-      "properties": {
-        "targetResourceId": "[resourceId('Microsoft.Web/sites/', parameters('uniqueDnsNameForWebApp'))]",
-        "endpointStatus": "Enabled"
-      }
+        "[resourceId('Microsoft.Web/sites', parameters('uniqueDnsNameForWebApp'))]"
+      ]
     }
   ]
 }

--- a/quickstarts/microsoft.network/traffic-manager-webapp/azuredeploy.parameters.json
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/azuredeploy.parameters.json
@@ -11,7 +11,7 @@
     "trafficManagerName": {
       "value": "GEN-UNIQUE"
     },
-    "webServerName": {
+    "appServicePlanName": {
       "value": "GEN-UNIQUE"
     }
   }

--- a/quickstarts/microsoft.network/traffic-manager-webapp/main.bicep
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/main.bicep
@@ -20,7 +20,7 @@ resource appServicePlan 'Microsoft.Web/serverFarms@2020-12-01' = {
   }
 }
 
-resource webSite 'Microsoft.Web/sites@2021-01-01' = {
+resource webSite 'Microsoft.Web/sites@2020-12-01' = {
   name: uniqueDnsNameForWebApp
   location: location
   properties: {

--- a/quickstarts/microsoft.network/traffic-manager-webapp/main.bicep
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/main.bicep
@@ -11,7 +11,7 @@ param location string = resourceGroup().location
 @description('Name of the trafficManager being created')
 param trafficManagerName string
 
-resource appServicePlan 'Microsoft.Web/serverfarms@2021-01-01' = {
+resource appServicePlan 'Microsoft.Web/serverFarms@2020-12-01' = {
   name: appServicePlanName
   location: location
   sku: {

--- a/quickstarts/microsoft.network/traffic-manager-webapp/main.bicep
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/main.bicep
@@ -1,0 +1,57 @@
+@description('Relative DNS name for the traffic manager profile, resulting FQDN will be <uniqueDnsName>.trafficmanager.net, must be globally unique.')
+param uniqueDnsName string
+
+@description('Relative DNS name for the WebApps, must be globally unique.  An index will be appended for each Web App.')
+param uniqueDnsNameForWebApp string
+
+@description('Name of the App Service Plan that is being created')
+param appServicePlanName string
+param location string = resourceGroup().location
+
+@description('Name of the trafficManager being created')
+param trafficManagerName string
+
+resource appServicePlan 'Microsoft.Web/serverfarms@2021-01-01' = {
+  name: appServicePlanName
+  location: location
+  sku: {
+    name: 'S1'
+    tier: 'Standard'
+  }
+}
+
+resource webSite 'Microsoft.Web/sites@2021-01-01' = {
+  name: uniqueDnsNameForWebApp
+  location: location
+  properties: {
+    serverFarmId: appServicePlan.id
+  }
+}
+
+resource trafficManagerProfile 'Microsoft.Network/trafficManagerProfiles@2018-08-01' = {
+  name: trafficManagerName
+  location: 'global'
+  properties: {
+    profileStatus: 'Enabled'
+    trafficRoutingMethod: 'Priority'
+    dnsConfig: {
+      relativeName: uniqueDnsName
+      ttl: 30
+    }
+    monitorConfig: {
+      protocol: 'HTTPS'
+      port: 443
+      path: '/'
+    }
+    endpoints: [
+      {
+        name: uniqueDnsNameForWebApp
+        type: 'Microsoft.Network/trafficManagerProfiles/azureEndpoints'
+        properties: {
+          targetResourceId: webSite.id
+          endpointStatus: 'Enabled'
+        }
+      }
+    ]
+  }
+}

--- a/quickstarts/microsoft.network/traffic-manager-webapp/metadata.json
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template shows how to create an Azure Traffic Manager profile for an App Service.",
   "summary": "This template creates an Azure Traffic Manager profile that provides an App Service behind it",
   "githubUsername": "GarethBradshawMSFT",
-  "dateUpdated": "2021-04-28"
+  "dateUpdated": "2021-06-22"
 }

--- a/quickstarts/microsoft.network/traffic-manager-webapp/metadata.json
+++ b/quickstarts/microsoft.network/traffic-manager-webapp/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template shows how to create an Azure Traffic Manager profile for an App Service.",
   "summary": "This template creates an Azure Traffic Manager profile that provides an App Service behind it",
   "githubUsername": "GarethBradshawMSFT",
-  "dateUpdated": "2021-06-22"
+  "dateUpdated": "2021-07-09"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/traffic-manager-webapp

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3319