### PR TITLE
Corrected typo virtualVan into VirtualWan

### DIFF
--- a/quickstarts/microsoft.network/fwm-docs-qs/main.bicep
+++ b/quickstarts/microsoft.network/fwm-docs-qs/main.bicep
@@ -11,7 +11,7 @@ param location string = resourceGroup().location
 @description('Size of the virtual machine.')
 param vmSize string = 'Standard_D2_v3'
 
-resource virtualVan 'Microsoft.Network/virtualWans@2021-08-01' = {
+resource virtualWan 'Microsoft.Network/virtualWans@2021-08-01' = {
   name: 'VWan-01'
   location: location
   properties: {
@@ -27,7 +27,7 @@ resource virtualHub 'Microsoft.Network/virtualHubs@2021-08-01' = {
   properties: {
     addressPrefix: '10.1.0.0/16'
     virtualWan: {
-      id: virtualVan.id
+      id: virtualWan.id
     }
   }
 }


### PR DESCRIPTION
Correcting typo virtualVan into virtualWan.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [v] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Corrected a type in the deployment reference name from virtualVan into VirtualWan.
*
*
