### PR TITLE
add defaultValue to adminPasswordOrKey

### DIFF
--- a/application-workloads/github-enterprise/github-enterprise/azuredeploy.json
+++ b/application-workloads/github-enterprise/github-enterprise/azuredeploy.json
@@ -50,6 +50,7 @@
     },
     "adminPasswordOrKey": {
       "type": "securestring",
+      "defaultValue": "GEN-SSH-PUB-KEY",
       "metadata": {
         "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Adds a defaultValue to `adminPasswordOrKey` so that errors like [this](https://github.com/Azure/azure-quickstart-templates/issues/12216) don't occur when using the [GitHub Enterprise on Azure template](https://github.com/Azure/azure-quickstart-templates/tree/master/application-workloads/github-enterprise/github-enterprise)
