### PR TITLE
Migrate bicep example: 101/front-door-custom-domain

### DIFF
--- a/quickstarts/microsoft.network/front-door-custom-domain/README.md
+++ b/quickstarts/microsoft.network/front-door-custom-domain/README.md
@@ -9,7 +9,11 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/front-door-custom-domain/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/front-door-custom-domain/CredScanResult.svg)
 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Ffront-door-custom-domain%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Ffront-door-custom-domain%2Fazuredeploy.json)
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/front-door-custom-domain/BicepVersion.svg)
+
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Ffront-door-custom-domain%2Fazuredeploy.json)
+
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Ffront-door-custom-domain%2Fazuredeploy.json)
 
 This template Creates a Front Door configuration with a single backend, onboards a custom domain with a path match '/*' for default frontend host and custom domain, and then secures custom domain with a Front Door managed certificate.
 
@@ -23,5 +27,4 @@ For the deployment of this template to succeed the specified custom domain will 
 For example, for a frontdoor named "contoso", default frontend host name would be "contoso.azurefd.net". To add a custom domain "www.contoso.com", CNAME www.contoso.com to contoso.azurefd.net
 
 For more details - https://docs.microsoft.com/en-us/azure/frontdoor/front-door-custom-domain
-
 

--- a/quickstarts/microsoft.network/front-door-custom-domain/azuredeploy.json
+++ b/quickstarts/microsoft.network/front-door-custom-domain/azuredeploy.json
@@ -1,167 +1,140 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.0",
-    "parameters": {
-        "frontDoorName": {
-            "type": "string",
-            "metadata": {
-                "description": "The name of the frontdoor resource."
-            }
-        },
-        "customDomainName": {
-            "type": "string",
-            "metadata": {
-                "description": "The hostname of the frontendEndpoints. Must be a domain name."
-            }
-        },
-        "backendAddress": {
-            "type": "string",
-            "metadata": {
-                "description": "The hostname of the backend. Must be an IP address or FQDN."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "2622102016433644211"
+    }
+  },
+  "parameters": {
+    "frontDoorName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the frontdoor resource."
+      }
     },
-    "variables": {
-        "frontdoorLocation": "global"
+    "customDomainName": {
+      "type": "string",
+      "metadata": {
+        "description": "The hostname of the frontendEndpoints. Must be a domain name."
+      }
     },
-    "resources": [
-        {
-            "apiVersion": "2020-07-01",
-            "type": "Microsoft.Network/frontDoors",
-            "name": "[parameters('frontDoorName')]",
-            "location": "[variables('frontdoorLocation')]",
+    "backendAddress": {
+      "type": "string",
+      "metadata": {
+        "description": "The hostname of the backend. Must be an IP address or FQDN."
+      }
+    }
+  },
+  "functions": [],
+  "variables": {
+    "frontEndEndpointDefaultName": "frontEndEndpointDefault",
+    "frontEndEndpointCustomName": "frontEndEndpointCustom",
+    "loadBalancingSettingsName": "loadBalancingSettings",
+    "healthProbeSettingsName": "healthProbeSettings",
+    "routingRuleName": "routingRule",
+    "backendPoolName": "backendPool"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Network/frontDoors",
+      "apiVersion": "2020-01-01",
+      "name": "[parameters('frontDoorName')]",
+      "location": "global",
+      "properties": {
+        "enabledState": "Enabled",
+        "frontendEndpoints": [
+          {
+            "name": "[variables('frontEndEndpointDefaultName')]",
             "properties": {
-                "routingRules": [
-                    {
-                        "name": "routingRule1",
-                        "properties": {
-                            "frontendEndpoints": [
-                                {
-                                    "id": "[resourceId('Microsoft.Network/frontDoors/frontendEndpoints', parameters('frontDoorName'), 'frontendEndpoint1')]"
-                                }
-                            ],
-                            "acceptedProtocols": [
-                                "Http",
-                                "Https"
-                            ],
-                            "patternsToMatch": [
-                                "/*"
-                            ],
-                            "routeConfiguration": {
-                                "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
-                                "forwardingProtocol": "MatchRequest",
-                                "backendPool": {
-                                    "id": "[resourceId('Microsoft.Network/frontDoors/backendPools', parameters('frontDoorName'), 'backendPool1')]"
-                                }
-                            },
-                            "enabledState": "Enabled"
-                        }
-                    },
-                    {
-                        "name": "routingRule2",
-                        "properties": {
-                            "frontendEndpoints": [
-                                {
-                                    "id": "[resourceId('Microsoft.Network/frontDoors/frontendEndpoints', parameters('frontDoorName'), 'frontendEndpoint2')]"
-                                }
-                            ],
-                            "acceptedProtocols": [
-                                "Http",
-                                "Https"
-                            ],
-                            "patternsToMatch": [
-                                "/*"
-                            ],
-                            "routeConfiguration": {
-                                "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
-                                "forwardingProtocol": "MatchRequest",
-                                "backendPool": {
-                                    "id": "[resourceId('Microsoft.Network/frontDoors/backendPools', parameters('frontDoorName'), 'backendPool1')]"
-                                }
-                            },
-                            "enabledState": "Enabled"
-                        }
-                    }
-                ],
-                "healthProbeSettings": [
-                    {
-                        "name": "healthProbeSettings1",
-                        "properties": {
-                            "path": "/",
-                            "protocol": "Http",
-                            "intervalInSeconds": 120
-                        }
-                    }
-                ],
-                "loadBalancingSettings": [
-                    {
-                        "name": "loadBalancingSettings1",
-                        "properties": {
-                            "sampleSize": 4,
-                            "successfulSamplesRequired": 2
-                        }
-                    }
-                ],
-                "backendPools": [
-                    {
-                        "name": "backendPool1",
-                        "properties": {
-                            "backends": [
-                                {
-                                    "address": "[parameters('backendAddress')]",
-                                    "httpPort": 80,
-                                    "httpsPort": 443,
-                                    "weight": 50,
-                                    "priority": 1,
-                                    "enabledState": "Enabled"
-                                }
-                            ],
-                            "loadBalancingSettings": {
-                                "id": "[resourceId('Microsoft.Network/frontDoors/loadBalancingSettings', parameters('frontDoorName'), 'loadBalancingSettings1')]"
-                            },
-                            "healthProbeSettings": {
-                                "id": "[resourceId('Microsoft.Network/frontDoors/healthProbeSettings', parameters('frontDoorName'), 'healthProbeSettings1')]"
-                            }
-                        }
-                    }
-                ],
-                "frontendEndpoints": [
-                    {
-                        "name": "frontendEndpoint1",
-                        "properties": {
-                            "hostName": "[concat(parameters('frontDoorName'), '.azurefd.net')]",
-                            "sessionAffinityEnabledState": "Disabled",
-                            "sessionAffinityTtlSeconds": 0
-                        }
-                    },
-                    {
-                        "name": "frontendEndpoint2",
-                        "properties": {
-                            "hostName": "[parameters('customDomainName')]",
-                            "sessionAffinityEnabledState": "Disabled",
-                            "sessionAffinityTtlSeconds": 0
-                        }
-                    }
-                ],
-                "enabledState": "Enabled"
+              "hostName": "[format('{0}.azurefd.net', parameters('frontDoorName'))]",
+              "sessionAffinityEnabledState": "Disabled"
             }
-        },
-        {
-            "type": "Microsoft.Network/frontdoors/frontendEndpoints/customHttpsConfiguration",
-            "apiVersion": "2020-07-01",
-            "name": "[concat(parameters('frontDoorName'), '/frontendEndpoint2/default')]",
-            "dependsOn": [
-                "[parameters('frontDoorName')]"
-            ],
+          },
+          {
+            "name": "[variables('frontEndEndpointCustomName')]",
             "properties": {
-                "protocolType": "ServerNameIndication",
-                "certificateSource": "FrontDoor",
-                "frontDoorCertificateSourceParameters": {
-                    "certificateType": "Dedicated"
+              "hostName": "[parameters('customDomainName')]",
+              "sessionAffinityEnabledState": "Disabled"
+            }
+          }
+        ],
+        "loadBalancingSettings": [
+          {
+            "name": "[variables('loadBalancingSettingsName')]",
+            "properties": {
+              "sampleSize": 4,
+              "successfulSamplesRequired": 2
+            }
+          }
+        ],
+        "healthProbeSettings": [
+          {
+            "name": "[variables('healthProbeSettingsName')]",
+            "properties": {
+              "path": "/",
+              "protocol": "Http",
+              "intervalInSeconds": 120
+            }
+          }
+        ],
+        "backendPools": [
+          {
+            "name": "[variables('backendPoolName')]",
+            "properties": {
+              "backends": [
+                {
+                  "address": "[parameters('backendAddress')]",
+                  "backendHostHeader": "[parameters('backendAddress')]",
+                  "httpPort": 80,
+                  "httpsPort": 443,
+                  "weight": 50,
+                  "priority": 1,
+                  "enabledState": "Enabled"
+                }
+              ],
+              "loadBalancingSettings": {
+                "id": "[resourceId('Microsoft.Network/frontDoors/loadBalancingSettings', parameters('frontDoorName'), variables('loadBalancingSettingsName'))]"
+              },
+              "healthProbeSettings": {
+                "id": "[resourceId('Microsoft.Network/frontDoors/healthProbeSettings', parameters('frontDoorName'), variables('healthProbeSettingsName'))]"
+              }
+            }
+          }
+        ],
+        "routingRules": [
+          {
+            "name": "[variables('routingRuleName')]",
+            "properties": {
+              "frontendEndpoints": [
+                {
+                  "id": "[resourceId('Microsoft.Network/frontDoors/frontEndEndpoints', parameters('frontDoorName'), variables('frontEndEndpointDefaultName'))]"
                 },
-                "minimumTlsVersion": "1.2"
+                {
+                  "id": "[resourceId('Microsoft.Network/frontDoors/frontEndEndpoints', parameters('frontDoorName'), variables('frontEndEndpointCustomName'))]"
+                }
+              ],
+              "acceptedProtocols": [
+                "Http",
+                "Https"
+              ],
+              "patternsToMatch": [
+                "/*"
+              ],
+              "routeConfiguration": {
+                "@odata.type": "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
+                "forwardingProtocol": "MatchRequest",
+                "backendPool": {
+                  "id": "[resourceId('Microsoft.Network/frontDoors/backEndPools', parameters('frontDoorName'), variables('backendPoolName'))]"
+                }
+              },
+              "enabledState": "Enabled"
             }
-        }
-    ],
-    "outputs": {}
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/quickstarts/microsoft.network/front-door-custom-domain/main.bicep
+++ b/quickstarts/microsoft.network/front-door-custom-domain/main.bicep
@@ -1,0 +1,117 @@
+@description('The name of the frontdoor resource.')
+param frontDoorName string
+
+@description('The hostname of the frontendEndpoints. Must be a domain name.')
+param customDomainName string
+
+@description('The hostname of the backend. Must be an IP address or FQDN.')
+param backendAddress string
+
+var frontEndEndpointDefaultName = 'frontEndEndpointDefault'
+var frontEndEndpointCustomName = 'frontEndEndpointCustom'
+var loadBalancingSettingsName = 'loadBalancingSettings'
+var healthProbeSettingsName = 'healthProbeSettings'
+var routingRuleName = 'routingRule'
+var backendPoolName = 'backendPool'
+
+resource frontDoor 'Microsoft.Network/frontDoors@2020-01-01' = {
+  name: frontDoorName
+  location: 'global'
+  properties: {
+    enabledState: 'Enabled'
+
+    frontendEndpoints: [
+      {
+        name: frontEndEndpointDefaultName
+        properties: {
+          hostName: '${frontDoorName}.azurefd.net'
+          sessionAffinityEnabledState: 'Disabled'
+        }
+      }
+      {
+        name: frontEndEndpointCustomName
+        properties: {
+          hostName: customDomainName
+          sessionAffinityEnabledState: 'Disabled'
+        }
+      }
+    ]
+
+    loadBalancingSettings: [
+      {
+        name: loadBalancingSettingsName
+        properties: {
+          sampleSize: 4
+          successfulSamplesRequired: 2
+        }
+      }
+    ]
+
+    healthProbeSettings: [
+      {
+        name: healthProbeSettingsName
+        properties: {
+          path: '/'
+          protocol: 'Http'
+          intervalInSeconds: 120
+        }
+      }
+    ]
+
+    backendPools: [
+      {
+        name: backendPoolName
+        properties: {
+          backends: [
+            {
+              address: backendAddress
+              backendHostHeader: backendAddress
+              httpPort: 80
+              httpsPort: 443
+              weight: 50
+              priority: 1
+              enabledState: 'Enabled'
+            }
+          ]
+          loadBalancingSettings: {
+            id: resourceId('Microsoft.Network/frontDoors/loadBalancingSettings', frontDoorName, loadBalancingSettingsName)
+          }
+          healthProbeSettings: {
+            id: resourceId('Microsoft.Network/frontDoors/healthProbeSettings', frontDoorName, healthProbeSettingsName)
+          }
+        }
+      }
+    ]
+
+    routingRules: [
+      {
+        name: routingRuleName
+        properties: {
+          frontendEndpoints: [
+            {
+              id: resourceId('Microsoft.Network/frontDoors/frontEndEndpoints', frontDoorName, frontEndEndpointDefaultName)
+            }
+            {
+              id: resourceId('Microsoft.Network/frontDoors/frontEndEndpoints', frontDoorName, frontEndEndpointCustomName)
+            }
+          ]
+          acceptedProtocols: [
+            'Http'
+            'Https'
+          ]
+          patternsToMatch: [
+            '/*'
+          ]
+          routeConfiguration: {
+            '@odata.type': '#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration'
+            forwardingProtocol: 'MatchRequest'
+            backendPool: {
+              id: resourceId('Microsoft.Network/frontDoors/backEndPools', frontDoorName, backendPoolName)
+            }
+          }
+          enabledState: 'Enabled'
+        }
+      }
+    ]
+  }
+}

--- a/quickstarts/microsoft.network/front-door-custom-domain/metadata.json
+++ b/quickstarts/microsoft.network/front-door-custom-domain/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template onboards and secures a custom domain with Front Door",
   "summary": "This template adds and secures a custom domain to your Front Door.",
   "githubUsername": "pichandwork",
-  "dateUpdated": "2021-05-18",
+  "dateUpdated": "2021-06-22",
   "validationType":"Manual",
   "environments": [
     "AzureCloud"


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/front-door-custom-domain

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3346