### PR TITLE
Installing Guest Attestation extension by default for Trusted Launch enabled Linux VMs

### DIFF
--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/README.md
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/README.md
@@ -13,7 +13,7 @@
 
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.compute%2Fvm-trustedlaunch-linux%2Fazuredeploy.json)
 
-This template deploys a [trusted launch](https://docs.microsoft.com/en-us/azure/virtual-machines/trusted-launch) capable Linux virtual machine using the latest patched version. By default, this will deploy a Standard_D2s_v3 size virtual machine in the resource group location and return the fully qualified domain name of the virtual machine.
+This template deploys a [trusted launch](https://docs.microsoft.com/en-us/azure/virtual-machines/trusted-launch) capable Linux virtual machine using the latest patched version. If you enable Secureboot and vTPM, the Guest Attestation extension will be installed on your VM. This extension will perform remote [attestation](https://docs.microsoft.com/en-us/windows/security/information-protection/tpm/tpm-fundamentals#measured-boot-with-support-for-attestation) by the cloud. By default, this will deploy a Standard_D2s_v3 size virtual machine in the resource group location and return the fully qualified domain name of the virtual machine.
 
 If you are new to Azure virtual machines, see:
 

--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
@@ -191,7 +191,6 @@
     },
     "addressPrefix": "10.0.0.0/16",
     "ascReportingEndpoint": "https://sharedeus2.eus2.attest.azure.net/",
-    "ascReportingFrequency": "",
     "disableAlerts": "false",
     "extensionName": "GuestAttestation",
     "extensionPublisher": "Microsoft.Azure.Security.LinuxAttestation",
@@ -354,9 +353,9 @@
       "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
       "location": "[parameters('location')]",
       "dependsOn": [
-        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+        "[resourceId('Microsoft.Compute/virtualMachines', parameters('vmName'))]"
       ],
-      "apiVersion": "2018-10-01",
+      "apiVersion": "2020-06-01",
       "properties": {
         "publisher": "[variables('extensionPublisher')]",
         "type": "[variables('extensionName')]",
@@ -367,7 +366,6 @@
             "maaEndpoint": "[parameters('maaEndpoint')]",
             "maaTenantName": "[variables('maaTenantName')]",
             "ascReportingEndpoint": "[variables('ascReportingEndpoint')]",
-            "ascReportingFrequency": "[variables('ascReportingFrequency')]",
             "useAlternateToken": "[variables('useAlternateToken')]",
             "disableAlerts": "[variables('disableAlerts')]"
           }

--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
@@ -309,6 +309,9 @@
       "apiVersion": "2020-12-01",
       "name": "[parameters('vmName')]",
       "location": "[parameters('location')]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
       "dependsOn": [
         "[resourceId('Microsoft.Network/networkInterfaces/', parameters('nicName'))]"
       ],

--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
@@ -136,6 +136,30 @@
       "metadata": {
         "description": "Name of the network security group"
       }
+    },
+    "maaEndpoint": {
+      "type": "string",
+      "defaultValue": "https://sharedeus2.eus2.attest.azure.net/",
+      "allowedValues": [
+        "https://sharedcus.cus.attest.azure.net/",
+        "https://sharedcae.cae.attest.azure.net/",
+        "https://sharedeus2.eus2.attest.azure.net/",
+        "https://shareduks.uks.attest.azure.net/",
+        "https://sharedcac.cac.attest.azure.net/",
+        "https://sharedukw.ukw.attest.azure.net/",
+        "https://sharedneu.neu.attest.azure.net/",
+        "https://sharedeus.eus.attest.azure.net/",
+        "https://sharedeau.eau.attest.azure.net/",
+        "https://sharedncus.ncus.attest.azure.net/",
+        "https://sharedwus.wus.attest.azure.net/",
+        "https://sharedweu.weu.attest.azure.net/",
+        "https://sharedscus.scus.attest.azure.net/",
+        "https://sharedsasia.sasia.attest.azure.net/",
+        "https://sharedsau.sau.attest.azure.net/"
+      ],
+      "metadata": {
+        "description": "MAA Endpoint to attest to."
+      }
     }
   },
   "variables": {
@@ -166,9 +190,17 @@
       }
     },
     "addressPrefix": "10.0.0.0/16",
+    "ascReportingEndpoint": "https://sharedeus2.eus2.attest.azure.net/",
+    "ascReportingFrequency": "",
+    "disableAlerts": "false",
+    "extensionName": "GuestAttestation",
+    "extensionPublisher": "Microsoft.Azure.Security.LinuxAttestation",
+    "extensionVersion": "1.0",
+    "maaTenantName": "GuestAttestation",
     "subnetName": "Subnet",
     "subnetPrefix": "10.0.0.0/24",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('virtualNetworkName'), variables('subnetName'))]",
+    "useAlternateToken": "false",
     "linuxConfiguration": {
       "disablePasswordAuthentication": true,
       "ssh": {
@@ -313,6 +345,32 @@
             "vTPMEnabled": "[parameters('VTPM')]"
           },
           "securityType": "TrustedLaunch"
+        }
+      }
+    },
+    {
+      "condition": "[and(equals(parameters('VTPM'), 'true'), equals(parameters('secureBoot'), 'true'))]",
+      "type": "Microsoft.Compute/virtualMachines/extensions",
+      "name": "[concat(parameters('vmName'), '/', variables('extensionName'))]",
+      "location": "[parameters('location')]",
+      "dependsOn": [
+        "[concat('Microsoft.Compute/virtualMachines/', parameters('vmName'))]"
+      ],
+      "apiVersion": "2018-10-01",
+      "properties": {
+        "publisher": "[variables('extensionPublisher')]",
+        "type": "[variables('extensionName')]",
+        "typeHandlerVersion": "[variables('extensionVersion')]",
+        "autoUpgradeMinorVersion": true,
+        "settings": {
+          "AttestationEndpointCfg": {
+            "maaEndpoint": "[parameters('maaEndpoint')]",
+            "maaTenantName": "[variables('maaTenantName')]",
+            "ascReportingEndpoint": "[variables('ascReportingEndpoint')]",
+            "ascReportingFrequency": "[variables('ascReportingFrequency')]",
+            "useAlternateToken": "[variables('useAlternateToken')]",
+            "disableAlerts": "[variables('disableAlerts')]"
+          }
         }
       }
     }

--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/metadata.json
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/metadata.json
@@ -3,11 +3,11 @@
   "type": "QuickStart",
   "itemDisplayName": "Deploy a trusted launch capable Linux virtual machine",
   "icon": "windowsVM",
-  "description": "This template allows you to deploy a trusted launch capable Linux virtual machine using a few different options for the Linux version, using the latest patched version. By default, this will deploy an Standard_D2_v3 size virtual machine in the resource group location and return the FQDN of the virtual machine.",
+  "description": "This template allows you to deploy a trusted launch capable Linux virtual machine using a few different options for the Linux version, using the latest patched version. If you enable Secureboot and vTPM, the Guest Attestation extension will be installed on your VM. This extension will perform remote [attestation](https://docs.microsoft.com/en-us/windows/security/information-protection/tpm/tpm-fundamentals#measured-boot-with-support-for-attestation) by the cloud. By default, this will deploy an Standard_D2_v3 size virtual machine in the resource group location and return the FQDN of the virtual machine.",
   "summary": "This template takes a minimum amount of parameters and deploys a trusted launch capable Linux virtual machine, using the latest patched version.",
-  "githubUsername": "prash2611",
+  "githubUsername": "sirfamelin",
   "docOwner": "cynthn",
-  "dateUpdated": "2021-05-12",
+  "dateUpdated": "2021-11-16",
   "environments": [
     "AzureCloud"
   ]


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Adding changes to install the Guest Attestation extension for Trusted Launch Linux VMs with Secureboot and vTPM enabled.
