### PR TITLE
Fix Key Vault private DNS zone name in microsoft.machinelearningservices/machine-learning-end-to-end-secure

### DIFF
--- a/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/metadata.json
+++ b/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/metadata.json
@@ -5,7 +5,7 @@
     "description": "This set of Bicep templates demonstrates how to set up Azure Machine Learning end-to-end in a secure set up. This reference implementation includes the Workspace, a compute cluster, compute instance and attached private AKS cluster.",
     "summary": "This set of Bicep templates demonstrates how to set up Azure Machine Learning end-to-end in a secure set up.",
     "githubUsername": "deeikele",
-    "dateUpdated": "2022-09-30",
+    "dateUpdated": "2022-12-07",
     "environments": [
       "AzureCloud",
       "AzureUSGovernment"

--- a/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/metadata.json
+++ b/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/metadata.json
@@ -5,7 +5,7 @@
     "description": "This set of Bicep templates demonstrates how to set up Azure Machine Learning end-to-end in a secure set up. This reference implementation includes the Workspace, a compute cluster, compute instance and attached private AKS cluster.",
     "summary": "This set of Bicep templates demonstrates how to set up Azure Machine Learning end-to-end in a secure set up.",
     "githubUsername": "deeikele",
-    "dateUpdated": "2022-09-15",
+    "dateUpdated": "2022-09-30",
     "environments": [
       "AzureCloud",
       "AzureUSGovernment"

--- a/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/metadata.json
+++ b/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/metadata.json
@@ -5,7 +5,7 @@
     "description": "This set of Bicep templates demonstrates how to set up Azure Machine Learning end-to-end in a secure set up. This reference implementation includes the Workspace, a compute cluster, compute instance and attached private AKS cluster.",
     "summary": "This set of Bicep templates demonstrates how to set up Azure Machine Learning end-to-end in a secure set up.",
     "githubUsername": "deeikele",
-    "dateUpdated": "2022-04-08",
+    "dateUpdated": "2022-09-15",
     "environments": [
       "AzureCloud",
       "AzureUSGovernment"

--- a/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/modules/keyvault.bicep
+++ b/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/modules/keyvault.bicep
@@ -17,7 +17,7 @@ param subnetId string
 @description('The VNet ID where the Key Vault Private Link is to be created')
 param virtualNetworkId string
 
-var privateDnsZoneName = 'privatelink${environment().suffixes.keyvaultDns}'
+var privateDnsZoneName = 'privatelink.vaultcore.azure.net'
 
 resource keyVault 'Microsoft.KeyVault/vaults@2021-10-01' = {
   name: keyvaultName

--- a/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/modules/privateaks.bicep
+++ b/quickstarts/microsoft.machinelearningservices/machine-learning-end-to-end-secure/modules/privateaks.bicep
@@ -28,7 +28,6 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2020-07-01' = {
     type: 'SystemAssigned'
   }
   properties: {
-    kubernetesVersion: '1.22.4'
     dnsPrefix: '${aksClusterName}-dns'
     agentPoolProfiles: [
       {


### PR DESCRIPTION
"privatelink${environment().suffixes.keyvaultDns}" resolves to "privatelink.vault.azure.net" which is incorrect. Correct private DNS zone for Key Vault should be "privatelink.vaultcore.azure.net"

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Fix Key Vault private DNS zone in microsoft.machinelearningservices/machine-learning-end-to-end-secure

