### PR TITLE
Migrate bicep example: 301/expressroute-circuit-vnet-connection

### DIFF
--- a/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/README.md
+++ b/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/README.md
@@ -9,11 +9,11 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/CredScanResult.svg)
 
-Connect a VNET to an ExpressRoute Circuit - 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fexpressroute-circuit-vnet-connection%2Fazuredeploy.json)  
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/BicepVersion.svg)
+
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fexpressroute-circuit-vnet-connection%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fexpressroute-circuit-vnet-connection%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.network%2Fexpressroute-circuit-vnet-connection%2Fazuredeploy.json)
 
 This template creates a VNET, an ExpresRoute Gateway and a connection to a provisioned and enabled ExpressRoute Circuit with AzurePrivatePeering configured..
-
 

--- a/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/azuredeploy.json
+++ b/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "11387816422217086291"
+      "version": "0.4.412.5873",
+      "templateHash": "10766098152758523429"
     }
   },
   "parameters": {
@@ -45,6 +45,16 @@
       "type": "string",
       "metadata": {
         "description": "The name of the first subnet in the new virtual network."
+      }
+    },
+    "gatewaySubnetName": {
+      "type": "string",
+      "defaultValue": "GatewaySubnet",
+      "allowedValues": [
+        "GatewaySubnet"
+      ],
+      "metadata": {
+        "description": "The name of the subnet where Gateway is to be deployed. This must always be named GatewaySubnet."
       }
     },
     "subnetPrefix": {
@@ -93,7 +103,7 @@
   },
   "functions": [],
   "variables": {
-    "gatewaySubnetName": "GatewaySubnet",
+    "gatewaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('virtualNetworkName'), parameters('gatewaySubnetName'))]",
     "routingWeight": 3
   },
   "resources": [
@@ -107,30 +117,22 @@
           "addressPrefixes": [
             "[parameters('virtualNetworkAddressPrefix')]"
           ]
-        }
+        },
+        "subnets": [
+          {
+            "name": "[parameters('subnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('subnetPrefix')]"
+            }
+          },
+          {
+            "name": "[parameters('gatewaySubnetName')]",
+            "properties": {
+              "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
+            }
+          }
+        ]
       }
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName'))]",
-      "properties": {
-        "addressPrefix": "[parameters('subnetPrefix')]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2020-06-01",
-      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), variables('gatewaySubnetName'))]",
-      "properties": {
-        "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
-      ]
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
@@ -153,7 +155,7 @@
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('gatewaySubnetName'))]"
+                "id": "[variables('gatewaySubnetRef')]"
               },
               "publicIPAddress": {
                 "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]"
@@ -164,8 +166,8 @@
         "gatewayType": "[parameters('gatewayType')]"
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('gatewaySubnetName'))]",
-        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]"
+        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]",
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
       ]
     },
     {

--- a/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/azuredeploy.json
+++ b/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "11387816422217086291"
+    }
+  },
   "parameters": {
     "gatewayType": {
       "type": "string",
@@ -28,7 +35,7 @@
         "description": "The name of the virtual network to create."
       }
     },
-    "addressPrefix": {
+    "virtualNetworkAddressPrefix": {
       "type": "string",
       "metadata": {
         "description": "The address space in CIDR notation for the new virtual network."
@@ -38,16 +45,6 @@
       "type": "string",
       "metadata": {
         "description": "The name of the first subnet in the new virtual network."
-      }
-    },
-    "gatewaySubnet": {
-      "type": "string",
-      "defaultValue": "GatewaySubnet",
-      "allowedValues": [
-        "GatewaySubnet"
-      ],
-      "metadata": {
-        "description": "The name of the subnet where Gateway is to be deployed. This must always be named GatewaySubnet."
       }
     },
     "subnetPrefix": {
@@ -94,41 +91,50 @@
       }
     }
   },
+  "functions": [],
   "variables": {
-    "gatewaySubnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets/', parameters('virtualNetworkName'),parameters('gatewaySubnet'))]",
+    "gatewaySubnetName": "GatewaySubnet",
     "routingWeight": 3
   },
   "resources": [
     {
-      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('virtualNetworkName')]",
       "location": "[parameters('location')]",
       "properties": {
         "addressSpace": {
           "addressPrefixes": [
-            "[parameters('addressPrefix')]"
+            "[parameters('virtualNetworkAddressPrefix')]"
           ]
-        },
-        "subnets": [
-          {
-            "name": "[parameters('subnetName')]",
-            "properties": {
-              "addressPrefix": "[parameters('subnetPrefix')]"
-            }
-          },
-          {
-            "name": "[parameters('gatewaySubnet')]",
-            "properties": {
-              "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
-            }
-          }
-        ]
+        }
       }
     },
     {
-      "apiVersion": "2015-06-15",
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), parameters('subnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('subnetPrefix')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2020-06-01",
+      "name": "[format('{0}/{1}', parameters('virtualNetworkName'), variables('gatewaySubnetName'))]",
+      "properties": {
+        "addressPrefix": "[parameters('gatewaySubnetPrefix')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+      ]
+    },
+    {
       "type": "Microsoft.Network/publicIPAddresses",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('gatewayPublicIPName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -136,50 +142,51 @@
       }
     },
     {
-      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/virtualNetworkGateways",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('gatewayName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/publicIPAddresses/', parameters('gatewayPublicIPName'))]",
-        "[concat('Microsoft.Network/virtualNetworks/', parameters('virtualNetworkName'))]"
-      ],
       "properties": {
         "ipConfigurations": [
           {
+            "name": "vnetGatewayConfig",
             "properties": {
               "privateIPAllocationMethod": "Dynamic",
               "subnet": {
-                "id": "[variables('gatewaySubnetRef')]"
+                "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('gatewaySubnetName'))]"
               },
               "publicIPAddress": {
-                "id": "[resourceId('Microsoft.Network/publicIPAddresses',parameters('gatewayPublicIPName'))]"
+                "id": "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]"
               }
-            },
-            "name": "vnetGatewayConfig"
+            }
           }
         ],
         "gatewayType": "[parameters('gatewayType')]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('gatewaySubnetName'))]",
+        "[resourceId('Microsoft.Network/publicIPAddresses', parameters('gatewayPublicIPName'))]"
+      ]
     },
     {
-      "apiVersion": "2015-06-15",
       "type": "Microsoft.Network/connections",
+      "apiVersion": "2021-02-01",
       "name": "[parameters('connectionName')]",
       "location": "[parameters('location')]",
-      "dependsOn": [
-        "[concat('Microsoft.Network/virtualNetworkGateways/', parameters('gatewayName'))]"
-      ],
       "properties": {
         "virtualNetworkGateway1": {
-          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways',parameters('gatewayName'))]"
+          "id": "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]",
+          "properties": {}
         },
         "peer": {
-          "id": "[resourceId('Microsoft.Network/expressRouteCircuits',parameters('circuitName'))]"
+          "id": "[resourceId('Microsoft.Network/expressRouteCircuits', parameters('circuitName'))]"
         },
         "connectionType": "[parameters('connectionType')]",
         "routingWeight": "[variables('routingWeight')]"
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Network/virtualNetworkGateways', parameters('gatewayName'))]"
+      ]
     }
   ]
 }

--- a/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/azuredeploy.parameters.json
+++ b/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/azuredeploy.parameters.json
@@ -11,10 +11,10 @@
         "gatewayName": {
             "value": "ERGw"
         },
-        "addressPrefix": {
+        "virtualNetworkAddressPrefix": {
             "value": "192.188.0.0/24"
         },
-        "subnetName":{
+        "subnetName": {
             "value": "Subnet1"
         },
         "subnetPrefix": {

--- a/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/main.bicep
+++ b/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/main.bicep
@@ -1,0 +1,118 @@
+@description('The type of gateway to deploy. For connecting to ExpressRoute circuits, the gateway must be of type ExpressRoute. Other types are Vpn.')
+@allowed([
+  'ExpressRoute'
+])
+param gatewayType string = 'ExpressRoute'
+
+@description('The type of connection. For connecting to ExpressRoute circuits, the connectionType must be of type ExpressRoute. Other types are IPsec and Vnet2Vnet.')
+@allowed([
+  'ExpressRoute'
+])
+param connectionType string = 'ExpressRoute'
+
+@description('The name of the virtual network to create.')
+param virtualNetworkName string
+
+@description('The address space in CIDR notation for the new virtual network.')
+param virtualNetworkAddressPrefix string
+
+@description('The name of the first subnet in the new virtual network.')
+param subnetName string
+
+@description('The address range in CIDR notation for the first subnet.')
+param subnetPrefix string
+
+@description('The address range in CIDR notation for the Gateway subnet. For ExpressRoute enabled Gateways, this must be minimum of /28.')
+param gatewaySubnetPrefix string
+
+@description('The resource name given to the public IP attached to the gateway.')
+param gatewayPublicIPName string
+
+@description('The resource name given to the ExpressRoute gateway.')
+param gatewayName string
+
+@description('The resource name given to the Connection which links VNet Gateway to ExpressRoute circuit.')
+param connectionName string
+
+@description('The name of the ExpressRoute circuit with which the VNet Gateway needs to connect. The Circuit must be already created successfully and must have its circuitProvisioningState property set to \'Enabled\', and serviceProviderProvisioningState property set to \'Provisioned\'. The Circuit must also have a BGP Peering of type AzurePrivatePeering.')
+param circuitName string
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+// The name of the subnet where Gateway is to be deployed. This must always be named GatewaySubnet.
+var gatewaySubnetName = 'GatewaySubnet'
+
+var routingWeight = 3
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2021-02-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        virtualNetworkAddressPrefix
+      ]
+    }
+  }
+}
+resource subnet 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+  parent: virtualNetwork
+  name: subnetName
+  properties: {
+    addressPrefix: subnetPrefix
+  }
+}
+resource gatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2020-06-01' = {
+  parent: virtualNetwork
+  name: gatewaySubnetName
+  properties: {
+    addressPrefix: gatewaySubnetPrefix
+  }
+}
+
+resource publicIP 'Microsoft.Network/publicIPAddresses@2021-02-01' = {
+  name: gatewayPublicIPName
+  location: location
+  properties: {
+    publicIPAllocationMethod: 'Dynamic'
+  }
+}
+
+resource virtualNetworkGateway 'Microsoft.Network/virtualNetworkGateways@2021-02-01' = {
+  name: gatewayName
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'vnetGatewayConfig'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          subnet: {
+            id: gatewaySubnet.id
+          }
+          publicIPAddress: {
+            id: publicIP.id
+          }
+        }
+      }
+    ]
+    gatewayType: gatewayType
+  }
+}
+
+resource connection 'Microsoft.Network/connections@2021-02-01' = {
+  name: connectionName
+  location: location
+  properties: {
+    virtualNetworkGateway1: {
+      id: virtualNetworkGateway.id
+      properties: {}
+    }
+    peer: {
+      id: resourceId('Microsoft.Network/expressRouteCircuits', circuitName)
+    }
+    connectionType: connectionType
+    routingWeight: routingWeight
+  }
+}

--- a/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/metadata.json
+++ b/quickstarts/microsoft.network/expressroute-circuit-vnet-connection/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template creates a VNET, an ExpresRoute Gateway and a connection to a provisioned and enabled ExpressRoute circuit with AzurePrivatePeering configured.",
   "summary": "Establish connection to a VNET via an ExpressRoute circuit",
   "githubUsername": "amitsriva",
-  "dateUpdated": "2021-06-09"
+  "dateUpdated": "2021-06-22"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/301/expressroute-circuit-vnet-connection

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3348