### PR TITLE
Migrate bicep example: 101/expressroute-circuit-create

### DIFF
--- a/quickstarts/microsoft.network/expressroute-circuit-create/README.md
+++ b/quickstarts/microsoft.network/expressroute-circuit-create/README.md
@@ -9,7 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/expressroute-circuit-create/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/expressroute-circuit-create/CredScanResult.svg)
 
-Create ExpressRoute Circuit  - 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/expressroute-circuit-create/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fexpressroute-circuit-create%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fexpressroute-circuit-create%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fexpressroute-circuit-create%2Fazuredeploy.json)
@@ -21,5 +22,3 @@ Refer to https://azure.microsoft.com/documentation/articles/expressroute-introdu
 Refer to https://azure.microsoft.com/pricing/details/expressroute/ for more details on pricing/SKU of ExpressRoute.
 
 Refer to https://azure.microsoft.com/documentation/articles/expressroute-locations/ for ExpressRoute partners and peering locations list.
-
-

--- a/quickstarts/microsoft.network/expressroute-circuit-create/azuredeploy.json
+++ b/quickstarts/microsoft.network/expressroute-circuit-create/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "16925925632640183045"
+    }
+  },
   "parameters": {
     "circuitName": {
       "type": "string",
@@ -26,7 +33,7 @@
         "description": "This is the bandwidth in Mbps of the circuit being created. It must exactly match one of the available bandwidth offers List ExpressRoute Service Providers API call."
       }
     },
-    "sku_tier": {
+    "skuTier": {
       "type": "string",
       "defaultValue": "Standard",
       "allowedValues": [
@@ -37,7 +44,7 @@
         "description": "Chosen SKU Tier of ExpressRoute circuit. Choose from Premium or Standard SKU tiers."
       }
     },
-    "sku_family": {
+    "skuFamily": {
       "type": "string",
       "defaultValue": "MeteredData",
       "allowedValues": [
@@ -56,20 +63,17 @@
       }
     }
   },
+  "functions": [],
   "resources": [
     {
-      "apiVersion": "2019-04-01",
       "type": "Microsoft.Network/expressRouteCircuits",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('circuitName')]",
       "location": "[parameters('location')]",
-      "tags": {
-        "key1": "value1",
-        "key2": "value2"
-      },
       "sku": {
-        "name": "[concat(parameters('sku_tier'),'_', parameters('sku_family'))]",
-        "tier": "[parameters('sku_tier')]",
-        "family": "[parameters('sku_family')]"
+        "name": "[format('{0}_{1}', parameters('skuTier'), parameters('skuFamily'))]",
+        "tier": "[parameters('skuTier')]",
+        "family": "[parameters('skuFamily')]"
       },
       "properties": {
         "serviceProviderProperties": {

--- a/quickstarts/microsoft.network/expressroute-circuit-create/azuredeploy.parameters.json
+++ b/quickstarts/microsoft.network/expressroute-circuit-create/azuredeploy.parameters.json
@@ -14,10 +14,10 @@
         "bandwidthInMbps": {
             "value": 500
         },
-        "sku_tier": {
+        "skuTier": {
             "value": "Premium"
         },
-        "sku_family": {
+        "skuFamily": {
             "value": "MeteredData"
         }
     }

--- a/quickstarts/microsoft.network/expressroute-circuit-create/main.bicep
+++ b/quickstarts/microsoft.network/expressroute-circuit-create/main.bicep
@@ -1,0 +1,45 @@
+@description('This is the name of the ExpressRoute circuit')
+param circuitName string
+
+@description('This is the name of the ExpressRoute Service Provider. It must exactly match one of the Service Providers from List ExpressRoute Service Providers API call.')
+param serviceProviderName string
+
+@description('This is the name of the peering location and not the ARM resource location. It must exactly match one of the available peering locations from List ExpressRoute Service Providers API call.')
+param peeringLocation string
+
+@description('This is the bandwidth in Mbps of the circuit being created. It must exactly match one of the available bandwidth offers List ExpressRoute Service Providers API call.')
+param bandwidthInMbps int
+
+@description('Chosen SKU Tier of ExpressRoute circuit. Choose from Premium or Standard SKU tiers.')
+@allowed([
+  'Standard'
+  'Premium'
+])
+param skuTier string = 'Standard'
+
+@description('Chosen SKU family of ExpressRoute circuit. Choose from MeteredData or UnlimitedData SKU families.')
+@allowed([
+  'MeteredData'
+  'UnlimitedData'
+])
+param skuFamily string = 'MeteredData'
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+resource circuit 'Microsoft.Network/expressRouteCircuits@2021-02-01' = {
+  name: circuitName
+  location: location
+  sku: {
+    name: '${skuTier}_${skuFamily}'
+    tier: skuTier
+    family: skuFamily
+  }
+  properties: {
+    serviceProviderProperties: {
+      serviceProviderName: serviceProviderName
+      peeringLocation: peeringLocation
+      bandwidthInMbps: bandwidthInMbps
+    }
+  }
+}

--- a/quickstarts/microsoft.network/expressroute-circuit-create/metadata.json
+++ b/quickstarts/microsoft.network/expressroute-circuit-create/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template creates an ExpressRoute Circuit for a specified Service Provider and SKU",
   "summary": "Create an ExpressRoute Circuit",
   "githubUsername": "amitsriva",
-  "dateUpdated": "2021-04-26"
+  "dateUpdated": "2021-06-22"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/expressroute-circuit-create

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3334