### PR TITLE
Replace depecated A2 v1 Sizes wiht A2_v2

### DIFF
--- a/application-workloads/rds/rds-deployment/azuredeploy.json
+++ b/application-workloads/rds/rds-deployment/azuredeploy.json
@@ -55,9 +55,9 @@
     },
     "VmSize": {
       "type": "string",
-      "defaultValue": "Standard_A2",
+      "defaultValue": "Standard_A2_v2",
       "allowedValues": [
-       "Standard_A2"
+       "Standard_A2_v2"
       ]
     },
     "rdshVmSize": {


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Replace deprecated A2 v1 VMSize with A2_v2 VMSize*
