### PR TITLE
Update metadata.json

### DIFF
--- a/demos/ag-docs-wafv2/metadata.json
+++ b/demos/ag-docs-wafv2/metadata.json
@@ -5,7 +5,7 @@
   "summary": "Create an Azure Web Application Firewall v2 on Azure Application Gateway",
   "githubUsername": "vhorne",
   "docOwner": "vhorne",
-  "dateUpdated": "2022-08-12",
+  "dateUpdated": "2022-08-19",
   "type": "QuickStart",
   "environments": [
     "AzureCloud"


### PR DESCRIPTION

[CreateADPDC.zip]

- contains modified CreateADPDC.ps1 with the following code added:

	Script GuestAgent
	    {
	    SetScript = {
            Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\WindowsAzureGuestAgent' -Name DependOnService -Type MultiString -Value DNS
	    Write-Verbose -Verbose "GuestAgent depends on DNS"
	    }
            GetScript =  { @{} }
            TestScript = { $false }
               DependsOn = "[WindowsFeature]DNS"
        }

This adds a delay to the guest agent after a reboot, that forces the guest agent to wait for the dns service to be up before trying to restart the dsc extension which fails in west us region because the DSC tries to make a connection to the azure AD server before the dns service is ready.
