### PR TITLE
Migrate bicep example: 201/vmss-windows-autoscale

### DIFF
--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/README.md
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/README.md
@@ -9,11 +9,13 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.compute/vmss-windows-autoscale/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.compute/vmss-windows-autoscale/CredScanResult.svg)
 
-The following template deploys a Windows VM Scale Set integrated with Azure autoscale
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.compute/vmss-windows-autoscale/BicepVersion.svg)
 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fvmss-windows-autoscale%2Fazuredeploy.json)  
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fvmss-windows-autoscale%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fvmss-windows-autoscale%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fvmss-windows-autoscale%2Fazuredeploy.json)
+
+This template deploys a Windows VM Scale Set integrated with Azure autoscale.
 
 The template deploys a Windows VMSS with a desired count of VMs in the scale set. Once the VM Scale Sets is deployed, user can deploy an application inside each of the VMs (either by directly logging into the VMs or via a custom script extension)
 
@@ -22,5 +24,4 @@ The Autoscale rules are configured as follows
 - sample for CPU (\\Processor\\PercentProcessorTime) in each VM every 1 Minute
 - if the Percent Processor Time is greater than 50% for 5 Minutes, then the scale out action (add more VM instances, one at a time) is triggered
 - once the scale out action is completed, the cool down period is 1 Minute
-
 

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "10526690402135839347"
+      "templateHash": "7379231288636260028"
     }
   },
   "parameters": {
@@ -211,7 +211,7 @@
                         ],
                         "loadBalancerInboundNatPools": [
                           {
-                            "id": "[format('{0}/inboundNatPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('natPoolName'))]"
+                            "id": "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('loadBalancerName'), variables('natPoolName'))]"
                           }
                         ]
                       }

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
@@ -1,40 +1,48 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "1300276563162816339"
+    }
+  },
   "parameters": {
     "vmSku": {
       "type": "string",
-      "defaultValue": "Standard_A1",
+      "defaultValue": "Standard_A1_v2",
       "metadata": {
         "description": "Size of VMs in the VM Scale Set."
       }
     },
     "windowsOSVersion": {
       "type": "string",
-      "defaultValue": "2012-R2-Datacenter",
+      "defaultValue": "2019-Datacenter",
       "allowedValues": [
-        "2008-R2-SP1",
-        "2012-Datacenter",
-        "2012-R2-Datacenter"
+        "2019-Datacenter",
+        "2016-Datacenter",
+        "2012-R2-Datacenter",
+        "2012-Datacenter"
       ],
       "metadata": {
-        "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version. Allowed values: 2008-R2-SP1, 2012-Datacenter, 2012-R2-Datacenter."
+        "description": "The Windows version for the VM. This will pick a fully patched image of this given Windows version."
       }
     },
     "vmssName": {
       "type": "string",
+      "maxLength": 61,
       "metadata": {
         "description": "String used as a base for naming resources. Must be 3-61 characters in length and globally unique across Azure. A hash is prepended to this string for some resources, and resource-specific information is appended."
-      },
-      "maxLength": 61
+      }
     },
     "instanceCount": {
       "type": "int",
+      "maxValue": 100,
+      "minValue": 1,
       "metadata": {
         "description": "Number of VM instances (100 or less)."
-      },
-      "minValue": 1,
-      "maxValue": 100
+      }
     },
     "adminUsername": {
       "type": "string",
@@ -43,7 +51,7 @@
       }
     },
     "adminPassword": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Admin password on all VMs."
       }
@@ -52,26 +60,27 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
-        "description": "Location of the resources."
+        "description": "Location for all resources."
       }
     }
   },
+  "functions": [],
   "variables": {
-    "namingInfix": "[toLower(substring(concat(parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
+    "namingInfix": "[toLower(substring(format('{0}{1}', parameters('vmssName'), uniqueString(resourceGroup().id)), 0, 9))]",
     "longNamingInfix": "[toLower(parameters('vmssName'))]",
     "addressPrefix": "10.0.0.0/16",
     "subnetPrefix": "10.0.0.0/24",
-    "virtualNetworkName": "[concat(variables('namingInfix'), 'vnet')]",
-    "publicIPAddressName": "[concat(variables('namingInfix'), 'pip')]",
-    "subnetName": "[concat(variables('namingInfix'), 'subnet')]",
-    "loadBalancerName": "[concat(variables('namingInfix'), 'lb')]",
-    "natPoolName": "[concat(variables('namingInfix'), 'natpool')]",
-    "bePoolName": "[concat(variables('namingInfix'), 'bepool')]",
+    "virtualNetworkName": "[format('{0}vnet', variables('namingInfix'))]",
+    "publicIPAddressName": "[format('{0}pip', variables('namingInfix'))]",
+    "subnetName": "[format('{0}subnet', variables('namingInfix'))]",
+    "loadBalancerName": "[format('{0}lb', variables('namingInfix'))]",
+    "natPoolName": "[format('{0}natpool', variables('namingInfix'))]",
+    "bePoolName": "[format('{0}bepool', variables('namingInfix'))]",
     "natStartPort": 50000,
     "natEndPort": 50119,
     "natBackendPort": 3389,
-    "nicName": "[concat(variables('namingInfix'), 'nic')]",
-    "ipConfigName": "[concat(variables('namingInfix'), 'ipconfig')]",
+    "nicName": "[format('{0}nic', variables('namingInfix'))]",
+    "ipConfigName": "[format('{0}ipconfig', variables('namingInfix'))]",
     "osType": {
       "publisher": "MicrosoftWindowsServer",
       "offer": "WindowsServer",
@@ -83,9 +92,9 @@
   "resources": [
     {
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2021-02-01",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
-      "apiVersion": "2020-11-01",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -104,9 +113,9 @@
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2021-02-01",
       "name": "[variables('publicIPAddressName')]",
       "location": "[parameters('location')]",
-      "apiVersion": "2020-11-01",
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
@@ -116,19 +125,16 @@
     },
     {
       "type": "Microsoft.Network/loadBalancers",
+      "apiVersion": "2021-02-01",
       "name": "[variables('loadBalancerName')]",
       "location": "[parameters('location')]",
-      "apiVersion": "2020-11-01",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/publicIPAddresses/', variables('publicIPAddressName'))]"
-      ],
       "properties": {
         "frontendIPConfigurations": [
           {
             "name": "LoadBalancerFrontEnd",
             "properties": {
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses',variables('publicIPAddressName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
               }
             }
           }
@@ -143,7 +149,7 @@
             "name": "[variables('natPoolName')]",
             "properties": {
               "frontendIPConfiguration": {
-                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIpConfigurations', variables('loadBalancerName'), 'loadBalancerFrontEnd')]"
+                "id": "[resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', variables('loadBalancerName'), 'loadBalancerFrontEnd')]"
               },
               "protocol": "Tcp",
               "frontendPortRangeStart": "[variables('natStartPort')]",
@@ -152,17 +158,16 @@
             }
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName'))]"
+      ]
     },
     {
       "type": "Microsoft.Compute/virtualMachineScaleSets",
-      "name": "[variables('namingInfix')]",
+      "apiVersion": "2021-03-01",
+      "name": "[parameters('vmssName')]",
       "location": "[parameters('location')]",
-      "apiVersion": "2020-12-01",
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/loadBalancers/', variables('loadBalancerName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/', variables('virtualNetworkName'))]"
-      ],
       "sku": {
         "name": "[parameters('vmSku')]",
         "tier": "Standard",
@@ -197,16 +202,16 @@
                       "name": "[variables('ipConfigName')]",
                       "properties": {
                         "subnet": {
-                          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
+                          "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnetName'))]"
                         },
                         "loadBalancerBackendAddressPools": [
                           {
-                            "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('bePoolName'))]"
+                            "id": "[format('{0}/backendAddressPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('bePoolName'))]"
                           }
                         ],
                         "loadBalancerInboundNatPools": [
                           {
-                            "id": "[resourceId('Microsoft.Network/loadBalancers/inboundNatPools', variables('loadBalancerName'), variables('natPoolName'))]"
+                            "id": "[format('{0}/inboundNatPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('natPoolName'))]"
                           }
                         ]
                       }
@@ -217,19 +222,20 @@
             ]
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName'))]"
+      ]
     },
     {
-      "type": "Microsoft.Insights/autoscaleSettings",
+      "type": "microsoft.insights/autoscalesettings",
       "apiVersion": "2015-04-01",
       "name": "cpuautoscale",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]"
-      ],
       "properties": {
         "name": "cpuautoscale",
-        "targetResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]",
+        "targetResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
         "enabled": true,
         "profiles": [
           {
@@ -243,13 +249,14 @@
               {
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
-                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]",
+                  "metricNamespace": "",
+                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
                   "timeGrain": "PT1M",
-                  "statistic": "Average",
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "GreaterThan",
-                  "threshold": 50
+                  "threshold": 50,
+                  "statistic": "Average"
                 },
                 "scaleAction": {
                   "direction": "Increase",
@@ -261,13 +268,14 @@
               {
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
-                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets/', variables('namingInfix'))]",
+                  "metricNamespace": "",
+                  "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
                   "timeGrain": "PT1M",
-                  "statistic": "Average",
                   "timeWindow": "PT5M",
                   "timeAggregation": "Average",
                   "operator": "LessThan",
-                  "threshold": 30
+                  "threshold": 30,
+                  "statistic": "Average"
                 },
                 "scaleAction": {
                   "direction": "Decrease",
@@ -279,7 +287,10 @@
             ]
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]"
+      ]
     }
   ]
 }

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "1457578975408662894"
+      "templateHash": "13748055172111759391"
     }
   },
   "parameters": {
@@ -249,7 +249,6 @@
               {
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
-                  "metricNamespace": "",
                   "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
                   "timeGrain": "PT1M",
                   "timeWindow": "PT5M",
@@ -268,7 +267,6 @@
               {
                 "metricTrigger": {
                   "metricName": "Percentage CPU",
-                  "metricNamespace": "",
                   "metricResourceUri": "[resourceId('Microsoft.Compute/virtualMachineScaleSets', parameters('vmssName'))]",
                   "timeGrain": "PT1M",
                   "timeWindow": "PT5M",

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "13748055172111759391"
+      "templateHash": "10526690402135839347"
     }
   },
   "parameters": {
@@ -202,11 +202,11 @@
                       "name": "[variables('ipConfigName')]",
                       "properties": {
                         "subnet": {
-                          "id": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', variables('virtualNetworkName')), variables('subnetName'))]"
+                          "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]"
                         },
                         "loadBalancerBackendAddressPools": [
                           {
-                            "id": "[format('{0}/backendAddressPools/{1}', resourceId('Microsoft.Network/loadBalancers', variables('loadBalancerName')), variables('bePoolName'))]"
+                            "id": "[resourceId('Microsoft.Network/loadBalancers/backendAddressPools', variables('loadBalancerName'), variables('bePoolName'))]"
                           }
                         ],
                         "loadBalancerInboundNatPools": [

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "1300276563162816339"
+      "version": "0.4.412.5873",
+      "templateHash": "1457578975408662894"
     }
   },
   "parameters": {
@@ -229,7 +229,7 @@
       ]
     },
     {
-      "type": "microsoft.insights/autoscalesettings",
+      "type": "Microsoft.Insights/autoscalesettings",
       "apiVersion": "2015-04-01",
       "name": "cpuautoscale",
       "location": "[parameters('location')]",

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
@@ -201,7 +201,6 @@ resource autoScaleSettings 'microsoft.insights/autoscalesettings@2015-04-01' = {
           {
             metricTrigger: {
               metricName: 'Percentage CPU'
-              metricNamespace: ''
               metricResourceUri: vmss.id
               timeGrain: 'PT1M'
               timeWindow: 'PT5M'
@@ -220,7 +219,6 @@ resource autoScaleSettings 'microsoft.insights/autoscalesettings@2015-04-01' = {
           {
             metricTrigger: {
               metricName: 'Percentage CPU'
-              metricNamespace: ''
               metricResourceUri: vmss.id
               timeGrain: 'PT1M'
               timeWindow: 'PT5M'

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
@@ -180,10 +180,6 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01' = {
       }
     }
   }
-  dependsOn: [
-    loadBalancer
-    virtualNetwork
-  ]
 }
 
 resource autoScaleSettings 'microsoft.insights/autoscalesettings@2015-04-01' = {
@@ -244,7 +240,4 @@ resource autoScaleSettings 'microsoft.insights/autoscalesettings@2015-04-01' = {
       }
     ]
   }
-  dependsOn: [
-    vmss
-  ]
 }

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
@@ -159,11 +159,11 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01' = {
                   name: ipConfigName
                   properties: {
                     subnet: {
-                      id: '${virtualNetwork.id}/subnets/${subnetName}'
+                      id: resourceId('Microsoft.Network/virtualNetworks/subnets', virtualNetwork.name, subnetName)
                     }
                     loadBalancerBackendAddressPools: [
                       {
-                        id: '${loadBalancer.id}/backendAddressPools/${bePoolName}'
+                        id: resourceId('Microsoft.Network/loadBalancers/backendAddressPools', loadBalancer.name, bePoolName)
                       }
                     ]
                     loadBalancerInboundNatPools: [

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
@@ -168,7 +168,7 @@ resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01' = {
                     ]
                     loadBalancerInboundNatPools: [
                       {
-                        id: '${loadBalancer.id}/inboundNatPools/${natPoolName}'
+                        id: resourceId('Microsoft.Network/loadBalancers/inboundNatPools', loadBalancer.name, natPoolName)
                       }
                     ]
                   }

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/main.bicep
@@ -1,0 +1,250 @@
+@description('Size of VMs in the VM Scale Set.')
+param vmSku string = 'Standard_A1_v2'
+
+@description('The Windows version for the VM. This will pick a fully patched image of this given Windows version.')
+@allowed([
+  '2019-Datacenter'
+  '2016-Datacenter'
+  '2012-R2-Datacenter'
+  '2012-Datacenter'
+])
+param windowsOSVersion string = '2019-Datacenter'
+
+@description('String used as a base for naming resources. Must be 3-61 characters in length and globally unique across Azure. A hash is prepended to this string for some resources, and resource-specific information is appended.')
+@maxLength(61)
+param vmssName string
+
+@description('Number of VM instances (100 or less).')
+@minValue(1)
+@maxValue(100)
+param instanceCount int
+
+@description('Admin username on all VMs.')
+param adminUsername string
+
+@description('Admin password on all VMs.')
+@secure()
+param adminPassword string
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+var namingInfix = toLower(substring('${vmssName}${uniqueString(resourceGroup().id)}', 0, 9))
+var longNamingInfix = toLower(vmssName)
+var addressPrefix = '10.0.0.0/16'
+var subnetPrefix = '10.0.0.0/24'
+
+var virtualNetworkName = '${namingInfix}vnet'
+var publicIPAddressName = '${namingInfix}pip'
+var subnetName = '${namingInfix}subnet'
+var loadBalancerName = '${namingInfix}lb'
+var natPoolName = '${namingInfix}natpool'
+var bePoolName = '${namingInfix}bepool'
+
+var natStartPort = 50000
+var natEndPort = 50119
+var natBackendPort = 3389
+var nicName = '${namingInfix}nic'
+var ipConfigName = '${namingInfix}ipconfig'
+
+var osType = {
+  publisher: 'MicrosoftWindowsServer'
+  offer: 'WindowsServer'
+  sku: windowsOSVersion
+  version: 'latest'
+}
+var imageReference = osType
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        addressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: subnetName
+        properties: {
+          addressPrefix: subnetPrefix
+        }
+      }
+    ]
+  }
+}
+
+resource publicIP 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
+  name: publicIPAddressName
+  location: location
+  properties: {
+    publicIPAllocationMethod: 'Dynamic'
+    dnsSettings: {
+      domainNameLabel: longNamingInfix
+    }
+  }
+}
+
+resource loadBalancer 'Microsoft.Network/loadBalancers@2021-02-01' = {
+  name: loadBalancerName
+  location: location
+  properties: {
+    frontendIPConfigurations: [
+      {
+        name: 'LoadBalancerFrontEnd'
+        properties: {
+          publicIPAddress: {
+            id: publicIP.id
+          }
+        }
+      }
+    ]
+    backendAddressPools: [
+      {
+        name: bePoolName
+      }
+    ]
+    inboundNatPools: [
+      {
+        name: natPoolName
+        properties: {
+          frontendIPConfiguration: {
+            id: resourceId('Microsoft.Network/loadBalancers/frontendIPConfigurations', loadBalancerName, 'loadBalancerFrontEnd')
+          }
+          protocol: 'Tcp'
+          frontendPortRangeStart: natStartPort
+          frontendPortRangeEnd: natEndPort
+          backendPort: natBackendPort
+        }
+      }
+    ]
+  }
+}
+
+resource vmss 'Microsoft.Compute/virtualMachineScaleSets@2021-03-01' = {
+  name: vmssName
+  location: location
+  sku: {
+    name: vmSku
+    tier: 'Standard'
+    capacity: instanceCount
+  }
+  properties: {
+    overprovision: true
+    upgradePolicy: {
+      mode: 'Manual'
+    }
+    virtualMachineProfile: {
+      storageProfile: {
+        osDisk: {
+          createOption: 'FromImage'
+          caching: 'ReadWrite'
+        }
+        imageReference: imageReference
+      }
+      osProfile: {
+        computerNamePrefix: namingInfix
+        adminUsername: adminUsername
+        adminPassword: adminPassword
+      }
+      networkProfile: {
+        networkInterfaceConfigurations: [
+          {
+            name: nicName
+            properties: {
+              primary: true
+              ipConfigurations: [
+                {
+                  name: ipConfigName
+                  properties: {
+                    subnet: {
+                      id: '${virtualNetwork.id}/subnets/${subnetName}'
+                    }
+                    loadBalancerBackendAddressPools: [
+                      {
+                        id: '${loadBalancer.id}/backendAddressPools/${bePoolName}'
+                      }
+                    ]
+                    loadBalancerInboundNatPools: [
+                      {
+                        id: '${loadBalancer.id}/inboundNatPools/${natPoolName}'
+                      }
+                    ]
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  }
+  dependsOn: [
+    loadBalancer
+    virtualNetwork
+  ]
+}
+
+resource autoScaleSettings 'microsoft.insights/autoscalesettings@2015-04-01' = {
+  name: 'cpuautoscale'
+  location: location
+  properties: {
+    name: 'cpuautoscale'
+    targetResourceUri: vmss.id
+    enabled: true
+    profiles: [
+      {
+        name: 'Profile1'
+        capacity: {
+          minimum: '1'
+          maximum: '10'
+          default: '1'
+        }
+        rules: [
+          {
+            metricTrigger: {
+              metricName: 'Percentage CPU'
+              metricNamespace: ''
+              metricResourceUri: vmss.id
+              timeGrain: 'PT1M'
+              timeWindow: 'PT5M'
+              timeAggregation: 'Average'
+              operator: 'GreaterThan'
+              threshold: 50
+              statistic: 'Average'
+            }
+            scaleAction: {
+              direction: 'Increase'
+              type: 'ChangeCount'
+              value: '1'
+              cooldown: 'PT5M'
+            }
+          }
+          {
+            metricTrigger: {
+              metricName: 'Percentage CPU'
+              metricNamespace: ''
+              metricResourceUri: vmss.id
+              timeGrain: 'PT1M'
+              timeWindow: 'PT5M'
+              timeAggregation: 'Average'
+              operator: 'LessThan'
+              threshold: 30
+              statistic: 'Average'
+            }
+            scaleAction: {
+              direction: 'Decrease'
+              type: 'ChangeCount'
+              value: '1'
+              cooldown: 'PT5M'
+            }
+          }
+        ]
+      }
+    ]
+  }
+  dependsOn: [
+    vmss
+  ]
+}

--- a/quickstarts/microsoft.compute/vmss-windows-autoscale/metadata.json
+++ b/quickstarts/microsoft.compute/vmss-windows-autoscale/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to deploy a simple VM Scale Set of Windows VMs using the latest patched version of Windows 2008-R2-SP1, 2012-Datacenter, or 2012-R2-Datacenter. These VMs are behind a load balancer with NAT rules for RDP connections. They also have Auto Scale integrated",
   "summary": "This template deploys a VM Scale Set of Windows VMs behind a load balancer with NAT rules for RDP connections and Auto scale integrated",
   "githubUsername": "gatneil",
-  "dateUpdated": "2021-07-03"
+  "dateUpdated": "2021-07-28"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/vmss-windows-autoscale

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3342