### PR TITLE
Fix appInsightsLocation variable

### DIFF
--- a/quickstarts/microsoft.machinelearningservices/machine-learning-workspace-vnet/azuredeploy.json
+++ b/quickstarts/microsoft.machinelearningservices/machine-learning-workspace-vnet/azuredeploy.json
@@ -493,7 +493,7 @@
     {
       "condition": "[equals(parameters('storageAccountOption'), 'new')]",
       "type": "Microsoft.Storage/storageAccounts",
-      "apiVersion": "2019-06-01",
+      "apiVersion": "2021-08-01",
       "name": "[parameters('storageAccountName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -523,7 +523,7 @@
     {
       "condition": "[equals(parameters('keyVaultOption'), 'new')]",
       "type": "Microsoft.KeyVault/vaults",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-10-01",
       "name": "[parameters('keyVaultName')]",
       "location": "[parameters('location')]",
       "dependsOn": [
@@ -543,7 +543,7 @@
     {
       "condition": "[equals(parameters('containerRegistryOption'), 'new')]",
       "type": "Microsoft.ContainerRegistry/registries",
-      "apiVersion": "2019-12-01-preview",
+      "apiVersion": "2021-09-01",
       "name": "[parameters('containerRegistryName')]",
       "location": "[parameters('location')]",
       "sku": {
@@ -561,7 +561,7 @@
     {
       "condition": "[equals(parameters('applicationInsightsOption'), 'new')]",
       "type": "Microsoft.Insights/components",
-      "apiVersion": "2020-02-02-preview",
+      "apiVersion": "2020-02-02",
       "name": "[parameters('applicationInsightsName')]",
       "location": "[variables('appInsightsLocation')]",
       "kind": "web",
@@ -572,7 +572,7 @@
     },
     {
       "type": "Microsoft.MachineLearningServices/workspaces",
-      "apiVersion": "2020-09-01-preview",
+      "apiVersion": "2021-10-01",
       "name": "[parameters('workspaceName')]",
       "location": "[parameters('location')]",
       "identity": {

--- a/quickstarts/microsoft.machinelearningservices/machine-learning-workspace-vnet/azuredeploy.json
+++ b/quickstarts/microsoft.machinelearningservices/machine-learning-workspace-vnet/azuredeploy.json
@@ -389,7 +389,7 @@
     },
     "subnetPolicyForPE": {
       "privateEndpointNetworkPolicies": "Disabled",
-      "privateLinkServiceNetworkPolicies": "Disabled"
+      "privateLinkServiceNetworkPolicies": "Enabled"
     },
     "serviceEndpointsAll": [
       {
@@ -434,42 +434,8 @@
 	"encryptionUserAssignedIdentity": {
 		"userAssignedIdentity": "[variables('cmkUserAssignedIdentity')]"
 	},
-	"encryptionIdentity": "[if(not(equals(parameters('cmkUserAssignedIdentityName'), '')), variables('encryptionUserAssignedIdentity'), json('{}'))]",
-    "azAppInsightsLocationMap": {
-      "eastasia": "eastasia",
-      "southeastasia": "southeastasia",
-      "centralus": "southcentralus",
-      "eastus": "eastus",
-      "eastus2": "eastus2",
-      "westus": "westus",
-      "northcentralus": "northcentralus",
-      "southcentralus": "southcentralus",
-      "northeurope": "northeurope",
-      "westeurope": "westeurope",
-      "japanwest": "japanwest",
-      "japaneast": "japaneast",
-      "brazilsouth": "brazilsouth",
-      "australiaeast": "australiaeast",
-      "australiasoutheast": "australiasoutheast",
-      "southindia": "southindia",
-      "centralindia": "centralindia",
-      "westindia": "westindia",
-      "canadacentral": "canadacentral",
-      "canadaeast": "canadaeast",
-      "uksouth": "uksouth",
-      "ukwest": "ukwest",
-      "francecentral": "francecentral",
-      "westcentralus": "southcentralus",
-      "westus2": "westus2",
-      "koreacentral": "koreacentral",
-      "koreasouth": "koreasouth",
-      "eastus2euap": "southcentralus",
-      "centraluseuap": "southcentralus",
-      "usgovarizona": "usgovarizona",
-      "usgovvirginia": "usgovvirginia",
-      "chinaeast2": "chinaeast2"
-    },
-    "appInsightsLocation": "[variables('azAppInsightsLocationMap')[parameters('location')]]"
+    "encryptionIdentity": "[if(not(equals(parameters('cmkUserAssignedIdentityName'), '')), variables('encryptionUserAssignedIdentity'), json('{}'))]",
+    "appInsightsLocation": "[if(or(equals(parameters('location'),'westcentralus'), equals(parameters('location'),'eastus2euap'), equals(parameters('location'),'centraluseuap'), equals(parameters('location'),'westus3')),'southcentralus',parameters('location'))]"
   },
   "resources": [
     {

--- a/quickstarts/microsoft.machinelearningservices/machine-learning-workspace-vnet/metadata.json
+++ b/quickstarts/microsoft.machinelearningservices/machine-learning-workspace-vnet/metadata.json
@@ -3,10 +3,10 @@
   "type": "QuickStart",
   "itemDisplayName": "Create an Azure Machine Learning service workspace.",
   "description": "This deployment template specifies an Azure Machine Learning workspace, and its associated resources including Azure Key Vault, Azure Storage, Azure Application Insights and Azure Container Registry. This configuration describes the set of resources you require to get started with Azure Machine Learning in a network isolated set up.",
-  "summary": "This template creates an Azure Machine Learning service workspace while allowing for various security configuraitons.",
+  "summary": "This template creates an Azure Machine Learning service workspace while allowing for various security configurations.",
   "githubUsername": "guanyu-240",
   "docOwner": "Blackmist",
-  "dateUpdated": "2021-04-29",
+  "dateUpdated": "2022-03-22",
   "environments": [
     "AzureCloud",
     "AzureUSGovernment",


### PR DESCRIPTION
Fixed appInsightsLocation variable to only map to a different region in the case that app insights is not supported in that particular region (otherwise use the location of the workspace region).

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Fixed appInsightsLocation variable to only map to a different region in the case that app insights is not supported in that particular region (otherwise use the location of the workspace region).
