### PR TITLE
Adding `defaultValue` to `adminPasswordOrKey` to avoid azure deploy failure

### DIFF
--- a/application-workloads/github-enterprise/github-enterprise/azuredeploy.json
+++ b/application-workloads/github-enterprise/github-enterprise/azuredeploy.json
@@ -50,6 +50,7 @@
     },
     "adminPasswordOrKey": {
       "type": "securestring",
+      "defaultValue": "",
       "metadata": {
         "description": "SSH Key or password for the Virtual Machine. SSH key is recommended."
       }


### PR DESCRIPTION
This will avoid error during deployment : `Deployment template validation failed: 'The value for the template parameter 'adminPasswordOrKey' at line '51' and column '27' is not provided. Please see <https://aka.ms/resource-manager-parameter-files> for usage details.'. (Code: InvalidTemplate)`

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
