### PR TITLE
Remove UpdateSubnetPolicy task for PE workspace creation with existing subnet

### DIFF
--- a/quickstarts/microsoft.machinelearningservices/machine-learning-workspace-vnet-v1-legacy-mode/azuredeploy.json
+++ b/quickstarts/microsoft.machinelearningservices/machine-learning-workspace-vnet-v1-legacy-mode/azuredeploy.json
@@ -387,10 +387,6 @@
         }
       ]
     },
-    "subnetPolicyForPE": {
-      "privateEndpointNetworkPolicies": "Disabled",
-      "privateLinkServiceNetworkPolicies": "Enabled"
-    },
     "serviceEndpointsAll": [
       {
         "service": "Microsoft.Storage"
@@ -463,31 +459,7 @@
       ],
       "properties": {
         "addressPrefix": "[parameters('subnetPrefix')]",
-        "privateEndpointNetworkPolicies": "Disabled",
-        "privateLinkServiceNetworkPolicies": "Enabled",
         "serviceEndpoints": "[if(equals(toLower(environment().name), 'azurechinacloud'), variables('serviceEndpointsAzureChinaCloud'), variables('serviceEndpointsAll') )]"
-      }
-    },
-    {
-      "condition": "[and(equals(parameters('subnetOption'), 'existing'), not(equals(parameters('privateEndpointType'), 'none')))]",
-      "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2021-04-01",
-      "name": "UpdateSubnetPolicy",
-      "resourceGroup": "[parameters('vnetResourceGroupName')]",
-      "properties": {
-        "mode": "Incremental",
-        "template": {
-          "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-          "contentVersion": "1.0.0.0",
-          "resources": [
-            {
-              "type": "Microsoft.Network/virtualNetworks/subnets",
-              "apiVersion": "2021-04-01",
-              "name": "[concat(parameters('vnetName'), '/', parameters('subnetName'))]",
-              "properties": "[if(and(equals(parameters('subnetOption'), 'existing'), not(equals(parameters('privateEndpointType'), 'none'))), union(reference(variables('subnet'), '2020-06-01'), variables('subnetPolicyForPE')), json('null'))]"
-            }
-          ]
-        }
       }
     },
     {


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Remove UpdateSubnetPolicy step from workspace creation deployment tasks so that Network Contributor role is not needed by user creating the workspace with PE and existing subnet. I confirmed that the two policies being updated, privateEndpointNetworkPolicies and privateLinkServiceNetworkPolicies, are both being set to the default values that subnets have upon creation, so removing this task will not create any issues unless the user-provided subnet had these properties modified after creation.
