### PR TITLE
Properly reference IoT Hub key value

### DIFF
--- a/quickstarts/microsoft.devices/iothub-device-provisioning/azuredeploy.json
+++ b/quickstarts/microsoft.devices/iothub-device-provisioning/azuredeploy.json
@@ -70,7 +70,7 @@
       "properties": {
         "iotHubs": [
           {
-            "connectionString": "[format('HostName={0};SharedAccessKeyName={1};SharedAccessKey={2}', reference(resourceId('Microsoft.Devices/IotHubs', parameters('iotHubName'))).hostName, variables('iotHubKey'), listkeys(resourceId('Microsoft.Devices/IotHubs', parameters('iotHubName')), '2021-07-02').value)]",
+            "connectionString": "[format('HostName={0};SharedAccessKeyName={1};SharedAccessKey={2}', reference(resourceId('Microsoft.Devices/IotHubs', parameters('iotHubName'))).hostName, variables('iotHubKey'), listkeys(resourceId('Microsoft.Devices/IotHubs', parameters('iotHubName')), '2021-07-02').value[0].primaryKey)]",
             "location": "[parameters('location')]"
           }
         ]


### PR DESCRIPTION
The current ARM template results in a "500019" error during deployment of the DPS resource. 

```json
{
    "status": "Failed",
    "error": {
        "code": "500019",
        "message": "Internal Error. If you contact a support representative please include this correlation identifier: ****, timestamp: ****, errorcode: IH500019."
    }
}
```

The reason behind this is the manner in which the "IoT Hub's `iothubowner` primary key" is referenced:

```json
{
    "connectionString": "[format('HostName={0};SharedAccessKeyName={1};SharedAccessKey={2}', reference(resourceId('Microsoft.Devices/IotHubs', parameters('iotHubName'))).hostName, variables('iotHubKey'), listkeys(resourceId('Microsoft.Devices/IotHubs', parameters('iotHubName')), '2021-07-02').value)]",
    "location": "[parameters('location')]"
}
```

The IoT Hub RP defines their "List Keys" operation by returning `value` as an **array of objects defining each key type**. 

[Iot Hub Resource - List Keys](https://learn.microsoft.com/en-us/rest/api/iothub/iot-hub-resource/list-keys?tabs=HTTP)

As such simply getting the `value` field would result in including the array as part of a string, resulting in DPS failing to decipher the "connection string".

The proposal here is to retrieve the `value[0].primaryKey` field from what is returned by the `listKeys` function. Hardcoding the index number is not an ideal solution, but no elegant solution can be achieved considering the limitation of the template syntax (e.g. no array iterations) and the definition of the return value.

I have confirmed that this modification led to a successful deployment of both the IoT Hub and DPS resources using the template.


# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
