### PR TITLE
Set dnssec-validation to no for dns-forwarder demo

### DIFF
--- a/demos/dns-forwarder/forwarderSetup.sh
+++ b/demos/dns-forwarder/forwarderSetup.sh
@@ -33,7 +33,7 @@ options {
         };
         forward only;
 
-        dnssec-validation auto;
+        dnssec-validation no; # needed for private dns zones
 
         auth-nxdomain no;    # conform to RFC1035
         listen-on { any; };


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [v] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

Set dnssec-validation to no for dns-forwarder demo because it does not work with "auto" for private
Hint from here : https://github.com/whiteducksoftware/az-dns-forwarder/blob/master/src/named.conf