### PR TITLE
Dynamically determine certificate end date for Windows VM with WinRM demo

### DIFF
--- a/demos/vm-winrm-windows/ConfigureWinRM.ps1
+++ b/demos/vm-winrm-windows/ConfigureWinRM.ps1
@@ -48,7 +48,11 @@ function Create-Certificate
 	# which golang tls/crypto <1.6.1 cannot handle
 	# https://github.com/golang/go/issues/8265
     $serial = Get-Random
-    .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e 01/01/2022 -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12 -# $serial 2>&1 | Out-Null
+    # Dynamically generate the end date for the certificate 
+    	# validity period to be a year from the date the
+	# script is run
+    $endDate = (Get-Date).AddYears(1).ToString("MM/dd/yyyy")
+    .\makecert -r -pe -n CN=$hostname -b 01/01/2012 -e $endDate -eku 1.3.6.1.5.5.7.3.1 -ss my -sr localmachine -sky exchange -sp "Microsoft RSA SChannel Cryptographic Provider" -sy 12 -# $serial 2>&1 | Out-Null
 
     $thumbprint=(Get-ChildItem cert:\Localmachine\my | Where-Object { $_.Subject -eq "CN=" + $hostname } | Select-Object -Last 1).Thumbprint
 

--- a/demos/vm-winrm-windows/azuredeploy.json
+++ b/demos/vm-winrm-windows/azuredeploy.json
@@ -244,7 +244,6 @@
           "apiVersion": "2021-07-01",
           "type": "Microsoft.Compute/virtualMachines/extensions",
           "name": "[concat(variables('vmName'),'/WinRMCustomScriptExtension')]",
-          "apiVersion": "[variables('apiVersion')]",
           "location": "[parameters('location')]",
           "dependsOn": [
             "[resourceId('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/demos/vm-winrm-windows/azuredeploy.json
+++ b/demos/vm-winrm-windows/azuredeploy.json
@@ -129,7 +129,7 @@
     {
       "comments": "Default Network Security Group for template",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2019-08-01",
+      "apiVersion": "2021-03-01",
       "name": "[variables('networkSecurityGroupName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -151,7 +151,7 @@
       }
     },
     {
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
@@ -178,7 +178,7 @@
       }
     },
     {
-      "apiVersion": "2015-06-15",
+      "apiVersion": "2021-03-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",
@@ -204,7 +204,7 @@
       }
     },
     {
-      "apiVersion": "2016-04-30-preview",
+      "apiVersion": "2021-07-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
@@ -241,6 +241,7 @@
       },
       "resources": [
         {
+          "apiVersion": "2021-07-01",
           "type": "Microsoft.Compute/virtualMachines/extensions",
           "name": "[concat(variables('vmName'),'/WinRMCustomScriptExtension')]",
           "apiVersion": "[variables('apiVersion')]",

--- a/demos/vm-winrm-windows/azuredeploy.json
+++ b/demos/vm-winrm-windows/azuredeploy.json
@@ -109,7 +109,6 @@
     "vmName": "[parameters('vmName')]",
     "virtualNetworkName": "[parameters('virtualNetworkName')]",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
-    "apiVersion": "2015-06-15",
     "hostDNSNameScriptArgument": "[concat('*.',parameters('location'),'.cloudapp.azure.com')]",
     "networkSecurityGroupName": "default-NSG"
   },

--- a/demos/vm-winrm-windows/metadata.json
+++ b/demos/vm-winrm-windows/metadata.json
@@ -5,5 +5,5 @@
   "description": "This template allows you to deploy a simple Windows VM using a few different options for the Windows version. This will then configure a WinRM https listener. User need to provide the value of parameter 'hostNameScriptArgument' which is the fqdn of the VM. Example: testvm.westus.cloupdapp.azure.com or *.westus.cloupdapp.azure.com",
   "summary": "This template takes a minimum amount of parameters and deploys a Windows VM and configures the WinRM https listener",
   "githubUsername": "MnrGreg",
-  "dateUpdated": "2021-05-18"
+  "dateUpdated": "2022-01-05"
 }


### PR DESCRIPTION
Updated the Create-Certification function to dynamically determine and set the certificate validity end date rather than using a static date string which is currently in the past, so new certificates are already expired.

This PR resolves Issue #12100 

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
