### PR TITLE
Update azuredeploy.json

### DIFF
--- a/quickstarts/microsoft.hdinsight/hdinsight-linux-add-edge-node/azuredeploy.json
+++ b/quickstarts/microsoft.hdinsight/hdinsight-linux-add-edge-node/azuredeploy.json
@@ -28,7 +28,7 @@
       "metadata": {
         "description": "A script action folder holding the script."
       },
-      "defaultValue": "scripts"
+      "defaultValue": "hdinsight-linux-add-edge-node/scripts"
     },
     "installScriptAction": {
       "type": "string",


### PR DESCRIPTION
default value is pointing to wrong script action uri https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/quickstarts/microsoft.hdinsight/scripts/EmptyNodeSetup.sh, changed installScriptActionFolder to hdinsight-linux-add-edge-node/scripts

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
