### PR TITLE
Migrate bicep example: 201/vnet-to-vnet-peering

### DIFF
--- a/quickstarts/microsoft.network/vnet-to-vnet-peering/README.md
+++ b/quickstarts/microsoft.network/vnet-to-vnet-peering/README.md
@@ -9,8 +9,11 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/vnet-to-vnet-peering/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/vnet-to-vnet-peering/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/vnet-to-vnet-peering/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fvnet-to-vnet-peering%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fvnet-to-vnet-peering%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fvnet-to-vnet-peering%2Fazuredeploy.json)
 
 This template creates two VNETs in the same location, each containing a single subnet, and creates connections between them using VNet peering.
+

--- a/quickstarts/microsoft.network/vnet-to-vnet-peering/azuredeploy.json
+++ b/quickstarts/microsoft.network/vnet-to-vnet-peering/azuredeploy.json
@@ -1,131 +1,127 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "location": {
-            "type": "string",
-            "metadata": {
-                "description": "Location of the resources"
-            },
-            "defaultValue": "[resourceGroup().location]"
-        },
-        "vNet1Name": {
-            "type": "string",
-            "defaultValue": "vNet1",
-            "metadata": {
-                "description": "Name for vNet 1"
-            }
-        },
-        "vNet2Name": {
-            "type": "string",
-            "defaultValue": "vNet2",
-            "metadata": {
-                "description": "Name for vNet 2"
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "5693428123113872453"
+    }
+  },
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location of the resources"
+      }
     },
-    "variables": {
-        "vNet1": {
-            "addressSpacePrefix": "10.0.0.0/24",
-            "subnetName": "subnet1",
-            "subnetPrefix": "10.0.0.0/24"
-        },
-        "vNet2": {
-            "addressSpacePrefix": "192.168.0.0/24",
-            "subnetName": "subnet1",
-            "subnetPrefix": "192.168.0.0/24"
-        },
-        "vNet1tovNet2PeeringName": "[concat(parameters('vNet1Name'), '-', parameters('vNet2Name'))]",
-        "vNet2tovNet1PeeringName": "[concat(parameters('vNet2Name'), '-', parameters('vNet1Name'))]"
+    "vnet1Name": {
+      "type": "string",
+      "defaultValue": "vNet1",
+      "metadata": {
+        "description": "Name for vNet 1"
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "2020-05-01",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[parameters('vNet1Name')]",
-            "location": "[parameters('location')]",
-            "comments": "This is the first vNet",
-            "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('vNet1').addressSpacePrefix]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('vNet1').subnetName]",
-                        "properties": {
-                            "addressPrefix": "[variables('vNet1').subnetPrefix]"
-                        }
-                    }
-                ]
-            },
-            "resources": [
-                {
-                    "apiVersion": "2020-05-01",
-                    "type": "virtualNetworkPeerings",
-                    "name": "[variables('vNet1tovNet2PeeringName')]",
-                    "location": "[parameters('location')]",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet1Name'))]",
-                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet2Name'))]"
-                    ],
-                    "comments": "This is the peering from vNet 1 to vNet 2",
-                    "properties": {
-                        "allowVirtualNetworkAccess": true,
-                        "allowForwardedTraffic": false,
-                        "allowGatewayTransit": false,
-                        "useRemoteGateways": false,
-                        "remoteVirtualNetwork": {
-                            "id": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vNet2Name'))]"
-                        }
-                    }
-                }
-            ]
+    "vnet2Name": {
+      "type": "string",
+      "defaultValue": "vNet2",
+      "metadata": {
+        "description": "Name for vNet 2"
+      }
+    }
+  },
+  "functions": [],
+  "variables": {
+    "vnet1Config": {
+      "addressSpacePrefix": "10.0.0.0/24",
+      "subnetName": "subnet1",
+      "subnetPrefix": "10.0.0.0/24"
+    },
+    "vnet2Config": {
+      "addressSpacePrefix": "192.168.0.0/24",
+      "subnetName": "subnet1",
+      "subnetPrefix": "192.168.0.0/24"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-05-01",
+      "name": "[parameters('vnet1Name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnet1Config').addressSpacePrefix]"
+          ]
         },
-        {
-            "apiVersion": "2020-05-01",
-            "type": "Microsoft.Network/virtualNetworks",
-            "name": "[parameters('vNet2Name')]",
-            "location": "[parameters('location')]",
-            "comments": "This is the second vNet",
+        "subnets": [
+          {
+            "name": "[variables('vnet1Config').subnetName]",
             "properties": {
-                "addressSpace": {
-                    "addressPrefixes": [
-                        "[variables('vNet2').addressSpacePrefix]"
-                    ]
-                },
-                "subnets": [
-                    {
-                        "name": "[variables('vNet2').subnetName]",
-                        "properties": {
-                            "addressPrefix": "[variables('vNet2').subnetPrefix]"
-                        }
-                    }
-                ]
-            },
-            "resources": [
-                {
-                    "apiVersion": "2020-05-01",
-                    "type": "virtualNetworkPeerings",
-                    "name": "[variables('vNet2tovNet1PeeringName')]",
-                    "location": "[parameters('location')]",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet1Name'))]",
-                        "[resourceId('Microsoft.Network/virtualNetworks/', parameters('vNet2Name'))]"
-                    ],
-                    "comments": "This is the peering from vNet 2 to vNet 1",
-                    "properties": {
-                        "allowVirtualNetworkAccess": true,
-                        "allowForwardedTraffic": false,
-                        "allowGatewayTransit": false,
-                        "useRemoteGateways": false,
-                        "remoteVirtualNetwork": {
-                            "id": "[resourceId('Microsoft.Network/virtualNetworks',parameters('vNet1Name'))]"
-                        }
-                    }
-                }
-            ]
+              "addressPrefix": "[variables('vnet1Config').subnetPrefix]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "[format('{0}/{1}', parameters('vnet1Name'), format('{0}-{1}', parameters('vnet1Name'), parameters('vnet2Name')))]",
+      "properties": {
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": false,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false,
+        "remoteVirtualNetwork": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet2Name'))]"
         }
-    ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet1Name'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet2Name'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2020-05-01",
+      "name": "[parameters('vnet2Name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "[variables('vnet2Config').addressSpacePrefix]"
+          ]
+        },
+        "subnets": [
+          {
+            "name": "[variables('vnet2Config').subnetName]",
+            "properties": {
+              "addressPrefix": "[variables('vnet2Config').subnetPrefix]"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/virtualNetworkPeerings",
+      "apiVersion": "2020-05-01",
+      "name": "[format('{0}/{1}', parameters('vnet2Name'), format('{0}-{1}', parameters('vnet2Name'), parameters('vnet1Name')))]",
+      "properties": {
+        "allowVirtualNetworkAccess": true,
+        "allowForwardedTraffic": false,
+        "allowGatewayTransit": false,
+        "useRemoteGateways": false,
+        "remoteVirtualNetwork": {
+          "id": "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet1Name'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet1Name'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('vnet2Name'))]"
+      ]
+    }
+  ]
 }

--- a/quickstarts/microsoft.network/vnet-to-vnet-peering/main.bicep
+++ b/quickstarts/microsoft.network/vnet-to-vnet-peering/main.bicep
@@ -1,0 +1,87 @@
+@description('Location of the resources')
+param location string = resourceGroup().location
+
+@description('Name for vNet 1')
+param vnet1Name string = 'vNet1'
+
+@description('Name for vNet 2')
+param vnet2Name string = 'vNet2'
+
+var vnet1Config = {
+  addressSpacePrefix: '10.0.0.0/24'
+  subnetName: 'subnet1'
+  subnetPrefix: '10.0.0.0/24'
+}
+var vnet2Config = {
+  addressSpacePrefix: '192.168.0.0/24'
+  subnetName: 'subnet1'
+  subnetPrefix: '192.168.0.0/24'
+}
+
+resource vnet1 'Microsoft.Network/virtualNetworks@2020-05-01' = {
+  name: vnet1Name
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnet1Config.addressSpacePrefix
+      ]
+    }
+    subnets: [
+      {
+        name: vnet1Config.subnetName
+        properties: {
+          addressPrefix: vnet1Config.subnetPrefix
+        }
+      }
+    ]
+  }
+}
+
+resource VnetPeering1 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  parent: vnet1
+  name: '${vnet1Name}-${vnet2Name}'
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: false
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: vnet2.id
+    }
+  }
+}
+
+resource vnet2 'Microsoft.Network/virtualNetworks@2020-05-01' = {
+  name: vnet2Name
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        vnet2Config.addressSpacePrefix
+      ]
+    }
+    subnets: [
+      {
+        name: vnet2Config.subnetName
+        properties: {
+          addressPrefix: vnet2Config.subnetPrefix
+        }
+      }
+    ]
+  }
+}
+
+resource vnetPeering2 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
+  parent: vnet2
+  name: '${vnet2Name}-${vnet1Name}'
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: false
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: vnet1.id
+    }
+  }
+}

--- a/quickstarts/microsoft.network/vnet-to-vnet-peering/metadata.json
+++ b/quickstarts/microsoft.network/vnet-to-vnet-peering/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to connect two vNets using vNet Peering",
   "summary": "Create a VNET to VNET connection using vNet Peering",
   "githubUsername": "bhummerstone",
-  "dateUpdated": "2021-05-14"
+  "dateUpdated": "2021-06-22"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/vnet-to-vnet-peering

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3331