### PR TITLE
Migrate bicep example: 101/monitor-action-groups

### DIFF
--- a/demos/monitor-action-groups/README.md
+++ b/demos/monitor-action-groups/README.md
@@ -9,6 +9,8 @@
 ![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/demos/monitor-action-groups/BestPracticeResult.svg)
 ![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/demos/monitor-action-groups/CredScanResult.svg)
 
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/demos/monitor-action-groups/BicepVersion.svg)
+
 This template deploys an [Action Group](https://docs.microsoft.com/en-us/azure/azure-monitor/platform/action-groups) to Azure. An action group is a collection of notification preferences defined by the owner of an Azure subscription. Azure Monitor and Service Health alerts use action groups to notify users that an alert has been triggered.
 
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fmonitor-action-groups%2Fazuredeploy.json)  [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fmonitor-action-groups%2Fazuredeploy.json)  [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fmonitor-action-groups%2Fazuredeploy.json)

--- a/demos/monitor-action-groups/azuredeploy.json
+++ b/demos/monitor-action-groups/azuredeploy.json
@@ -1,93 +1,65 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.4.412.5873",
+      "templateHash": "18259469121057093405"
+    }
+  },
   "parameters": {
     "actionGroupName": {
-      "type": "string",
-      "metadata": {
-        "description": "Unique name (within the Resource Group) for the Action group."
-      }
+      "type": "string"
     },
     "actionGroupShortName": {
-      "type": "string",
-      "metadata": {
-        "description": "Short name (maximum 12 characters) for the Action group."
-      }
+      "type": "string"
     },
     "emailReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of email receivers that are part of this action group."
-      },
       "defaultValue": []
     },
     "smsReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of SMS receivers that are part of this action group."
-      },
       "defaultValue": []
     },
     "webhookReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of webhook receivers that are part of this action group."
-      },
       "defaultValue": []
     },
     "itsmReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of ITSM receivers that are part of this action group"
-      },
       "defaultValue": []
     },
     "azureAppPushReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of AzureAppPush receivers that are part of this action group"
-      },
       "defaultValue": []
     },
     "automationRunbookReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of AutomationRunbook receivers that are part of this action group."
-      },
       "defaultValue": []
     },
     "voiceReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of voice receivers that are part of this action group."
-      },
       "defaultValue": []
     },
     "logicAppReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of logic app receivers that are part of this action group."
-      },
       "defaultValue": []
     },
     "azureFunctionReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of azure function receivers that are part of this action group."
-      },
       "defaultValue": []
     },
     "armRoleReceivers": {
       "type": "array",
-      "metadata": {
-        "description": "The list of ARM role receivers that are part of this action group. Roles are Azure RBAC roles and only built-in roles are supported."
-      },
       "defaultValue": []
     }
   },
+  "functions": [],
   "resources": [
     {
-      "type": "Microsoft.Insights/actionGroups",
+      "type": "microsoft.insights/actionGroups",
       "apiVersion": "2019-06-01",
       "name": "[parameters('actionGroupName')]",
       "location": "Global",
@@ -110,7 +82,7 @@
   "outputs": {
     "actionGroupId": {
       "type": "string",
-      "value": "[resourceId('Microsoft.Insights/actionGroups', parameters('actionGroupName'))]"
+      "value": "[resourceId('microsoft.insights/actionGroups', parameters('actionGroupName'))]"
     }
   }
 }

--- a/demos/monitor-action-groups/azuredeploy.json
+++ b/demos/monitor-action-groups/azuredeploy.json
@@ -5,55 +5,91 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.412.5873",
-      "templateHash": "18259469121057093405"
+      "templateHash": "16070852643720121598"
     }
   },
   "parameters": {
     "actionGroupName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Unique name (within the Resource Group) for the Action group."
+      }
     },
     "actionGroupShortName": {
-      "type": "string"
+      "type": "string",
+      "metadata": {
+        "description": "Short name (maximum 12 characters) for the Action group."
+      }
     },
     "emailReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of email receivers that are part of this action group."
+      }
     },
     "smsReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of SMS receivers that are part of this action group."
+      }
     },
     "webhookReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of webhook receivers that are part of this action group."
+      }
     },
     "itsmReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of ITSM receivers that are part of this action group"
+      }
     },
     "azureAppPushReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of AzureAppPush receivers that are part of this action group"
+      }
     },
     "automationRunbookReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of AutomationRunbook receivers that are part of this action group."
+      }
     },
     "voiceReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of voice receivers that are part of this action group."
+      }
     },
     "logicAppReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of logic app receivers that are part of this action group."
+      }
     },
     "azureFunctionReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of azure function receivers that are part of this action group."
+      }
     },
     "armRoleReceivers": {
       "type": "array",
-      "defaultValue": []
+      "defaultValue": [],
+      "metadata": {
+        "description": "The list of ARM role receivers that are part of this action group. Roles are Azure RBAC roles and only built-in roles are supported."
+      }
     }
   },
   "functions": [],

--- a/demos/monitor-action-groups/main.bicep
+++ b/demos/monitor-action-groups/main.bicep
@@ -1,0 +1,33 @@
+param actionGroupName string
+param actionGroupShortName string
+param emailReceivers array = []
+param smsReceivers array = []
+param webhookReceivers array = []
+param itsmReceivers array = []
+param azureAppPushReceivers array = []
+param automationRunbookReceivers array = []
+param voiceReceivers array = []
+param logicAppReceivers array = []
+param azureFunctionReceivers array = []
+param armRoleReceivers array = []
+
+resource actionGroup 'Microsoft.Insights/actionGroups@2019-06-01' = {
+  name: actionGroupName
+  location: 'Global'
+  properties: {
+    groupShortName: actionGroupShortName
+    enabled: true
+    emailReceivers: emailReceivers
+    smsReceivers: smsReceivers
+    webhookReceivers: webhookReceivers
+    itsmReceivers: itsmReceivers
+    azureAppPushReceivers: azureAppPushReceivers
+    automationRunbookReceivers: automationRunbookReceivers
+    voiceReceivers: voiceReceivers
+    logicAppReceivers: logicAppReceivers
+    azureFunctionReceivers: azureFunctionReceivers
+    armRoleReceivers: armRoleReceivers
+  }
+}
+
+output actionGroupId string = actionGroup.id

--- a/demos/monitor-action-groups/main.bicep
+++ b/demos/monitor-action-groups/main.bicep
@@ -1,14 +1,37 @@
+@description('Unique name (within the Resource Group) for the Action group.')
 param actionGroupName string
+
+@description('Short name (maximum 12 characters) for the Action group.')
 param actionGroupShortName string
+
+@description('The list of email receivers that are part of this action group.')
 param emailReceivers array = []
+
+@description('The list of SMS receivers that are part of this action group.')
 param smsReceivers array = []
+
+@description('The list of webhook receivers that are part of this action group.')
 param webhookReceivers array = []
+
+@description('The list of ITSM receivers that are part of this action group')
 param itsmReceivers array = []
+
+@description('The list of AzureAppPush receivers that are part of this action group')
 param azureAppPushReceivers array = []
+
+@description('The list of AutomationRunbook receivers that are part of this action group.')
 param automationRunbookReceivers array = []
+
+@description('The list of voice receivers that are part of this action group.')
 param voiceReceivers array = []
+
+@description('The list of logic app receivers that are part of this action group.')
 param logicAppReceivers array = []
+
+@description('The list of azure function receivers that are part of this action group.')
 param azureFunctionReceivers array = []
+
+@description('The list of ARM role receivers that are part of this action group. Roles are Azure RBAC roles and only built-in roles are supported.')
 param armRoleReceivers array = []
 
 resource actionGroup 'Microsoft.Insights/actionGroups@2019-06-01' = {

--- a/demos/monitor-action-groups/metadata.json
+++ b/demos/monitor-action-groups/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template creates a new Action group on Azure, this action group can be then used for configuring alerts on Azure.",
   "summary": "This template creates an Azure action group",
   "githubUsername": "arpitjain099",
-  "dateUpdated": "2021-05-05"
+  "dateUpdated": "2021-07-30"
 }


### PR DESCRIPTION
Added bicep support to this sample by integrating bicep.main from the example in https://github.com/Azure/bicep/tree/main/docs/examples/101/monitor-action-groups
