### PR TITLE
Migrate bicep example: 301/nested-vms-in-virtual-network

### DIFF
--- a/demos/nested-vms-in-virtual-network/README.md
+++ b/demos/nested-vms-in-virtual-network/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/demos/nested-vms-in-virtual-network/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/demos/nested-vms-in-virtual-network/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/demos/nested-vms-in-virtual-network/BicepVersion.svg)
+
 This template will automate the deployment of a Virtual Machine to be a Hyper-V Host to be used for nested virtualization. Nested Virtual Machines will be able to communicate out to the internet and to other resources on your network.
 
 The setup is completed based on the procedure from the article [Nested VMs in Azure Virtual Networks](https://docs.microsoft.com/en-gb/virtualization/hyper-v-on-windows/user-guide/nested-virtualization-azure-virtual-network)

--- a/demos/nested-vms-in-virtual-network/azuredeploy.json
+++ b/demos/nested-vms-in-virtual-network/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "14172707274627034069"
+      "templateHash": "8360920427510730960"
     }
   },
   "parameters": {
@@ -131,6 +131,7 @@
     },
     "HostVirtualMachineSize": {
       "type": "string",
+      "defaultValue": "Standard_D4s_v3",
       "allowedValues": [
         "Standard_D2_v3",
         "Standard_D4_v3",

--- a/demos/nested-vms-in-virtual-network/azuredeploy.json
+++ b/demos/nested-vms-in-virtual-network/azuredeploy.json
@@ -1,20 +1,27 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "7104461790267266311"
+    }
+  },
   "parameters": {
     "_artifactsLocation": {
       "type": "string",
+      "defaultValue": "[deployment().properties.templateLink.uri]",
       "metadata": {
         "description": "The base URI where artifacts required by this template are located including a trailing '/'"
-      },
-      "defaultValue": "[deployment().properties.templatelink.uri]"
+      }
     },
     "_artifactsLocationSasToken": {
-      "type": "securestring",
+      "type": "secureString",
+      "defaultValue": "",
       "metadata": {
         "description": "The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated. Use the defaultValue if the staging location is not secured."
-      },
-      "defaultValue": ""
+      }
     },
     "location": {
       "type": "string",
@@ -39,80 +46,80 @@
     },
     "virtualNetworkAddressPrefix": {
       "type": "string",
+      "defaultValue": "10.0.0.0/22",
       "metadata": {
         "description": "Virtual Network Address Space"
-      },
-      "defaultValue": "10.0.0.0/22"
+      }
     },
     "NATSubnetName": {
       "type": "string",
+      "defaultValue": "NAT",
       "metadata": {
         "description": "NAT Subnet Name"
-      },
-      "defaultValue": "NAT"
+      }
     },
     "NATSubnetPrefix": {
       "type": "string",
+      "defaultValue": "10.0.0.0/24",
       "metadata": {
         "description": "NAT Subnet Address Space"
-      },
-      "defaultValue": "10.0.0.0/24"
+      }
     },
     "hyperVSubnetName": {
       "type": "string",
+      "defaultValue": "Hyper-V-LAN",
       "metadata": {
         "description": "Hyper-V Host Subnet Name"
-      },
-      "defaultValue": "Hyper-V-LAN"
+      }
     },
     "hyperVSubnetPrefix": {
       "type": "string",
+      "defaultValue": "10.0.1.0/24",
       "metadata": {
         "description": "Hyper-V Host Subnet Address Space"
-      },
-      "defaultValue": "10.0.1.0/24"
+      }
     },
     "ghostedSubnetName": {
       "type": "string",
+      "defaultValue": "Ghosted",
       "metadata": {
         "description": "Ghosted Subnet Name"
-      },
-      "defaultValue": "Ghosted"
+      }
     },
     "ghostedSubnetPrefix": {
       "type": "string",
+      "defaultValue": "10.0.2.0/24",
       "metadata": {
         "description": "Ghosted Subnet Address Space"
-      },
-      "defaultValue": "10.0.2.0/24"
+      }
     },
     "azureVMsSubnetName": {
       "type": "string",
+      "defaultValue": "Azure-VMs",
       "metadata": {
         "description": "Azure VMs Subnet Name"
-      },
-      "defaultValue": "Azure-VMs"
+      }
     },
     "azureVMsSubnetPrefix": {
       "type": "string",
+      "defaultValue": "10.0.3.0/24",
       "metadata": {
         "description": "Azure VMs Address Space"
-      },
-      "defaultValue": "10.0.3.0/24"
+      }
     },
     "HostNetworkInterface1Name": {
       "type": "string",
+      "defaultValue": "HVHOSTNIC1",
       "metadata": {
         "description": "Hyper-V Host Network Interface 1 Name, attached to NAT Subnet"
-      },
-      "defaultValue": "HVHOSTNIC1"
+      }
     },
     "HostNetworkInterface2Name": {
       "type": "string",
+      "defaultValue": "HVHOSTNIC2",
       "metadata": {
         "description": "Hyper-V Host Network Interface 2 Name, attached to Hyper-V LAN Subnet"
-      },
-      "defaultValue": "HVHOSTNIC2"
+      }
     },
     "HostVirtualMachineName": {
       "type": "string",
@@ -124,7 +131,6 @@
     },
     "HostVirtualMachineSize": {
       "type": "string",
-      "defaultValue": "Standard_D4s_v3",
       "allowedValues": [
         "Standard_D2_v3",
         "Standard_D4_v3",
@@ -136,25 +142,19 @@
         "Standard_D8s_v3",
         "Standard_D16s_v3",
         "Standard_D32s_v3",
-        "Standard_D48_v3",
         "Standard_D64_v3",
         "Standard_E2_v3",
         "Standard_E4_v3",
         "Standard_E8_v3",
         "Standard_E16_v3",
-        "Standard_E20_v3",
         "Standard_E32_v3",
-        "Standard_E48_v3",
         "Standard_E64_v3",
-        "Standard_D48s_v3",
         "Standard_D64s_v3",
         "Standard_E2s_v3",
         "Standard_E4s_v3",
         "Standard_E8s_v3",
         "Standard_E16s_v3",
-        "Standard_E20s_v3",
         "Standard_E32s_v3",
-        "Standard_E48s_v3",
         "Standard_E64s_v3"
       ],
       "metadata": {
@@ -174,14 +174,15 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "NATSubnetNSGName": "[concat(parameters('NATSubnetName'), 'NSG')]",
-    "hyperVSubnetNSGName": "[concat(parameters('hyperVSubnetName'), 'NSG')]",
-    "ghostedSubnetNSGName": "[concat(parameters('ghostedSubnetName'), 'NSG')]",
-    "azureVMsSubnetNSGName": "[concat(parameters('azureVMsSubnetName'), 'NSG')]",
-    "azureVMsSubnetUDRName": "[concat(parameters('azureVMsSubnetName'), 'UDR')]",
-    "DSCInstallWindowsFeaturesUri": "[uri(parameters('_artifactsLocation'), concat('dsc/dscinstallwindowsfeatures.zip', parameters('_artifactsLocationSasToken')))]",
-    "HVHostSetupScriptUri": "[uri(parameters('_artifactsLocation'), concat('hvhostsetup.ps1', parameters('_artifactsLocationSasToken')))]"
+    "NATSubnetNSGName": "[format('{0}NSG', parameters('NATSubnetName'))]",
+    "hyperVSubnetNSGName": "[format('{0}NSG', parameters('hyperVSubnetName'))]",
+    "ghostedSubnetNSGName": "[format('{0}NSG', parameters('ghostedSubnetName'))]",
+    "azureVMsSubnetNSGName": "[format('{0}NSG', parameters('azureVMsSubnetName'))]",
+    "azureVMsSubnetUDRName": "[format('{0}UDR', parameters('azureVMsSubnetName'))]",
+    "DSCInstallWindowsFeaturesUri": "[uri(parameters('_artifactsLocation'), format('dsc/dscinstallwindowsfeatures.zip{0}', parameters('_artifactsLocationSasToken')))]",
+    "HVHostSetupScriptUri": "[uri(parameters('_artifactsLocation'), format('hvhostsetup.ps1{0}', parameters('_artifactsLocationSasToken')))]"
   },
   "resources": [
     {
@@ -190,12 +191,12 @@
       "name": "[parameters('HostPublicIPAddressName')]",
       "location": "[parameters('location')]",
       "sku": {
-        "name": "basic"
+        "name": "Basic"
       },
       "properties": {
         "publicIPAllocationMethod": "Dynamic",
         "dnsSettings": {
-          "domainNameLabel": "[toLower(concat(parameters('HostVirtualMachineName'), '-', uniqueString(resourceGroup().id)))]"
+          "domainNameLabel": "[toLower(format('{0}-{1}', parameters('HostVirtualMachineName'), uniqueString(resourceGroup().id)))]"
         }
       }
     },
@@ -204,53 +205,34 @@
       "apiVersion": "2019-04-01",
       "name": "[variables('NATSubnetNSGName')]",
       "location": "[parameters('location')]",
-      "properties": {
-      }
+      "properties": {}
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-04-01",
       "name": "[variables('hyperVSubnetNSGName')]",
       "location": "[parameters('location')]",
-      "properties": {
-      }
+      "properties": {}
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-04-01",
       "name": "[variables('ghostedSubnetNSGName')]",
       "location": "[parameters('location')]",
-      "properties": {
-      }
+      "properties": {}
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
       "apiVersion": "2019-04-01",
       "name": "[variables('azureVMsSubnetNSGName')]",
       "location": "[parameters('location')]",
-      "properties": {
-      }
-    },
-    {
-      "type": "Microsoft.Network/routeTables",
-      "apiVersion": "2019-04-01",
-      "name": "[variables('azureVMsSubnetUDRName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-      }
+      "properties": {}
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2019-04-01",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('NATSubnetNSGName')]",
-        "[variables('hyperVSubnetNSGName')]",
-        "[variables('ghostedSubnetNSGName')]",
-        "[variables('azureVMsSubnetNSGName')]",
-        "[variables('azureVMsSubnetUDRName')]"
-      ],
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
@@ -293,154 +275,25 @@
                 "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('azureVMsSubnetNSGName'))]"
               },
               "routeTable": {
-                "id": "[resourceId('Microsoft.Network/routeTables', variables('azureVMsSubnetUDRName'))]"
+                "id": "[reference(resourceId('Microsoft.Resources/deployments', 'udrDeploy'), '2019-10-01').outputs.udrId.value]"
               }
             }
           }
         ]
-      }
-    },
-    {
-      "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2019-04-01",
-      "name": "[parameters('HostNetworkInterface1Name')]",
-      "location": "[parameters('location')]",
+      },
       "dependsOn": [
-        "[parameters('virtualNetworkName')]",
-        "[parameters('HostPublicIPAddressName')]"
-      ],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig",
-            "properties": {
-              "primary": "true",
-              "privateIPAllocationMethod": "dynamic",
-              "subnet": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('NATSubnetName'))]"
-              },
-              "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('HostPublicIPAddressName'))]"
-              }
-            }
-          }
-        ]
-      }
-    },
-    {
-      "type": "Microsoft.Network/networkInterfaces",
-      "apiVersion": "2019-04-01",
-      "name": "[parameters('HostNetworkInterface2Name')]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[parameters('virtualNetworkName')]"
-      ],
-      "properties": {
-        "ipConfigurations": [
-          {
-            "name": "ipconfig",
-            "properties": {
-              "primary": "true",
-              "privateIPAllocationMethod": "dynamic",
-              "subnet": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('hyperVSubnetName'))]"
-              }
-            }
-          }
-        ],
-        "enableIPForwarding": true
-      }
-    },
-    {
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2019-05-01",
-      "name": "UpdateNetworking",
-      "dependsOn": [
-        "[parameters('HostNetworkInterface1Name')]",
-        "[parameters('HostNetworkInterface2Name')]"
-      ],
-      "properties": {
-        "mode": "Incremental",
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "resources": [
-            {
-              "type": "Microsoft.Network/routeTables",
-              "apiVersion": "2019-04-01",
-              "name": "[variables('azureVMsSubnetUDRName')]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "routes": [
-                  {
-                    "name": "Nested-VMs",
-                    "properties": {
-                      "addressPrefix": "[parameters('ghostedSubnetPrefix')]",
-                      "nextHopType": "VirtualAppliance",
-                      "nextHopIPAddress": "[reference(parameters('HostNetworkInterface2Name')).ipconfigurations[0].properties.privateIPAddress]"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "type": "Microsoft.Network/networkInterfaces",
-              "apiVersion": "2019-04-01",
-              "name": "[parameters('HostNetworkInterface1Name')]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "ipConfigurations": [
-                  {
-                    "name": "ipconfig",
-                    "properties": {
-                      "primary": "true",
-                      "privateIPAllocationMethod": "Static",
-                      "privateIPAddress": "[reference(parameters('HostNetworkInterface1Name')).ipconfigurations[0].properties.privateIPAddress]",
-                      "subnet": {
-                        "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('NATSubnetName'))]"
-                      },
-                      "publicIPAddress": {
-                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('HostPublicIPAddressName'))]"
-                      }
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "type": "Microsoft.Network/networkInterfaces",
-              "apiVersion": "2019-04-01",
-              "name": "[parameters('HostNetworkInterface2Name')]",
-              "location": "[parameters('location')]",
-              "properties": {
-                "ipConfigurations": [
-                  {
-                    "name": "ipconfig",
-                    "properties": {
-                      "primary": "true",
-                      "privateIPAllocationMethod": "Static",
-                      "privateIPAddress": "[reference(parameters('HostNetworkInterface2Name')).ipconfigurations[0].properties.privateIPAddress]",
-                      "subnet": {
-                        "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('hyperVSubnetName'))]"
-                      }
-                    }
-                  }
-                ],
-                "enableIPForwarding": true
-              }
-            }
-          ]
-        }
-      }
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('azureVMsSubnetNSGName'))]",
+        "[resourceId('Microsoft.Resources/deployments', 'udrDeploy')]",
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('ghostedSubnetNSGName'))]",
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('hyperVSubnetNSGName'))]",
+        "[resourceId('Microsoft.Network/networkSecurityGroups', variables('NATSubnetNSGName'))]"
+      ]
     },
     {
       "type": "Microsoft.Compute/virtualMachines",
       "apiVersion": "2019-03-01",
-      "location": "[parameters('location')]",
       "name": "[parameters('HostVirtualMachineName')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.Resources/deployments', 'UpdateNetworking')]"
-      ],
+      "location": "[parameters('location')]",
       "properties": {
         "hardwareProfile": {
           "vmSize": "[parameters('HostVirtualMachineSize')]"
@@ -449,21 +302,21 @@
           "imageReference": {
             "publisher": "MicrosoftWindowsServer",
             "offer": "WindowsServer",
-            "Sku": "2016-Datacenter",
+            "sku": "2016-Datacenter",
             "version": "latest"
           },
           "osDisk": {
-            "name": "[concat(parameters('HostVirtualMachineName'), 'OsDisk')]",
-            "createOption": "fromImage",
+            "name": "[format('{0}OsDisk', parameters('HostVirtualMachineName'))]",
+            "createOption": "FromImage",
             "managedDisk": {
               "storageAccountType": "Premium_LRS"
             },
             "caching": "ReadWrite"
           },
-          "DataDisks": [
+          "dataDisks": [
             {
               "lun": 0,
-              "name": "[concat(parameters('HostVirtualMachineName'), 'DataDisk1')]",
+              "name": "[format('{0}DataDisk1', parameters('HostVirtualMachineName'))]",
               "createOption": "Empty",
               "diskSizeGB": 1024,
               "caching": "ReadOnly",
@@ -476,34 +329,35 @@
         "osProfile": {
           "computerName": "[parameters('HostVirtualMachineName')]",
           "adminUsername": "[parameters('HostAdminUsername')]",
-          "adminPassword": "[parameters('hostAdminPassword')]"
+          "adminPassword": "[parameters('HostAdminPassword')]"
         },
         "networkProfile": {
           "networkInterfaces": [
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('HostNetworkInterface1Name'))]",
+              "id": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic1'), '2019-10-01').outputs.nicId.value]",
               "properties": {
                 "primary": true
               }
             },
             {
-              "id": "[resourceId('Microsoft.Network/networkInterfaces', parameters('HostNetworkInterface2Name'))]",
+              "id": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2019-10-01').outputs.nicId.value]",
               "properties": {
                 "primary": false
               }
             }
           ]
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'createNic1')]",
+        "[resourceId('Microsoft.Resources/deployments', 'createNic2')]"
+      ]
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2019-03-01",
+      "name": "[format('{0}/{1}', parameters('HostVirtualMachineName'), 'InstallWindowsFeatures')]",
       "location": "[parameters('location')]",
-      "name": "[concat(parameters('HostVirtualMachineName'), '/InstallWindowsFeatures')]",
-      "dependsOn": [
-        "[parameters('HostVirtualMachineName')]"
-      ],
       "properties": {
         "publisher": "Microsoft.Powershell",
         "type": "DSC",
@@ -517,31 +371,599 @@
             "function": "InstallWindowsFeatures"
           }
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Compute/virtualMachines', parameters('HostVirtualMachineName'))]"
+      ]
     },
     {
-       "type": "Microsoft.Compute/virtualMachines/extensions",
-       "apiVersion": "2019-03-01",
-       "location": "[parameters('location')]",
-       "name": "[concat(parameters('HostVirtualMachineName'), '/HVHOSTSetup')]",
-       "dependsOn":[
-        "[parameters('HostVirtualMachineName')]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('HostVirtualMachineName'), 'InstallWindowsFeatures')]"
-      ],
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "apiVersion": "2019-03-01",
+      "name": "[format('{0}/{1}', parameters('HostVirtualMachineName'), 'HVHOSTSetup')]",
+      "location": "[parameters('location')]",
       "properties": {
         "publisher": "Microsoft.Compute",
         "type": "CustomScriptExtension",
         "typeHandlerVersion": "1.9",
         "autoUpgradeMinorVersion": true,
-        "settings":{
+        "settings": {
           "fileUris": [
             "[variables('HVHostSetupScriptUri')]"
           ],
-          "commandToExecute": "[concat('powershell -ExecutionPolicy Unrestricted -File HVHostSetup.ps1 -NIC1IPAddress ', reference(parameters('HostNetworkInterface1Name')).ipconfigurations[0].properties.privateIPAddress, ' -NIC2IPAddress ', reference(parameters('HostNetworkInterface2Name')).ipconfigurations[0].properties.privateIPAddress, ' -GhostedSubnetPrefix ', parameters('ghostedSubnetPrefix'), ' -VirtualNetworkPrefix ', parameters('virtualNetworkAddressPrefix'))]"
+          "commandToExecute": "[format('powershell -ExecutionPolicy Unrestricted -File HVHostSetup.ps1 -NIC1IPAddress {0} -NIC2IPAddress {1} -GhostedSubnetPrefix {2} -VirtualNetworkPrefix {3}', reference(resourceId('Microsoft.Resources/deployments', 'createNic1'), '2019-10-01').outputs.assignedIp.value, reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2019-10-01').outputs.assignedIp.value, parameters('ghostedSubnetPrefix'), parameters('virtualNetworkAddressPrefix'))]"
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'createNic1')]",
+        "[resourceId('Microsoft.Resources/deployments', 'createNic2')]",
+        "[resourceId('Microsoft.Compute/virtualMachines', parameters('HostVirtualMachineName'))]",
+        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('HostVirtualMachineName'), 'InstallWindowsFeatures')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "createNic1",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "nicName": {
+            "value": "[parameters('HostNetworkInterface1Name')]"
+          },
+          "subnetId": {
+            "value": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), parameters('NATSubnetName'))]"
+          },
+          "pipId": {
+            "value": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('HostPublicIPAddressName'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "11129654787050363682"
+            }
+          },
+          "parameters": {
+            "nicName": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "subnetId": {
+              "type": "string"
+            },
+            "pipId": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "ipAllocationMethod": {
+              "type": "string",
+              "defaultValue": "Dynamic",
+              "allowedValues": [
+                "Dynamic",
+                "Static"
+              ]
+            },
+            "staticIpAddress": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "enableIPForwarding": {
+              "type": "bool",
+              "defaultValue": false
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/networkInterfaces",
+              "apiVersion": "2020-06-01",
+              "name": "[parameters('nicName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig",
+                    "properties": {
+                      "primary": true,
+                      "privateIPAllocationMethod": "[parameters('ipAllocationMethod')]",
+                      "privateIPAddress": "[parameters('staticIpAddress')]",
+                      "subnet": {
+                        "id": "[parameters('subnetId')]"
+                      },
+                      "publicIPAddress": "[if(equals(parameters('pipId'), ''), null(), createObject('id', parameters('pipId')))]"
+                    }
+                  }
+                ],
+                "enableIPForwarding": "[parameters('enableIPForwarding')]"
+              }
+            }
+          ],
+          "outputs": {
+            "nicId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            },
+            "assignedIp": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))).ipConfigurations[0].properties.privateIPAddress]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('HostPublicIPAddressName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "createNic2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "nicName": {
+            "value": "[parameters('HostNetworkInterface2Name')]"
+          },
+          "enableIPForwarding": {
+            "value": true
+          },
+          "subnetId": {
+            "value": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), parameters('hyperVSubnetName'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "11129654787050363682"
+            }
+          },
+          "parameters": {
+            "nicName": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "subnetId": {
+              "type": "string"
+            },
+            "pipId": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "ipAllocationMethod": {
+              "type": "string",
+              "defaultValue": "Dynamic",
+              "allowedValues": [
+                "Dynamic",
+                "Static"
+              ]
+            },
+            "staticIpAddress": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "enableIPForwarding": {
+              "type": "bool",
+              "defaultValue": false
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/networkInterfaces",
+              "apiVersion": "2020-06-01",
+              "name": "[parameters('nicName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig",
+                    "properties": {
+                      "primary": true,
+                      "privateIPAllocationMethod": "[parameters('ipAllocationMethod')]",
+                      "privateIPAddress": "[parameters('staticIpAddress')]",
+                      "subnet": {
+                        "id": "[parameters('subnetId')]"
+                      },
+                      "publicIPAddress": "[if(equals(parameters('pipId'), ''), null(), createObject('id', parameters('pipId')))]"
+                    }
+                  }
+                ],
+                "enableIPForwarding": "[parameters('enableIPForwarding')]"
+              }
+            }
+          ],
+          "outputs": {
+            "nicId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            },
+            "assignedIp": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))).ipConfigurations[0].properties.privateIPAddress]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "updateNic1",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "ipAllocationMethod": {
+            "value": "Static"
+          },
+          "staticIpAddress": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic1'), '2019-10-01').outputs.assignedIp.value]"
+          },
+          "nicName": {
+            "value": "[parameters('HostNetworkInterface1Name')]"
+          },
+          "subnetId": {
+            "value": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), parameters('NATSubnetName'))]"
+          },
+          "pipId": {
+            "value": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('HostPublicIPAddressName'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "11129654787050363682"
+            }
+          },
+          "parameters": {
+            "nicName": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "subnetId": {
+              "type": "string"
+            },
+            "pipId": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "ipAllocationMethod": {
+              "type": "string",
+              "defaultValue": "Dynamic",
+              "allowedValues": [
+                "Dynamic",
+                "Static"
+              ]
+            },
+            "staticIpAddress": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "enableIPForwarding": {
+              "type": "bool",
+              "defaultValue": false
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/networkInterfaces",
+              "apiVersion": "2020-06-01",
+              "name": "[parameters('nicName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig",
+                    "properties": {
+                      "primary": true,
+                      "privateIPAllocationMethod": "[parameters('ipAllocationMethod')]",
+                      "privateIPAddress": "[parameters('staticIpAddress')]",
+                      "subnet": {
+                        "id": "[parameters('subnetId')]"
+                      },
+                      "publicIPAddress": "[if(equals(parameters('pipId'), ''), null(), createObject('id', parameters('pipId')))]"
+                    }
+                  }
+                ],
+                "enableIPForwarding": "[parameters('enableIPForwarding')]"
+              }
+            }
+          ],
+          "outputs": {
+            "nicId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            },
+            "assignedIp": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))).ipConfigurations[0].properties.privateIPAddress]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'createNic1')]",
+        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('HostPublicIPAddressName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "updateNic2",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "ipAllocationMethod": {
+            "value": "Static"
+          },
+          "staticIpAddress": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2019-10-01').outputs.assignedIp.value]"
+          },
+          "nicName": {
+            "value": "[parameters('HostNetworkInterface2Name')]"
+          },
+          "enableIPForwarding": {
+            "value": true
+          },
+          "subnetId": {
+            "value": "[format('{0}/subnets/{1}', resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), parameters('hyperVSubnetName'))]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "11129654787050363682"
+            }
+          },
+          "parameters": {
+            "nicName": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "subnetId": {
+              "type": "string"
+            },
+            "pipId": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "ipAllocationMethod": {
+              "type": "string",
+              "defaultValue": "Dynamic",
+              "allowedValues": [
+                "Dynamic",
+                "Static"
+              ]
+            },
+            "staticIpAddress": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "enableIPForwarding": {
+              "type": "bool",
+              "defaultValue": false
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/networkInterfaces",
+              "apiVersion": "2020-06-01",
+              "name": "[parameters('nicName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig",
+                    "properties": {
+                      "primary": true,
+                      "privateIPAllocationMethod": "[parameters('ipAllocationMethod')]",
+                      "privateIPAddress": "[parameters('staticIpAddress')]",
+                      "subnet": {
+                        "id": "[parameters('subnetId')]"
+                      },
+                      "publicIPAddress": "[if(equals(parameters('pipId'), ''), null(), createObject('id', parameters('pipId')))]"
+                    }
+                  }
+                ],
+                "enableIPForwarding": "[parameters('enableIPForwarding')]"
+              }
+            }
+          ],
+          "outputs": {
+            "nicId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))]"
+            },
+            "assignedIp": {
+              "type": "string",
+              "value": "[reference(resourceId('Microsoft.Network/networkInterfaces', parameters('nicName'))).ipConfigurations[0].properties.privateIPAddress]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'createNic2')]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "udrDeploy",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "udrName": {
+            "value": "[variables('azureVMsSubnetUDRName')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "17447004573065928570"
+            }
+          },
+          "parameters": {
+            "udrName": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "addressPrefix": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "nextHopAddress": {
+              "type": "string",
+              "defaultValue": ""
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/routeTables",
+              "apiVersion": "2020-06-01",
+              "name": "[parameters('udrName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "routes": "[if(equals(parameters('addressPrefix'), ''), null(), createArray(createObject('name', 'Nested-VMs', 'properties', createObject('addressPrefix', parameters('addressPrefix'), 'nextHopType', 'VirtualAppliance', 'nextHopIpAddress', parameters('nextHopAddress')))))]"
+              }
+            }
+          ],
+          "outputs": {
+            "udrId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/routeTables', parameters('udrName'))]"
+            }
+          }
         }
       }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "udrUpdate",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "udrName": {
+            "value": "[variables('azureVMsSubnetUDRName')]"
+          },
+          "addressPrefix": {
+            "value": "[parameters('ghostedSubnetPrefix')]"
+          },
+          "nextHopAddress": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'createNic2'), '2019-10-01').outputs.assignedIp.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "17447004573065928570"
+            }
+          },
+          "parameters": {
+            "udrName": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]"
+            },
+            "addressPrefix": {
+              "type": "string",
+              "defaultValue": ""
+            },
+            "nextHopAddress": {
+              "type": "string",
+              "defaultValue": ""
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.Network/routeTables",
+              "apiVersion": "2020-06-01",
+              "name": "[parameters('udrName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "routes": "[if(equals(parameters('addressPrefix'), ''), null(), createArray(createObject('name', 'Nested-VMs', 'properties', createObject('addressPrefix', parameters('addressPrefix'), 'nextHopType', 'VirtualAppliance', 'nextHopIpAddress', parameters('nextHopAddress')))))]"
+              }
+            }
+          ],
+          "outputs": {
+            "udrId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/routeTables', parameters('udrName'))]"
+            }
+          }
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'createNic2')]"
+      ]
     }
-  ],
-  "outputs": {
-  }
+  ]
 }

--- a/demos/nested-vms-in-virtual-network/azuredeploy.json
+++ b/demos/nested-vms-in-virtual-network/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "8360920427510730960"
+      "templateHash": "4253688112151179551"
     }
   },
   "parameters": {
@@ -188,7 +188,7 @@
   "resources": [
     {
       "type": "Microsoft.Network/publicIPAddresses",
-      "apiVersion": "2019-04-01",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('HostPublicIPAddressName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -203,35 +203,35 @@
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2019-04-01",
+      "apiVersion": "2021-02-01",
       "name": "[variables('NATSubnetNSGName')]",
       "location": "[parameters('location')]",
       "properties": {}
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2019-04-01",
+      "apiVersion": "2021-02-01",
       "name": "[variables('hyperVSubnetNSGName')]",
       "location": "[parameters('location')]",
       "properties": {}
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2019-04-01",
+      "apiVersion": "2021-02-01",
       "name": "[variables('ghostedSubnetNSGName')]",
       "location": "[parameters('location')]",
       "properties": {}
     },
     {
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2019-04-01",
+      "apiVersion": "2021-02-01",
       "name": "[variables('azureVMsSubnetNSGName')]",
       "location": "[parameters('location')]",
       "properties": {}
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2019-04-01",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -292,7 +292,7 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines",
-      "apiVersion": "2019-03-01",
+      "apiVersion": "2021-03-01",
       "name": "[parameters('HostVirtualMachineName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -356,7 +356,7 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "apiVersion": "2019-03-01",
+      "apiVersion": "2021-03-01",
       "name": "[format('{0}/{1}', parameters('HostVirtualMachineName'), 'InstallWindowsFeatures')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -379,7 +379,7 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "apiVersion": "2019-03-01",
+      "apiVersion": "2021-03-01",
       "name": "[format('{0}/{1}', parameters('HostVirtualMachineName'), 'HVHOSTSetup')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -411,6 +411,9 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
           "nicName": {
             "value": "[parameters('HostNetworkInterface1Name')]"
           },
@@ -428,7 +431,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.412.5873",
-              "templateHash": "16399702259343274345"
+              "templateHash": "15585594711656125126"
             }
           },
           "parameters": {
@@ -436,8 +439,7 @@
               "type": "string"
             },
             "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]"
+              "type": "string"
             },
             "subnetId": {
               "type": "string"
@@ -516,6 +518,9 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
           "nicName": {
             "value": "[parameters('HostNetworkInterface2Name')]"
           },
@@ -533,7 +538,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.412.5873",
-              "templateHash": "16399702259343274345"
+              "templateHash": "15585594711656125126"
             }
           },
           "parameters": {
@@ -541,8 +546,7 @@
               "type": "string"
             },
             "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]"
+              "type": "string"
             },
             "subnetId": {
               "type": "string"
@@ -620,6 +624,9 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
           "ipAllocationMethod": {
             "value": "Static"
           },
@@ -643,7 +650,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.412.5873",
-              "templateHash": "16399702259343274345"
+              "templateHash": "15585594711656125126"
             }
           },
           "parameters": {
@@ -651,8 +658,7 @@
               "type": "string"
             },
             "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]"
+              "type": "string"
             },
             "subnetId": {
               "type": "string"
@@ -732,6 +738,9 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
           "ipAllocationMethod": {
             "value": "Static"
           },
@@ -755,7 +764,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.412.5873",
-              "templateHash": "16399702259343274345"
+              "templateHash": "15585594711656125126"
             }
           },
           "parameters": {
@@ -763,8 +772,7 @@
               "type": "string"
             },
             "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]"
+              "type": "string"
             },
             "subnetId": {
               "type": "string"
@@ -843,6 +851,9 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
           "udrName": {
             "value": "[variables('azureVMsSubnetUDRName')]"
           }
@@ -854,7 +865,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.412.5873",
-              "templateHash": "14776869940030245474"
+              "templateHash": "7650487793556412399"
             }
           },
           "parameters": {
@@ -862,8 +873,7 @@
               "type": "string"
             },
             "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]"
+              "type": "string"
             },
             "addressPrefix": {
               "type": "string",
@@ -905,6 +915,9 @@
         },
         "mode": "Incremental",
         "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
           "udrName": {
             "value": "[variables('azureVMsSubnetUDRName')]"
           },
@@ -922,7 +935,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.412.5873",
-              "templateHash": "14776869940030245474"
+              "templateHash": "7650487793556412399"
             }
           },
           "parameters": {
@@ -930,8 +943,7 @@
               "type": "string"
             },
             "location": {
-              "type": "string",
-              "defaultValue": "[resourceGroup().location]"
+              "type": "string"
             },
             "addressPrefix": {
               "type": "string",

--- a/demos/nested-vms-in-virtual-network/azuredeploy.json
+++ b/demos/nested-vms-in-virtual-network/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "7104461790267266311"
+      "version": "0.4.412.5873",
+      "templateHash": "14172707274627034069"
     }
   },
   "parameters": {
@@ -426,8 +426,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1.14562",
-              "templateHash": "11129654787050363682"
+              "version": "0.4.412.5873",
+              "templateHash": "16399702259343274345"
             }
           },
           "parameters": {
@@ -531,8 +531,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1.14562",
-              "templateHash": "11129654787050363682"
+              "version": "0.4.412.5873",
+              "templateHash": "16399702259343274345"
             }
           },
           "parameters": {
@@ -641,8 +641,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1.14562",
-              "templateHash": "11129654787050363682"
+              "version": "0.4.412.5873",
+              "templateHash": "16399702259343274345"
             }
           },
           "parameters": {
@@ -753,8 +753,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1.14562",
-              "templateHash": "11129654787050363682"
+              "version": "0.4.412.5873",
+              "templateHash": "16399702259343274345"
             }
           },
           "parameters": {
@@ -852,8 +852,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1.14562",
-              "templateHash": "17447004573065928570"
+              "version": "0.4.412.5873",
+              "templateHash": "14776869940030245474"
             }
           },
           "parameters": {
@@ -920,8 +920,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.4.1.14562",
-              "templateHash": "17447004573065928570"
+              "version": "0.4.412.5873",
+              "templateHash": "14776869940030245474"
             }
           },
           "parameters": {

--- a/demos/nested-vms-in-virtual-network/main.bicep
+++ b/demos/nested-vms-in-virtual-network/main.bicep
@@ -1,0 +1,345 @@
+@description('The base URI where artifacts required by this template are located including a trailing \'/\'')
+param _artifactsLocation string = deployment().properties.templateLink.uri
+
+@description('The sasToken required to access _artifactsLocation.  When the template is deployed using the accompanying scripts, a sasToken will be automatically generated. Use the defaultValue if the staging location is not secured.')
+@secure()
+param _artifactsLocationSasToken string = ''
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+@description('Resource Name for Public IP address attached to Hyper-V Host')
+param HostPublicIPAddressName string = 'HVHOSTPIP'
+
+@description('Hyper-V Host and Guest VMs Virtual Network')
+param virtualNetworkName string = 'VirtualNetwork'
+
+@description('Virtual Network Address Space')
+param virtualNetworkAddressPrefix string = '10.0.0.0/22'
+
+@description('NAT Subnet Name')
+param NATSubnetName string = 'NAT'
+
+@description('NAT Subnet Address Space')
+param NATSubnetPrefix string = '10.0.0.0/24'
+
+@description('Hyper-V Host Subnet Name')
+param hyperVSubnetName string = 'Hyper-V-LAN'
+
+@description('Hyper-V Host Subnet Address Space')
+param hyperVSubnetPrefix string = '10.0.1.0/24'
+
+@description('Ghosted Subnet Name')
+param ghostedSubnetName string = 'Ghosted'
+
+@description('Ghosted Subnet Address Space')
+param ghostedSubnetPrefix string = '10.0.2.0/24'
+
+@description('Azure VMs Subnet Name')
+param azureVMsSubnetName string = 'Azure-VMs'
+
+@description('Azure VMs Address Space')
+param azureVMsSubnetPrefix string = '10.0.3.0/24'
+
+@description('Hyper-V Host Network Interface 1 Name, attached to NAT Subnet')
+param HostNetworkInterface1Name string = 'HVHOSTNIC1'
+
+@description('Hyper-V Host Network Interface 2 Name, attached to Hyper-V LAN Subnet')
+param HostNetworkInterface2Name string = 'HVHOSTNIC2'
+
+@description('Name of Hyper-V Host Virtual Machine, Maximum of 15 characters, use letters and numbers only.')
+@maxLength(15)
+param HostVirtualMachineName string = 'HVHOST'
+
+@description('Size of the Host Virtual Machine')
+@allowed([
+  'Standard_D2_v3'
+  'Standard_D4_v3'
+  'Standard_D8_v3'
+  'Standard_D16_v3'
+  'Standard_D32_v3'
+  'Standard_D2s_v3'
+  'Standard_D4s_v3'
+  'Standard_D8s_v3'
+  'Standard_D16s_v3'
+  'Standard_D32s_v3'
+  'Standard_D64_v3'
+  'Standard_E2_v3'
+  'Standard_E4_v3'
+  'Standard_E8_v3'
+  'Standard_E16_v3'
+  'Standard_E32_v3'
+  'Standard_E64_v3'
+  'Standard_D64s_v3'
+  'Standard_E2s_v3'
+  'Standard_E4s_v3'
+  'Standard_E8s_v3'
+  'Standard_E16s_v3'
+  'Standard_E32s_v3'
+  'Standard_E64s_v3'
+])
+param HostVirtualMachineSize string //asdf = 'Standard_D4s_v3'
+
+@description('Admin Username for the Host Virtual Machine')
+param HostAdminUsername string
+
+@description('Admin User Password for the Host Virtual Machine')
+@secure()
+param HostAdminPassword string
+
+var NATSubnetNSGName = '${NATSubnetName}NSG'
+var hyperVSubnetNSGName = '${hyperVSubnetName}NSG'
+var ghostedSubnetNSGName = '${ghostedSubnetName}NSG'
+var azureVMsSubnetNSGName = '${azureVMsSubnetName}NSG'
+var azureVMsSubnetUDRName = '${azureVMsSubnetName}UDR'
+var DSCInstallWindowsFeaturesUri = uri(_artifactsLocation, 'dsc/dscinstallwindowsfeatures.zip${_artifactsLocationSasToken}')
+var HVHostSetupScriptUri = uri(_artifactsLocation, 'hvhostsetup.ps1${_artifactsLocationSasToken}')
+
+resource publicIp 'Microsoft.Network/publicIpAddresses@2019-04-01' = {
+  name: HostPublicIPAddressName
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Dynamic'
+    dnsSettings: {
+      domainNameLabel: toLower('${HostVirtualMachineName}-${uniqueString(resourceGroup().id)}')
+    }
+  }
+}
+
+resource natNsg 'Microsoft.Network/networkSecurityGroups@2019-04-01' = {
+  name: NATSubnetNSGName
+  location: location
+  properties: {}
+}
+
+resource hyperVNsg 'Microsoft.Network/networkSecurityGroups@2019-04-01' = {
+  name: hyperVSubnetNSGName
+  location: location
+  properties: {}
+}
+
+resource ghostedNsg 'Microsoft.Network/networkSecurityGroups@2019-04-01' = {
+  name: ghostedSubnetNSGName
+  location: location
+  properties: {}
+}
+
+resource azureVmsSubnet 'Microsoft.Network/networkSecurityGroups@2019-04-01' = {
+  name: azureVMsSubnetNSGName
+  location: location
+  properties: {}
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2019-04-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        virtualNetworkAddressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: NATSubnetName
+        properties: {
+          addressPrefix: NATSubnetPrefix
+          networkSecurityGroup: {
+            id: natNsg.id
+          }
+        }
+      }
+      {
+        name: hyperVSubnetName
+        properties: {
+          addressPrefix: hyperVSubnetPrefix
+          networkSecurityGroup: {
+            id: hyperVNsg.id
+          }
+        }
+      }
+      {
+        name: ghostedSubnetName
+        properties: {
+          addressPrefix: ghostedSubnetPrefix
+          networkSecurityGroup: {
+            id: ghostedNsg.id
+          }
+        }
+      }
+      {
+        name: azureVMsSubnetName
+        properties: {
+          addressPrefix: azureVMsSubnetPrefix
+          networkSecurityGroup: {
+            id: azureVmsSubnet.id
+          }
+          routeTable: {
+            id: createAzureVmUdr.outputs.udrId
+          }
+        }
+      }
+    ]
+  }
+}
+
+module createNic1 './nic.bicep' = {
+  name: 'createNic1'
+  params: {
+    nicName: HostNetworkInterface1Name
+    subnetId: '${vnet.id}/subnets/${NATSubnetName}'
+    pipId: publicIp.id
+  }
+}
+
+module createNic2 './nic.bicep' = {
+  name: 'createNic2'
+  params: {
+    nicName: HostNetworkInterface2Name
+    enableIPForwarding: true
+    subnetId: '${vnet.id}/subnets/${hyperVSubnetName}'
+  }
+}
+
+// update nic to staticIp now that nic has been created
+module updateNic1 './nic.bicep' = {
+  name: 'updateNic1'
+  params: {
+    ipAllocationMethod: 'Static'
+    staticIpAddress: createNic1.outputs.assignedIp
+    nicName: HostNetworkInterface1Name
+    subnetId: '${vnet.id}/subnets/${NATSubnetName}'
+    pipId: publicIp.id
+  }
+}
+
+// update nic to staticIp now that nic has been created
+module updateNic2 './nic.bicep' = {
+  name: 'updateNic2'
+  params: {
+    ipAllocationMethod: 'Static'
+    staticIpAddress: createNic2.outputs.assignedIp
+    nicName: HostNetworkInterface2Name
+    enableIPForwarding: true
+    subnetId: '${vnet.id}/subnets/${hyperVSubnetName}'
+  }
+}
+
+module createAzureVmUdr './udr.bicep' = {
+  name: 'udrDeploy'
+  params: {
+    udrName: azureVMsSubnetUDRName
+  }
+}
+
+module updateAzureVmUdr './udr.bicep' = {
+  name: 'udrUpdate'
+  params: {
+    udrName: azureVMsSubnetUDRName
+    addressPrefix: ghostedSubnetPrefix
+    nextHopAddress: createNic2.outputs.assignedIp
+  }
+}
+
+resource hostVm 'Microsoft.Compute/virtualMachines@2019-03-01' = {
+  name: HostVirtualMachineName
+  location: location
+  properties: {
+    hardwareProfile: {
+      vmSize: HostVirtualMachineSize
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: 'MicrosoftWindowsServer'
+        offer: 'WindowsServer'
+        sku: '2016-Datacenter'
+        version: 'latest'
+      }
+      osDisk: {
+        name: '${HostVirtualMachineName}OsDisk'
+        createOption: 'FromImage'
+        managedDisk: {
+          storageAccountType: 'Premium_LRS'
+        }
+        caching: 'ReadWrite'
+      }
+      dataDisks: [
+        {
+          lun: 0
+          name: '${HostVirtualMachineName}DataDisk1'
+          createOption: 'Empty'
+          diskSizeGB: 1024
+          caching: 'ReadOnly'
+          managedDisk: {
+            storageAccountType: 'Premium_LRS'
+          }
+        }
+      ]
+    }
+    osProfile: {
+      computerName: HostVirtualMachineName
+      adminUsername: HostAdminUsername
+      adminPassword: HostAdminPassword
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: createNic1.outputs.nicId
+          properties: {
+            primary: true
+          }
+        }
+        {
+          id: createNic2.outputs.nicId
+          properties: {
+            primary: false
+          }
+        }
+      ]
+    }
+  }
+}
+
+resource vmExtension 'Microsoft.Compute/virtualMachines/extensions@2019-03-01' = {
+  parent: hostVm
+  name: 'InstallWindowsFeatures'
+  location: location
+  properties: {
+    publisher: 'Microsoft.Powershell'
+    type: 'DSC'
+    typeHandlerVersion: '2.77'
+    autoUpgradeMinorVersion: true
+    settings: {
+      wmfVersion: 'latest'
+      configuration: {
+        url: DSCInstallWindowsFeaturesUri
+        script: 'DSCInstallWindowsFeatures.ps1'
+        function: 'InstallWindowsFeatures'
+      }
+    }
+  }
+}
+
+resource hostVmSetupExtension 'Microsoft.Compute/virtualMachines/extensions@2019-03-01' = {
+  parent: hostVm
+  name: 'HVHOSTSetup'
+  location: location
+  properties: {
+    publisher: 'Microsoft.Compute'
+    type: 'CustomScriptExtension'
+    typeHandlerVersion: '1.9'
+    autoUpgradeMinorVersion: true
+    settings: {
+      fileUris: [
+        HVHostSetupScriptUri
+      ]
+      commandToExecute: 'powershell -ExecutionPolicy Unrestricted -File HVHostSetup.ps1 -NIC1IPAddress ${createNic1.outputs.assignedIp} -NIC2IPAddress ${createNic2.outputs.assignedIp} -GhostedSubnetPrefix ${ghostedSubnetPrefix} -VirtualNetworkPrefix ${virtualNetworkAddressPrefix}'
+    }
+  }
+  dependsOn: [
+    vmExtension
+  ]
+}

--- a/demos/nested-vms-in-virtual-network/main.bicep
+++ b/demos/nested-vms-in-virtual-network/main.bicep
@@ -95,7 +95,7 @@ var azureVMsSubnetUDRName = '${azureVMsSubnetName}UDR'
 var DSCInstallWindowsFeaturesUri = uri(_artifactsLocation, 'dsc/dscinstallwindowsfeatures.zip${_artifactsLocationSasToken}')
 var HVHostSetupScriptUri = uri(_artifactsLocation, 'hvhostsetup.ps1${_artifactsLocationSasToken}')
 
-resource publicIp 'Microsoft.Network/publicIpAddresses@2019-04-01' = {
+resource publicIp 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
   name: HostPublicIPAddressName
   location: location
   sku: {
@@ -109,31 +109,31 @@ resource publicIp 'Microsoft.Network/publicIpAddresses@2019-04-01' = {
   }
 }
 
-resource natNsg 'Microsoft.Network/networkSecurityGroups@2019-04-01' = {
+resource natNsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: NATSubnetNSGName
   location: location
   properties: {}
 }
 
-resource hyperVNsg 'Microsoft.Network/networkSecurityGroups@2019-04-01' = {
+resource hyperVNsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: hyperVSubnetNSGName
   location: location
   properties: {}
 }
 
-resource ghostedNsg 'Microsoft.Network/networkSecurityGroups@2019-04-01' = {
+resource ghostedNsg 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: ghostedSubnetNSGName
   location: location
   properties: {}
 }
 
-resource azureVmsSubnet 'Microsoft.Network/networkSecurityGroups@2019-04-01' = {
+resource azureVmsSubnet 'Microsoft.Network/networkSecurityGroups@2021-02-01' = {
   name: azureVMsSubnetNSGName
   location: location
   properties: {}
 }
 
-resource vnet 'Microsoft.Network/virtualNetworks@2019-04-01' = {
+resource vnet 'Microsoft.Network/virtualNetworks@2021-02-01' = {
   name: virtualNetworkName
   location: location
   properties: {
@@ -189,6 +189,7 @@ resource vnet 'Microsoft.Network/virtualNetworks@2019-04-01' = {
 module createNic1 './nic.bicep' = {
   name: 'createNic1'
   params: {
+    location: location
     nicName: HostNetworkInterface1Name
     subnetId: '${vnet.id}/subnets/${NATSubnetName}'
     pipId: publicIp.id
@@ -198,6 +199,7 @@ module createNic1 './nic.bicep' = {
 module createNic2 './nic.bicep' = {
   name: 'createNic2'
   params: {
+    location: location
     nicName: HostNetworkInterface2Name
     enableIPForwarding: true
     subnetId: '${vnet.id}/subnets/${hyperVSubnetName}'
@@ -208,6 +210,7 @@ module createNic2 './nic.bicep' = {
 module updateNic1 './nic.bicep' = {
   name: 'updateNic1'
   params: {
+    location: location
     ipAllocationMethod: 'Static'
     staticIpAddress: createNic1.outputs.assignedIp
     nicName: HostNetworkInterface1Name
@@ -220,6 +223,7 @@ module updateNic1 './nic.bicep' = {
 module updateNic2 './nic.bicep' = {
   name: 'updateNic2'
   params: {
+    location: location
     ipAllocationMethod: 'Static'
     staticIpAddress: createNic2.outputs.assignedIp
     nicName: HostNetworkInterface2Name
@@ -231,6 +235,7 @@ module updateNic2 './nic.bicep' = {
 module createAzureVmUdr './udr.bicep' = {
   name: 'udrDeploy'
   params: {
+    location: location
     udrName: azureVMsSubnetUDRName
   }
 }
@@ -238,13 +243,14 @@ module createAzureVmUdr './udr.bicep' = {
 module updateAzureVmUdr './udr.bicep' = {
   name: 'udrUpdate'
   params: {
+    location: location
     udrName: azureVMsSubnetUDRName
     addressPrefix: ghostedSubnetPrefix
     nextHopAddress: createNic2.outputs.assignedIp
   }
 }
 
-resource hostVm 'Microsoft.Compute/virtualMachines@2019-03-01' = {
+resource hostVm 'Microsoft.Compute/virtualMachines@2021-03-01' = {
   name: HostVirtualMachineName
   location: location
   properties: {
@@ -303,7 +309,7 @@ resource hostVm 'Microsoft.Compute/virtualMachines@2019-03-01' = {
   }
 }
 
-resource vmExtension 'Microsoft.Compute/virtualMachines/extensions@2019-03-01' = {
+resource vmExtension 'Microsoft.Compute/virtualMachines/extensions@2021-03-01' = {
   parent: hostVm
   name: 'InstallWindowsFeatures'
   location: location
@@ -323,7 +329,7 @@ resource vmExtension 'Microsoft.Compute/virtualMachines/extensions@2019-03-01' =
   }
 }
 
-resource hostVmSetupExtension 'Microsoft.Compute/virtualMachines/extensions@2019-03-01' = {
+resource hostVmSetupExtension 'Microsoft.Compute/virtualMachines/extensions@2021-03-01' = {
   parent: hostVm
   name: 'HVHOSTSetup'
   location: location

--- a/demos/nested-vms-in-virtual-network/main.bicep
+++ b/demos/nested-vms-in-virtual-network/main.bicep
@@ -78,7 +78,7 @@ param HostVirtualMachineName string = 'HVHOST'
   'Standard_E32s_v3'
   'Standard_E64s_v3'
 ])
-param HostVirtualMachineSize string //asdf = 'Standard_D4s_v3'
+param HostVirtualMachineSize string = 'Standard_D4s_v3'
 
 @description('Admin Username for the Host Virtual Machine')
 param HostAdminUsername string

--- a/demos/nested-vms-in-virtual-network/metadata.json
+++ b/demos/nested-vms-in-virtual-network/metadata.json
@@ -5,5 +5,5 @@
   "description": "Deploys a Virtual Machine to by a Hyper-V Host and all dependent resources including virtual network, public IP address and route tables.",
   "summary": "Deploys a Virtual Machine to by a Hyper-V Host and all dependent resources including virtual network, public IP address and route tables. Windows Features installed and setup completed by Template",
   "githubUsername": "RyanLWilliams",
-  "dateUpdated": "2021-05-04"
+  "dateUpdated": "2021-06-22"
 }

--- a/demos/nested-vms-in-virtual-network/nic.bicep
+++ b/demos/nested-vms-in-virtual-network/nic.bicep
@@ -1,0 +1,42 @@
+param nicName string
+param location string = resourceGroup().location
+param subnetId string
+param pipId string = ''
+
+@allowed([
+  'Dynamic'
+  'Static'
+])
+param ipAllocationMethod string = 'Dynamic'
+
+param staticIpAddress string = ''
+param enableIPForwarding bool = false
+
+resource nic 'Microsoft.Network/networkInterfaces@2020-06-01' = {
+  name: nicName
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig'
+        properties: {
+          primary: true
+          privateIPAllocationMethod: ipAllocationMethod
+          // pip is optional
+          privateIPAddress: staticIpAddress
+          subnet: {
+            id: subnetId
+          }
+          // pip looks to be optional
+          publicIPAddress: any((pipId == '') ? null : {
+            id: pipId
+          })
+        }
+      }
+    ]
+    enableIPForwarding: enableIPForwarding
+  }
+}
+
+output nicId string = nic.id
+output assignedIp string = nic.properties.ipConfigurations[0].properties.privateIPAddress

--- a/demos/nested-vms-in-virtual-network/nic.bicep
+++ b/demos/nested-vms-in-virtual-network/nic.bicep
@@ -1,5 +1,5 @@
 param nicName string
-param location string = resourceGroup().location
+param location string
 param subnetId string
 param pipId string = ''
 

--- a/demos/nested-vms-in-virtual-network/udr.bicep
+++ b/demos/nested-vms-in-virtual-network/udr.bicep
@@ -1,0 +1,24 @@
+param udrName string
+param location string = resourceGroup().location
+param addressPrefix string = ''
+param nextHopAddress string = ''
+
+resource udr 'Microsoft.Network/routeTables@2020-06-01' = {
+  name: udrName
+  location: location
+  properties: {
+    // conditionally deploy route
+    routes: any(addressPrefix == '' ? null : [
+      {
+        name: 'Nested-VMs'
+        properties: {
+          addressPrefix: addressPrefix
+          nextHopType: 'VirtualAppliance'
+          nextHopIpAddress: nextHopAddress
+        }
+      }
+    ])
+  }
+}
+
+output udrId string = udr.id

--- a/demos/nested-vms-in-virtual-network/udr.bicep
+++ b/demos/nested-vms-in-virtual-network/udr.bicep
@@ -1,5 +1,5 @@
 param udrName string
-param location string = resourceGroup().location
+param location string
 param addressPrefix string = ''
 param nextHopAddress string = ''
 


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/301/nested-vms-in-virtual-network

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3344