### PR TITLE
Disable allowBlobPublicAccess to storage account

### DIFF
--- a/quickstarts/microsoft.web/function-app-storage-private-endpoints/main.bicep
+++ b/quickstarts/microsoft.web/function-app-storage-private-endpoints/main.bicep
@@ -325,6 +325,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
   }
   properties: {
     publicNetworkAccess: 'Disabled'
+    allowBlobPublicAccess: 'false'
     networkAcls: {
       bypass: 'None'
       defaultAction: 'Deny'

--- a/quickstarts/microsoft.web/function-app-storage-private-endpoints/main.bicep
+++ b/quickstarts/microsoft.web/function-app-storage-private-endpoints/main.bicep
@@ -64,7 +64,7 @@ var functionContentShareName = 'function-content-share'
 // See https://docs.microsoft.com/en-us/azure/templates/microsoft.web/serverfarms?tabs=json#appserviceplanproperties-object.
 var isReserved = (functionPlanOS == 'Linux') ? true : false
 
-resource virtualNetwork 'Microsoft.Network/virtualNetworks@2020-07-01' = {
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2022-05-01' = {
   name: vnetName
   location: location
   properties: {
@@ -325,7 +325,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2021-09-01' = {
   }
   properties: {
     publicNetworkAccess: 'Disabled'
-    allowBlobPublicAccess: 'false'
+    allowBlobPublicAccess: false
     networkAcls: {
       bypass: 'None'
       defaultAction: 'Deny'

--- a/quickstarts/microsoft.web/function-app-storage-private-endpoints/metadata.json
+++ b/quickstarts/microsoft.web/function-app-storage-private-endpoints/metadata.json
@@ -4,7 +4,7 @@
   "description": "This template allows you to deploy an Azure Function App that communicates with Azure Storage over private endpoints.",
   "summary": "This template allows you to deploy an Azure Function App that communicates with Azure Storage over private endpoints.",
   "githubUsername": "gabesmsft",
-  "dateUpdated": "2022-06-06",
+  "dateUpdated": "2022-10-31",
   "type": "QuickStart",
   "environments": [
     "AzureCloud"


### PR DESCRIPTION
Adding the allowBlobPublicAccess attribute to false in the bicep code. This will block public access to the blob storage account.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
