### PR TITLE
adding option to skip certain bp tests

### DIFF
--- a/test/ci-scripts/Test-BestPractices.ps1
+++ b/test/ci-scripts/Test-BestPractices.ps1
@@ -10,14 +10,15 @@ Note: This script is only needed in the Azure pipeline, not intended for local u
 param (
     [string] $SampleFolder = $ENV:SAMPLE_FOLDER,
     [string] $MainTemplateDeploymentFilename = $ENV:MAINTEMPLATE_DEPLOYMENT_FILENAME,
-    [string] $ttkFolder = $ENV:TTK_FOLDER
+    [string] $ttkFolder = $ENV:TTK_FOLDER,
+    [string[]] $Skip = $ENV:TTK_SKIP_TESTS 
 )
 
 Import-Module "$($ttkFolder)/arm-ttk/arm-ttk.psd1"
 
 $templatePath = "$($SampleFolder)/$MainTemplateDeploymentFilename"
 Write-Host "Calling Test-AzureTemplate on $templatePath"
-$testOutput = @(Test-AzTemplate -TemplatePath $templatePath)
+$testOutput = @(Test-AzTemplate -TemplatePath $templatePath -Skip "$Skip")
 $testOutput
 
 if ($testOutput | ? { $_.Errors }) {


### PR DESCRIPTION
One of the param tests (checking the sytnax of kv references) doesn't make sense for the repo due to gen vaules, so adding the option to skip that test.

The pipeline was also updated (just not here)