### PR TITLE
Update siteextensions and config resource names to match the resource type

### DIFF
--- a/quickstarts/microsoft.web/web-app-loganalytics/azuredeploy.json
+++ b/quickstarts/microsoft.web/web-app-loganalytics/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.4.412.5873",
-      "templateHash": "17494547911142744507"
+      "version": "0.4.1272.37030",
+      "templateHash": "14772506277968356191"
     }
   },
   "parameters": {
@@ -38,7 +38,6 @@
       }
     }
   },
-  "functions": [],
   "variables": {
     "appServicePlanName": "[toLower(format('asp-{0}', parameters('appName')))]",
     "webSiteName": "[toLower(format('wapp-{0}', parameters('appName')))]",

--- a/quickstarts/microsoft.web/web-app-loganalytics/main.bicep
+++ b/quickstarts/microsoft.web/web-app-loganalytics/main.bicep
@@ -57,11 +57,11 @@ resource appServiceLogging 'Microsoft.Web/sites/config@2020-06-01' = {
     APPINSIGHTS_INSTRUMENTATIONKEY: appInsights.properties.InstrumentationKey
   }
   dependsOn: [
-    appServiceAppSettings
+    appServiceSiteExtension
   ]
 }
 
-resource appServiceAppSettings 'Microsoft.Web/sites/siteextensions@2020-06-01' = {
+resource appServiceSiteExtension 'Microsoft.Web/sites/siteextensions@2020-06-01' = {
   parent: appService
   name: 'Microsoft.ApplicationInsights.AzureWebSites'
   dependsOn: [
@@ -69,7 +69,7 @@ resource appServiceAppSettings 'Microsoft.Web/sites/siteextensions@2020-06-01' =
   ]
 }
 
-resource appServiceSiteExtension 'Microsoft.Web/sites/config@2020-06-01' = {
+resource appServiceAppSettings 'Microsoft.Web/sites/config@2020-06-01' = {
   parent: appService
   name: 'logs'
   properties: {


### PR DESCRIPTION
Fix for issue #12389

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Update [web-app-loganalytics](https://github.com/Azure/azure-quickstart-templates/blob/df7965f67a76566bdb5c9f3e62452471595f1fdb/quickstarts/microsoft.web/web-app-loganalytics) bicep template siteextensions and config resource names to match the resource type.
