### PR TITLE
Migrate bicep example: 301/servicebus-namespace-vnet

### DIFF
--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/README.md
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/README.md
@@ -9,11 +9,11 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/CredScanResult.svg)
 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.servicebus%2Fservicebus-namespace-vnet%2Fazuredeploy.json)  
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/BicepVersion.svg)
+
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.servicebus%2Fservicebus-namespace-vnet%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.servicebus%2Fservicebus-namespace-vnet%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.servicebus%2Fservicebus-namespace-vnet%2Fazuredeploy.json)
 
 For information about using this template, see [Create a Service Bus Virtual Network rule for a Namespace](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-service-endpoints)
-
-
 

--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "17095389617017977833"
+      "version": "0.4.412.5873",
+      "templateHash": "3106236766736560000"
     }
   },
   "parameters": {
@@ -64,7 +64,7 @@
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2021-02-01",
-      "name": "[parameters('subnetName')]",
+      "name": "[format('{0}/{1}', '{vnetRuleName}-vn', parameters('subnetName'))]",
       "properties": {
         "addressPrefix": "10.0.0.0/23",
         "serviceEndpoints": [
@@ -72,18 +72,21 @@
             "service": "Microsoft.ServiceBus"
           }
         ]
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', '{vnetRuleName}-vn')]"
+      ]
     },
     {
       "type": "Microsoft.ServiceBus/namespaces/virtualnetworkrules",
       "apiVersion": "2018-01-01-preview",
       "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('vnetRuleName'))]",
       "properties": {
-        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]"
+        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', '{vnetRuleName}-vn', parameters('subnetName'))]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]"
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', '{vnetRuleName}-vn', parameters('subnetName'))]"
       ]
     }
   ]

--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "17095389617017977833"
+    }
+  },
   "parameters": {
     "serviceBusNamespaceName": {
       "type": "string",
@@ -28,58 +35,56 @@
       }
     }
   },
-  "variables": {
-    "namespaceVirtualNetworkRuleName": "[concat(parameters('serviceBusNamespaceName'), concat('/', parameters('vnetRuleName')))]"
-  },
+  "functions": [],
   "resources": [
     {
+      "type": "Microsoft.ServiceBus/namespaces",
       "apiVersion": "2018-01-01-preview",
       "name": "[parameters('serviceBusNamespaceName')]",
-      "type": "Microsoft.ServiceBus/namespaces",
       "location": "[parameters('location')]",
       "sku": {
         "name": "Premium",
         "tier": "Premium"
       },
-      "properties": { }
+      "properties": {}
     },
     {
-      "apiVersion": "2020-07-01",
-      "name": "[parameters('vnetRuleName')]",
-      "location": "[parameters('location')]",
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2021-02-01",
+      "name": "{vnetRuleName}-vn",
+      "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
             "10.0.0.0/23"
           ]
-        },
-        "subnets": [
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2021-02-01",
+      "name": "[parameters('subnetName')]",
+      "properties": {
+        "addressPrefix": "10.0.0.0/23",
+        "serviceEndpoints": [
           {
-            "name": "[parameters('subnetName')]",
-            "properties": {
-              "addressPrefix": "10.0.0.0/23",
-              "serviceEndpoints": [
-                {
-                  "service": "Microsoft.ServiceBus"
-                }
-              ]
-            }
+            "service": "Microsoft.ServiceBus"
           }
         ]
       }
     },
     {
+      "type": "Microsoft.ServiceBus/namespaces/virtualnetworkrules",
       "apiVersion": "2018-01-01-preview",
-      "name": "[variables('namespaceVirtualNetworkRuleName')]",
-      "type": "Microsoft.ServiceBus/namespaces/VirtualNetworkRules",
-      "dependsOn": [
-        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]"
-      ],
+      "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('vnetRuleName'))]",
       "properties": {
-        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('vnetRuleName'),  parameters('subnetName'))]"
-      }
+        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', split(parameters('subnetName'), '/')[0], split(parameters('subnetName'), '/')[1])]"
+      ]
     }
-  ],
-  "outputs": { }
+  ]
 }

--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "2412821598427232750"
+      "templateHash": "16916914025867978966"
     }
   },
   "parameters": {
@@ -39,7 +39,7 @@
   "resources": [
     {
       "type": "Microsoft.ServiceBus/namespaces",
-      "apiVersion": "2018-01-01-preview",
+      "apiVersion": "2017-04-01",
       "name": "[parameters('serviceBusNamespaceName')]",
       "location": "[parameters('location')]",
       "sku": {

--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/azuredeploy.json
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "3106236766736560000"
+      "templateHash": "2412821598427232750"
     }
   },
   "parameters": {
@@ -51,7 +51,7 @@
     {
       "type": "Microsoft.Network/virtualNetworks",
       "apiVersion": "2021-02-01",
-      "name": "{vnetRuleName}-vn",
+      "name": "[format('{0}-vn', parameters('vnetRuleName'))]",
       "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
@@ -64,7 +64,7 @@
     {
       "type": "Microsoft.Network/virtualNetworks/subnets",
       "apiVersion": "2021-02-01",
-      "name": "[format('{0}/{1}', '{vnetRuleName}-vn', parameters('subnetName'))]",
+      "name": "[format('{0}/{1}', format('{0}-vn', parameters('vnetRuleName')), parameters('subnetName'))]",
       "properties": {
         "addressPrefix": "10.0.0.0/23",
         "serviceEndpoints": [
@@ -74,7 +74,7 @@
         ]
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', '{vnetRuleName}-vn')]"
+        "[resourceId('Microsoft.Network/virtualNetworks', format('{0}-vn', parameters('vnetRuleName')))]"
       ]
     },
     {
@@ -82,11 +82,11 @@
       "apiVersion": "2018-01-01-preview",
       "name": "[format('{0}/{1}', parameters('serviceBusNamespaceName'), parameters('vnetRuleName'))]",
       "properties": {
-        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', '{vnetRuleName}-vn', parameters('subnetName'))]"
+        "virtualNetworkSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', format('{0}-vn', parameters('vnetRuleName')), parameters('subnetName'))]"
       },
       "dependsOn": [
         "[resourceId('Microsoft.ServiceBus/namespaces', parameters('serviceBusNamespaceName'))]",
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', '{vnetRuleName}-vn', parameters('subnetName'))]"
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', format('{0}-vn', parameters('vnetRuleName')), parameters('subnetName'))]"
       ]
     }
   ]

--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/main.bicep
@@ -1,0 +1,53 @@
+@description('Name of the Service Bus namespace')
+param serviceBusNamespaceName string
+
+@description('Name of the Virtual Network Rule')
+param vnetRuleName string
+
+@description('Name of the Virtual Network Sub Net')
+param subnetName string
+
+@description('Location for Namespace')
+param location string = resourceGroup().location
+
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
+  name: serviceBusNamespaceName
+  location: location
+  sku: {
+    name: 'Premium'
+    tier: 'Premium'
+  }
+  properties: {}
+}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+  name: '{vnetRuleName}-vn'
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.0.0.0/23'
+      ]
+    }
+  }
+}
+
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-02-01' = {
+  name: subnetName
+  properties: {
+    addressPrefix: '10.0.0.0/23'
+    serviceEndpoints: [
+      {
+        service: 'Microsoft.ServiceBus'
+      }
+    ]
+  }
+}
+
+resource namespaceVirtualNetworkRule 'Microsoft.ServiceBus/namespaces/virtualnetworkrules@2018-01-01-preview' = {
+  parent: serviceBusNamespace
+  name: vnetRuleName
+  properties: {
+    virtualNetworkSubnetId: subnet.id
+  }
+}

--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/main.bicep
@@ -21,7 +21,7 @@ resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2018-01-01-preview
 }
 
 resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
-  name: '{vnetRuleName}-vn'
+  name: '${vnetRuleName}-vn'
   location: location
   properties: {
     addressSpace: {

--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/main.bicep
@@ -33,6 +33,7 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
 }
 
 resource subnet 'Microsoft.Network/virtualNetworks/subnets@2021-02-01' = {
+  parent: virtualNetwork
   name: subnetName
   properties: {
     addressPrefix: '10.0.0.0/23'

--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/main.bicep
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/main.bicep
@@ -10,7 +10,7 @@ param subnetName string
 @description('Location for Namespace')
 param location string = resourceGroup().location
 
-resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2018-01-01-preview' = {
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2017-04-01' = {
   name: serviceBusNamespaceName
   location: location
   sku: {

--- a/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/metadata.json
+++ b/quickstarts/microsoft.servicebus/servicebus-namespace-vnet/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template enables you to deploy a Service Bus Premium namespace with Virtual Network rule",
   "summary": "This template creates a Service Bus namespace and virtual network rule",
   "githubUsername": "v-ajnava",
-  "dateUpdated": "2021-05-21"
+  "dateUpdated": "2021-06-22"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/301/servicebus-namespace-vnet

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3345