### PR TITLE
Update azuredeploy.json

### DIFF
--- a/demos/haproxy-redundant-floatingip-ubuntu/azuredeploy.json
+++ b/demos/haproxy-redundant-floatingip-ubuntu/azuredeploy.json
@@ -99,7 +99,7 @@
     "imageOffer": "UbuntuServer",
     "sshKeyPath": "[concat('/home/',parameters('adminUsername'),'/.ssh/authorized_keys')]",
     "nicNamePrefix": "nic-",
-    "storageAccountType": "StandardSSD_LRS",
+    "storageAccountType": "Standard_LRS",
     "haproxyAvailabilitySetName": "haproxyAvSet",
     "appAvailabilitySetName": "appAvSet",
     "vnetName": "haproxyVNet",


### PR DESCRIPTION
The variable StandardSSD_LRS is not a valid type of storage account, the deployment will fail with this value. Changing it to Standard_LRS will work.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
