### PR TITLE
- move GatewaySubnet * 2 to be created as part of the vnet resource

### DIFF
--- a/quickstarts/microsoft.network/vnet-to-vnet-bgp/azuredeploy.json
+++ b/quickstarts/microsoft.network/vnet-to-vnet-bgp/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.1.14562",
-      "templateHash": "8746312922182991255"
+      "version": "0.4.613.9944",
+      "templateHash": "1418584031951125500"
     }
   },
   "parameters": {
@@ -80,20 +80,15 @@
             "properties": {
               "addressPrefix": "[variables('vnet1cfg').subnetPrefix]"
             }
+          },
+          {
+            "name": "GatewaySubnet",
+            "properties": {
+              "addressPrefix": "[variables('vnet1cfg').gatewaySubnetPrefix]"
+            }
           }
         ]
       }
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2021-02-01",
-      "name": "[format('{0}/{1}', variables('vnet1cfg').name, 'GatewaySubnet')]",
-      "properties": {
-        "addressPrefix": "[variables('vnet1cfg').gatewaySubnetPrefix]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', variables('vnet1cfg').name)]"
-      ]
     },
     {
       "type": "Microsoft.Network/virtualNetworks",
@@ -112,20 +107,15 @@
             "properties": {
               "addressPrefix": "[variables('vnet2cfg').subnetPrefix]"
             }
+          },
+          {
+            "name": "GatewaySubnet",
+            "properties": {
+              "addressPrefix": "[variables('vnet2cfg').gatewaySubnetPrefix]"
+            }
           }
         ]
       }
-    },
-    {
-      "type": "Microsoft.Network/virtualNetworks/subnets",
-      "apiVersion": "2021-02-01",
-      "name": "[format('{0}/{1}', variables('vnet2cfg').name, 'GatewaySubnet')]",
-      "properties": {
-        "addressPrefix": "[variables('vnet2cfg').gatewaySubnetPrefix]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Network/virtualNetworks', variables('vnet2cfg').name)]"
-      ]
     },
     {
       "type": "Microsoft.Network/publicIPAddresses",
@@ -178,7 +168,7 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Network/publicIPAddresses', variables('vnet1cfg').gatewayPublicIPName)]",
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnet1cfg').name, 'GatewaySubnet')]"
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('vnet1cfg').name)]"
       ]
     },
     {
@@ -214,7 +204,7 @@
       },
       "dependsOn": [
         "[resourceId('Microsoft.Network/publicIPAddresses', variables('vnet2cfg').gatewayPublicIPName)]",
-        "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnet2cfg').name, 'GatewaySubnet')]"
+        "[resourceId('Microsoft.Network/virtualNetworks', variables('vnet2cfg').name)]"
       ]
     },
     {

--- a/quickstarts/microsoft.network/vnet-to-vnet-bgp/main.bicep
+++ b/quickstarts/microsoft.network/vnet-to-vnet-bgp/main.bicep
@@ -54,16 +54,19 @@ resource vnet1 'Microsoft.Network/virtualNetworks@2020-06-01' = {
           addressPrefix: vnet1cfg.subnetPrefix
         }
       }
+      {
+        name: 'GatewaySubnet'
+        properties: {
+          addressPrefix: vnet1cfg.gatewaySubnetPrefix
+        }
+      }
     ]
   }
 }
 
-resource vnet1GatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2021-02-01' = {
-  parent: vnet1
+resource vnet1GatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2021-02-01' existing = {
   name: 'GatewaySubnet'
-  properties: {
-    addressPrefix: vnet1cfg.gatewaySubnetPrefix
-  }
+  parent: vnet1
 }
 
 resource vnet2 'Microsoft.Network/virtualNetworks@2020-06-01' = {
@@ -82,16 +85,19 @@ resource vnet2 'Microsoft.Network/virtualNetworks@2020-06-01' = {
           addressPrefix: vnet2cfg.subnetPrefix
         }
       }
+      {
+        name: 'GatewaySubnet'
+        properties: {
+          addressPrefix: vnet2cfg.gatewaySubnetPrefix
+        }
+      }
     ]
   }
 }
 
-resource net2GatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2021-02-01' = {
+resource vnet2GatewaySubnet 'Microsoft.Network/virtualNetworks/subnets@2021-02-01' existing = {
   parent: vnet2
   name: 'GatewaySubnet'
-  properties: {
-    addressPrefix: vnet2cfg.gatewaySubnetPrefix
-  }
 }
 resource gw1pip 'Microsoft.Network/publicIPAddresses@2020-06-01' = {
   name: vnet1cfg.gatewayPublicIPName
@@ -150,7 +156,7 @@ resource vnet2Gateway 'Microsoft.Network/virtualNetworkGateways@2020-05-01' = {
         properties: {
           privateIPAllocationMethod: 'Dynamic'
           subnet: {
-            id: net2GatewaySubnet.id
+            id: vnet2GatewaySubnet.id
           }
           publicIPAddress: {
             id: gw2pip.id

--- a/quickstarts/microsoft.network/vnet-to-vnet-bgp/metadata.json
+++ b/quickstarts/microsoft.network/vnet-to-vnet-bgp/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to connect two VNETs using Virtual Network Gateways and BGP",
   "summary": "Create a VNET to VNET connection across using BGP",
   "githubUsername": "bhummerstone",
-  "dateUpdated": "2021-06-22"
+  "dateUpdated": "2021-09-28"
 }


### PR DESCRIPTION
[vnet-to-vnet-bgp]

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

- move GatewaySubnet * 2 to be created as part of the vnet resource
- rename net2GatewaySubnet to vnet2GatewaySubnet
- update vnet2GatewaySubnet + vnet2GatewaySubnet subnets to be an 'existing' resource
- build main.bicep to azuredeploy.json
- update 'dateUpdated' in metadata