### PR TITLE
Only support ASE install for mobilenetwork-create-full-5gc-deployment

### DIFF
--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/README.md
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/README.md
@@ -30,7 +30,7 @@ This template deploys a Private 5G Core. The Private 5G Core is a deployed with 
 
 ## Prerequisites
 
-By default this template does not deploy any resources to the Azure Stack Edge. If you want to deploy to an Azure Stack Edge then you must follow the pre-requisite instructions in the Private 5G Core [documentation](https://docs.microsoft.com/azure/private-5g-core/complete-private-mobile-network-prerequisites) before starting the deployment so that you can specify the customLocation and azureStackEdgeDevice parameters.
+By default this template does not deploy any resources to the Azure Stack Edge. If you want to deploy to an Azure Stack Edge then you must follow the pre-requisite instructions in the Private 5G Core [documentation](https://docs.microsoft.com/azure/private-5g-core/complete-private-mobile-network-prerequisites) before starting the deployment so that you can specify the customLocation parameter.
 
 ## Deployment steps
 

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/README.md
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/README.md
@@ -30,7 +30,7 @@ This template deploys a Private 5G Core. The Private 5G Core is a deployed with 
 
 ## Prerequisites
 
-By default this template does not deploy any resources to the Azure Stack Edge. If you want to deploy to an Azure Stack Edge then you must follow the pre-requisite instructions in the Private 5G Core [documentation](https://docs.microsoft.com/azure/private-5g-core/complete-private-mobile-network-prerequisites) before starting the deployment so that you can specify the customLocation parameter.
+By default this template does not deploy any resources to the Azure Stack Edge. If you want to deploy to an Azure Stack Edge then you must follow the pre-requisite instructions in the Private 5G Core [documentation](https://docs.microsoft.com/azure/private-5g-core/complete-private-mobile-network-prerequisites) before starting the deployment so that you can specify the customLocation and azureStackEdgeDevice parameters.
 
 ## Deployment steps
 

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/azuredeploy.parameters.json
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/azuredeploy.parameters.json
@@ -41,8 +41,8 @@
                 }
             ]
         },
-        "platformType": {
-            "value": "AKS-HCI"
+        "azureStackEdgeDevice": {
+            "value": ""
         },
         "controlPlaneAccessInterfaceName": {
             "value": "GEN-UNIQUE"
@@ -53,26 +53,8 @@
         "userPlaneAccessInterfaceName": {
             "value": "GEN-UNIQUE"
         },
-        "userPlaneAccessInterfaceIpAddress": {
-            "value": "10.0.0.3"
-        },
-        "accessSubnet": {
-            "value": "10.0.0.0/24"
-        },
-        "accessGateway": {
-            "value": "10.0.0.1"
-        },
         "userPlaneDataInterfaceName": {
             "value": "GEN-UNIQUE"
-        },
-        "userPlaneDataInterfaceIpAddress": {
-            "value": "11.0.0.2"
-        },
-        "userPlaneDataInterfaceSubnet": {
-            "value": "11.0.0.0/24"
-        },
-        "userPlaneDataInterfaceGateway": {
-            "value": "11.0.0.1"
         },
         "userEquipmentAddressPoolPrefix": {
             "value": "12.0.0.0/24"

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/azuredeploy.parameters.json
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/azuredeploy.parameters.json
@@ -42,7 +42,7 @@
             ]
         },
         "azureStackEdgeDevice": {
-            "value": ""
+            "value": "GET-PREREQ-aseID"
         },
         "controlPlaneAccessInterfaceName": {
             "value": "GEN-UNIQUE"

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
@@ -25,6 +25,12 @@ param sliceName string = 'slice-1'
 @description('The name for the SIM group.')
 param simGroupName string = ''
 
+@description('A unversioned key vault key to encrypt the SIM data that belongs to this SIM group. For example: https://contosovault.vault.azure.net/keys/azureKey.')
+param existingEncryptionKeyUrl string = ''
+
+@description('User-assigned identity is an identity in Azure Active Directory that can be used to give access to other Azure resource such as Azure Key Vault. This identity should have Get, Wrap key, and Unwrap key permissions on the key vault.')
+param existingUserAssignedIdentityResourceId string = ''
+
 @description('An array containing properties of the SIM(s) you wish to create. See [Provision proxy SIM(s)](https://docs.microsoft.com/en-gb/azure/private-5g-core/provision-sims-azure-portal) for a full description of the required properties and their format.')
 param simResources array = []
 

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
@@ -232,7 +232,7 @@ resource examplePacketCoreControlPlane 'Microsoft.MobileNetwork/packetCoreContro
       customLocation: empty(customLocation) ? null : {
         id: customLocation
       }
-      azureStackEdgeDevice: empty(azureStackEdgeDevice) ? null : {
+      azureStackEdgeDevice: {
         id: azureStackEdgeDevice
       }
     }

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
@@ -192,13 +192,24 @@ resource exampleSimPolicy 'Microsoft.MobileNetwork/mobileNetworks/simPolicies@20
 }
 
 #disable-next-line BCP081
-resource exampleSimGroupResource 'Microsoft.MobileNetwork/simGroups@2022-04-01-preview' = if (!empty(simGroupName)) {
+resource exampleSimGroupResource 'Microsoft.Network/simGroups@2022-04-01-preview' = if (!empty(simGroupName)) {
   name: empty(simGroupName) ? 'placeHolderForValidation' : simGroupName
   location: location
   properties: {
     mobileNetwork: {
       id: exampleMobileNetwork.id
     }
+    encryptionKey: {
+        keyUrl: existingEncryptionKeyUrl
+    }
+  }
+  identity: !empty(existingUserAssignedIdentityResourceId) ? {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${existingUserAssignedIdentityResourceId}': {}
+    }
+  } : {
+    type: 'None'
   }
 
   #disable-next-line BCP081

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
@@ -232,7 +232,7 @@ resource examplePacketCoreControlPlane 'Microsoft.MobileNetwork/packetCoreContro
       customLocation: empty(customLocation) ? null : {
         id: customLocation
       }
-      azureStackEdgeDevice: {
+      azureStackEdgeDevice: empty(azureStackEdgeDevice) ? null : {
         id: azureStackEdgeDevice
       }
     }

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
@@ -25,51 +25,23 @@ param sliceName string = 'slice-1'
 @description('The name for the SIM group.')
 param simGroupName string = ''
 
-@description('A unversioned key vault key to encrypt the SIM data that belongs to this SIM group. For example: https://contosovault.vault.azure.net/keys/azureKey.')
-param existingEncryptionKeyUrl string = ''
-
-@description('User-assigned identity is an identity in Azure Active Directory that can be used to give access to other Azure resource such as Azure Key Vault. This identity should have Get, Wrap key, and Unwrap key permissions on the key vault.')
-param existingUserAssignedIdentityResourceId string = ''
-
 @description('An array containing properties of the SIM(s) you wish to create. See [Provision proxy SIM(s)](https://docs.microsoft.com/en-gb/azure/private-5g-core/provision-sims-azure-portal) for a full description of the required properties and their format.')
 param simResources array = []
 
-@description('The platform type where packet core is deployed.')
-@allowed([
-  'AKS-HCI'
-  'BaseVM'
-])
-param platformType string = 'AKS-HCI'
+@description('The resource ID of the Azure Stack Edge device to deploy to')
+param azureStackEdgeDevice string = ''
 
-@description('The name of the control plane interface on the access network. In 5G networks this is called the N2 interface whereas in 4G networks this is called the S1-MME interface. This should match one of the interfaces configured on your Azure Stack Edge machine.')
+@description('The virtual network name on port 5 on your Azure Stack Edge Pro device. This is the virtual network that will be used for the control plane interface on the access network. For 5G, this interface is the N2 interface, whereas for 4G, it\'s the S1-MME interface.')
 param controlPlaneAccessInterfaceName string = ''
 
 @description('The IP address of the control plane interface on the access network. In 5G networks this is called the N2 interface whereas in 4G networks this is called the S1-MME interface.')
 param controlPlaneAccessIpAddress string = ''
 
-@description('The logical name of the user plane interface on the access network. In 5G networks this is called the N3 interface whereas in 4G networks this is called the S1-U interface. This should match one of the interfaces configured on your Azure Stack Edge machine.')
+@description('The virtual network name on port 5 on your Azure Stack Edge Pro device. This is the virtual network that will be used for the user plane interface on the access network. For 5G, this interface is the N3 interface, whereas for 4G, it\'s the S1-U interface.')
 param userPlaneAccessInterfaceName string = ''
 
-@description('The IP address of the user plane interface on the access network. In 5G networks this is called the N3 interface whereas in 4G networks this is called the S1-U interface. Not required for AKS-HCI.')
-param userPlaneAccessInterfaceIpAddress string = ''
-
-@description('The network address of the access subnet in CIDR notation')
-param accessSubnet string = ''
-
-@description('The access subnet default gateway')
-param accessGateway string = ''
-
-@description('The logical name of the user plane interface on the data network. In 5G networks this is called the N6 interface whereas in 4G networks this is called the SGi interface. This should match one of the interfaces configured on your Azure Stack Edge machine.')
+@description('The virtual network name on port 6 on your Azure Stack Edge Pro device. This is the virtual network that will be used for the user plane interface on the data network. For 5G, this interface is the N6 interface, whereas for 4G, it\'s the SGi interface.')
 param userPlaneDataInterfaceName string = ''
-
-@description('The IP address of the user plane interface on the data network. In 5G networks this is called the N6 interface whereas in 4G networks this is called the SGi interface. Not required for AKS-HCI.')
-param userPlaneDataInterfaceIpAddress string = ''
-
-@description('The network address of the data subnet in CIDR notation')
-param userPlaneDataInterfaceSubnet string = ''
-
-@description('The data subnet default gateway')
-param userPlaneDataInterfaceGateway string = ''
 
 @description('The network address of the subnet from which dynamic IP addresses must be allocated to UEs, given in CIDR notation. Optional if userEquipmentStaticAddressPoolPrefix is specified. If both are specified, they must be the same size and not overlap.')
 param userEquipmentAddressPoolPrefix string = ''
@@ -227,17 +199,6 @@ resource exampleSimGroupResource 'Microsoft.MobileNetwork/simGroups@2022-04-01-p
     mobileNetwork: {
       id: exampleMobileNetwork.id
     }
-    encryptionKey: {
-        keyUrl: existingEncryptionKeyUrl
-    }
-  }
-  identity: !empty(existingUserAssignedIdentityResourceId) ? {
-    type: 'UserAssigned'
-    userAssignedIdentities: {
-      '${existingUserAssignedIdentityResourceId}': {}
-    }
-  } : {
-    type: 'None'
   }
 
   #disable-next-line BCP081
@@ -267,15 +228,16 @@ resource examplePacketCoreControlPlane 'Microsoft.MobileNetwork/packetCoreContro
     sku: 'EvaluationPackage'
     coreNetworkTechnology: coreNetworkTechnology
     platform: {
-      type: platformType
+      type: 'AKS-HCI'
       customLocation: empty(customLocation) ? null : {
         id: customLocation
+      }
+      azureStackEdgeDevice: {
+        id: azureStackEdgeDevice
       }
     }
     controlPlaneAccessInterface: {
       ipv4Address: controlPlaneAccessIpAddress
-      ipv4Subnet: accessSubnet
-      ipv4Gateway: accessGateway
       name: controlPlaneAccessInterfaceName
     }
   }
@@ -286,9 +248,6 @@ resource examplePacketCoreControlPlane 'Microsoft.MobileNetwork/packetCoreContro
     location: location
     properties: {
       userPlaneAccessInterface: {
-        ipv4Address: userPlaneAccessInterfaceIpAddress
-        ipv4Subnet: accessSubnet
-        ipv4Gateway: accessGateway
         name: userPlaneAccessInterfaceName
       }
     }
@@ -299,9 +258,6 @@ resource examplePacketCoreControlPlane 'Microsoft.MobileNetwork/packetCoreContro
       location: location
       properties: {
         userPlaneDataInterface: {
-          ipv4Address: userPlaneDataInterfaceIpAddress
-          ipv4Subnet: userPlaneDataInterfaceSubnet
-          ipv4Gateway: userPlaneDataInterfaceGateway
           name: userPlaneDataInterfaceName
         }
         userEquipmentAddressPoolPrefix: empty(userEquipmentAddressPoolPrefix) ? null : [

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/main.bicep
@@ -198,7 +198,7 @@ resource exampleSimPolicy 'Microsoft.MobileNetwork/mobileNetworks/simPolicies@20
 }
 
 #disable-next-line BCP081
-resource exampleSimGroupResource 'Microsoft.Network/simGroups@2022-04-01-preview' = if (!empty(simGroupName)) {
+resource exampleSimGroupResource 'Microsoft.MobileNetwork/simGroups@2022-04-01-preview' = if (!empty(simGroupName)) {
   name: empty(simGroupName) ? 'placeHolderForValidation' : simGroupName
   location: location
   properties: {

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/metadata.json
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/metadata.json
@@ -4,7 +4,7 @@
     "description": "This template creates all resources required to deploy a Private 5G Core, including provisioning sims and creating sample QoS policy. It can optionally be deployed to a Kubernetes cluster running on an Azure Stack Edge device.",
     "summary": "Create a Private 5G Core with all required elements and optionally deploy to an ASE.",
     "githubUsername": "rainbowFi",
-    "dateUpdated": "2022-09-26",
+    "dateUpdated": "2022-10-25",
     "type": "QuickStart",
     "environments": [
         "AzureCloud"

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/prereqs/prereq.azuredeploy.parameters.json
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/prereqs/prereq.azuredeploy.parameters.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "location": {
+            "value": "eastus"
+        },
+        "azureStackEdgeName": {
+            "value": "GEN-UNIQUE"
+        }
+    }
+}

--- a/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/prereqs/prereq.main.bicep
+++ b/quickstarts/microsoft.mobilenetwork/mobilenetwork-create-full-5gc-deployment/prereqs/prereq.main.bicep
@@ -1,0 +1,12 @@
+@description('The name for the AzureStackEdgeName')
+param azureStackEdgeName string
+
+@description('Region where the AzureStackEdgeName will be deployed (must match the resource group region)')
+param location string = resourceGroup().location
+
+resource exampleAzureStackEdge 'Microsoft.DataBoxEdge/DataBoxEdgeDevices@2020-01-01' = {
+  name: azureStackEdgeName
+  location: location
+}
+
+output aseID string = exampleAzureStackEdge.id


### PR DESCRIPTION
# PR Checklist

This supercedes https://github.com/Azure/azure-quickstart-templates/pull/12811
and is the sister commit to https://github.com/Azure/azure-quickstart-templates/pull/12939


Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* The 'mobilenetwork-create-full-5gc-deployment' now only works on ASEs and therefore the parameters for the template have changed - subnet and gateway information is no longer needed, instead a AzureStackEdgeDevice ID is now mandatory. 

