### PR TITLE
Migrate bicep example: 201/cdn-with-storage-account

### DIFF
--- a/quickstarts/microsoft.cdn/cdn-with-storage-account/README.md
+++ b/quickstarts/microsoft.cdn/cdn-with-storage-account/README.md
@@ -9,8 +9,11 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.cdn/cdn-with-storage-account/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.cdn/cdn-with-storage-account/CredScanResult.svg)
 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.cdn%2Fcdn-with-storage-account%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.cdn%2Fcdn-with-storage-account%2Fazuredeploy.json)
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.cdn/cdn-with-storage-account/BicepVersion.svg)
+
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.cdn%2Fcdn-with-storage-account%2Fazuredeploy.json)
+
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.cdn%2Fcdn-with-storage-account%2Fazuredeploy.json)
 
 This template creates a CDN Profile and a CDN Endpoint with origin as a Storage Account. Note that user needs to create a public container in the Storage Account in order for CDN Endpoint to serve content from the Storage Account.
-
 

--- a/quickstarts/microsoft.cdn/cdn-with-storage-account/azuredeploy.json
+++ b/quickstarts/microsoft.cdn/cdn-with-storage-account/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "17059297737130475169"
+    }
+  },
   "parameters": {
     "location": {
       "type": "string",
@@ -10,85 +17,82 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "storageAccountName": "[concat('storage', uniqueString(resourceGroup().id))]",
-    "endpointName": "[concat('endpoint-', uniqueString(resourceGroup().id))]",
-    "profileName": "[concat('cdn-', uniqueString(resourceGroup().id))]"
+    "storageAccountName": "[format('storage{0}', uniqueString(resourceGroup().id))]",
+    "endpointName": "[format('endpoint-{0}', uniqueString(resourceGroup().id))]",
+    "profileName": "[format('cdn-{0}', uniqueString(resourceGroup().id))]"
   },
   "resources": [
     {
       "type": "Microsoft.Storage/storageAccounts",
-      "name": "[variables('storageAccountName')]",
       "apiVersion": "2021-01-01",
+      "name": "[variables('storageAccountName')]",
       "location": "[parameters('location')]",
       "tags": {
         "displayName": "[variables('storageAccountName')]"
       },
-      "kind": "Storage",
+      "kind": "StorageV2",
       "sku": {
         "name": "Standard_LRS"
-      },
-      "properties": {}
+      }
     },
     {
-      "name": "[variables('profileName')]",
       "type": "Microsoft.Cdn/profiles",
+      "apiVersion": "2020-09-01",
+      "name": "[variables('profileName')]",
       "location": "[parameters('location')]",
-      "apiVersion": "2016-04-02",
       "tags": {
         "displayName": "[variables('profileName')]"
       },
       "sku": {
         "name": "Standard_Verizon"
+      }
+    },
+    {
+      "type": "Microsoft.Cdn/profiles/endpoints",
+      "apiVersion": "2020-09-01",
+      "name": "[format('{0}/{1}', variables('profileName'), variables('endpointName'))]",
+      "location": "[parameters('location')]",
+      "tags": {
+        "displayName": "[variables('endpointName')]"
       },
-      "properties": {},
-      "resources": [
-        {
-          "apiVersion": "2016-04-02",
-          "name": "[variables('endpointName')]",
-          "type": "endpoints",
-          "dependsOn": [
-            "[variables('profileName')]",
-            "[variables('storageAccountName')]"
-          ],
-          "location": "[parameters('location')]",
-          "tags": {
-            "displayName": "[variables('endpointName')]"
-          },
-          "properties": {
-            "originHostHeader": "[replace(replace(reference(variables('storageAccountName')).primaryEndpoints.blob,'https://',''),'/','')]",
-            "isHttpAllowed": true,
-            "isHttpsAllowed": true,
-            "queryStringCachingBehavior": "IgnoreQueryString",
-            "contentTypesToCompress": [
-              "text/plain",
-              "text/html",
-              "text/css",
-              "application/x-javascript",
-              "text/javascript"
-            ],
-            "isCompressionEnabled": true,
-            "origins": [
-              {
-                "name": "origin1",
-                "properties": {
-                  "hostName": "[replace(replace(reference(variables('storageAccountName')).primaryEndpoints.blob,'https://',''),'/','')]"
-                }
-              }
-            ]
+      "properties": {
+        "originHostHeader": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob, 'https://', ''), '/', '')]",
+        "isHttpAllowed": true,
+        "isHttpsAllowed": true,
+        "queryStringCachingBehavior": "IgnoreQueryString",
+        "contentTypesToCompress": [
+          "text/plain",
+          "text/html",
+          "text/css",
+          "application/x-javascript",
+          "text/javascript"
+        ],
+        "isCompressionEnabled": true,
+        "origins": [
+          {
+            "name": "origin1",
+            "properties": {
+              "hostName": "[replace(replace(reference(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))).primaryEndpoints.blob, 'https://', ''), '/', '')]"
+            }
           }
-        }
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Cdn/profiles', variables('profileName'))]",
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
       ]
     }
   ],
   "outputs": {
     "hostName": {
       "type": "string",
-      "value": "[reference(variables('endpointName')).hostName]"
+      "value": "[reference(resourceId('Microsoft.Cdn/profiles/endpoints', variables('profileName'), variables('endpointName'))).hostName]"
     },
     "originHostHeader": {
       "type": "string",
-      "value": "[reference(variables('endpointName')).originHostHeader]"
+      "value": "[reference(resourceId('Microsoft.Cdn/profiles/endpoints', variables('profileName'), variables('endpointName'))).originHostHeader]"
     }
   }
 }

--- a/quickstarts/microsoft.cdn/cdn-with-storage-account/main.bicep
+++ b/quickstarts/microsoft.cdn/cdn-with-storage-account/main.bicep
@@ -1,0 +1,64 @@
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+var storageAccountName = 'storage${uniqueString(resourceGroup().id)}'
+var endpointName = 'endpoint-${uniqueString(resourceGroup().id)}'
+var profileName = 'cdn-${uniqueString(resourceGroup().id)}'
+var storageAccountHostName = replace(replace(storageAccount.properties.primaryEndpoints.blob, 'https://', ''), '/', '')
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' = {
+  name: storageAccountName
+  location: location
+  tags: {
+    displayName: storageAccountName
+  }
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+}
+
+resource cdnProfile 'Microsoft.Cdn/profiles@2020-09-01' = {
+  name: profileName
+  location: location
+  tags: {
+    displayName: profileName
+  }
+  sku: {
+    name: 'Standard_Verizon'
+  }
+}
+
+resource endpoint 'Microsoft.Cdn/profiles/endpoints@2020-09-01' = {
+  parent: cdnProfile
+  name: endpointName
+  location: location
+  tags: {
+    displayName: endpointName
+  }
+  properties: {
+    originHostHeader: storageAccountHostName
+    isHttpAllowed: true
+    isHttpsAllowed: true
+    queryStringCachingBehavior: 'IgnoreQueryString'
+    contentTypesToCompress: [
+      'text/plain'
+      'text/html'
+      'text/css'
+      'application/x-javascript'
+      'text/javascript'
+    ]
+    isCompressionEnabled: true
+    origins: [
+      {
+        name: 'origin1'
+        properties: {
+          hostName: storageAccountHostName
+        }
+      }
+    ]
+  }
+}
+
+output hostName string = endpoint.properties.hostName
+output originHostHeader string = endpoint.properties.originHostHeader

--- a/quickstarts/microsoft.cdn/cdn-with-storage-account/metadata.json
+++ b/quickstarts/microsoft.cdn/cdn-with-storage-account/metadata.json
@@ -6,7 +6,7 @@
   "description": "This template creates a CDN Profile and a CDN Endpoint with origin as a Storage Account. Note that user needs to create a public container in the Storage Account in order for CDN Endpoint to serve content from the Storage Account.",
   "summary": "Create a CDN Profile and a CDN Endpoint with a Storage Account as origin",
   "githubUsername": "kuangweizhang",
-  "dateUpdated": "2021-05-27",
+  "dateUpdated": "2021-06-22",
   "environments": [
     "AzureCloud"
   ]


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/cdn-with-storage-account

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3338