### PR TITLE
[ApiMangement] Make Load BALANCER port requirement strict

### DIFF
--- a/quickstarts/microsoft.apimanagement/api-management-create-with-external-vnet-publicip/azuredeploy.json
+++ b/quickstarts/microsoft.apimanagement/api-management-create-with-external-vnet-publicip/azuredeploy.json
@@ -281,7 +281,7 @@
             "properties": {
               "protocol": "Tcp",
               "sourcePortRange": "*",
-              "destinationPortRange": "*",
+              "destinationPortRange": "6390",
               "sourceAddressPrefix": "AzureLoadBalancer",
               "destinationAddressPrefix": "VirtualNetwork",
               "access": "Allow",

--- a/quickstarts/microsoft.apimanagement/api-management-create-with-external-vnet-publicip/metadata.json
+++ b/quickstarts/microsoft.apimanagement/api-management-create-with-external-vnet-publicip/metadata.json
@@ -8,5 +8,5 @@
   "environments": [
     "AzureCloud"
   ],
-  "dateUpdated": "2021-06-18"
+  "dateUpdated": "2021-07-09"
 }


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* AZURE_LOAD_BALANCER port can be limited to 6390 port instead of "*" inbound
*
*
