### PR TITLE
Migrate bicep example: 201/private-aks-cluster

### DIFF
--- a/demos/private-aks-cluster/README.md
+++ b/demos/private-aks-cluster/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/demos/private-aks-cluster/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/demos/private-aks-cluster/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/demos/private-aks-cluster/BicepVersion.svg)
+
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fprivate-aks-cluster%2Fazuredeploy.json)
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fprivate-aks-cluster%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fprivate-aks-cluster%2Fazuredeploy.json)
@@ -78,3 +80,4 @@ sudo az aks install-cli
 echo "Getting access credentials configure kubectl to connect to the ["$aksName"] AKS cluster..."
 az aks get-credentials --name $name --resource-group $resourceGroup
 ```
+

--- a/demos/private-aks-cluster/aks.bicep
+++ b/demos/private-aks-cluster/aks.bicep
@@ -1,0 +1,239 @@
+@description('Specifies the location of AKS cluster.')
+param location string = resourceGroup().location
+
+@description('Specifies the name of the AKS cluster.')
+param aksClusterName string = 'aks-${uniqueString(resourceGroup().id)}'
+
+@description('Specifies the DNS prefix specified when creating the managed cluster.')
+param aksClusterDnsPrefix string = aksClusterName
+
+@description('Specifies the tags of the AKS cluster.')
+param aksClusterTags object = {
+  resourceType: 'AKS Cluster'
+  createdBy: 'ARM Template'
+}
+
+@allowed([
+  'azure'
+  'kubenet'
+])
+@description('Specifies the network plugin used for building Kubernetes network. - azure or kubenet.')
+param aksClusterNetworkPlugin string = 'azure'
+
+@allowed([
+  'azure'
+  'calico'
+])
+@description('Specifies the network policy used for building Kubernetes network. - calico or azure')
+param aksClusterNetworkPolicy string = 'azure'
+
+@description('Specifies the CIDR notation IP range from which to assign pod IPs when kubenet is used.')
+param aksClusterPodCidr string = '10.244.0.0/16'
+
+@description('A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.')
+param aksClusterServiceCidr string = '10.2.0.0/16'
+
+@description('Specifies the IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.')
+param aksClusterDnsServiceIP string = '10.2.0.10'
+
+@description('Specifies the CIDR notation IP range assigned to the Docker bridge network. It must not overlap with any Subnet IP ranges or the Kubernetes service address range.')
+param aksClusterDockerBridgeCidr string = '172.17.0.1/16'
+
+@allowed([
+  'basic'
+  'standard'
+])
+@description('Specifies the sku of the load balancer used by the virtual machine scale sets used by nodepools.')
+param aksClusterLoadBalancerSku string = 'standard'
+
+@allowed([
+  'Paid'
+  'Free'
+])
+@description('Specifies the tier of a managed cluster SKU: Paid or Free')
+param aksClusterSkuTier string = 'Paid'
+
+@description('Specifies the version of Kubernetes specified when creating the managed cluster.')
+param aksClusterKubernetesVersion string = '1.19.7'
+
+@description('Specifies the administrator username of Linux virtual machines.')
+param aksClusterAdminUsername string
+
+@description('Specifies the SSH RSA public key string for the Linux nodes.')
+param aksClusterSshPublicKey string
+
+@description('Specifies whether enabling AAD integration.')
+param aadEnabled bool = false
+
+@description('Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication.')
+param aadProfileTenantId string = subscription().tenantId
+
+@description('Specifies the AAD group object IDs that will have admin role of the cluster.')
+param aadProfileAdminGroupObjectIDs array = []
+
+@description('Specifies whether to create the cluster as a private cluster or not.')
+param aksClusterEnablePrivateCluster bool = true
+
+@description('Specifies whether to enable managed AAD integration.')
+param aadProfileManaged bool = false
+
+@description('Specifies whether to  to enable Azure RBAC for Kubernetes authorization.')
+param aadProfileEnableAzureRBAC bool = false
+
+@description('Specifies the unique name of the node pool profile in the context of the subscription and resource group.')
+param nodePoolName string = 'nodepool1'
+
+@description('Specifies the vm size of nodes in the node pool.')
+param nodePoolVmSize string = 'Standard_DS3_v2'
+
+@description('Specifies the OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified..')
+param nodePoolOsDiskSizeGB int = 100
+
+@description('Specifies the number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.')
+param nodePoolCount int = 3
+
+@allowed([
+  'Linux'
+  'Windows'
+])
+@description('Specifies the OS type for the vms in the node pool. Choose from Linux and Windows. Default to Linux.')
+param nodePoolOsType string = 'Linux'
+
+@description('Specifies the maximum number of pods that can run on a node. The maximum number of pods per node in an AKS cluster is 250. The default maximum number of pods per node varies between kubenet and Azure CNI networking, and the method of cluster deployment.')
+param nodePoolMaxPods int = 30
+
+@description('Specifies the maximum number of nodes for auto-scaling for the node pool.')
+param nodePoolMaxCount int = 5
+
+@description('Specifies the minimum number of nodes for auto-scaling for the node pool.')
+param nodePoolMinCount int = 3
+
+@description('Specifies whether to enable auto-scaling for the node pool.')
+param nodePoolEnableAutoScaling bool = true
+
+@allowed([
+  'Spot'
+  'Regular'
+])
+@description('Specifies the virtual machine scale set priority: Spot or Regular.')
+param nodePoolScaleSetPriority string = 'Regular'
+
+@description('Specifies the Agent pool node labels to be persisted across all nodes in agent pool.')
+param nodePoolNodeLabels object = {}
+
+@description('Specifies the taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. - string')
+param nodePoolNodeTaints array = []
+
+@allowed([
+  'System'
+  'User'
+])
+@description('Specifies the mode of an agent pool: System or User')
+param nodePoolMode string = 'System'
+
+@allowed([
+  'VirtualMachineScaleSets'
+  'AvailabilitySet'
+])
+@description('Specifies the type of a node pool: VirtualMachineScaleSets or AvailabilitySet')
+param nodePoolType string = 'VirtualMachineScaleSets'
+
+@description('Specifies the availability zones for nodes. Requirese the use of VirtualMachineScaleSets as node pool type.')
+param nodePoolAvailabilityZones array = []
+
+@description('Specifies the id of the virtual network.')
+param virtualNetworkId string
+
+@description('Specifies the name of the default subnet hosting the AKS cluster.')
+param aksSubnetName string = 'AksSubnet'
+
+@description('Specifies the name of the Log Analytics Workspace.')
+param logAnalyticsWorkspaceId string
+
+var aadProfileConfiguration = {
+  managed: aadProfileManaged
+  enableAzureRBAC: aadProfileEnableAzureRBAC
+  adminGroupObjectIDs: aadProfileAdminGroupObjectIDs
+  tenantID: aadProfileTenantId
+}
+
+var virtualNetworkName = last(split(virtualNetworkId, '/'))
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2020-08-01' existing = {
+  name: virtualNetworkName
+}
+
+resource aksSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-08-01' existing = {
+  parent: virtualNetwork
+  name: aksSubnetName
+}
+
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2021-02-01' = {
+  name: aksClusterName
+  location: location
+  identity: {
+    type: 'SystemAssigned'
+  }
+  tags: aksClusterTags
+  sku: {
+    name: 'Basic'
+    tier: aksClusterSkuTier
+  }
+  properties: {
+    kubernetesVersion: aksClusterKubernetesVersion
+    dnsPrefix: aksClusterDnsPrefix
+    //TODO nodeResourceGroup: ''
+    agentPoolProfiles: [
+      {
+        name: toLower(nodePoolName)
+        count: nodePoolCount
+        vmSize: nodePoolVmSize
+        osDiskSizeGB: nodePoolOsDiskSizeGB
+        vnetSubnetID: aksSubnet.id
+        maxPods: nodePoolMaxPods
+        osType: nodePoolOsType
+        maxCount: nodePoolMaxCount
+        minCount: nodePoolMinCount
+        scaleSetPriority: nodePoolScaleSetPriority
+        enableAutoScaling: nodePoolEnableAutoScaling
+        mode: nodePoolMode
+        type: nodePoolType
+        availabilityZones: any(empty(nodePoolAvailabilityZones) ? null : nodePoolAvailabilityZones)
+        nodeLabels: nodePoolNodeLabels
+        nodeTaints: nodePoolNodeTaints
+      }
+    ]
+    linuxProfile: {
+      adminUsername: aksClusterAdminUsername
+      ssh: {
+        publicKeys: [
+          {
+            keyData: aksClusterSshPublicKey
+          }
+        ]
+      }
+    }
+    addonProfiles: {
+      omsagent: {
+        enabled: true
+        config: {
+          logAnalyticsWorkspaceResourceID: logAnalyticsWorkspaceId
+        }
+      }
+    }
+    enableRBAC: true
+    networkProfile: {
+      networkPlugin: aksClusterNetworkPlugin
+      networkPolicy: aksClusterNetworkPolicy
+      podCidr: aksClusterPodCidr
+      serviceCidr: aksClusterServiceCidr
+      dnsServiceIP: aksClusterDnsServiceIP
+      dockerBridgeCidr: aksClusterDockerBridgeCidr
+      loadBalancerSku: aksClusterLoadBalancerSku
+    }
+    aadProfile: (aadEnabled ? aadProfileConfiguration : json('null'))
+    apiServerAccessProfile: {
+      enablePrivateCluster: aksClusterEnablePrivateCluster
+    }
+  }
+}

--- a/demos/private-aks-cluster/azuredeploy.json
+++ b/demos/private-aks-cluster/azuredeploy.json
@@ -1,41 +1,48 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-  "contentVersion": "1.0.0.1",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.1.14562",
+      "templateHash": "14470176366521704801"
+    }
+  },
   "parameters": {
     "location": {
-      "defaultValue": "[resourceGroup().location]",
       "type": "string",
+      "defaultValue": "[resourceGroup().location]",
       "metadata": {
         "description": "Specifies the location of AKS cluster."
       }
     },
     "aksClusterName": {
-      "defaultValue": "[concat('aks-', uniqueString(resourceGroup().id))]",
       "type": "string",
+      "defaultValue": "[format('aks-{0}', uniqueString(resourceGroup().id))]",
       "metadata": {
         "description": "Specifies the name of the AKS cluster."
       }
     },
     "aksClusterDnsPrefix": {
-      "defaultValue": "[parameters('aksClusterName')]",
       "type": "string",
+      "defaultValue": "[parameters('aksClusterName')]",
       "metadata": {
         "description": "Specifies the DNS prefix specified when creating the managed cluster."
       }
     },
     "aksClusterTags": {
+      "type": "object",
       "defaultValue": {
         "resourceType": "AKS Cluster",
         "createdBy": "ARM Template"
       },
-      "type": "object",
       "metadata": {
         "description": "Specifies the tags of the AKS cluster."
       }
     },
     "aksClusterNetworkPlugin": {
-      "defaultValue": "azure",
       "type": "string",
+      "defaultValue": "azure",
       "allowedValues": [
         "azure",
         "kubenet"
@@ -45,8 +52,8 @@
       }
     },
     "aksClusterNetworkPolicy": {
-      "defaultValue": "azure",
       "type": "string",
+      "defaultValue": "azure",
       "allowedValues": [
         "azure",
         "calico"
@@ -56,36 +63,36 @@
       }
     },
     "aksClusterPodCidr": {
-      "defaultValue": "10.244.0.0/16",
       "type": "string",
+      "defaultValue": "10.244.0.0/16",
       "metadata": {
         "description": "Specifies the CIDR notation IP range from which to assign pod IPs when kubenet is used."
       }
     },
     "aksClusterServiceCidr": {
-      "defaultValue": "10.2.0.0/16",
       "type": "string",
+      "defaultValue": "10.2.0.0/16",
       "metadata": {
         "description": "A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges."
       }
     },
     "aksClusterDnsServiceIP": {
-      "defaultValue": "10.2.0.10",
       "type": "string",
+      "defaultValue": "10.2.0.10",
       "metadata": {
         "description": "Specifies the IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr."
       }
     },
     "aksClusterDockerBridgeCidr": {
-      "defaultValue": "172.17.0.1/16",
       "type": "string",
+      "defaultValue": "172.17.0.1/16",
       "metadata": {
         "description": "Specifies the CIDR notation IP range assigned to the Docker bridge network. It must not overlap with any Subnet IP ranges or the Kubernetes service address range."
       }
     },
     "aksClusterLoadBalancerSku": {
-      "defaultValue": "standard",
       "type": "string",
+      "defaultValue": "standard",
       "allowedValues": [
         "basic",
         "standard"
@@ -107,7 +114,7 @@
     },
     "aksClusterKubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.18.14",
+      "defaultValue": "1.19.7",
       "metadata": {
         "description": "Specifies the version of Kubernetes specified when creating the managed cluster."
       }
@@ -125,78 +132,78 @@
       }
     },
     "aadEnabled": {
-      "defaultValue": false,
       "type": "bool",
+      "defaultValue": false,
       "metadata": {
         "description": "Specifies whether enabling AAD integration."
       }
     },
     "aadProfileTenantId": {
-      "defaultValue": "[subscription().tenantId]",
       "type": "string",
+      "defaultValue": "[subscription().tenantId]",
       "metadata": {
         "description": "Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication."
       }
     },
     "aadProfileAdminGroupObjectIDs": {
-      "defaultValue": [],
       "type": "array",
+      "defaultValue": [],
       "metadata": {
         "description": "Specifies the AAD group object IDs that will have admin role of the cluster."
       }
     },
     "aksClusterEnablePrivateCluster": {
-      "defaultValue": true,
       "type": "bool",
+      "defaultValue": true,
       "metadata": {
         "description": "Specifies whether to create the cluster as a private cluster or not."
       }
     },
     "aadProfileManaged": {
-      "defaultValue": false,
       "type": "bool",
+      "defaultValue": false,
       "metadata": {
         "description": "Specifies whether to enable managed AAD integration."
       }
     },
     "aadProfileEnableAzureRBAC": {
-      "defaultValue": false,
       "type": "bool",
+      "defaultValue": false,
       "metadata": {
         "description": "Specifies whether to  to enable Azure RBAC for Kubernetes authorization."
       }
     },
     "nodePoolName": {
-      "defaultValue": "nodepool1",
       "type": "string",
+      "defaultValue": "nodepool1",
       "metadata": {
         "description": "Specifies the unique name of the node pool profile in the context of the subscription and resource group."
       }
     },
     "nodePoolVmSize": {
-      "defaultValue": "Standard_DS3_v2",
       "type": "string",
+      "defaultValue": "Standard_DS3_v2",
       "metadata": {
         "description": "Specifies the vm size of nodes in the node pool."
       }
     },
     "nodePoolOsDiskSizeGB": {
-      "defaultValue": 100,
       "type": "int",
+      "defaultValue": 100,
       "metadata": {
         "description": "Specifies the OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.."
       }
     },
     "nodePoolCount": {
-      "defaultValue": 5,
       "type": "int",
+      "defaultValue": 5,
       "metadata": {
         "description": "Specifies the number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1."
       }
     },
     "nodePoolOsType": {
-      "defaultValue": "Linux",
       "type": "string",
+      "defaultValue": "Linux",
       "allowedValues": [
         "Linux",
         "Windows"
@@ -206,61 +213,61 @@
       }
     },
     "nodePoolMaxPods": {
-      "defaultValue": 30,
       "type": "int",
+      "defaultValue": 30,
       "metadata": {
         "description": "Specifies the maximum number of pods that can run on a node. The maximum number of pods per node in an AKS cluster is 250. The default maximum number of pods per node varies between kubenet and Azure CNI networking, and the method of cluster deployment."
       }
     },
     "nodePoolMaxCount": {
-      "defaultValue": 5,
       "type": "int",
+      "defaultValue": 5,
       "metadata": {
         "description": "Specifies the maximum number of nodes for auto-scaling for the node pool."
       }
     },
     "nodePoolMinCount": {
-      "defaultValue": 3,
       "type": "int",
+      "defaultValue": 3,
       "metadata": {
         "description": "Specifies the minimum number of nodes for auto-scaling for the node pool."
       }
     },
     "nodePoolEnableAutoScaling": {
-      "defaultValue": true,
       "type": "bool",
+      "defaultValue": true,
       "metadata": {
         "description": "Specifies whether to enable auto-scaling for the node pool."
       }
     },
     "nodePoolScaleSetPriority": {
+      "type": "string",
       "defaultValue": "Regular",
       "allowedValues": [
         "Spot",
         "Regular"
       ],
-      "type": "string",
       "metadata": {
         "description": "Specifies the virtual machine scale set priority: Spot or Regular."
       }
     },
     "nodePoolNodeLabels": {
-      "defaultValue": {},
       "type": "object",
+      "defaultValue": {},
       "metadata": {
         "description": "Specifies the Agent pool node labels to be persisted across all nodes in agent pool."
       }
     },
     "nodePoolNodeTaints": {
-      "defaultValue": [],
       "type": "array",
+      "defaultValue": [],
       "metadata": {
         "description": "Specifies the taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. - string"
       }
     },
     "nodePoolMode": {
-      "defaultValue": "System",
       "type": "string",
+      "defaultValue": "System",
       "allowedValues": [
         "System",
         "User"
@@ -270,8 +277,8 @@
       }
     },
     "nodePoolType": {
-      "defaultValue": "VirtualMachineScaleSets",
       "type": "string",
+      "defaultValue": "VirtualMachineScaleSets",
       "allowedValues": [
         "VirtualMachineScaleSets",
         "AvailabilitySet"
@@ -281,36 +288,36 @@
       }
     },
     "nodePoolAvailabilityZones": {
-      "defaultValue": [],
       "type": "array",
+      "defaultValue": [],
       "metadata": {
         "description": "Specifies the availability zones for nodes. Requirese the use of VirtualMachineScaleSets as node pool type."
       }
     },
     "virtualNetworkName": {
-      "defaultValue": "[concat(parameters('aksClusterName'), 'Vnet')]",
       "type": "string",
+      "defaultValue": "[format('{0}Vnet', parameters('aksClusterName'))]",
       "metadata": {
         "description": "Specifies the name of the virtual network."
       }
     },
     "virtualNetworkAddressPrefixes": {
-      "defaultValue": "10.0.0.0/8",
       "type": "string",
+      "defaultValue": "10.0.0.0/8",
       "metadata": {
         "description": "Specifies the address prefixes of the virtual network."
       }
     },
     "aksSubnetName": {
-      "defaultValue": "AksSubnet",
       "type": "string",
+      "defaultValue": "AksSubnet",
       "metadata": {
         "description": "Specifies the name of the default subnet hosting the AKS cluster."
       }
     },
     "aksSubnetAddressPrefix": {
-      "defaultValue": "10.0.0.0/16",
       "type": "string",
+      "defaultValue": "10.0.0.0/16",
       "metadata": {
         "description": "Specifies the address prefix of the subnet hosting the AKS cluster."
       }
@@ -323,13 +330,13 @@
     },
     "logAnalyticsSku": {
       "type": "string",
+      "defaultValue": "PerGB2018",
       "allowedValues": [
         "Free",
         "Standalone",
         "PerNode",
         "PerGB2018"
       ],
-      "defaultValue": "PerGB2018",
       "metadata": {
         "description": "Specifies the service tier of the workspace: Free, Standalone, PerNode, Per-GB."
       }
@@ -408,7 +415,7 @@
       }
     },
     "vmAdminPasswordOrKey": {
-      "type": "securestring",
+      "type": "secureString",
       "metadata": {
         "description": "Specifies the SSH Key or password for the virtual machine. SSH key is recommended."
       }
@@ -429,8 +436,8 @@
     "numDataDisks": {
       "type": "int",
       "defaultValue": 1,
-      "minValue": 0,
       "maxValue": 64,
+      "minValue": 0,
       "metadata": {
         "description": "Specifies the number of data disks of the virtual machine."
       }
@@ -458,7 +465,7 @@
     },
     "blobStorageAccountName": {
       "type": "string",
-      "defaultValue": "[concat('blob', uniquestring(resourceGroup().id))]",
+      "defaultValue": "[format('blob{0}', uniqueString(resourceGroup().id))]",
       "metadata": {
         "description": "Specifies the globally unique name for the storage account used to store the boot diagnostics logs of the virtual machine."
       }
@@ -477,596 +484,1506 @@
         "description": "Specifies the Bastion subnet IP prefix. This prefix must be within vnet IP prefix address space."
       }
     },
-    "bastionHostName": {
+    "bastionName": {
       "type": "string",
-      "defaultValue": "[concat(parameters('aksClusterName'), 'Bastion')]",
+      "defaultValue": "[format('{0}Bastion', parameters('aksClusterName'))]",
       "metadata": {
         "description": "Specifies the name of the Azure Bastion resource."
       }
     }
   },
-  "variables": {
-    "vmSubnetNsgName": "[concat(parameters('vmSubnetName'), 'Nsg')]",
-    "vmSubnetNsgId": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('vmSubnetNsgName'))]",
-    "bastionSubnetNsgName": "[concat(parameters('bastionHostName'),'Nsg')]",
-    "bastionSubnetNsgId": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('bastionSubnetNsgName'))]",
-    "vnetId": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]",
-    "vmSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('vmSubnetName'))]",
-    "aksSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('aksSubnetName'))]",
-    "vmNicName": "[concat(parameters('vmName'), 'Nic')]",
-    "vmNicId": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]",
-    "blobStorageAccountId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('blobStorageAccountName'))]",
-    "blobPublicDNSZoneForwarder": "[concat('.blob.', environment().suffixes.storage)]",
-    "blobPrivateDnsZoneName": "[concat('privatelink', variables('blobPublicDNSZoneForwarder'))]",
-    "blobPrivateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('blobPrivateDnsZoneName'))]",
-    "blobStorageAccountPrivateEndpointGroupName": "blob",
-    "blobPrivateDnsZoneGroup": "[concat(parameters('blobStorageAccountPrivateEndpointName'),'/', variables('blobStorageAccountPrivateEndpointGroupName'), 'PrivateDnsZoneGroup')]",
-    "blobStorageAccountPrivateEndpointId": "[resourceId('Microsoft.Network/privateEndpoints', parameters('blobStorageAccountPrivateEndpointName'))]",
-    "vmId": "[resourceId('Microsoft.Compute/virtualMachines', parameters('vmName'))]",
-    "omsAgentForLinuxName": "LogAnalytics",
-    "omsAgentForLinuxId": "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('vmName'), variables('omsAgentForLinuxName'))]",
-    "omsDependencyAgentForLinuxName": "DependencyAgent",
-    "linuxConfiguration": {
-      "disablePasswordAuthentication": true,
-      "ssh": {
-        "publicKeys": [{
-          "path": "[concat('/home/', parameters('vmAdminUsername'), '/.ssh/authorized_keys')]",
-          "keyData": "[parameters('vmAdminPasswordOrKey')]"
-        }]
-      },
-      "provisionVMAgent": true
-    },
-    "bastionPublicIpAddressName": "[concat(parameters('bastionHostName'),'PublicIp')]",
-    "bastionPublicIpAddressId": "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionPublicIpAddressName'))]",
-    "bastionSubnetName": "AzureBastionSubnet",
-    "bastionSubnetId": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('bastionSubnetName'))]",
-    "workspaceId": "[resourceId('Microsoft.OperationalInsights/workspaces/', parameters('logAnalyticsWorkspaceName'))]",
-    "aadProfileConfiguration": {
-      "managed": "[parameters('aadProfileManaged')]",
-      "enableAzureRBAC": "[parameters('aadProfileEnableAzureRBAC')]",
-      "adminGroupObjectIDs": "[parameters('aadProfileAdminGroupObjectIDs')]",
-      "tenantID": "[parameters('aadProfileTenantId')]"
-    }
-  },
-  "resources": [{
-      "apiVersion": "2020-05-01",
-      "type": "Microsoft.Network/publicIPAddresses",
-      "name": "[variables('bastionPublicIpAddressName')]",
-      "location": "[parameters('location')]",
-      "sku": {
-        "name": "Standard"
-      },
-      "properties": {
-        "publicIPAllocationMethod": "Static"
-      }
-    },
+  "functions": [],
+  "resources": [
     {
-      "apiVersion": "2020-05-01",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('bastionSubnetNsgName')]",
-      "location": "[parameters('location')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "vnet",
       "properties": {
-        "securityRules": [
-                    {
-                        "name": "AllowHttpsInBound",
-                        "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "sourceAddressPrefix": "Internet",
-                            "destinationPortRange": "443",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 100,
-                            "direction": "Inbound"
-                        }
-                    },
-                    {
-                        "name": "AllowGatewayManagerInBound",
-                        "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "sourceAddressPrefix": "GatewayManager",
-                            "destinationPortRange": "443",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 110,
-                            "direction": "Inbound"
-                        }
-                    },
-                    {
-                        "name": "AllowLoadBalancerInBound",
-                        "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "sourceAddressPrefix": "AzureLoadBalancer",
-                            "destinationPortRange": "443",
-                            "destinationAddressPrefix": "*",
-                            "access": "Allow",
-                            "priority": 120,
-                            "direction": "Inbound"
-                        }
-                    },
-                    {
-                        "name": "AllowBastionHostCommunicationInBound",
-                        "properties": {
-                            "protocol": "*",
-                            "sourcePortRange": "*",
-                            "sourceAddressPrefix": "VirtualNetwork",
-                            "destinationPortRanges": [
-                                "8080",
-                                "5701"
-                            ],
-                            "destinationAddressPrefix": "VirtualNetwork",
-                            "access": "Allow",
-                            "priority": 130,
-                            "direction": "Inbound"
-                        }
-                    },
-                    {
-                        "name": "DenyAllInBound",
-                        "properties": {
-                            "protocol": "*",
-                            "sourcePortRange": "*",
-                            "sourceAddressPrefix": "*",
-                            "destinationPortRange": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Deny",
-                            "priority": 1000,
-                            "direction": "Inbound"
-                        }
-                    },
-                    {
-                        "name": "AllowSshRdpOutBound",
-                        "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "sourceAddressPrefix": "*",
-                            "destinationPortRanges": [
-                                "22",
-                                "3389"
-                            ],
-                            "destinationAddressPrefix": "VirtualNetwork",
-                            "access": "Allow",
-                            "priority": 100,
-                            "direction": "Outbound"
-                        }
-                    },
-                    {
-                        "name": "AllowAzureCloudCommunicationOutBound",
-                        "properties": {
-                            "protocol": "Tcp",
-                            "sourcePortRange": "*",
-                            "sourceAddressPrefix": "*",
-                            "destinationPortRange": "443",
-                            "destinationAddressPrefix": "AzureCloud",
-                            "access": "Allow",
-                            "priority": 110,
-                            "direction": "Outbound"
-                        }
-                    },
-                    {
-                        "name": "AllowBastionHostCommunicationOutBound",
-                        "properties": {
-                            "protocol": "*",
-                            "sourcePortRange": "*",
-                            "sourceAddressPrefix": "VirtualNetwork",
-                            "destinationPortRanges": [
-                                "8080",
-                                "5701"
-                            ],
-                            "destinationAddressPrefix": "VirtualNetwork",
-                            "access": "Allow",
-                            "priority": 120,
-                            "direction": "Outbound"
-                        }
-                    },
-                    {
-                        "name": "AllowGetSessionInformationOutBound",
-                        "properties": {
-                            "protocol": "*",
-                            "sourcePortRange": "*",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "Internet",
-                            "destinationPortRanges": [
-                                "80",
-                                "443"
-                            ],
-                            "access": "Allow",
-                            "priority": 130,
-                            "direction": "Outbound"
-                        }
-                    },
-                    {
-                        "name": "DenyAllOutBound",
-                        "properties": {
-                            "protocol": "*",
-                            "sourcePortRange": "*",
-                            "destinationPortRange": "*",
-                            "sourceAddressPrefix": "*",
-                            "destinationAddressPrefix": "*",
-                            "access": "Deny",
-                            "priority": 1000,
-                            "direction": "Outbound"
-                        }
-                    }
-                ]
-      }
-    },
-    {
-      "apiVersion": "2020-05-01",
-      "type": "Microsoft.Network/bastionHosts",
-      "name": "[parameters('bastionHostName')]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('bastionPublicIpAddressId')]",
-        "[variables('vnetId')]"
-      ],
-      "properties": {
-        "ipConfigurations": [{
-          "name": "IpConf",
-          "properties": {
-            "subnet": {
-              "id": "[variables('bastionSubnetId')]"
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "virtualNetworkName": {
+            "value": "[parameters('virtualNetworkName')]"
+          },
+          "virtualNetworkAddressPrefixes": {
+            "value": "[parameters('virtualNetworkAddressPrefixes')]"
+          },
+          "aksSubnetName": {
+            "value": "[parameters('aksSubnetName')]"
+          },
+          "aksSubnetAddressPrefix": {
+            "value": "[parameters('aksSubnetAddressPrefix')]"
+          },
+          "bastionSubnetAddressPrefix": {
+            "value": "[parameters('bastionSubnetAddressPrefix')]"
+          },
+          "vmSubnetName": {
+            "value": "[parameters('vmSubnetName')]"
+          },
+          "vmSubnetAddressPrefix": {
+            "value": "[parameters('vmSubnetAddressPrefix')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "6671169088798982698"
+            }
+          },
+          "parameters": {
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Specifies the location of AKS cluster."
+              }
             },
-            "publicIPAddress": {
-              "id": "[variables('bastionPublicIpAddressId')]"
-            }
-          }
-        }]
-      }
-    },
-    {
-      "apiVersion": "2019-06-01",
-      "type": "Microsoft.Storage/storageAccounts",
-      "name": "[parameters('blobStorageAccountName')]",
-      "location": "[parameters('location')]",
-      "sku": {
-        "name": "Standard_LRS"
-      },
-      "kind": "StorageV2"
-    },
-    {
-      "apiVersion": "2020-04-01",
-      "type": "Microsoft.Network/networkInterfaces",
-      "name": "[variables('vmNicName')]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('vnetId')]"
-      ],
-      "properties": {
-        "ipConfigurations": [{
-          "name": "ipconfig1",
-          "properties": {
-            "privateIPAllocationMethod": "Dynamic",
-            "subnet": {
-              "id": "[variables('vmSubnetId')]"
-            }
-          }
-        }]
-      }
-    },
-    {
-      "apiVersion": "2019-12-01",
-      "type": "Microsoft.Compute/virtualMachines",
-      "name": "[parameters('vmName')]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('vmNicId')]"
-      ],
-      "properties": {
-        "hardwareProfile": {
-          "vmSize": "[parameters('vmSize')]"
-        },
-        "osProfile": {
-          "computerName": "[parameters('vmName')]",
-          "adminUsername": "[parameters('vmAdminUsername')]",
-          "adminPassword": "[parameters('vmAdminPasswordOrKey')]",
-          "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
-        },
-        "storageProfile": {
-          "imageReference": {
-            "publisher": "[parameters('imagePublisher')]",
-            "offer": "[parameters('imageOffer')]",
-            "sku": "[parameters('imageSku')]",
-            "version": "latest"
-          },
-          "osDisk": {
-            "name": "[concat(parameters('vmName'),'_OSDisk')]",
-            "caching": "ReadWrite",
-            "createOption": "FromImage",
-            "diskSizeGB": "[parameters('osDiskSize')]",
-            "managedDisk": {
-              "storageAccountType": "[parameters('diskStorageAccounType')]"
-            }
-          },
-          "copy": [{
-            "name": "dataDisks",
-            "count": "[parameters('numDataDisks')]",
-            "input": {
-              "caching": "[parameters('dataDiskCaching')]",
-              "diskSizeGB": "[parameters('dataDiskSize')]",
-              "lun": "[copyIndex('dataDisks')]",
-              "name": "[concat(parameters('vmName'),'-DataDisk',copyIndex('dataDisks'))]",
-              "createOption": "Empty",
-              "managedDisk": {
-                "storageAccountType": "[parameters('diskStorageAccounType')]"
+            "bastionSubnetAddressPrefix": {
+              "type": "string",
+              "defaultValue": "10.1.1.0/26",
+              "metadata": {
+                "description": "Specifies the Bastion subnet IP prefix. This prefix must be within vnet IP prefix address space."
+              }
+            },
+            "vmSubnetName": {
+              "type": "string",
+              "defaultValue": "VmSubnet",
+              "metadata": {
+                "description": "Specifies the name of the subnet which contains the virtual machine."
+              }
+            },
+            "vmSubnetAddressPrefix": {
+              "type": "string",
+              "defaultValue": "10.1.0.0/24",
+              "metadata": {
+                "description": "Specifies the address prefix of the subnet which contains the virtual machine."
+              }
+            },
+            "aksSubnetName": {
+              "type": "string",
+              "defaultValue": "AksSubnet",
+              "metadata": {
+                "description": "Specifies the name of the default subnet hosting the AKS cluster."
+              }
+            },
+            "aksSubnetAddressPrefix": {
+              "type": "string",
+              "defaultValue": "10.0.0.0/16",
+              "metadata": {
+                "description": "Specifies the address prefix of the subnet hosting the AKS cluster."
+              }
+            },
+            "virtualNetworkName": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the name of the virtual network."
+              }
+            },
+            "virtualNetworkAddressPrefixes": {
+              "type": "string",
+              "defaultValue": "10.0.0.0/8",
+              "metadata": {
+                "description": "Specifies the address prefixes of the virtual network."
               }
             }
-          }]
-        },
-        "networkProfile": {
-          "networkInterfaces": [{
-            "id": "[resourceId('Microsoft.Network/networkInterfaces',variables('vmNicName'))]"
-          }]
-        },
-        "diagnosticsProfile": {
-          "bootDiagnostics": {
-            "enabled": true,
-            "storageUri": "[reference(variables('blobStorageAccountId')).primaryEndpoints['blob']]"
-          }
-        }
-      }
-    },
-    {
-      "apiVersion": "2019-12-01",
-      "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(parameters('vmName'),'/', variables('omsAgentForLinuxName'))]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('vmId')]",
-        "[variables('workspaceId')]"
-      ],
-      "properties": {
-        "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-        "type": "OmsAgentForLinux",
-        "typeHandlerVersion": "1.12",
-        "settings": {
-          "workspaceId": "[reference(variables('workspaceId'), '2020-03-01-preview').customerId]",
-          "stopOnMultipleConnections": false
-        },
-        "protectedSettings": {
-          "workspaceKey": "[listKeys(variables('workspaceId'),'2020-03-01-preview').primarySharedKey]"
-        }
-      }
-    },
-    {
-      "apiVersion": "2019-12-01",
-      "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(parameters('vmName'),'/', variables('omsDependencyAgentForLinuxName'))]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('vmId')]",
-        "[variables('workspaceId')]",
-        "[variables('omsAgentForLinuxId')]"
-      ],
-      "properties": {
-        "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
-        "type": "DependencyAgentLinux",
-        "typeHandlerVersion": "9.10",
-        "autoUpgradeMinorVersion": true
-      }
-    },
-    {
-      "apiVersion": "2020-05-01",
-      "type": "Microsoft.Network/networkSecurityGroups",
-      "name": "[variables('vmSubnetNsgName')]",
-      "location": "[parameters('location')]",
-      "properties": {
-        "securityRules": [{
-          "name": "AllowSshInbound",
-          "properties": {
-            "priority": 100,
-            "access": "Allow",
-            "direction": "Inbound",
-            "destinationPortRange": "22",
-            "protocol": "Tcp",
-            "sourceAddressPrefix": "*",
-            "sourcePortRange": "*",
-            "destinationAddressPrefix": "*"
-          }
-        }]
-      }
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks",
-      "apiVersion": "2020-05-01",
-      "name": "[parameters('virtualNetworkName')]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('bastionSubnetNsgId')]"
-      ],
-      "properties": {
-        "addressSpace": {
-          "addressPrefixes": [
-            "[parameters('virtualNetworkAddressPrefixes')]"
-          ]
-        },
-        "subnets": [{
-            "name": "[parameters('aksSubnetName')]",
-            "properties": {
-              "addressPrefix": "[parameters('aksSubnetAddressPrefix')]",
-              "privateEndpointNetworkPolicies": "Disabled",
-              "privateLinkServiceNetworkPolicies": "Enabled"
-            }
           },
-          {
-            "name": "[parameters('vmSubnetName')]",
-            "properties": {
-              "addressPrefix": "[parameters('vmSubnetAddressPrefix')]",
-              "networkSecurityGroup": {
-                "id": "[variables('vmSubnetNsgId')]"
+          "functions": [],
+          "variables": {
+            "bastionSubnetName": "AzureBastionSubnet",
+            "bastionSubnetNsgName": "[format('{0}Nsg', variables('bastionSubnetName'))]",
+            "vmSubnetNsgName": "[format('{0}Nsg', parameters('vmSubnetName'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2020-08-01",
+              "name": "[variables('vmSubnetNsgName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "securityRules": [
+                  {
+                    "name": "AllowSshInbound",
+                    "properties": {
+                      "priority": 100,
+                      "access": "Allow",
+                      "direction": "Inbound",
+                      "destinationPortRange": "22",
+                      "protocol": "Tcp",
+                      "sourceAddressPrefix": "*",
+                      "sourcePortRange": "*",
+                      "destinationAddressPrefix": "*"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Network/networkSecurityGroups",
+              "apiVersion": "2020-08-01",
+              "name": "[variables('bastionSubnetNsgName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "securityRules": [
+                  {
+                    "name": "bastionInAllow",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "Internet",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 100,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "bastionControlInAllow",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "GatewayManager",
+                      "destinationPortRanges": [
+                        "443",
+                        "4443"
+                      ],
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 120,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "AllowLoadBalancerInBound",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "AzureLoadBalancer",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "*",
+                      "access": "Allow",
+                      "priority": 130,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "AllowBastionHostCommunicationInBound",
+                    "properties": {
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "VirtualNetwork",
+                      "destinationPortRanges": [
+                        "8080",
+                        "5701"
+                      ],
+                      "destinationAddressPrefix": "VirtualNetwork",
+                      "access": "Allow",
+                      "priority": 140,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "bastionInDeny",
+                    "properties": {
+                      "protocol": "*",
+                      "sourcePortRange": "*",
+                      "destinationPortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationAddressPrefix": "*",
+                      "access": "Deny",
+                      "priority": 900,
+                      "direction": "Inbound"
+                    }
+                  },
+                  {
+                    "name": "bastionVnetOutAllow",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationPortRanges": [
+                        "22",
+                        "3389"
+                      ],
+                      "destinationAddressPrefix": "VirtualNetwork",
+                      "access": "Allow",
+                      "priority": 100,
+                      "direction": "Outbound"
+                    }
+                  },
+                  {
+                    "name": "bastionAzureOutAllow",
+                    "properties": {
+                      "protocol": "Tcp",
+                      "sourcePortRange": "*",
+                      "sourceAddressPrefix": "*",
+                      "destinationPortRange": "443",
+                      "destinationAddressPrefix": "AzureCloud",
+                      "access": "Allow",
+                      "priority": 120,
+                      "direction": "Outbound"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Network/virtualNetworks",
+              "apiVersion": "2020-08-01",
+              "name": "[parameters('virtualNetworkName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "addressSpace": {
+                  "addressPrefixes": [
+                    "[parameters('virtualNetworkAddressPrefixes')]"
+                  ]
+                },
+                "subnets": [
+                  {
+                    "name": "[parameters('aksSubnetName')]",
+                    "properties": {
+                      "addressPrefix": "[parameters('aksSubnetAddressPrefix')]",
+                      "privateEndpointNetworkPolicies": "Disabled",
+                      "privateLinkServiceNetworkPolicies": "Enabled"
+                    }
+                  },
+                  {
+                    "name": "[parameters('vmSubnetName')]",
+                    "properties": {
+                      "addressPrefix": "[parameters('vmSubnetAddressPrefix')]",
+                      "networkSecurityGroup": {
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('vmSubnetNsgName'))]"
+                      },
+                      "privateEndpointNetworkPolicies": "Disabled",
+                      "privateLinkServiceNetworkPolicies": "Enabled"
+                    }
+                  },
+                  {
+                    "name": "[variables('bastionSubnetName')]",
+                    "properties": {
+                      "addressPrefix": "[parameters('bastionSubnetAddressPrefix')]",
+                      "networkSecurityGroup": {
+                        "id": "[resourceId('Microsoft.Network/networkSecurityGroups', variables('bastionSubnetNsgName'))]"
+                      }
+                    }
+                  }
+                ],
+                "enableDdosProtection": false,
+                "enableVmProtection": false
               },
-              "privateEndpointNetworkPolicies": "Disabled",
-              "privateLinkServiceNetworkPolicies": "Enabled"
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('bastionSubnetNsgName'))]",
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('vmSubnetNsgName'))]"
+              ]
+            }
+          ],
+          "outputs": {
+            "virtualNetworkResourceId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/virtualNetworks', parameters('virtualNetworkName'))]"
+            },
+            "bastionSubnetId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('bastionSubnetName'))]"
+            },
+            "aksSubnetId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('aksSubnetName'))]"
+            },
+            "vmSubnetId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), parameters('vmSubnetName'))]"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "bastion",
+      "properties": {
+        "expressionEvaluationOptions": {
+          "scope": "inner"
+        },
+        "mode": "Incremental",
+        "parameters": {
+          "bastionHostName": {
+            "value": "[parameters('bastionName')]"
+          },
+          "bastionSubnetId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.bastionSubnetId.value]"
+          },
+          "location": {
+            "value": "[parameters('location')]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "13967474456372168665"
             }
           },
-          {
-            "name": "[variables('bastionSubnetName')]",
-            "properties": {
-              "addressPrefix": "[parameters('bastionSubnetAddressPrefix')]",
-              "networkSecurityGroup": {
-                "id": "[variables('bastionSubnetNsgId')]"
+          "parameters": {
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Specifies the location of AKS cluster."
+              }
+            },
+            "bastionHostName": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the name of the Azure Bastion resource."
+              }
+            },
+            "bastionSubnetId": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the id of the Azure Bastion subnet resource id."
               }
             }
-          }
-        ],
-        "enableDdosProtection": false,
-        "enableVmProtection": false
-      }
+          },
+          "functions": [],
+          "variables": {
+            "bastionPublicIpAddressName": "[format('{0}PublicIp', parameters('bastionHostName'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Network/publicIPAddresses",
+              "apiVersion": "2020-08-01",
+              "name": "[variables('bastionPublicIpAddressName')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "Standard"
+              },
+              "properties": {
+                "publicIPAllocationMethod": "Static"
+              }
+            },
+            {
+              "type": "Microsoft.Network/bastionHosts",
+              "apiVersion": "2020-08-01",
+              "name": "[parameters('bastionHostName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "IpConf",
+                    "properties": {
+                      "subnet": {
+                        "id": "[parameters('bastionSubnetId')]"
+                      },
+                      "publicIPAddress": {
+                        "id": "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionPublicIpAddressName'))]"
+                      }
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/publicIPAddresses', variables('bastionPublicIpAddressName'))]"
+              ]
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'vnet')]"
+      ]
     },
     {
-      "type": "Microsoft.ContainerService/managedClusters",
-      "apiVersion": "2020-07-01",
-      "name": "[parameters('aksClusterName')]",
-      "location": "[parameters('location')]",
-      "identity": {
-        "type": "SystemAssigned"
-      },
-      "tags": "[parameters('aksClusterTags')]",
-      "dependsOn": [
-        "[variables('vnetId')]",
-        "[variables('workspaceId')]"
-      ],
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "log-analytics.bicep",
       "properties": {
-        "kubernetesVersion": "[parameters('aksClusterKubernetesVersion')]",
-        "dnsPrefix": "[parameters('aksClusterDnsPrefix')]",
-        "sku": {
-          "name": "Basic",
-          "tier": "[parameters('aksClusterSkuTier')]"
+        "expressionEvaluationOptions": {
+          "scope": "inner"
         },
-        "agentPoolProfiles": [{
-          "name": "[tolower(parameters('nodePoolName'))]",
-          "count": "[parameters('nodePoolCount')]",
-          "vmSize": "[parameters('nodePoolVmSize')]",
-          "osDiskSizeGB": "[parameters('nodePoolOsDiskSizeGB')]",
-          "vnetSubnetID": "[variables('aksSubnetId')]",
-          "maxPods": "[parameters('nodePoolMaxPods')]",
-          "osType": "[parameters('nodePoolOsType')]",
-          "maxCount": "[parameters('nodePoolMaxCount')]",
-          "minCount": "[parameters('nodePoolMinCount')]",
-          "scaleSetPriority": "[parameters('nodePoolScaleSetPriority')]",
-          "enableAutoScaling": "[parameters('nodePoolEnableAutoScaling')]",
-          "mode": "[parameters('nodePoolMode')]",
-          "type": "[parameters('nodePoolType')]",
-          "availabilityZones": "[parameters('nodePoolAvailabilityZones')]",
-          "nodeLabels": "[parameters('nodePoolNodeLabels')]",
-          "nodeTaints": "[parameters('nodePoolNodeTaints')]"
-        }],
-        "linuxProfile": {
-          "adminUsername": "[parameters('aksClusterAdminUsername')]",
-          "ssh": {
-            "publicKeys": [{
-              "keyData": "[parameters('aksClusterSshPublicKey')]"
-            }]
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "logAnalyticsWorkspaceName": {
+            "value": "[parameters('logAnalyticsWorkspaceName')]"
+          },
+          "logAnalyticsSku": {
+            "value": "[parameters('logAnalyticsSku')]"
+          },
+          "logAnalyticsRetentionInDays": {
+            "value": "[parameters('logAnalyticsRetentionInDays')]"
           }
         },
-        "addonProfiles": {
-          "omsagent": {
-            "enabled": true,
-            "config": {
-              "logAnalyticsWorkspaceResourceID": "[variables('workspaceId')]"
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "2506587136035878062"
+            }
+          },
+          "parameters": {
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Specifies the location of AKS cluster."
+              }
+            },
+            "logAnalyticsWorkspaceName": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the name of the Log Analytics Workspace."
+              }
+            },
+            "logAnalyticsSku": {
+              "type": "string",
+              "defaultValue": "PerGB2018",
+              "metadata": {
+                "description": "Specifies the service tier of the workspace: Free, Standalone, PerNode, Per-GB."
+              },
+              "allowedValues": [
+                "Free",
+                "Standalone",
+                "PerNode",
+                "PerGB2018"
+              ]
+            },
+            "logAnalyticsRetentionInDays": {
+              "type": "int",
+              "defaultValue": 60,
+              "metadata": {
+                "description": "Specifies the workspace data retention in days. -1 means Unlimited retention for the Unlimited Sku. 730 days is the maximum allowed for all other Skus."
+              }
+            }
+          },
+          "functions": [],
+          "resources": [
+            {
+              "type": "Microsoft.OperationalInsights/workspaces",
+              "apiVersion": "2020-10-01",
+              "name": "[parameters('logAnalyticsWorkspaceName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "sku": {
+                  "name": "[parameters('logAnalyticsSku')]"
+                },
+                "retentionInDays": "[parameters('logAnalyticsRetentionInDays')]"
+              }
+            }
+          ],
+          "outputs": {
+            "logAnalyticsWorkspaceId": {
+              "type": "string",
+              "value": "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('logAnalyticsWorkspaceName'))]"
             }
           }
-        },
-        "enableRBAC": true,
-        "networkProfile": {
-          "networkPlugin": "[parameters('aksClusterNetworkPlugin')]",
-          "networkPolicy": "[parameters('aksClusterNetworkPolicy')]",
-          "podCidr": "[parameters('aksClusterPodCidr')]",
-          "serviceCidr": "[parameters('aksClusterServiceCidr')]",
-          "dnsServiceIP": "[parameters('aksClusterDnsServiceIP')]",
-          "dockerBridgeCidr": "[parameters('aksClusterDockerBridgeCidr')]",
-          "loadBalancerSku": "[parameters('aksClusterLoadBalancerSku')]"
-        },
-        "aadProfile": "[if(parameters('aadEnabled'), variables('aadProfileConfiguration'), json('null'))]",
-        "apiServerAccessProfile": {
-          "enablePrivateCluster": "[parameters('aksClusterEnablePrivateCluster')]"
         }
       }
     },
     {
-      "type": "Microsoft.OperationalInsights/workspaces",
-      "apiVersion": "2020-03-01-preview",
-      "name": "[parameters('logAnalyticsWorkspaceName')]",
-      "location": "[parameters('location')]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "jumpbox",
       "properties": {
-        "sku": {
-          "name": "[parameters('logAnalyticsSku')]"
+        "expressionEvaluationOptions": {
+          "scope": "inner"
         },
-        "retentionInDays": "[parameters('logAnalyticsRetentionInDays')]"
-      }
-    },
-    {
-      "type": "Microsoft.Network/privateDnsZones",
-      "apiVersion": "2020-01-01",
-      "name": "[variables('blobPrivateDnsZoneName')]",
-      "location": "global",
-      "properties": {
-        "maxNumberOfRecordSets": 25000,
-        "maxNumberOfVirtualNetworkLinks": 1000,
-        "maxNumberOfVirtualNetworkLinksWithRegistration": 100
-      }
-    },
-    {
-      "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
-      "apiVersion": "2020-01-01",
-      "name": "[concat(variables('blobPrivateDnsZoneName'), '/link_to_', toLower(parameters('virtualNetworkName')))]",
-      "location": "global",
-      "dependsOn": [
-        "[variables('blobPrivateDnsZoneId')]",
-        "[variables('vnetId')]"
-      ],
-      "properties": {
-        "registrationEnabled": false,
-        "virtualNetwork": {
-          "id": "[variables('vnetId')]"
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "vmName": {
+            "value": "[parameters('vmName')]"
+          },
+          "vmAdminUsername": {
+            "value": "[parameters('vmAdminUsername')]"
+          },
+          "vmAdminPasswordOrKey": {
+            "value": "[parameters('vmAdminPasswordOrKey')]"
+          },
+          "vmSize": {
+            "value": "[parameters('vmSize')]"
+          },
+          "authenticationType": {
+            "value": "[parameters('authenticationType')]"
+          },
+          "diskStorageAccounType": {
+            "value": "[parameters('diskStorageAccounType')]"
+          },
+          "osDiskSize": {
+            "value": "[parameters('osDiskSize')]"
+          },
+          "dataDiskCaching": {
+            "value": "[parameters('dataDiskCaching')]"
+          },
+          "dataDiskSize": {
+            "value": "[parameters('dataDiskSize')]"
+          },
+          "numDataDisks": {
+            "value": "[parameters('numDataDisks')]"
+          },
+          "imageOffer": {
+            "value": "[parameters('imageOffer')]"
+          },
+          "imagePublisher": {
+            "value": "[parameters('imagePublisher')]"
+          },
+          "imageSku": {
+            "value": "[parameters('imageSku')]"
+          },
+          "blobStorageAccountName": {
+            "value": "[parameters('blobStorageAccountName')]"
+          },
+          "blobStorageAccountPrivateEndpointName": {
+            "value": "[parameters('blobStorageAccountPrivateEndpointName')]"
+          },
+          "logAnalyticsWorkspaceId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'log-analytics.bicep'), '2019-10-01').outputs.logAnalyticsWorkspaceId.value]"
+          },
+          "virtualNetworkId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.virtualNetworkResourceId.value]"
+          },
+          "vmSubnetId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.vmSubnetId.value]"
+          }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "11892345781820647768"
+            }
+          },
+          "parameters": {
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Specifies the location of AKS cluster."
+              }
+            },
+            "virtualNetworkId": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the id of the virtual network."
+              }
+            },
+            "vmSubnetId": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the idof the subnet which contains the virtual machine."
+              }
+            },
+            "vmName": {
+              "type": "string",
+              "defaultValue": "TestVm",
+              "metadata": {
+                "description": "Specifies the name of the virtual machine."
+              }
+            },
+            "vmSize": {
+              "type": "string",
+              "defaultValue": "Standard_DS3_v2",
+              "metadata": {
+                "description": "Specifies the size of the virtual machine."
+              }
+            },
+            "imagePublisher": {
+              "type": "string",
+              "defaultValue": "Canonical",
+              "metadata": {
+                "description": "Specifies the image publisher of the disk image used to create the virtual machine."
+              }
+            },
+            "imageOffer": {
+              "type": "string",
+              "defaultValue": "UbuntuServer",
+              "metadata": {
+                "description": "Specifies the offer of the platform image or marketplace image used to create the virtual machine."
+              }
+            },
+            "imageSku": {
+              "type": "string",
+              "defaultValue": "18.04-LTS",
+              "metadata": {
+                "description": "Specifies the Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
+              }
+            },
+            "authenticationType": {
+              "type": "string",
+              "defaultValue": "password",
+              "metadata": {
+                "description": "Specifies the type of authentication when accessing the Virtual Machine. SSH key is recommended."
+              },
+              "allowedValues": [
+                "sshPublicKey",
+                "password"
+              ]
+            },
+            "vmAdminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the name of the administrator account of the virtual machine."
+              }
+            },
+            "vmAdminPasswordOrKey": {
+              "type": "secureString",
+              "metadata": {
+                "description": "Specifies the SSH Key or password for the virtual machine. SSH key is recommended."
+              }
+            },
+            "diskStorageAccounType": {
+              "type": "string",
+              "defaultValue": "Premium_LRS",
+              "metadata": {
+                "description": "Specifies the storage account type for OS and data disk."
+              },
+              "allowedValues": [
+                "Premium_LRS",
+                "StandardSSD_LRS",
+                "Standard_LRS",
+                "UltraSSD_LRS"
+              ]
+            },
+            "numDataDisks": {
+              "type": "int",
+              "defaultValue": 1,
+              "metadata": {
+                "description": "Specifies the number of data disks of the virtual machine."
+              },
+              "maxValue": 64,
+              "minValue": 0
+            },
+            "osDiskSize": {
+              "type": "int",
+              "defaultValue": 50,
+              "metadata": {
+                "description": "Specifies the size in GB of the OS disk of the VM."
+              }
+            },
+            "dataDiskSize": {
+              "type": "int",
+              "defaultValue": 50,
+              "metadata": {
+                "description": "Specifies the size in GB of the OS disk of the virtual machine."
+              }
+            },
+            "dataDiskCaching": {
+              "type": "string",
+              "defaultValue": "ReadWrite",
+              "metadata": {
+                "description": "Specifies the caching requirements for the data disks."
+              }
+            },
+            "blobStorageAccountName": {
+              "type": "string",
+              "defaultValue": "[format('blob{0}', uniqueString(resourceGroup().id))]",
+              "metadata": {
+                "description": "Specifies the globally unique name for the storage account used to store the boot diagnostics logs of the virtual machine."
+              }
+            },
+            "blobStorageAccountPrivateEndpointName": {
+              "type": "string",
+              "defaultValue": "BlobStorageAccountPrivateEndpoint",
+              "metadata": {
+                "description": "Specifies the name of the private link to the boot diagnostics storage account."
+              }
+            },
+            "logAnalyticsWorkspaceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the id of the Log Analytics Workspace."
+              }
+            }
+          },
+          "functions": [],
+          "variables": {
+            "vmNicName": "[format('{0}Nic', parameters('vmName'))]",
+            "blobPublicDNSZoneForwarder": "[format('.blob.{0}', environment().suffixes.storage)]",
+            "blobPrivateDnsZoneName": "[format('privatelink{0}', variables('blobPublicDNSZoneForwarder'))]",
+            "blobStorageAccountPrivateEndpointGroupName": "blob",
+            "omsAgentForLinuxName": "LogAnalytics",
+            "omsDependencyAgentForLinuxName": "DependencyAgent",
+            "linuxConfiguration": {
+              "disablePasswordAuthentication": true,
+              "ssh": {
+                "publicKeys": [
+                  {
+                    "path": "[format('/home/{0}/.ssh/authorized_keys', parameters('vmAdminUsername'))]",
+                    "keyData": "[parameters('vmAdminPasswordOrKey')]"
+                  }
+                ]
+              },
+              "provisionVMAgent": true
+            },
+            "virtualNetworkName": "[last(split(parameters('virtualNetworkId'), '/'))]",
+            "logAnalyticsWorkspaceName": "[last(split(parameters('logAnalyticsWorkspaceId'), '/'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.Storage/storageAccounts",
+              "apiVersion": "2021-01-01",
+              "name": "[parameters('blobStorageAccountName')]",
+              "location": "[parameters('location')]",
+              "sku": {
+                "name": "Standard_LRS"
+              },
+              "kind": "StorageV2"
+            },
+            {
+              "type": "Microsoft.Network/networkInterfaces",
+              "apiVersion": "2020-08-01",
+              "name": "[variables('vmNicName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "ipConfigurations": [
+                  {
+                    "name": "ipconfig1",
+                    "properties": {
+                      "privateIPAllocationMethod": "Dynamic",
+                      "subnet": {
+                        "id": "[parameters('vmSubnetId')]"
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "type": "Microsoft.Compute/virtualMachines",
+              "apiVersion": "2020-12-01",
+              "name": "[parameters('vmName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "hardwareProfile": {
+                  "vmSize": "[parameters('vmSize')]"
+                },
+                "osProfile": {
+                  "computerName": "[parameters('vmName')]",
+                  "adminUsername": "[parameters('vmAdminUsername')]",
+                  "adminPassword": "[parameters('vmAdminPasswordOrKey')]",
+                  "linuxConfiguration": "[if(equals(parameters('authenticationType'), 'password'), json('null'), variables('linuxConfiguration'))]"
+                },
+                "storageProfile": {
+                  "copy": [
+                    {
+                      "name": "dataDisks",
+                      "count": "[length(range(0, parameters('numDataDisks')))]",
+                      "input": {
+                        "caching": "[parameters('dataDiskCaching')]",
+                        "diskSizeGB": "[parameters('dataDiskSize')]",
+                        "lun": "[range(0, parameters('numDataDisks'))[copyIndex('dataDisks')]]",
+                        "name": "[format('{0}-DataDisk{1}', parameters('vmName'), range(0, parameters('numDataDisks'))[copyIndex('dataDisks')])]",
+                        "createOption": "Empty",
+                        "managedDisk": {
+                          "storageAccountType": "[parameters('diskStorageAccounType')]"
+                        }
+                      }
+                    }
+                  ],
+                  "imageReference": {
+                    "publisher": "[parameters('imagePublisher')]",
+                    "offer": "[parameters('imageOffer')]",
+                    "sku": "[parameters('imageSku')]",
+                    "version": "latest"
+                  },
+                  "osDisk": {
+                    "name": "[format('{0}_OSDisk', parameters('vmName'))]",
+                    "caching": "ReadWrite",
+                    "createOption": "FromImage",
+                    "diskSizeGB": "[parameters('osDiskSize')]",
+                    "managedDisk": {
+                      "storageAccountType": "[parameters('diskStorageAccounType')]"
+                    }
+                  }
+                },
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {
+                      "id": "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]"
+                    }
+                  ]
+                },
+                "diagnosticsProfile": {
+                  "bootDiagnostics": {
+                    "enabled": true,
+                    "storageUri": "[reference(resourceId('Microsoft.Storage/storageAccounts', parameters('blobStorageAccountName'))).primaryEndpoints.blob]"
+                  }
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('blobStorageAccountName'))]",
+                "[resourceId('Microsoft.Network/networkInterfaces', variables('vmNicName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Compute/virtualMachines/extensions",
+              "apiVersion": "2020-12-01",
+              "name": "[format('{0}/{1}', parameters('vmName'), variables('omsAgentForLinuxName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "publisher": "Microsoft.EnterpriseCloud.Monitoring",
+                "type": "OmsAgentForLinux",
+                "typeHandlerVersion": "1.13",
+                "settings": {
+                  "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2020-10-01').customerId]",
+                  "stopOnMultipleConnections": false
+                },
+                "protectedSettings": {
+                  "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', variables('logAnalyticsWorkspaceName')), '2020-10-01').primarySharedKey]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Compute/virtualMachines', parameters('vmName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Compute/virtualMachines/extensions",
+              "apiVersion": "2020-12-01",
+              "name": "[format('{0}/{1}', parameters('vmName'), variables('omsDependencyAgentForLinuxName'))]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
+                "type": "DependencyAgentLinux",
+                "typeHandlerVersion": "9.10",
+                "autoUpgradeMinorVersion": true
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Compute/virtualMachines', parameters('vmName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones",
+              "apiVersion": "2020-06-01",
+              "name": "[variables('blobPrivateDnsZoneName')]",
+              "location": "global"
+            },
+            {
+              "type": "Microsoft.Network/privateDnsZones/virtualNetworkLinks",
+              "apiVersion": "2020-06-01",
+              "name": "[format('{0}/{1}', variables('blobPrivateDnsZoneName'), format('link_to_{0}', toLower(variables('virtualNetworkName'))))]",
+              "location": "global",
+              "properties": {
+                "registrationEnabled": false,
+                "virtualNetwork": {
+                  "id": "[parameters('virtualNetworkId')]"
+                }
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('blobPrivateDnsZoneName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints",
+              "apiVersion": "2020-08-01",
+              "name": "[parameters('blobStorageAccountPrivateEndpointName')]",
+              "location": "[parameters('location')]",
+              "properties": {
+                "privateLinkServiceConnections": [
+                  {
+                    "name": "[parameters('blobStorageAccountPrivateEndpointName')]",
+                    "properties": {
+                      "privateLinkServiceId": "[resourceId('Microsoft.Storage/storageAccounts', parameters('blobStorageAccountName'))]",
+                      "groupIds": [
+                        "[variables('blobStorageAccountPrivateEndpointGroupName')]"
+                      ]
+                    }
+                  }
+                ],
+                "subnet": {
+                  "id": "[parameters('vmSubnetId')]"
+                },
+                "customDnsConfigs": [
+                  {
+                    "fqdn": "[format('{0}{1}', parameters('blobStorageAccountName'), variables('blobPublicDNSZoneForwarder'))]"
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('blobStorageAccountName'))]"
+              ]
+            },
+            {
+              "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
+              "apiVersion": "2020-08-01",
+              "name": "[format('{0}/{1}', parameters('blobStorageAccountPrivateEndpointName'), format('{0}PrivateDnsZoneGroup', variables('blobStorageAccountPrivateEndpointGroupName')))]",
+              "properties": {
+                "privateDnsZoneConfigs": [
+                  {
+                    "name": "dnsConfig",
+                    "properties": {
+                      "privateDnsZoneId": "[resourceId('Microsoft.Network/privateDnsZones', variables('blobPrivateDnsZoneName'))]"
+                    }
+                  }
+                ]
+              },
+              "dependsOn": [
+                "[resourceId('Microsoft.Network/privateDnsZones', variables('blobPrivateDnsZoneName'))]",
+                "[resourceId('Microsoft.Network/privateEndpoints', parameters('blobStorageAccountPrivateEndpointName'))]"
+              ]
+            }
+          ]
         }
-      }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'log-analytics.bicep')]",
+        "[resourceId('Microsoft.Resources/deployments', 'vnet')]"
+      ]
     },
     {
-      "type": "Microsoft.Network/privateEndpoints",
-      "apiVersion": "2020-04-01",
-      "name": "[parameters('blobStorageAccountPrivateEndpointName')]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('vnetId')]",
-        "[variables('blobStorageAccountId')]"
-      ],
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2019-10-01",
+      "name": "aks",
       "properties": {
-        "privateLinkServiceConnections": [{
-          "name": "[parameters('blobStorageAccountPrivateEndpointName')]",
-          "properties": {
-            "privateLinkServiceId": "[variables('blobStorageAccountId')]",
-            "groupIds": [
-              "[variables('blobStorageAccountPrivateEndpointGroupName')]"
-            ]
-          }
-        }],
-        "subnet": {
-          "id": "[variables('vmSubnetId')]"
+        "expressionEvaluationOptions": {
+          "scope": "inner"
         },
-        "customDnsConfigs": [{
-          "fqdn": "[concat(parameters('blobStorageAccountName'), variables('blobPublicDNSZoneForwarder'))]"
-        }]
-      }
-    },
-    {
-      "type": "Microsoft.Network/privateEndpoints/privateDnsZoneGroups",
-      "apiVersion": "2020-03-01",
-      "name": "[variables('blobPrivateDnsZoneGroup')]",
-      "location": "[parameters('location')]",
-      "dependsOn": [
-        "[variables('blobPrivateDnsZoneId')]",
-        "[variables('blobStorageAccountPrivateEndpointId')]"
-      ],
-      "properties": {
-        "privateDnsZoneConfigs": [{
-          "name": "dnsConfig",
-          "properties": {
-            "privateDnsZoneId": "[variables('blobPrivateDnsZoneId')]"
+        "mode": "Incremental",
+        "parameters": {
+          "location": {
+            "value": "[parameters('location')]"
+          },
+          "aadEnabled": {
+            "value": "[parameters('aadEnabled')]"
+          },
+          "aadProfileAdminGroupObjectIDs": {
+            "value": "[parameters('aadProfileAdminGroupObjectIDs')]"
+          },
+          "aadProfileEnableAzureRBAC": {
+            "value": "[parameters('aadProfileEnableAzureRBAC')]"
+          },
+          "aadProfileManaged": {
+            "value": "[parameters('aadProfileManaged')]"
+          },
+          "aadProfileTenantId": {
+            "value": "[parameters('aadProfileTenantId')]"
+          },
+          "aksClusterAdminUsername": {
+            "value": "[parameters('aksClusterAdminUsername')]"
+          },
+          "aksClusterDnsPrefix": {
+            "value": "[parameters('aksClusterDnsPrefix')]"
+          },
+          "aksClusterDnsServiceIP": {
+            "value": "[parameters('aksClusterDnsServiceIP')]"
+          },
+          "aksClusterDockerBridgeCidr": {
+            "value": "[parameters('aksClusterDockerBridgeCidr')]"
+          },
+          "aksClusterEnablePrivateCluster": {
+            "value": "[parameters('aksClusterEnablePrivateCluster')]"
+          },
+          "aksClusterKubernetesVersion": {
+            "value": "[parameters('aksClusterKubernetesVersion')]"
+          },
+          "aksClusterLoadBalancerSku": {
+            "value": "[parameters('aksClusterLoadBalancerSku')]"
+          },
+          "aksClusterName": {
+            "value": "[parameters('aksClusterName')]"
+          },
+          "aksClusterNetworkPlugin": {
+            "value": "[parameters('aksClusterNetworkPlugin')]"
+          },
+          "aksClusterNetworkPolicy": {
+            "value": "[parameters('aksClusterNetworkPolicy')]"
+          },
+          "aksClusterPodCidr": {
+            "value": "[parameters('aksClusterPodCidr')]"
+          },
+          "aksClusterServiceCidr": {
+            "value": "[parameters('aksClusterServiceCidr')]"
+          },
+          "aksClusterSkuTier": {
+            "value": "[parameters('aksClusterSkuTier')]"
+          },
+          "aksClusterSshPublicKey": {
+            "value": "[parameters('aksClusterSshPublicKey')]"
+          },
+          "aksClusterTags": {
+            "value": "[parameters('aksClusterTags')]"
+          },
+          "aksSubnetName": {
+            "value": "[parameters('aksSubnetName')]"
+          },
+          "nodePoolAvailabilityZones": {
+            "value": "[parameters('nodePoolAvailabilityZones')]"
+          },
+          "nodePoolCount": {
+            "value": "[parameters('nodePoolCount')]"
+          },
+          "nodePoolEnableAutoScaling": {
+            "value": "[parameters('nodePoolEnableAutoScaling')]"
+          },
+          "nodePoolMaxCount": {
+            "value": "[parameters('nodePoolMaxCount')]"
+          },
+          "nodePoolMaxPods": {
+            "value": "[parameters('nodePoolMaxPods')]"
+          },
+          "nodePoolMinCount": {
+            "value": "[parameters('nodePoolMinCount')]"
+          },
+          "nodePoolMode": {
+            "value": "[parameters('nodePoolMode')]"
+          },
+          "nodePoolName": {
+            "value": "[parameters('nodePoolName')]"
+          },
+          "nodePoolNodeLabels": {
+            "value": "[parameters('nodePoolNodeLabels')]"
+          },
+          "nodePoolNodeTaints": {
+            "value": "[parameters('nodePoolNodeTaints')]"
+          },
+          "nodePoolOsDiskSizeGB": {
+            "value": "[parameters('nodePoolOsDiskSizeGB')]"
+          },
+          "nodePoolOsType": {
+            "value": "[parameters('nodePoolOsType')]"
+          },
+          "nodePoolScaleSetPriority": {
+            "value": "[parameters('nodePoolScaleSetPriority')]"
+          },
+          "nodePoolType": {
+            "value": "[parameters('nodePoolType')]"
+          },
+          "nodePoolVmSize": {
+            "value": "[parameters('nodePoolVmSize')]"
+          },
+          "virtualNetworkId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'vnet'), '2019-10-01').outputs.virtualNetworkResourceId.value]"
+          },
+          "logAnalyticsWorkspaceId": {
+            "value": "[reference(resourceId('Microsoft.Resources/deployments', 'log-analytics.bicep'), '2019-10-01').outputs.logAnalyticsWorkspaceId.value]"
           }
-        }]
-      }
+        },
+        "template": {
+          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+          "contentVersion": "1.0.0.0",
+          "metadata": {
+            "_generator": {
+              "name": "bicep",
+              "version": "0.4.1.14562",
+              "templateHash": "6101996693566858137"
+            }
+          },
+          "parameters": {
+            "location": {
+              "type": "string",
+              "defaultValue": "[resourceGroup().location]",
+              "metadata": {
+                "description": "Specifies the location of AKS cluster."
+              }
+            },
+            "aksClusterName": {
+              "type": "string",
+              "defaultValue": "[format('aks-{0}', uniqueString(resourceGroup().id))]",
+              "metadata": {
+                "description": "Specifies the name of the AKS cluster."
+              }
+            },
+            "aksClusterDnsPrefix": {
+              "type": "string",
+              "defaultValue": "[parameters('aksClusterName')]",
+              "metadata": {
+                "description": "Specifies the DNS prefix specified when creating the managed cluster."
+              }
+            },
+            "aksClusterTags": {
+              "type": "object",
+              "defaultValue": {
+                "resourceType": "AKS Cluster",
+                "createdBy": "ARM Template"
+              },
+              "metadata": {
+                "description": "Specifies the tags of the AKS cluster."
+              }
+            },
+            "aksClusterNetworkPlugin": {
+              "type": "string",
+              "defaultValue": "azure",
+              "metadata": {
+                "description": "Specifies the network plugin used for building Kubernetes network. - azure or kubenet."
+              },
+              "allowedValues": [
+                "azure",
+                "kubenet"
+              ]
+            },
+            "aksClusterNetworkPolicy": {
+              "type": "string",
+              "defaultValue": "azure",
+              "metadata": {
+                "description": "Specifies the network policy used for building Kubernetes network. - calico or azure"
+              },
+              "allowedValues": [
+                "azure",
+                "calico"
+              ]
+            },
+            "aksClusterPodCidr": {
+              "type": "string",
+              "defaultValue": "10.244.0.0/16",
+              "metadata": {
+                "description": "Specifies the CIDR notation IP range from which to assign pod IPs when kubenet is used."
+              }
+            },
+            "aksClusterServiceCidr": {
+              "type": "string",
+              "defaultValue": "10.2.0.0/16",
+              "metadata": {
+                "description": "A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges."
+              }
+            },
+            "aksClusterDnsServiceIP": {
+              "type": "string",
+              "defaultValue": "10.2.0.10",
+              "metadata": {
+                "description": "Specifies the IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr."
+              }
+            },
+            "aksClusterDockerBridgeCidr": {
+              "type": "string",
+              "defaultValue": "172.17.0.1/16",
+              "metadata": {
+                "description": "Specifies the CIDR notation IP range assigned to the Docker bridge network. It must not overlap with any Subnet IP ranges or the Kubernetes service address range."
+              }
+            },
+            "aksClusterLoadBalancerSku": {
+              "type": "string",
+              "defaultValue": "standard",
+              "metadata": {
+                "description": "Specifies the sku of the load balancer used by the virtual machine scale sets used by nodepools."
+              },
+              "allowedValues": [
+                "basic",
+                "standard"
+              ]
+            },
+            "aksClusterSkuTier": {
+              "type": "string",
+              "defaultValue": "Paid",
+              "metadata": {
+                "description": "Specifies the tier of a managed cluster SKU: Paid or Free"
+              },
+              "allowedValues": [
+                "Paid",
+                "Free"
+              ]
+            },
+            "aksClusterKubernetesVersion": {
+              "type": "string",
+              "defaultValue": "1.19.7",
+              "metadata": {
+                "description": "Specifies the version of Kubernetes specified when creating the managed cluster."
+              }
+            },
+            "aksClusterAdminUsername": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the administrator username of Linux virtual machines."
+              }
+            },
+            "aksClusterSshPublicKey": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the SSH RSA public key string for the Linux nodes."
+              }
+            },
+            "aadEnabled": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Specifies whether enabling AAD integration."
+              }
+            },
+            "aadProfileTenantId": {
+              "type": "string",
+              "defaultValue": "[subscription().tenantId]",
+              "metadata": {
+                "description": "Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication."
+              }
+            },
+            "aadProfileAdminGroupObjectIDs": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Specifies the AAD group object IDs that will have admin role of the cluster."
+              }
+            },
+            "aksClusterEnablePrivateCluster": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Specifies whether to create the cluster as a private cluster or not."
+              }
+            },
+            "aadProfileManaged": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Specifies whether to enable managed AAD integration."
+              }
+            },
+            "aadProfileEnableAzureRBAC": {
+              "type": "bool",
+              "defaultValue": false,
+              "metadata": {
+                "description": "Specifies whether to  to enable Azure RBAC for Kubernetes authorization."
+              }
+            },
+            "nodePoolName": {
+              "type": "string",
+              "defaultValue": "nodepool1",
+              "metadata": {
+                "description": "Specifies the unique name of the node pool profile in the context of the subscription and resource group."
+              }
+            },
+            "nodePoolVmSize": {
+              "type": "string",
+              "defaultValue": "Standard_DS3_v2",
+              "metadata": {
+                "description": "Specifies the vm size of nodes in the node pool."
+              }
+            },
+            "nodePoolOsDiskSizeGB": {
+              "type": "int",
+              "defaultValue": 100,
+              "metadata": {
+                "description": "Specifies the OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.."
+              }
+            },
+            "nodePoolCount": {
+              "type": "int",
+              "defaultValue": 3,
+              "metadata": {
+                "description": "Specifies the number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1."
+              }
+            },
+            "nodePoolOsType": {
+              "type": "string",
+              "defaultValue": "Linux",
+              "metadata": {
+                "description": "Specifies the OS type for the vms in the node pool. Choose from Linux and Windows. Default to Linux."
+              },
+              "allowedValues": [
+                "Linux",
+                "Windows"
+              ]
+            },
+            "nodePoolMaxPods": {
+              "type": "int",
+              "defaultValue": 30,
+              "metadata": {
+                "description": "Specifies the maximum number of pods that can run on a node. The maximum number of pods per node in an AKS cluster is 250. The default maximum number of pods per node varies between kubenet and Azure CNI networking, and the method of cluster deployment."
+              }
+            },
+            "nodePoolMaxCount": {
+              "type": "int",
+              "defaultValue": 5,
+              "metadata": {
+                "description": "Specifies the maximum number of nodes for auto-scaling for the node pool."
+              }
+            },
+            "nodePoolMinCount": {
+              "type": "int",
+              "defaultValue": 3,
+              "metadata": {
+                "description": "Specifies the minimum number of nodes for auto-scaling for the node pool."
+              }
+            },
+            "nodePoolEnableAutoScaling": {
+              "type": "bool",
+              "defaultValue": true,
+              "metadata": {
+                "description": "Specifies whether to enable auto-scaling for the node pool."
+              }
+            },
+            "nodePoolScaleSetPriority": {
+              "type": "string",
+              "defaultValue": "Regular",
+              "metadata": {
+                "description": "Specifies the virtual machine scale set priority: Spot or Regular."
+              },
+              "allowedValues": [
+                "Spot",
+                "Regular"
+              ]
+            },
+            "nodePoolNodeLabels": {
+              "type": "object",
+              "defaultValue": {},
+              "metadata": {
+                "description": "Specifies the Agent pool node labels to be persisted across all nodes in agent pool."
+              }
+            },
+            "nodePoolNodeTaints": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Specifies the taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. - string"
+              }
+            },
+            "nodePoolMode": {
+              "type": "string",
+              "defaultValue": "System",
+              "metadata": {
+                "description": "Specifies the mode of an agent pool: System or User"
+              },
+              "allowedValues": [
+                "System",
+                "User"
+              ]
+            },
+            "nodePoolType": {
+              "type": "string",
+              "defaultValue": "VirtualMachineScaleSets",
+              "metadata": {
+                "description": "Specifies the type of a node pool: VirtualMachineScaleSets or AvailabilitySet"
+              },
+              "allowedValues": [
+                "VirtualMachineScaleSets",
+                "AvailabilitySet"
+              ]
+            },
+            "nodePoolAvailabilityZones": {
+              "type": "array",
+              "defaultValue": [],
+              "metadata": {
+                "description": "Specifies the availability zones for nodes. Requirese the use of VirtualMachineScaleSets as node pool type."
+              }
+            },
+            "virtualNetworkId": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the id of the virtual network."
+              }
+            },
+            "aksSubnetName": {
+              "type": "string",
+              "defaultValue": "AksSubnet",
+              "metadata": {
+                "description": "Specifies the name of the default subnet hosting the AKS cluster."
+              }
+            },
+            "logAnalyticsWorkspaceId": {
+              "type": "string",
+              "metadata": {
+                "description": "Specifies the name of the Log Analytics Workspace."
+              }
+            }
+          },
+          "functions": [],
+          "variables": {
+            "aadProfileConfiguration": {
+              "managed": "[parameters('aadProfileManaged')]",
+              "enableAzureRBAC": "[parameters('aadProfileEnableAzureRBAC')]",
+              "adminGroupObjectIDs": "[parameters('aadProfileAdminGroupObjectIDs')]",
+              "tenantID": "[parameters('aadProfileTenantId')]"
+            },
+            "virtualNetworkName": "[last(split(parameters('virtualNetworkId'), '/'))]"
+          },
+          "resources": [
+            {
+              "type": "Microsoft.ContainerService/managedClusters",
+              "apiVersion": "2021-02-01",
+              "name": "[parameters('aksClusterName')]",
+              "location": "[parameters('location')]",
+              "identity": {
+                "type": "SystemAssigned"
+              },
+              "tags": "[parameters('aksClusterTags')]",
+              "sku": {
+                "name": "Basic",
+                "tier": "[parameters('aksClusterSkuTier')]"
+              },
+              "properties": {
+                "kubernetesVersion": "[parameters('aksClusterKubernetesVersion')]",
+                "dnsPrefix": "[parameters('aksClusterDnsPrefix')]",
+                "agentPoolProfiles": [
+                  {
+                    "name": "[toLower(parameters('nodePoolName'))]",
+                    "count": "[parameters('nodePoolCount')]",
+                    "vmSize": "[parameters('nodePoolVmSize')]",
+                    "osDiskSizeGB": "[parameters('nodePoolOsDiskSizeGB')]",
+                    "vnetSubnetID": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), parameters('aksSubnetName'))]",
+                    "maxPods": "[parameters('nodePoolMaxPods')]",
+                    "osType": "[parameters('nodePoolOsType')]",
+                    "maxCount": "[parameters('nodePoolMaxCount')]",
+                    "minCount": "[parameters('nodePoolMinCount')]",
+                    "scaleSetPriority": "[parameters('nodePoolScaleSetPriority')]",
+                    "enableAutoScaling": "[parameters('nodePoolEnableAutoScaling')]",
+                    "mode": "[parameters('nodePoolMode')]",
+                    "type": "[parameters('nodePoolType')]",
+                    "availabilityZones": "[if(empty(parameters('nodePoolAvailabilityZones')), null(), parameters('nodePoolAvailabilityZones'))]",
+                    "nodeLabels": "[parameters('nodePoolNodeLabels')]",
+                    "nodeTaints": "[parameters('nodePoolNodeTaints')]"
+                  }
+                ],
+                "linuxProfile": {
+                  "adminUsername": "[parameters('aksClusterAdminUsername')]",
+                  "ssh": {
+                    "publicKeys": [
+                      {
+                        "keyData": "[parameters('aksClusterSshPublicKey')]"
+                      }
+                    ]
+                  }
+                },
+                "addonProfiles": {
+                  "omsagent": {
+                    "enabled": true,
+                    "config": {
+                      "logAnalyticsWorkspaceResourceID": "[parameters('logAnalyticsWorkspaceId')]"
+                    }
+                  }
+                },
+                "enableRBAC": true,
+                "networkProfile": {
+                  "networkPlugin": "[parameters('aksClusterNetworkPlugin')]",
+                  "networkPolicy": "[parameters('aksClusterNetworkPolicy')]",
+                  "podCidr": "[parameters('aksClusterPodCidr')]",
+                  "serviceCidr": "[parameters('aksClusterServiceCidr')]",
+                  "dnsServiceIP": "[parameters('aksClusterDnsServiceIP')]",
+                  "dockerBridgeCidr": "[parameters('aksClusterDockerBridgeCidr')]",
+                  "loadBalancerSku": "[parameters('aksClusterLoadBalancerSku')]"
+                },
+                "aadProfile": "[if(parameters('aadEnabled'), variables('aadProfileConfiguration'), json('null'))]",
+                "apiServerAccessProfile": {
+                  "enablePrivateCluster": "[parameters('aksClusterEnablePrivateCluster')]"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Resources/deployments', 'log-analytics.bicep')]",
+        "[resourceId('Microsoft.Resources/deployments', 'vnet')]"
+      ]
     }
   ]
 }

--- a/demos/private-aks-cluster/bastion.bicep
+++ b/demos/private-aks-cluster/bastion.bicep
@@ -1,0 +1,41 @@
+@description('Specifies the location of AKS cluster.')
+param location string = resourceGroup().location
+
+@description('Specifies the name of the Azure Bastion resource.')
+param bastionHostName string
+
+@description('Specifies the id of the Azure Bastion subnet resource id.')
+param bastionSubnetId string
+
+var bastionPublicIpAddressName = '${bastionHostName}PublicIp'
+
+resource bastionPublicIpAddress 'Microsoft.Network/publicIPAddresses@2020-08-01' = {
+  name: bastionPublicIpAddressName
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+}
+
+resource bastionHost 'Microsoft.Network/bastionHosts@2020-08-01' = {
+  name: bastionHostName
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'IpConf'
+        properties: {
+          subnet: {
+            id: bastionSubnetId
+          }
+          publicIPAddress: {
+            id: bastionPublicIpAddress.id
+          }
+        }
+      }
+    ]
+  }
+}

--- a/demos/private-aks-cluster/jumpbox.bicep
+++ b/demos/private-aks-cluster/jumpbox.bicep
@@ -1,0 +1,266 @@
+@description('Specifies the location of AKS cluster.')
+param location string = resourceGroup().location
+
+@description('Specifies the id of the virtual network.')
+param virtualNetworkId string
+
+@description('Specifies the idof the subnet which contains the virtual machine.')
+param vmSubnetId string
+
+@description('Specifies the name of the virtual machine.')
+param vmName string = 'TestVm'
+
+@description('Specifies the size of the virtual machine.')
+param vmSize string = 'Standard_DS3_v2'
+
+@description('Specifies the image publisher of the disk image used to create the virtual machine.')
+param imagePublisher string = 'Canonical'
+
+@description('Specifies the offer of the platform image or marketplace image used to create the virtual machine.')
+param imageOffer string = 'UbuntuServer'
+
+@description('Specifies the Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version.')
+param imageSku string = '18.04-LTS'
+
+@allowed([
+  'sshPublicKey'
+  'password'
+])
+@description('Specifies the type of authentication when accessing the Virtual Machine. SSH key is recommended.')
+param authenticationType string = 'password'
+
+@description('Specifies the name of the administrator account of the virtual machine.')
+param vmAdminUsername string
+
+@description('Specifies the SSH Key or password for the virtual machine. SSH key is recommended.')
+@secure()
+param vmAdminPasswordOrKey string
+
+@allowed([
+  'Premium_LRS'
+  'StandardSSD_LRS'
+  'Standard_LRS'
+  'UltraSSD_LRS'
+])
+@description('Specifies the storage account type for OS and data disk.')
+param diskStorageAccounType string = 'Premium_LRS'
+
+@minValue(0)
+@maxValue(64)
+@description('Specifies the number of data disks of the virtual machine.')
+param numDataDisks int = 1
+
+@description('Specifies the size in GB of the OS disk of the VM.')
+param osDiskSize int = 50
+
+@description('Specifies the size in GB of the OS disk of the virtual machine.')
+param dataDiskSize int = 50
+
+@description('Specifies the caching requirements for the data disks.')
+param dataDiskCaching string = 'ReadWrite'
+
+@description('Specifies the globally unique name for the storage account used to store the boot diagnostics logs of the virtual machine.')
+param blobStorageAccountName string = 'blob${uniqueString(resourceGroup().id)}'
+
+@description('Specifies the name of the private link to the boot diagnostics storage account.')
+param blobStorageAccountPrivateEndpointName string = 'BlobStorageAccountPrivateEndpoint'
+
+@description('Specifies the id of the Log Analytics Workspace.')
+param logAnalyticsWorkspaceId string
+
+var vmNicName = '${vmName}Nic'
+var blobPublicDNSZoneForwarder = '.blob.${environment().suffixes.storage}'
+var blobPrivateDnsZoneName = 'privatelink${blobPublicDNSZoneForwarder}'
+var blobStorageAccountPrivateEndpointGroupName = 'blob'
+var omsAgentForLinuxName = 'LogAnalytics'
+var omsDependencyAgentForLinuxName = 'DependencyAgent'
+var linuxConfiguration = {
+  disablePasswordAuthentication: true
+  ssh: {
+    publicKeys: [
+      {
+        path: '/home/${vmAdminUsername}/.ssh/authorized_keys'
+        keyData: vmAdminPasswordOrKey
+      }
+    ]
+  }
+  provisionVMAgent: true
+}
+
+var virtualNetworkName = last(split(virtualNetworkId, '/'))
+var logAnalyticsWorkspaceName = last(split(logAnalyticsWorkspaceId, '/'))
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
+resource blobStorageAccount 'Microsoft.Storage/storageAccounts@2021-01-01' = {
+  name: blobStorageAccountName
+  location: location
+  sku: {
+    name: 'Standard_LRS'
+  }
+  kind: 'StorageV2'
+}
+
+resource vmNic 'Microsoft.Network/networkInterfaces@2020-08-01' = {
+  name: vmNicName
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          subnet: {
+            id: vmSubnetId
+          }
+        }
+      }
+    ]
+  }
+}
+
+resource virtualMachines 'Microsoft.Compute/virtualMachines@2020-12-01' = {
+  name: vmName
+  location: location
+  properties: {
+    hardwareProfile: {
+      vmSize: vmSize
+    }
+    osProfile: {
+      computerName: vmName
+      adminUsername: vmAdminUsername
+      adminPassword: vmAdminPasswordOrKey
+      linuxConfiguration: ((authenticationType == 'password') ? json('null') : linuxConfiguration)
+    }
+    storageProfile: {
+      imageReference: {
+        publisher: imagePublisher
+        offer: imageOffer
+        sku: imageSku
+        version: 'latest'
+      }
+      osDisk: {
+        name: '${vmName}_OSDisk'
+        caching: 'ReadWrite'
+        createOption: 'FromImage'
+        diskSizeGB: osDiskSize
+        managedDisk: {
+          storageAccountType: diskStorageAccounType
+        }
+      }
+      dataDisks: [for j in range(0, numDataDisks): {
+        caching: dataDiskCaching
+        diskSizeGB: dataDiskSize
+        lun: j
+        name: '${vmName}-DataDisk${j}'
+        createOption: 'Empty'
+        managedDisk: {
+          storageAccountType: diskStorageAccounType
+        }
+      }]
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: vmNic.id
+        }
+      ]
+    }
+    diagnosticsProfile: {
+      bootDiagnostics: {
+        enabled: true
+        storageUri: blobStorageAccount.properties.primaryEndpoints.blob
+      }
+    }
+  }
+}
+
+resource omsAgentForLinux 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {
+  parent: virtualMachines
+  name: omsAgentForLinuxName
+  location: location
+  properties: {
+    publisher: 'Microsoft.EnterpriseCloud.Monitoring'
+    type: 'OmsAgentForLinux'
+    typeHandlerVersion: '1.13'
+    settings: {
+      workspaceId: logAnalyticsWorkspace.properties.customerId
+      stopOnMultipleConnections: false
+    }
+    protectedSettings: {
+      workspaceKey: listKeys(logAnalyticsWorkspace.id, logAnalyticsWorkspace.apiVersion).primarySharedKey
+    }
+  }
+}
+
+resource omsDependencyAgentForLinux 'Microsoft.Compute/virtualMachines/extensions@2020-12-01' = {
+  parent: virtualMachines
+  name: omsDependencyAgentForLinuxName
+  location: location
+  properties: {
+    publisher: 'Microsoft.Azure.Monitoring.DependencyAgent'
+    type: 'DependencyAgentLinux'
+    typeHandlerVersion: '9.10'
+    autoUpgradeMinorVersion: true
+  }
+}
+
+resource blobPrivateDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: blobPrivateDnsZoneName
+  location: 'global'
+}
+
+resource blobPrivateDnsZoneLinkToVirtualNetwork 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: blobPrivateDnsZone
+  name: 'link_to_${toLower(virtualNetworkName)}'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: virtualNetworkId
+    }
+  }
+}
+
+resource blobStorageAccountPrivateEndpoint 'Microsoft.Network/privateEndpoints@2020-08-01' = {
+  name: blobStorageAccountPrivateEndpointName
+  location: location
+  properties: {
+    privateLinkServiceConnections: [
+      {
+        name: blobStorageAccountPrivateEndpointName
+        properties: {
+          privateLinkServiceId: blobStorageAccount.id
+          groupIds: [
+            blobStorageAccountPrivateEndpointGroupName
+          ]
+        }
+      }
+    ]
+    subnet: {
+      id: vmSubnetId
+    }
+    customDnsConfigs: [
+      {
+        fqdn: '${blobStorageAccountName}${blobPublicDNSZoneForwarder}'
+      }
+    ]
+  }
+}
+
+resource blobPrivateDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2020-08-01' = {
+  parent: blobStorageAccountPrivateEndpoint
+  name: '${blobStorageAccountPrivateEndpointGroupName}PrivateDnsZoneGroup'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'dnsConfig'
+        properties: {
+          privateDnsZoneId: blobPrivateDnsZone.id
+        }
+      }
+    ]
+  }
+}

--- a/demos/private-aks-cluster/log-analytics.bicep
+++ b/demos/private-aks-cluster/log-analytics.bicep
@@ -1,0 +1,30 @@
+@description('Specifies the location of AKS cluster.')
+param location string = resourceGroup().location
+
+@description('Specifies the name of the Log Analytics Workspace.')
+param logAnalyticsWorkspaceName string
+
+@allowed([
+  'Free'
+  'Standalone'
+  'PerNode'
+  'PerGB2018'
+])
+@description('Specifies the service tier of the workspace: Free, Standalone, PerNode, Per-GB.')
+param logAnalyticsSku string = 'PerGB2018'
+
+@description('Specifies the workspace data retention in days. -1 means Unlimited retention for the Unlimited Sku. 730 days is the maximum allowed for all other Skus.')
+param logAnalyticsRetentionInDays int = 60
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2020-10-01' = {
+  name: logAnalyticsWorkspaceName
+  location: location
+  properties: {
+    sku: {
+      name: logAnalyticsSku
+    }
+    retentionInDays: logAnalyticsRetentionInDays
+  }
+}
+
+output logAnalyticsWorkspaceId string = logAnalyticsWorkspace.id

--- a/demos/private-aks-cluster/main.bicep
+++ b/demos/private-aks-cluster/main.bicep
@@ -1,0 +1,351 @@
+@description('Specifies the location of AKS cluster.')
+param location string = resourceGroup().location
+
+@description('Specifies the name of the AKS cluster.')
+param aksClusterName string = 'aks-${uniqueString(resourceGroup().id)}'
+
+@description('Specifies the DNS prefix specified when creating the managed cluster.')
+param aksClusterDnsPrefix string = aksClusterName
+
+@description('Specifies the tags of the AKS cluster.')
+param aksClusterTags object = {
+  resourceType: 'AKS Cluster'
+  createdBy: 'ARM Template'
+}
+
+@description('Specifies the network plugin used for building Kubernetes network. - azure or kubenet.')
+@allowed([
+  'azure'
+  'kubenet'
+])
+param aksClusterNetworkPlugin string = 'azure'
+
+@description('Specifies the network policy used for building Kubernetes network. - calico or azure')
+@allowed([
+  'azure'
+  'calico'
+])
+param aksClusterNetworkPolicy string = 'azure'
+
+@description('Specifies the CIDR notation IP range from which to assign pod IPs when kubenet is used.')
+param aksClusterPodCidr string = '10.244.0.0/16'
+
+@description('A CIDR notation IP range from which to assign service cluster IPs. It must not overlap with any Subnet IP ranges.')
+param aksClusterServiceCidr string = '10.2.0.0/16'
+
+@description('Specifies the IP address assigned to the Kubernetes DNS service. It must be within the Kubernetes service address range specified in serviceCidr.')
+param aksClusterDnsServiceIP string = '10.2.0.10'
+
+@description('Specifies the CIDR notation IP range assigned to the Docker bridge network. It must not overlap with any Subnet IP ranges or the Kubernetes service address range.')
+param aksClusterDockerBridgeCidr string = '172.17.0.1/16'
+
+@description('Specifies the sku of the load balancer used by the virtual machine scale sets used by nodepools.')
+@allowed([
+  'basic'
+  'standard'
+])
+param aksClusterLoadBalancerSku string = 'standard'
+
+@description('Specifies the tier of a managed cluster SKU: Paid or Free')
+@allowed([
+  'Paid'
+  'Free'
+])
+param aksClusterSkuTier string = 'Paid'
+
+@description('Specifies the version of Kubernetes specified when creating the managed cluster.')
+param aksClusterKubernetesVersion string = '1.19.7'
+
+@description('Specifies the administrator username of Linux virtual machines.')
+param aksClusterAdminUsername string
+
+@description('Specifies the SSH RSA public key string for the Linux nodes.')
+param aksClusterSshPublicKey string
+
+@description('Specifies whether enabling AAD integration.')
+param aadEnabled bool = false
+
+@description('Specifies the tenant id of the Azure Active Directory used by the AKS cluster for authentication.')
+param aadProfileTenantId string = subscription().tenantId
+
+@description('Specifies the AAD group object IDs that will have admin role of the cluster.')
+param aadProfileAdminGroupObjectIDs array = []
+
+@description('Specifies whether to create the cluster as a private cluster or not.')
+param aksClusterEnablePrivateCluster bool = true
+
+@description('Specifies whether to enable managed AAD integration.')
+param aadProfileManaged bool = false
+
+@description('Specifies whether to  to enable Azure RBAC for Kubernetes authorization.')
+param aadProfileEnableAzureRBAC bool = false
+
+@description('Specifies the unique name of the node pool profile in the context of the subscription and resource group.')
+param nodePoolName string = 'nodepool1'
+
+@description('Specifies the vm size of nodes in the node pool.')
+param nodePoolVmSize string = 'Standard_DS3_v2'
+
+@description('Specifies the OS Disk Size in GB to be used to specify the disk size for every machine in this master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified..')
+param nodePoolOsDiskSizeGB int = 100
+
+@description('Specifies the number of agents (VMs) to host docker containers. Allowed values must be in the range of 1 to 100 (inclusive). The default value is 1.')
+param nodePoolCount int = 5
+
+@description('Specifies the OS type for the vms in the node pool. Choose from Linux and Windows. Default to Linux.')
+@allowed([
+  'Linux'
+  'Windows'
+])
+param nodePoolOsType string = 'Linux'
+
+@description('Specifies the maximum number of pods that can run on a node. The maximum number of pods per node in an AKS cluster is 250. The default maximum number of pods per node varies between kubenet and Azure CNI networking, and the method of cluster deployment.')
+param nodePoolMaxPods int = 30
+
+@description('Specifies the maximum number of nodes for auto-scaling for the node pool.')
+param nodePoolMaxCount int = 5
+
+@description('Specifies the minimum number of nodes for auto-scaling for the node pool.')
+param nodePoolMinCount int = 3
+
+@description('Specifies whether to enable auto-scaling for the node pool.')
+param nodePoolEnableAutoScaling bool = true
+
+@description('Specifies the virtual machine scale set priority: Spot or Regular.')
+@allowed([
+  'Spot'
+  'Regular'
+])
+param nodePoolScaleSetPriority string = 'Regular'
+
+@description('Specifies the Agent pool node labels to be persisted across all nodes in agent pool.')
+param nodePoolNodeLabels object = {}
+
+@description('Specifies the taints added to new nodes during node pool create and scale. For example, key=value:NoSchedule. - string')
+param nodePoolNodeTaints array = []
+
+@description('Specifies the mode of an agent pool: System or User')
+@allowed([
+  'System'
+  'User'
+])
+param nodePoolMode string = 'System'
+
+@description('Specifies the type of a node pool: VirtualMachineScaleSets or AvailabilitySet')
+@allowed([
+  'VirtualMachineScaleSets'
+  'AvailabilitySet'
+])
+param nodePoolType string = 'VirtualMachineScaleSets'
+
+@description('Specifies the availability zones for nodes. Requirese the use of VirtualMachineScaleSets as node pool type.')
+param nodePoolAvailabilityZones array = []
+
+@description('Specifies the name of the virtual network.')
+param virtualNetworkName string = '${aksClusterName}Vnet'
+
+@description('Specifies the address prefixes of the virtual network.')
+param virtualNetworkAddressPrefixes string = '10.0.0.0/8'
+
+@description('Specifies the name of the default subnet hosting the AKS cluster.')
+param aksSubnetName string = 'AksSubnet'
+
+@description('Specifies the address prefix of the subnet hosting the AKS cluster.')
+param aksSubnetAddressPrefix string = '10.0.0.0/16'
+
+@description('Specifies the name of the Log Analytics Workspace.')
+param logAnalyticsWorkspaceName string
+
+@description('Specifies the service tier of the workspace: Free, Standalone, PerNode, Per-GB.')
+@allowed([
+  'Free'
+  'Standalone'
+  'PerNode'
+  'PerGB2018'
+])
+param logAnalyticsSku string = 'PerGB2018'
+
+@description('Specifies the workspace data retention in days. -1 means Unlimited retention for the Unlimited Sku. 730 days is the maximum allowed for all other Skus.')
+param logAnalyticsRetentionInDays int = 60
+
+@description('Specifies the name of the subnet which contains the virtual machine.')
+param vmSubnetName string = 'VmSubnet'
+
+@description('Specifies the address prefix of the subnet which contains the virtual machine.')
+param vmSubnetAddressPrefix string = '10.1.0.0/24'
+
+@description('Specifies the name of the virtual machine.')
+param vmName string = 'TestVm'
+
+@description('Specifies the size of the virtual machine.')
+param vmSize string = 'Standard_DS3_v2'
+
+@description('Specifies the image publisher of the disk image used to create the virtual machine.')
+param imagePublisher string = 'Canonical'
+
+@description('Specifies the offer of the platform image or marketplace image used to create the virtual machine.')
+param imageOffer string = 'UbuntuServer'
+
+@description('Specifies the Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version.')
+param imageSku string = '18.04-LTS'
+
+@description('Specifies the type of authentication when accessing the Virtual Machine. SSH key is recommended.')
+@allowed([
+  'sshPublicKey'
+  'password'
+])
+param authenticationType string = 'password'
+
+@description('Specifies the name of the administrator account of the virtual machine.')
+param vmAdminUsername string
+
+@description('Specifies the SSH Key or password for the virtual machine. SSH key is recommended.')
+@secure()
+param vmAdminPasswordOrKey string
+
+@description('Specifies the storage account type for OS and data disk.')
+@allowed([
+  'Premium_LRS'
+  'StandardSSD_LRS'
+  'Standard_LRS'
+  'UltraSSD_LRS'
+])
+param diskStorageAccounType string = 'Premium_LRS'
+
+@description('Specifies the number of data disks of the virtual machine.')
+@minValue(0)
+@maxValue(64)
+param numDataDisks int = 1
+
+@description('Specifies the size in GB of the OS disk of the VM.')
+param osDiskSize int = 50
+
+@description('Specifies the size in GB of the OS disk of the virtual machine.')
+param dataDiskSize int = 50
+
+@description('Specifies the caching requirements for the data disks.')
+param dataDiskCaching string = 'ReadWrite'
+
+@description('Specifies the globally unique name for the storage account used to store the boot diagnostics logs of the virtual machine.')
+param blobStorageAccountName string = 'blob${uniqueString(resourceGroup().id)}'
+
+@description('Specifies the name of the private link to the boot diagnostics storage account.')
+param blobStorageAccountPrivateEndpointName string = 'BlobStorageAccountPrivateEndpoint'
+
+@description('Specifies the Bastion subnet IP prefix. This prefix must be within vnet IP prefix address space.')
+param bastionSubnetAddressPrefix string = '10.1.1.0/26'
+
+@description('Specifies the name of the Azure Bastion resource.')
+param bastionName string = '${aksClusterName}Bastion'
+
+module vnet 'vnet.bicep' = {
+  name: 'vnet'
+  params: {
+    location: location
+    virtualNetworkName: virtualNetworkName
+    virtualNetworkAddressPrefixes: virtualNetworkAddressPrefixes
+    aksSubnetName: aksSubnetName
+    aksSubnetAddressPrefix: aksSubnetAddressPrefix
+    bastionSubnetAddressPrefix: bastionSubnetAddressPrefix
+    vmSubnetName: vmSubnetName
+    vmSubnetAddressPrefix: vmSubnetAddressPrefix
+  }
+}
+
+module bastion 'bastion.bicep' = {
+  name: 'bastion'
+  params: {
+    bastionHostName: bastionName
+    bastionSubnetId: vnet.outputs.bastionSubnetId
+    location: location
+  }
+}
+
+module logAnalytics 'log-analytics.bicep' = {
+  name: 'log-analytics.bicep'
+  params: {
+    location: location
+    logAnalyticsWorkspaceName: logAnalyticsWorkspaceName
+    logAnalyticsSku: logAnalyticsSku
+    logAnalyticsRetentionInDays: logAnalyticsRetentionInDays
+  }
+}
+
+module jumpbox 'jumpbox.bicep' = {
+  name: 'jumpbox'
+  params: {
+    location: location
+
+    vmName: vmName
+    vmAdminUsername: vmAdminUsername
+    vmAdminPasswordOrKey: vmAdminPasswordOrKey
+
+    vmSize: vmSize
+    authenticationType: authenticationType
+
+    diskStorageAccounType: diskStorageAccounType
+    osDiskSize: osDiskSize
+    dataDiskCaching: dataDiskCaching
+    dataDiskSize: dataDiskSize
+    numDataDisks: numDataDisks
+
+    imageOffer: imageOffer
+    imagePublisher: imagePublisher
+    imageSku: imageSku
+
+    blobStorageAccountName: blobStorageAccountName
+    blobStorageAccountPrivateEndpointName: blobStorageAccountPrivateEndpointName
+
+    logAnalyticsWorkspaceId: logAnalytics.outputs.logAnalyticsWorkspaceId
+    virtualNetworkId: vnet.outputs.virtualNetworkResourceId
+    vmSubnetId: vnet.outputs.vmSubnetId
+  }
+}
+
+module aks 'aks.bicep' = {
+  name: 'aks'
+  params: {
+    location: location
+
+    aadEnabled: aadEnabled
+    aadProfileAdminGroupObjectIDs: aadProfileAdminGroupObjectIDs
+    aadProfileEnableAzureRBAC: aadProfileEnableAzureRBAC
+    aadProfileManaged: aadProfileManaged
+    aadProfileTenantId: aadProfileTenantId
+    aksClusterAdminUsername: aksClusterAdminUsername
+    aksClusterDnsPrefix: aksClusterDnsPrefix
+    aksClusterDnsServiceIP: aksClusterDnsServiceIP
+    aksClusterDockerBridgeCidr: aksClusterDockerBridgeCidr
+    aksClusterEnablePrivateCluster: aksClusterEnablePrivateCluster
+    aksClusterKubernetesVersion: aksClusterKubernetesVersion
+    aksClusterLoadBalancerSku: aksClusterLoadBalancerSku
+    aksClusterName: aksClusterName
+    aksClusterNetworkPlugin: aksClusterNetworkPlugin
+    aksClusterNetworkPolicy: aksClusterNetworkPolicy
+    aksClusterPodCidr: aksClusterPodCidr
+    aksClusterServiceCidr: aksClusterServiceCidr
+    aksClusterSkuTier: aksClusterSkuTier
+    aksClusterSshPublicKey: aksClusterSshPublicKey
+    aksClusterTags: aksClusterTags
+    aksSubnetName: aksSubnetName
+
+    nodePoolAvailabilityZones: nodePoolAvailabilityZones
+    nodePoolCount: nodePoolCount
+    nodePoolEnableAutoScaling: nodePoolEnableAutoScaling
+    nodePoolMaxCount: nodePoolMaxCount
+    nodePoolMaxPods: nodePoolMaxPods
+    nodePoolMinCount: nodePoolMinCount
+    nodePoolMode: nodePoolMode
+    nodePoolName: nodePoolName
+    nodePoolNodeLabels: nodePoolNodeLabels
+    nodePoolNodeTaints: nodePoolNodeTaints
+    nodePoolOsDiskSizeGB: nodePoolOsDiskSizeGB
+    nodePoolOsType: nodePoolOsType
+    nodePoolScaleSetPriority: nodePoolScaleSetPriority
+    nodePoolType: nodePoolType
+    nodePoolVmSize: nodePoolVmSize
+
+    virtualNetworkId: vnet.outputs.virtualNetworkResourceId
+    logAnalyticsWorkspaceId: logAnalytics.outputs.logAnalyticsWorkspaceId
+  }
+}

--- a/demos/private-aks-cluster/metadata.json
+++ b/demos/private-aks-cluster/metadata.json
@@ -5,5 +5,5 @@
   "description": "This sample shows how to create a private AKS cluster in a virtual network along with a jumpbox virtual machine.",
   "summary": "This template creates a virtual network, a private AKS cluster, a jumpbox virtual machine and a log analytics worspace.",
   "githubUsername": "paolosalvatori",
-  "dateUpdated": "2021-05-14"
+  "dateUpdated": "2021-06-22"
 }

--- a/demos/private-aks-cluster/vnet.bicep
+++ b/demos/private-aks-cluster/vnet.bicep
@@ -1,0 +1,225 @@
+@description('Specifies the location of AKS cluster.')
+param location string = resourceGroup().location
+
+@description('Specifies the Bastion subnet IP prefix. This prefix must be within vnet IP prefix address space.')
+param bastionSubnetAddressPrefix string = '10.1.1.0/26'
+
+@description('Specifies the name of the subnet which contains the virtual machine.')
+param vmSubnetName string = 'VmSubnet'
+
+@description('Specifies the address prefix of the subnet which contains the virtual machine.')
+param vmSubnetAddressPrefix string = '10.1.0.0/24'
+
+@description('Specifies the name of the default subnet hosting the AKS cluster.')
+param aksSubnetName string = 'AksSubnet'
+
+@description('Specifies the address prefix of the subnet hosting the AKS cluster.')
+param aksSubnetAddressPrefix string = '10.0.0.0/16'
+
+@description('Specifies the name of the virtual network.')
+param virtualNetworkName string
+
+@description('Specifies the address prefixes of the virtual network.')
+param virtualNetworkAddressPrefixes string = '10.0.0.0/8'
+
+var bastionSubnetName = 'AzureBastionSubnet'
+var bastionSubnetNsgName = '${bastionSubnetName}Nsg'
+
+var vmSubnetNsgName = '${vmSubnetName}Nsg'
+
+resource vmSubnetNsg 'Microsoft.Network/networkSecurityGroups@2020-08-01' = {
+  name: vmSubnetNsgName
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowSshInbound'
+        properties: {
+          priority: 100
+          access: 'Allow'
+          direction: 'Inbound'
+          destinationPortRange: '22'
+          protocol: 'Tcp'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+        }
+      }
+    ]
+  }
+}
+
+resource bastionSubnetNsg 'Microsoft.Network/networkSecurityGroups@2020-08-01' = {
+  name: bastionSubnetNsgName
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'bastionInAllow'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'Internet'
+          destinationPortRange: '443'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 100
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'bastionControlInAllow'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'GatewayManager'
+          destinationPortRanges: [
+            '443'
+            '4443'
+          ]
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 120
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'AllowLoadBalancerInBound'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'AzureLoadBalancer'
+          destinationPortRange: '443'
+          destinationAddressPrefix: '*'
+          access: 'Allow'
+          priority: 130
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'AllowBastionHostCommunicationInBound'
+        properties: {
+          protocol: '*'
+          sourcePortRange: '*'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationPortRanges: [
+            '8080'
+            '5701'
+          ]
+          destinationAddressPrefix: 'VirtualNetwork'
+          access: 'Allow'
+          priority: 140
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'bastionInDeny'
+        properties: {
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: '*'
+          access: 'Deny'
+          priority: 900
+          direction: 'Inbound'
+        }
+      }
+      {
+        name: 'bastionVnetOutAllow'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationPortRanges: [
+            '22'
+            '3389'
+          ]
+          destinationAddressPrefix: 'VirtualNetwork'
+          access: 'Allow'
+          priority: 100
+          direction: 'Outbound'
+        }
+      }
+      {
+        name: 'bastionAzureOutAllow'
+        properties: {
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationPortRange: '443'
+          destinationAddressPrefix: 'AzureCloud'
+          access: 'Allow'
+          priority: 120
+          direction: 'Outbound'
+        }
+      }
+    ]
+  }
+}
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2020-08-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        virtualNetworkAddressPrefixes
+      ]
+    }
+    subnets: [
+      {
+        name: aksSubnetName
+        properties: {
+          addressPrefix: aksSubnetAddressPrefix
+          privateEndpointNetworkPolicies: 'Disabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+      {
+        name: vmSubnetName
+        properties: {
+          addressPrefix: vmSubnetAddressPrefix
+          networkSecurityGroup: {
+            id: vmSubnetNsg.id
+          }
+          privateEndpointNetworkPolicies: 'Disabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+      }
+      {
+        name: bastionSubnetName
+        properties: {
+          addressPrefix: bastionSubnetAddressPrefix
+          networkSecurityGroup: {
+            id: bastionSubnetNsg.id
+          }
+        }
+      }
+    ]
+    enableDdosProtection: false
+    enableVmProtection: false
+  }
+}
+
+resource bastionSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-08-01' existing = {
+  parent: virtualNetwork
+  name: bastionSubnetName
+}
+
+resource aksSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-08-01' existing = {
+  parent: virtualNetwork
+  name: aksSubnetName
+}
+
+resource vmSubnet 'Microsoft.Network/virtualNetworks/subnets@2020-08-01' existing = {
+  parent: virtualNetwork
+  name: vmSubnetName
+}
+
+output virtualNetworkResourceId string = virtualNetwork.id
+
+// if I can use associative array then I can write match better code.
+output bastionSubnetId string = bastionSubnet.id
+output aksSubnetId string = aksSubnet.id
+output vmSubnetId string = vmSubnet.id


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/201/private-aks-cluster

The corresponding PR for the modified bicep example is here: <TODO: Fill in>