### PR TITLE
Improvements on the integration with BPA

### DIFF
--- a/test/ci-scripts/Run-TemplateAnalyzer.ps1
+++ b/test/ci-scripts/Run-TemplateAnalyzer.ps1
@@ -80,9 +80,4 @@ Get-ChildItem $sampleFolder -Recurse -Filter *.json |
         }
 
 Write-Host "##vso[task.setvariable variable=template.analyzer.result]$passed"
-
-if ($passed) {
-    exit 0
-} else {
-    exit 1
-}
+exit [int]!$passed

--- a/test/ci-scripts/Run-TemplateAnalyzer.ps1
+++ b/test/ci-scripts/Run-TemplateAnalyzer.ps1
@@ -45,14 +45,15 @@ function Analyze-Template {
     }
     $testOutput = $testOutput -join "`n"
 
+    Write-Host $testOutput
+    $testOutput >> $templateAnalyzerOutputFilePath
+
     if($testOutput.length -ne 0 -and $LASTEXITCODE -eq 0)
     {
-        $testOutput >> $templateAnalyzerOutputFilePath
-
         return $testOutput.Contains($RULE_FAILED_MESSAGE)
     } else {
         Write-Error "TemplateAnalyzer failed trying to analyze: $templateFilePath $parametersFilePath"
-        exit 1
+        return $false
     }
 }
 
@@ -73,4 +74,8 @@ Get-ChildItem $sampleFolder -Recurse -Filter *.json |
 
 Write-Host "##vso[task.setvariable variable=template.analyzer.result]$passed"
 
-exit 0
+if ($passed) {
+    exit 0
+} else {
+    exit 1
+}

--- a/test/ci-scripts/Write-TestResults.ps1
+++ b/test/ci-scripts/Write-TestResults.ps1
@@ -539,12 +539,13 @@ foreach ($badge in $badges) {
         -Force -Verbose
 }
 
-# Upload BPA Results file
+# Upload BPA results file:
+$templateAnalyzerLogFileName = "$($ENV:BUILD_BUILDNUMBER)_$RowKey"
+Write-Host "Uploading TemplateAnalyzer log file: $templateAnalyzerLogFileName"
 try {
-    Write-Host "Uploading TemplateAnalyzer log file..."
     Set-AzStorageBlobContent -Container $TemplateAnalyzerLogsContainerName `
         -File $TemplateAnalyzerOutputFilePath `
-        -Blob $RowKey `
+        -Blob $templateAnalyzerLogFileName `
         -Context $ctx `
         -Properties @{ "ContentType" = "text/plain" } `
         -Force -Verbose


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Add build number to logs file names
* Exit BPA task with an error code when a rule fails, and output analysis logs also to stdout
* Run BPA only against templates (followed the same logic as in [this other pipeline script](https://github.com/Azure/azure-quickstart-templates/blob/630402d0da8100b162bcec4ec1817bad3062e814/test/ci-scripts/Update-templateHash.ps1#L66) to check the schema)
* Continue analysis even when BPA failed trying with a template
* Fix bug that broke the final analysis boolean result