### PR TITLE
Fixes default VM size...

### DIFF
--- a/demos/ubuntu-desktop-gnome-rdp/azuredeploy.json
+++ b/demos/ubuntu-desktop-gnome-rdp/azuredeploy.json
@@ -16,7 +16,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_D2s_v3",
+      "defaultValue": "Standard_DS2",
       "metadata": {
         "description": "The size of the virtual machines used when provisioning"
       }

--- a/demos/ubuntu-desktop-gnome-rdp/metadata.json
+++ b/demos/ubuntu-desktop-gnome-rdp/metadata.json
@@ -5,7 +5,7 @@
   "description": "This template deploys an Ubuntu Server VM, then uses the Linux CustomScript extension to install the Ubuntu Gnome Desktop and Remote Desktop support (via xrdp). The final provisioned Ubuntu VM support remote connections over RDP.",
   "summary": "Deploy Ubuntu Desktop VM with RDP support",
   "githubUsername": "leestott",
-  "dateUpdated": "2021-07-30",
+  "dateUpdated": "2021-11-04",
   "tags":{
     "subscriptiontype":"Azure4Student",
     "resource": "Virtual Machine, Azure CLI, VSCode",


### PR DESCRIPTION
... which is not compatible with Premium_LRS storage type.

Or should the fix be the other way round, fixing the storage type?

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Updated default VM Size to Standard_DS2 which is compatible with Premium_LRS storage type
