### PR TITLE
Allow time for identity creation

### DIFF
--- a/demos/imagebuilder-windowsbaseline/azuredeploy.json
+++ b/demos/imagebuilder-windowsbaseline/azuredeploy.json
@@ -1,13 +1,6 @@
 {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
-  "metadata": {
-    "_generator": {
-      "name": "bicep",
-      "version": "0.4.613.9944",
-      "templateHash": "802255667085113336"
-    }
-  },
   "parameters": {
     "_artifactsLocation": {
       "type": "string",
@@ -274,7 +267,7 @@
       "properties": {
         "forceUpdateTag": "[parameters('forceUpdateTag')]",
         "azPowerShellVersion": "6.2",
-        "scriptContent": "[format('Invoke-AzResourceAction -ResourceName \"{0}\" -ResourceGroupName \"{1}\" -ResourceType \"Microsoft.VirtualMachineImages/imageTemplates\" -ApiVersion \"2020-02-14\" -Action Run -Force', reference(resourceId('Microsoft.VirtualMachineImages/imageTemplates', parameters('imageTemplateName')), '2020-02-14', 'full'), resourceGroup().name)]",
+        "scriptContent": "[format('Start-Sleep -Seconds 120;Invoke-AzResourceAction -ResourceName \"{0}\" -ResourceGroupName \"{1}\" -ResourceType \"Microsoft.VirtualMachineImages/imageTemplates\" -ApiVersion \"2020-02-14\" -Action Run -Force', reference(resourceId('Microsoft.VirtualMachineImages/imageTemplates', parameters('imageTemplateName')), '2020-02-14', 'full'), resourceGroup().name)]",
         "timeout": "PT1H",
         "cleanupPreference": "OnSuccess",
         "retentionInterval": "P1D"

--- a/demos/imagebuilder-windowsbaseline/azuredeploy.json
+++ b/demos/imagebuilder-windowsbaseline/azuredeploy.json
@@ -267,7 +267,7 @@
       "properties": {
         "forceUpdateTag": "[parameters('forceUpdateTag')]",
         "azPowerShellVersion": "6.2",
-        "scriptContent": "[format('Start-Sleep -Seconds 120;Invoke-AzResourceAction -ResourceName \"{0}\" -ResourceGroupName \"{1}\" -ResourceType \"Microsoft.VirtualMachineImages/imageTemplates\" -ApiVersion \"2020-02-14\" -Action Run -Force', reference(resourceId('Microsoft.VirtualMachineImages/imageTemplates', parameters('imageTemplateName')), '2020-02-14', 'full'), resourceGroup().name)]",
+        "scriptContent": "[format('Start-Sleep -Seconds 180;Invoke-AzResourceAction -ResourceName \"{0}\" -ResourceGroupName \"{1}\" -ResourceType \"Microsoft.VirtualMachineImages/imageTemplates\" -ApiVersion \"2020-02-14\" -Action Run -Force', reference(resourceId('Microsoft.VirtualMachineImages/imageTemplates', parameters('imageTemplateName')), '2020-02-14', 'full'), resourceGroup().name)]",
         "timeout": "PT1H",
         "cleanupPreference": "OnSuccess",
         "retentionInterval": "P1D"

--- a/demos/imagebuilder-windowsbaseline/main.bicep
+++ b/demos/imagebuilder-windowsbaseline/main.bicep
@@ -198,7 +198,7 @@ resource imageTemplate_build 'Microsoft.Resources/deploymentScripts@2020-10-01' 
   properties: {
     forceUpdateTag: forceUpdateTag
     azPowerShellVersion: '6.2'
-    scriptContent: 'Invoke-AzResourceAction -ResourceName "${imageTemplate}" -ResourceGroupName "${resourceGroup().name}" -ResourceType "Microsoft.VirtualMachineImages/imageTemplates" -ApiVersion "2020-02-14" -Action Run -Force'
+    scriptContent: 'Start-Sleep -Seconds 120;Invoke-AzResourceAction -ResourceName "${imageTemplate}" -ResourceGroupName "${resourceGroup().name}" -ResourceType "Microsoft.VirtualMachineImages/imageTemplates" -ApiVersion "2020-02-14" -Action Run -Force'
     timeout: 'PT1H'
     cleanupPreference: 'OnSuccess'
     retentionInterval: 'P1D'

--- a/demos/imagebuilder-windowsbaseline/main.bicep
+++ b/demos/imagebuilder-windowsbaseline/main.bicep
@@ -198,7 +198,7 @@ resource imageTemplate_build 'Microsoft.Resources/deploymentScripts@2020-10-01' 
   properties: {
     forceUpdateTag: forceUpdateTag
     azPowerShellVersion: '6.2'
-    scriptContent: 'Start-Sleep -Seconds 120;Invoke-AzResourceAction -ResourceName "${imageTemplate}" -ResourceGroupName "${resourceGroup().name}" -ResourceType "Microsoft.VirtualMachineImages/imageTemplates" -ApiVersion "2020-02-14" -Action Run -Force'
+    scriptContent: 'Start-Sleep -Seconds 180;Invoke-AzResourceAction -ResourceName "${imageTemplate}" -ResourceGroupName "${resourceGroup().name}" -ResourceType "Microsoft.VirtualMachineImages/imageTemplates" -ApiVersion "2020-02-14" -Action Run -Force'
     timeout: 'PT1H'
     cleanupPreference: 'OnSuccess'
     retentionInterval: 'P1D'


### PR DESCRIPTION
Small fix that sleeps the deployment script for 2 minutes before invoking the image gallery build. This is to give time for the identity system to finish before running.