### PR TITLE
Attempt to fix failure for accounts without higher level of permissions.

### DIFF
--- a/quickstarts/microsoft.datafactory/data-factory-copy-data-tool/main.bicep
+++ b/quickstarts/microsoft.datafactory/data-factory-copy-data-tool/main.bicep
@@ -45,11 +45,11 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2022-
   location: location
 }
 
-resource bootstrapRoleAssignmentId 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+resource bootstrapRoleAssignmentId 'Microsoft.Authorization/roleAssignments@2022-01-01-preview' = {
   name: bootstrapRoleAssignmentName 
   properties: {
     roleDefinitionId: roleDefinitionId
-    principalId: managedIdentity.properties.principalId
+    principalId: reference(managedIdentity.id, '2022-01-31-preview').principalId
     principalType: 'ServicePrincipal'
   }
 }


### PR DESCRIPTION
A very similar data-factory-get-started quickstart template succeeds for a less privileged account but this template requires a higher level of permissions, so it fails for my account where the other template succeeds.  The only change I made in this one was to remove all of the data factory specific objects that we don't need in this quickstart, and later, in an attempt to fix a build error, changing the version of a reference that Jonathan Gao suggested might resolve the build failure.  It ended up being something else, but afterward, I discovered the failure running it.  My theory is that version reference update caused a higher level of permissions to be required.  I'm reverting it here in hopes that I can make the quickstart work for lower privileged accounts the same as the get-started template does now.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
