### PR TITLE
Migrate bicep example: 201/api-management-create-all-resources

### DIFF
--- a/quickstarts/microsoft.apimanagement/api-management-create-all-resources/README.md
+++ b/quickstarts/microsoft.apimanagement/api-management-create-all-resources/README.md
@@ -9,11 +9,11 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.apimanagement/api-management-create-all-resources/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.apimanagement/api-management-create-all-resources/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.apimanagement/api-management-create-all-resources/BicepVersion.svg)
 
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.apimanagement%2Fapi-management-create-all-resources%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.apimanagement%2Fapi-management-create-all-resources%2Fazuredeploy.json)
-[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.apimanagement%2Fapi-management-create-all-resources%2Fazuredeploy.json) 
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.apimanagement%2Fapi-management-create-all-resources%2Fazuredeploy.json)
 
 This template provides an example of how to create API Management service and configure all sub-entities. NOTE: this is an example and most of the entities need to be modified to your needs before using this template.
-
 

--- a/quickstarts/microsoft.apimanagement/api-management-create-all-resources/azuredeploy.json
+++ b/quickstarts/microsoft.apimanagement/api-management-create-all-resources/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "6218244555909351017"
+    }
+  },
   "parameters": {
     "publisherEmail": {
       "type": "string",
@@ -18,12 +25,12 @@
     },
     "sku": {
       "type": "string",
+      "defaultValue": "Standard",
       "allowedValues": [
         "Developer",
         "Standard",
         "Premium"
       ],
-      "defaultValue": "Standard",
       "metadata": {
         "description": "The pricing tier of this API Management service"
       }
@@ -36,31 +43,31 @@
       }
     },
     "mutualAuthenticationCertificate": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Base-64 encoded Mutual authentication PFX certificate."
       }
     },
     "certificatePassword": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Mutual authentication certificate password."
       }
     },
     "eventHubNamespaceConnectionString": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "EventHub connection string for logger."
       }
     },
     "googleClientSecret": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Google client secret to configure google identity."
       }
     },
     "openIdConnectClientSecret": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "OpenId connect client secret."
       }
@@ -97,350 +104,331 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "apiManagementServiceName": "[concat('apiservice', uniqueString(resourceGroup().id))]"
+    "apiManagementServiceName": "[format('apiservice{0}', uniqueString(resourceGroup().id))]"
   },
   "resources": [
     {
-      "apiVersion": "2017-03-01",
-      "name": "[variables('apiManagementServiceName')]",
       "type": "Microsoft.ApiManagement/service",
+      "apiVersion": "2020-12-01",
+      "name": "[variables('apiManagementServiceName')]",
       "location": "[parameters('location')]",
-      "tags": {},
       "sku": {
         "name": "[parameters('sku')]",
         "capacity": "[parameters('skuCount')]"
       },
       "properties": {
-        "publisherEmail": "[parameters('publisherEmail')]",
-        "publisherName": "[parameters('publisherName')]"
+        "publisherName": "[parameters('publisherName')]",
+        "publisherEmail": "[parameters('publisherEmail')]"
+      }
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/policies",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'policy')]",
+      "properties": {
+        "value": "[parameters('tenantPolicy')]"
       },
-      "resources": [
-        {
-          "apiVersion": "2017-03-01",
-          "type": "policies",
-          "name": "policy",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "policyContent": "[parameters('tenantPolicy')]"
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "apis",
-          "name": "PetStoreSwaggerImportExample",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "contentFormat": "SwaggerLinkJson",
-            "contentValue": "http://petstore.swagger.io/v2/swagger.json",
-            "path": "examplepetstore"
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "apis",
-          "name": "exampleApi",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "displayName": "Example API Name",
-            "description": "Description for example API",
-            "serviceUrl": "https://example.net",
-            "path": "exampleapipath",
-            "protocols": [
-              "HTTPS"
-            ]
-          },
-          "resources": [
-            {
-              "apiVersion": "2017-03-01",
-              "type": "operations",
-              "name": "exampleOperationsDELETE",
-              "dependsOn": [
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/apis/exampleApi')]"
-              ],
-              "properties": {
-                "displayName": "DELETE resource",
-                "method": "DELETE",
-                "urlTemplate": "/resource",
-                "description": "A demonstration of a DELETE call"
-              }
-            },
-            {
-              "apiVersion": "2017-03-01",
-              "type": "operations",
-              "name": "exampleOperationsGET",
-              "dependsOn": [
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/apis/exampleApi')]"
-              ],
-              "properties": {
-                "displayName": "GET resource",
-                "method": "GET",
-                "urlTemplate": "/resource",
-                "description": "A demonstration of a GET call"
-              },
-              "resources": [
-                {
-                  "apiVersion": "2017-03-01",
-                  "type": "policies",
-                  "name": "policy",
-                  "dependsOn": [
-                    "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]",
-                    "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/apis/exampleApi')]",
-                    "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/apis/exampleApi/operations/exampleOperationsGET')]"
-                  ],
-                  "properties": {
-                    "policyContent": "[parameters('operationPolicy')]"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "apis",
-          "name": "exampleApiWithPolicy",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "displayName": "Example API Name with Policy",
-            "description": "Description for example API with policy",
-            "serviceUrl": "https://exampleapiwithpolicy.net",
-            "path": "exampleapiwithpolicypath",
-            "protocols": [
-              "HTTPS"
-            ]
-          },
-          "resources": [
-            {
-              "apiVersion": "2017-03-01",
-              "type": "policies",
-              "name": "policy",
-              "dependsOn": [
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]",
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/apis/exampleApiWithPolicy')]"
-              ],
-              "properties": {
-                "policyContent": "[parameters('apiPolicy')]"
-              }
-            }
-          ]
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "products",
-          "name": "exampleProduct",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "displayName": "Example Product Name",
-            "description": "Description for example product",
-            "terms": "Terms for example product",
-            "subscriptionRequired": true,
-            "approvalRequired": false,
-            "subscriptionsLimit": 1,
-            "state": "published"
-          },
-          "resources": [
-            {
-              "apiVersion": "2017-03-01",
-              "type": "apis",
-              "name": "exampleApi",
-              "dependsOn": [
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]",
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/apis/exampleApi')]",
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/products/exampleProduct')]"
-              ]
-            },
-            {
-              "apiVersion": "2017-03-01",
-              "type": "policies",
-              "name": "policy",
-              "dependsOn": [
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]",
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/products/exampleProduct')]"
-              ],
-              "properties": {
-                "policyContent": "[parameters('productPolicy')]"
-              }
-            }
-          ]
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "users",
-          "name": "exampleUser1",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "firstName": "ExampleFirstName1",
-            "lastName": "ExampleLastName1",
-            "email": "ExampleFirst1@example.com",
-            "state": "active",
-            "note": "note for example user 1"
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "users",
-          "name": "exampleUser2",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "firstName": "ExampleFirstName2",
-            "lastName": "ExampleLastName2",
-            "email": "ExampleFirst2@example.com",
-            "state": "active",
-            "note": "note for example user 2"
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "users",
-          "name": "exampleUser3",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "firstName": "ExampleFirstName3",
-            "lastName": "ExampleLastName3",
-            "email": "ExampleFirst3@example.com",
-            "state": "active",
-            "note": "note for example user 3"
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "properties",
-          "name": "exampleproperties",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "displayName": "propertyExampleName",
-            "value": "propertyExampleValue",
-            "tags": [
-              "exampleTag"
-            ]
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "subscriptions",
-          "name": "examplesubscription1",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]",
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/products/exampleProduct')]",
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/users/exampleUser1')]"
-          ],
-          "properties": {
-            "productId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/exampleServiceName/products/exampleProduct",
-            "userId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/exampleServiceName/users/exampleUser1"
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "subscriptions",
-          "name": "examplesubscription2",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]",
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/products/exampleProduct')]",
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/users/exampleUser3')]",
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/subscriptions/examplesubscription1')]"
-          ],
-          "properties": {
-            "productId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/exampleServiceName/products/exampleProduct",
-            "userId": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ApiManagement/service/exampleServiceName/users/exampleUser3"
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "certificates",
-          "name": "exampleCertificate",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "data": "[parameters('mutualAuthenticationCertificate')]",
-            "password": "[parameters('certificatePassword')]"
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "groups",
-          "name": "exampleGroup",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "displayName": "Example Group Name",
-            "description": "Example group description"
-          },
-          "resources": [
-            {
-              "apiVersion": "2017-03-01",
-              "type": "users",
-              "name": "exampleUser3",
-              "dependsOn": [
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]",
-                "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'), '/groups/exampleGroup')]"
-              ]
-            }
-          ]
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "openidConnectProviders",
-          "name": "exampleOpenIdConnectProvider",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "displayName": "exampleOpenIdConnectProviderName",
-            "description": "Description for example OpenId Connect provider",
-            "metadataEndpoint": "https://example-openIdConnect-url.net",
-            "clientId": "exampleClientId",
-            "clientSecret": "[parameters('openIdConnectClientSecret')]"
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "loggers",
-          "name": "exampleLogger",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "loggerType": "azureEventHub",
-            "description": "Description for example logger",
-            "credentials": {
-              "name": "exampleEventHubName",
-              "connectionString": "[parameters('eventHubNamespaceConnectionString')]"
-            }
-          }
-        },
-        {
-          "apiVersion": "2017-03-01",
-          "type": "identityProviders",
-          "name": "google",
-          "dependsOn": [
-            "[concat('Microsoft.ApiManagement/service/', variables('apiManagementServiceName'))]"
-          ],
-          "properties": {
-            "clientId": "googleClientId",
-            "clientSecret": "[parameters('googleClientSecret')]"
-          }
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/apis",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'PetStoreSwaggerImportExample')]",
+      "properties": {
+        "format": "swagger-link-json",
+        "value": "http://petstore.swagger.io/v2/swagger.json",
+        "path": "examplepetstore"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/apis",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleApi')]",
+      "properties": {
+        "displayName": "Example API Name",
+        "description": "Description for example API",
+        "serviceUrl": "https://example.net",
+        "path": "exampleapipath",
+        "protocols": [
+          "https"
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/apis/operations",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}/{2}', variables('apiManagementServiceName'), 'exampleApi', 'exampleOperationsDELETE')]",
+      "properties": {
+        "displayName": "DELETE resource",
+        "method": "DELETE",
+        "urlTemplate": "/resource",
+        "description": "A demonstration of a DELETE call"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]",
+        "[resourceId('Microsoft.ApiManagement/service/apis', variables('apiManagementServiceName'), 'exampleApi')]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/apis/operations",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}/{2}', variables('apiManagementServiceName'), 'exampleApi', 'exampleOperationsGET')]",
+      "properties": {
+        "displayName": "GET resource",
+        "method": "GET",
+        "urlTemplate": "/resource",
+        "description": "A demonstration of a GET call"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]",
+        "[resourceId('Microsoft.ApiManagement/service/apis', variables('apiManagementServiceName'), 'exampleApi')]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/apis/operations/policies",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}/{2}/{3}', variables('apiManagementServiceName'), 'exampleApi', 'exampleOperationsGET', 'policy')]",
+      "properties": {
+        "value": "[parameters('operationPolicy')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]",
+        "[resourceId('Microsoft.ApiManagement/service/apis', variables('apiManagementServiceName'), 'exampleApi')]",
+        "[resourceId('Microsoft.ApiManagement/service/apis/operations', variables('apiManagementServiceName'), 'exampleApi', 'exampleOperationsGET')]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/apis",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleApiWithPolicy')]",
+      "properties": {
+        "displayName": "Example API Name with policy",
+        "description": "Description for example API with policy",
+        "serviceUrl": "https://examplewithpolicy.net",
+        "path": "exampleapipolicypath",
+        "protocols": [
+          "https"
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/apis/policies",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}/{2}', variables('apiManagementServiceName'), 'exampleApiWithPolicy', 'policy')]",
+      "properties": {
+        "value": "[parameters('apiPolicy')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]",
+        "[resourceId('Microsoft.ApiManagement/service/apis', variables('apiManagementServiceName'), 'exampleApiWithPolicy')]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/products",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleProduct')]",
+      "properties": {
+        "displayName": "Example Product Name",
+        "description": "Description for example product",
+        "terms": "Terms for example product",
+        "subscriptionRequired": true,
+        "approvalRequired": false,
+        "subscriptionsLimit": 1,
+        "state": "published"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/products/apis",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}/{2}', variables('apiManagementServiceName'), 'exampleProduct', 'exampleApi')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]",
+        "[resourceId('Microsoft.ApiManagement/service/products', variables('apiManagementServiceName'), 'exampleProduct')]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/products/policies",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}/{2}', variables('apiManagementServiceName'), 'exampleProduct', 'policy')]",
+      "properties": {
+        "value": "[parameters('productPolicy')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]",
+        "[resourceId('Microsoft.ApiManagement/service/products', variables('apiManagementServiceName'), 'exampleProduct')]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/users",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleUser1')]",
+      "properties": {
+        "firstName": "ExampleFirstName1",
+        "lastName": "ExampleLastName1",
+        "email": "examplefirst1@example.com",
+        "state": "active",
+        "note": "note for example user 1"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/users",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleUser2')]",
+      "properties": {
+        "firstName": "ExampleFirstName2",
+        "lastName": "ExampleLastName2",
+        "email": "examplefirst2@example.com",
+        "state": "active",
+        "note": "note for example user 2"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/users",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleUser3')]",
+      "properties": {
+        "firstName": "ExampleFirstName3",
+        "lastName": "ExampleLastName3",
+        "email": "examplefirst3@example.com",
+        "state": "active",
+        "note": "note for example user 3"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/properties",
+      "apiVersion": "2019-01-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleproperties')]",
+      "properties": {
+        "displayName": "propertyExampleName",
+        "value": "propertyExampleValue",
+        "tags": [
+          "exampleTag"
+        ]
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/subscriptions",
+      "apiVersion": "2018-01-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'examplesubscription1')]",
+      "properties": {
+        "displayName": "examplesubscription1",
+        "productId": "[resourceId('Microsoft.ApiManagement/service/products', variables('apiManagementServiceName'), 'exampleProduct')]",
+        "userId": "[resourceId('Microsoft.ApiManagement/service/users', variables('apiManagementServiceName'), 'exampleUser1')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]",
+        "[resourceId('Microsoft.ApiManagement/service/products', variables('apiManagementServiceName'), 'exampleProduct')]",
+        "[resourceId('Microsoft.ApiManagement/service/users', variables('apiManagementServiceName'), 'exampleUser1')]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/subscriptions",
+      "apiVersion": "2018-01-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'examplesubscription2')]",
+      "properties": {
+        "displayName": "examplesubscription2",
+        "productId": "[resourceId('Microsoft.ApiManagement/service/products', variables('apiManagementServiceName'), 'exampleProduct')]",
+        "userId": "[resourceId('Microsoft.ApiManagement/service/users', variables('apiManagementServiceName'), 'exampleUser3')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]",
+        "[resourceId('Microsoft.ApiManagement/service/products', variables('apiManagementServiceName'), 'exampleProduct')]",
+        "[resourceId('Microsoft.ApiManagement/service/users', variables('apiManagementServiceName'), 'exampleUser3')]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/certificates",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleCertificate')]",
+      "properties": {
+        "data": "[parameters('mutualAuthenticationCertificate')]",
+        "password": "[parameters('certificatePassword')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/groups",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleGroup')]",
+      "properties": {
+        "displayName": "Example Group Name",
+        "description": "Example group description"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/openidConnectProviders",
+      "apiVersion": "2020-06-01-preview",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleOpenIdConnectProvider')]",
+      "properties": {
+        "displayName": "exampleOpenIdConnectProviderName",
+        "description": "Description for example OpenId Connect provider",
+        "metadataEndpoint": "https://example-openIdConnect-url.net",
+        "clientId": "exampleClientId",
+        "clientSecret": "[parameters('openIdConnectClientSecret')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/loggers",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'exampleLogger')]",
+      "properties": {
+        "loggerType": "azureEventHub",
+        "description": "Description for example logger",
+        "credentials": {
+          "name": "exampleEventHubName",
+          "eventHubNamespaceConnectionString": "[parameters('eventHubNamespaceConnectionString')]"
         }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.ApiManagement/service/identityProviders",
+      "apiVersion": "2020-12-01",
+      "name": "[format('{0}/{1}', variables('apiManagementServiceName'), 'google')]",
+      "properties": {
+        "clientId": "googleClientId",
+        "clientSecret": "[parameters('googleClientSecret')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.ApiManagement/service', variables('apiManagementServiceName'))]"
       ]
     }
   ]

--- a/quickstarts/microsoft.apimanagement/api-management-create-all-resources/main.bicep
+++ b/quickstarts/microsoft.apimanagement/api-management-create-all-resources/main.bicep
@@ -1,0 +1,299 @@
+@description('The email address of the owner of the service')
+@minLength(1)
+param publisherEmail string
+
+@description('The name of the owner of the service')
+@minLength(1)
+param publisherName string
+
+@description('The pricing tier of this API Management service')
+@allowed([
+  'Developer'
+  'Standard'
+  'Premium'
+])
+param sku string = 'Standard'
+
+@description('The instance size of this API Management service.')
+param skuCount int = 1
+
+@description('Base-64 encoded Mutual authentication PFX certificate.')
+@secure()
+param mutualAuthenticationCertificate string
+
+@description('Mutual authentication certificate password.')
+@secure()
+param certificatePassword string
+
+@description('EventHub connection string for logger.')
+@secure()
+param eventHubNamespaceConnectionString string
+
+@description('Google client secret to configure google identity.')
+@secure()
+param googleClientSecret string
+
+@description('OpenId connect client secret.')
+@secure()
+param openIdConnectClientSecret string
+
+@description('Tenant policy XML.')
+param tenantPolicy string
+
+@description('API policy XML.')
+param apiPolicy string
+
+@description('Operation policy XML.')
+param operationPolicy string
+
+@description('Product policy XML.')
+param productPolicy string
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+var apiManagementServiceName = 'apiservice${uniqueString(resourceGroup().id)}'
+
+resource apiManagementService 'Microsoft.ApiManagement/service@2020-12-01' = {
+  name: apiManagementServiceName
+  location: location
+  sku: {
+    name: sku
+    capacity: skuCount
+  }
+  properties: {
+    publisherName: publisherName
+    publisherEmail: publisherEmail
+  }
+}
+
+resource policy 'Microsoft.ApiManagement/service/policies@2020-12-01' = {
+  parent: apiManagementService
+  name: 'policy'
+  properties: {
+    value: tenantPolicy
+  }
+}
+
+resource apiManagementServiceName_PetStoreSwaggerImportExample 'Microsoft.ApiManagement/service/apis@2020-12-01' = {
+  parent: apiManagementService
+  name: 'PetStoreSwaggerImportExample'
+  properties: {
+    format: 'swagger-link-json'
+    value: 'http://petstore.swagger.io/v2/swagger.json'
+    path: 'examplepetstore'
+  }
+}
+
+resource exampleApi 'Microsoft.ApiManagement/service/apis@2020-12-01' = {
+  parent: apiManagementService
+  name: 'exampleApi'
+  properties: {
+    displayName: 'Example API Name'
+    description: 'Description for example API'
+    serviceUrl: 'https://example.net'
+    path: 'exampleapipath'
+    protocols: [
+      'https'
+    ]
+  }
+}
+
+resource exampleApiOperationDelete 'Microsoft.ApiManagement/service/apis/operations@2020-12-01' = {
+  parent: exampleApi
+  name: 'exampleOperationsDELETE'
+  properties: {
+    displayName: 'DELETE resource'
+    method: 'DELETE'
+    urlTemplate: '/resource'
+    description: 'A demonstration of a DELETE call'
+  }
+}
+
+resource exampleApiOperationGet 'Microsoft.ApiManagement/service/apis/operations@2020-12-01' = {
+  parent: exampleApi
+  name: 'exampleOperationsGET'
+  properties: {
+    displayName: 'GET resource'
+    method: 'GET'
+    urlTemplate: '/resource'
+    description: 'A demonstration of a GET call'
+  }
+}
+
+resource exampleApiOperationGetPolicy 'Microsoft.ApiManagement/service/apis/operations/policies@2020-12-01' = {
+  parent: exampleApiOperationGet
+  name: 'policy'
+  properties: {
+    value: operationPolicy
+  }
+}
+
+resource exampleApiWithPolicy 'Microsoft.ApiManagement/service/apis@2020-12-01' = {
+  parent: apiManagementService
+  name: 'exampleApiWithPolicy'
+  properties: {
+    displayName: 'Example API Name with policy'
+    description: 'Description for example API with policy'
+    serviceUrl: 'https://examplewithpolicy.net'
+    path: 'exampleapipolicypath'
+    protocols: [
+      'https'
+    ]
+  }
+}
+
+resource exampleApiWithPolicyPolicy 'Microsoft.ApiManagement/service/apis/policies@2020-12-01' = {
+  parent: exampleApiWithPolicy
+  name: 'policy'
+  properties: {
+    value: apiPolicy
+  }
+}
+
+resource exampleProduct 'Microsoft.ApiManagement/service/products@2020-12-01' = {
+  parent: apiManagementService
+  name: 'exampleProduct'
+  properties: {
+    displayName: 'Example Product Name'
+    description: 'Description for example product'
+    terms: 'Terms for example product'
+    subscriptionRequired: true
+    approvalRequired: false
+    subscriptionsLimit: 1
+    state: 'published'
+  }
+}
+
+resource exampleProductApi 'Microsoft.ApiManagement/service/products/apis@2020-12-01' = {
+  parent: exampleProduct
+  name: 'exampleApi'
+}
+
+resource exampleProductPolicy 'Microsoft.ApiManagement/service/products/policies@2020-12-01' = {
+  parent: exampleProduct
+  name: 'policy'
+  properties: {
+    value: productPolicy
+  }
+}
+
+resource exampleUser1 'Microsoft.ApiManagement/service/users@2020-12-01' = {
+  parent: apiManagementService
+  name: 'exampleUser1'
+  properties: {
+    firstName: 'ExampleFirstName1'
+    lastName: 'ExampleLastName1'
+    email: 'examplefirst1@example.com'
+    state: 'active'
+    note: 'note for example user 1'
+  }
+}
+
+resource exampleUser2 'Microsoft.ApiManagement/service/users@2020-12-01' = {
+  parent: apiManagementService
+  name: 'exampleUser2'
+  properties: {
+    firstName: 'ExampleFirstName2'
+    lastName: 'ExampleLastName2'
+    email: 'examplefirst2@example.com'
+    state: 'active'
+    note: 'note for example user 2'
+  }
+}
+
+resource exampleUser3 'Microsoft.ApiManagement/service/users@2020-12-01' = {
+  parent: apiManagementService
+  name: 'exampleUser3'
+  properties: {
+    firstName: 'ExampleFirstName3'
+    lastName: 'ExampleLastName3'
+    email: 'examplefirst3@example.com'
+    state: 'active'
+    note: 'note for example user 3'
+  }
+}
+
+resource exampleProperty 'Microsoft.ApiManagement/service/properties@2019-01-01' = {
+  parent: apiManagementService
+  name: 'exampleproperties'
+  properties: {
+    displayName: 'propertyExampleName'
+    value: 'propertyExampleValue'
+    tags: [
+      'exampleTag'
+    ]
+  }
+}
+
+resource subscription1 'Microsoft.ApiManagement/service/subscriptions@2018-01-01' = {
+  parent: apiManagementService
+  name: 'examplesubscription1'
+  properties: {
+    displayName: 'examplesubscription1'
+    productId: exampleProduct.id
+    userId: exampleUser1.id
+  }
+}
+
+resource subscription2 'Microsoft.ApiManagement/service/subscriptions@2018-01-01' = {
+  parent: apiManagementService
+  name: 'examplesubscription2'
+  properties: {
+    displayName: 'examplesubscription2'
+    productId: exampleProduct.id
+    userId: exampleUser3.id
+  }
+}
+
+resource certificate 'Microsoft.ApiManagement/service/certificates@2020-12-01' = {
+  parent: apiManagementService
+  name: 'exampleCertificate'
+  properties: {
+    data: mutualAuthenticationCertificate
+    password: certificatePassword
+  }
+}
+
+resource exampleGroup 'Microsoft.ApiManagement/service/groups@2020-12-01' = {
+  parent: apiManagementService
+  name: 'exampleGroup'
+  properties: {
+    displayName: 'Example Group Name'
+    description: 'Example group description'
+  }
+}
+
+resource openIdConnectProvider 'Microsoft.ApiManagement/service/openidConnectProviders@2020-06-01-preview' = {
+  parent: apiManagementService
+  name: 'exampleOpenIdConnectProvider'
+  properties: {
+    displayName: 'exampleOpenIdConnectProviderName'
+    description: 'Description for example OpenId Connect provider'
+    metadataEndpoint: 'https://example-openIdConnect-url.net'
+    clientId: 'exampleClientId'
+    clientSecret: openIdConnectClientSecret
+  }
+}
+
+resource exampleLogger 'Microsoft.ApiManagement/service/loggers@2020-12-01' = {
+  parent: apiManagementService
+  name: 'exampleLogger'
+  properties: {
+    loggerType: 'azureEventHub'
+    description: 'Description for example logger'
+    credentials: {
+      name: 'exampleEventHubName'
+      eventHubNamespaceConnectionString: eventHubNamespaceConnectionString
+    }
+  }
+}
+
+resource identityProvider 'Microsoft.ApiManagement/service/identityProviders@2020-12-01' = {
+  parent: apiManagementService
+  name: 'google'
+  properties: {
+    clientId: 'googleClientId'
+    clientSecret: googleClientSecret
+  }
+}

--- a/quickstarts/microsoft.apimanagement/api-management-create-all-resources/metadata.json
+++ b/quickstarts/microsoft.apimanagement/api-management-create-all-resources/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
   "type": "QuickStart",
-  "itemDisplayName": "Create an API Management instance and all sub resources using template",
+  "itemDisplayName": "Create an API Management instance and all subresources",
   "description": "This template demonstrates how to create a API Management service and configure sub-entities",
   "summary": "This template provides an example of how to create API Management service and configure all sub-entities",
   "githubUsername": "kedarjoshi",

--- a/quickstarts/microsoft.apimanagement/api-management-create-all-resources/metadata.json
+++ b/quickstarts/microsoft.apimanagement/api-management-create-all-resources/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template demonstrates how to create a API Management service and configure sub-entities",
   "summary": "This template provides an example of how to create API Management service and configure all sub-entities",
   "githubUsername": "kedarjoshi",
-  "dateUpdated": "2021-06-10"
+  "dateUpdated": "2021-06-22"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/api-management-create-all-resources

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3347