### PR TITLE
Restrict allowed length of VM name  to 15

### DIFF
--- a/application-workloads/active-directory/active-directory-new-domain/azuredeploy.json
+++ b/application-workloads/active-directory/active-directory-new-domain/azuredeploy.json
@@ -56,6 +56,7 @@
         },
         "virtualMachineName": {
             "type": "string",
+            "maxLength": 15,
             "defaultValue": "adVM",
             "metadata": {
                 "description": "Virtual machine name."


### PR DESCRIPTION
Since VM name is used as the computer name, the maximum allowed length is 15. If this template is deployed with usual naming conventions of VM, most likely it will fail.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
