### PR TITLE
Generate role definition ID for parameters to use

### DIFF
--- a/1-CONTRIBUTION-GUIDE/README.md
+++ b/1-CONTRIBUTION-GUIDE/README.md
@@ -356,6 +356,9 @@ Quickstart CI engine provides few pre-created azure components which can be used
 + **GEN-STATIC-WEBSITE-URL** - full URL of a static website
 + **GEN-STATIC-WEBSITE-HOST-NAME** - host name of a static website
 
+**Role definition related placeholders:**
++ **GEN-ROLE-DEFINITION-RESOURCE-ID-READER** - fully qualified resource ID of the Reader built-in role definition
+
 Here's an example in an `azuredeploy.parameters.json` file:
 
 ```json

--- a/test/ci-gen-setup/Create-GEN-Artifacts.ps1
+++ b/test/ci-gen-setup/Create-GEN-Artifacts.ps1
@@ -352,5 +352,11 @@ $json.Add("APPCONFIGSTORE-KEY1", "key1")
 $json.Add("APPCONFIGSTORE-KEY1", "windowsOSVersion")
 $json.Add("APPCONFIGSTORE-KEY1", "diskSizeGB")
 
+# Propagate a role definition ID to make it available for quickstarts and modules to use.
+$subscriptionId = (Get-AzureRmContext).Subscription.Id
+$readerRoleDefinitionId = (Get-AzureRmRoleDefinition -Name Reader).Id
+$readerRoleDefinitionResourceId = "/subscriptions/$subscriptionId/providers/Microsoft.Authorization/roleDefinitions/$readerRoleDefinitionId"
+$json.Add("ROLE-DEFINITION-RESOURCE-ID-READER", $readerRoleDefinitionId)
+
 # Output all the values needed for the config file
 Write-Output $($json | ConvertTo-json -Depth 30)


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Add a role definition ID for the built-in Reader role so that it can be used by quickstarts and modules in their parameter files.
* Document the `GEN-ROLE-DEFINITION-RESOURCE-ID-READER` placeholder.