### PR TITLE
Enable Guest Attestation by default in Trusted Launch templates

### DIFF
--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
@@ -136,6 +136,30 @@
       "metadata": {
         "description": "Name of the network security group"
       }
+    },
+    "maaEndpoint": {
+      "type": "string",
+      "defaultValue": "https://sharedeus2.eus2.attest.azure.net/",
+      "allowedValues": [
+        "https://sharedcus.cus.attest.azure.net/",
+        "https://sharedcae.cae.attest.azure.net/",
+        "https://sharedeus2.eus2.attest.azure.net/",
+        "https://shareduks.uks.attest.azure.net/",
+        "https://sharedcac.cac.attest.azure.net/",
+        "https://sharedukw.ukw.attest.azure.net/",
+        "https://sharedneu.neu.attest.azure.net/",
+        "https://sharedeus.eus.attest.azure.net/",
+        "https://sharedeau.eau.attest.azure.net/",
+        "https://sharedncus.ncus.attest.azure.net/",
+        "https://sharedwus.wus.attest.azure.net/",
+        "https://sharedweu.weu.attest.azure.net/",
+        "https://sharedscus.scus.attest.azure.net/",
+        "https://sharedsasia.sasia.attest.azure.net/",
+        "https://sharedsau.sau.attest.azure.net/"
+      ],
+      "metadata": {
+        "description": "MAA Endpoint to attest to."
+      }
     }
   },
   "variables": {
@@ -166,9 +190,17 @@
       }
     },
     "addressPrefix": "10.0.0.0/16",
+    "ascReportingEndpoint": "https://sharedeus2.eus2.attest.azure.net/",
+    "ascReportingFrequency": "",
+    "disableAlerts": "false",
+    "extensionName": "GuestAttestation",
+    "extensionPublisher": "Microsoft.Azure.Security.LinuxAttestation",
+    "extensionVersion": "1.0",
+    "maaTenantName": "GuestAttestation",
     "subnetName": "Subnet",
     "subnetPrefix": "10.0.0.0/24",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('subnetName'))]",
+    "useAlternateToken": "false",
     "linuxConfiguration": {
       "disablePasswordAuthentication": true,
       "ssh": {
@@ -313,6 +345,32 @@
             "vTPMEnabled": "[parameters('VTPM')]"
           },
           "securityType": "TrustedLaunch"
+        }
+      }
+    },
+    {
+      "condition": "[and(equals(parameters('VTPM'), 'true'), equals(parameters('secureBoot'), 'true'))]",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "apiVersion": "2018-10-01",
+      "properties": {
+        "publisher": "[variables('extensionPublisher')]",
+        "type": "[variables('extensionName')]",
+        "typeHandlerVersion": "[variables('extensionVersion')]",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "AttestationEndpointCfg": {
+            "maaEndpoint": "[parameters('maaEndpoint')]",
+            "maaTenantName": "[variables('maaTenantName')]",
+            "ascReportingEndpoint": "[variables('ascReportingEndpoint')]",
+            "ascReportingFrequency": "[variables('ascReportingFrequency')]",
+            "useAlternateToken": "[variables('useAlternateToken')]",
+            "disableAlerts": "[variables('disableAlerts')]"
+          }
         }
       }
     }

--- a/quickstarts/microsoft.compute/vm-trustedlaunch-windows/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-windows/azuredeploy.json
@@ -161,6 +161,30 @@
       "metadata": {
         "description": "Name of the network security group"
       }
+    },
+    "maaEndpoint": {
+      "defaultValue": "https://sharedeus2.eus2.attest.azure.net/",
+      "type": "string",
+      "allowedValues": [
+        "https://sharedcus.cus.attest.azure.net/",
+        "https://sharedcae.cae.attest.azure.net/",
+        "https://sharedeus2.eus2.attest.azure.net/",
+        "https://shareduks.uks.attest.azure.net/",
+        "https://sharedcac.cac.attest.azure.net/",
+        "https://sharedukw.ukw.attest.azure.net/",
+        "https://sharedneu.neu.attest.azure.net/",
+        "https://sharedeus.eus.attest.azure.net/",
+        "https://sharedeau.eau.attest.azure.net/",
+        "https://sharedncus.ncus.attest.azure.net/",
+        "https://sharedwus.wus.attest.azure.net/",
+        "https://sharedweu.weu.attest.azure.net/",
+        "https://sharedscus.scus.attest.azure.net/",
+        "https://sharedsasia.sasia.attest.azure.net/",
+        "https://sharedsau.sau.attest.azure.net/"
+      ],
+      "metadata": {
+        "description": "MAA Endpoint to attest to."
+      }
     }
   },
   "variables": {
@@ -401,9 +425,17 @@
       }
     },
     "addressPrefix": "10.0.0.0/16",
+    "ascReportingEndpoint": "https://sharedeus2.eus2.attest.azure.net/",
+    "ascReportingFrequency": "",
+    "disableAlerts": "false",
+    "extensionName": "GuestAttestation",
+    "extensionPublisher": "Microsoft.Azure.Security.WindowsAttestation",
+    "extensionVersion": "1.0",
+    "maaTenantName": "GuestAttestation",
     "subnetName": "Subnet",
     "subnetPrefix": "10.0.0.0/24",
-    "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('subnetName'))]"
+    "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('subnetName'))]",
+    "useAlternateToken": "false"
   },
   "resources": [
     {
@@ -536,6 +568,32 @@
             "vTPMEnabled": "[parameters('VTPM')]"
           },
           "securityType": "TrustedLaunch"
+        }
+      }
+    },
+    {
+      "condition": "[and(equals(parameters('VTPM'), 'true'), equals(parameters('secureBoot'), 'true'))]",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "apiVersion": "2018-10-01",
+      "properties": {
+        "publisher": "[variables('extensionPublisher')]",
+        "type": "[variables('extensionName')]",
+        "typeHandlerVersion": "[variables('extensionVersion')]",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "AttestationEndpointCfg": {
+            "maaEndpoint": "[parameters('maaEndpoint')]",
+            "maaTenantName": "[variables('maaTenantName')]",
+            "ascReportingEndpoint": "[variables('ascReportingEndpoint')]",
+            "ascReportingFrequency": "[variables('ascReportingFrequency')]",
+            "useAlternateToken": "[variables('useAlternateToken')]",
+            "disableAlerts": "[variables('disableAlerts')]"
+          }
         }
       }
     }


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Adding Guest Attestation extension by default for Trusted Launch VMs that have Secureboot and vTPM enabled
