### PR TITLE
Migrate bicep example: 201/decrypt-running-windows-vm-without-aad

### DIFF
--- a/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/README.md
+++ b/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/README.md
@@ -9,7 +9,11 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/CredScanResult.svg)
 
-[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fdecrypt-running-windows-vm-without-aad%2Fazuredeploy.json)  [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fdecrypt-running-windows-vm-without-aad%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fdecrypt-running-windows-vm-without-aad%2Fazuredeploy.json)
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/BicepVersion.svg)
+
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fdecrypt-running-windows-vm-without-aad%2Fazuredeploy.json)
+[![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fdecrypt-running-windows-vm-without-aad%2Fazuredeploy.json)
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fdecrypt-running-windows-vm-without-aad%2Fazuredeploy.json)
 
 This template disables encryption on a running windows VM which was encrypted without using AAD application.
 
@@ -17,3 +21,4 @@ Tags: AzureDiskEncryption
 
 References:
 White paper - https://azure.microsoft.com/en-us/documentation/articles/azure-security-disk-encryption/
+

--- a/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/azuredeploy.json
+++ b/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/azuredeploy.json
@@ -1,6 +1,13 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "18313553163139197031"
+    }
+  },
   "parameters": {
     "vmName": {
       "type": "string",
@@ -30,12 +37,13 @@
       }
     }
   },
+  "functions": [],
   "resources": [
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(parameters('vmName'),'/','AzureDiskEncryption')]",
-      "location": "[parameters('location')]",
       "apiVersion": "2019-12-01",
+      "name": "[format('{0}/AzureDiskEncryption', parameters('vmName'))]",
+      "location": "[parameters('location')]",
       "properties": {
         "publisher": "Microsoft.Azure.Security",
         "type": "AzureDiskEncryption",

--- a/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/main.bicep
+++ b/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/main.bicep
@@ -1,0 +1,27 @@
+@description('Name of the virtual machine')
+param vmName string
+
+@description('Type of the volume OS or Data to perform encryption operation')
+param volumeType string = 'All'
+
+@description('Pass in an unique value like a GUID everytime the operation needs to be force run')
+param forceUpdateTag string = uniqueString(resourceGroup().id, deployment().name)
+
+@description('Location for all resources.')
+param location string = resourceGroup().location
+
+resource vmExt 'Microsoft.Compute/virtualMachines/extensions@2019-12-01' = {
+  name: '${vmName}/AzureDiskEncryption'
+  location: location
+  properties: {
+    publisher: 'Microsoft.Azure.Security'
+    type: 'AzureDiskEncryption'
+    typeHandlerVersion: '2.2'
+    autoUpgradeMinorVersion: true
+    forceUpdateTag: forceUpdateTag
+    settings: {
+      EncryptionOperation: 'DisableEncryption'
+      VolumeType: volumeType
+    }
+  }
+}

--- a/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/metadata.json
+++ b/quickstarts/microsoft.compute/decrypt-running-windows-vm-without-aad/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template disables encryption on a running windows VM which was encrypted without using AAD application",
   "summary": "This template disables encryption on a running windows VM which was encrypted without AAD",
   "githubUsername": "sudhakarareddyevuri",
-  "dateUpdated": "2021-06-10"
+  "dateUpdated": "2021-06-22"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/decrypt-running-windows-vm-without-aad

The corresponding PR for the modified bicep example is here: https://github.com/Azure/bicep/pull/3349