### PR TITLE
[BULK] Replace incorrect "AlwaysOn" with "availability group"

### DIFF
--- a/quickstarts/microsoft.sqlvirtualmachine/sql-vm-aglistener-setup/README.md
+++ b/quickstarts/microsoft.sqlvirtualmachine/sql-vm-aglistener-setup/README.md
@@ -1,5 +1,5 @@
 ---
-description: Deploy SQL AvailabilityGroup listener on existing Always ON setup. This creates Listener on an existing SQL Availability Group, sets up corresponding load balancer rules and probe ports on Azure Load balancer to get the listener connections working.
+description: Deploy SQL AvailabilityGroup listener on existing Always ON setup. This creates Listener on an existing SQL Server availability group, sets up corresponding load balancer rules and probe ports on Azure Load balancer to get the listener connections working.
 page_type: sample
 products:
 - azure
@@ -22,7 +22,7 @@ languages:
 Before deploying the template you must have the following
 
 1. **AlwaysON setup** Always ON setup must exist as created by azure-quickstart-templates/101-sql-vm-ag-setup. This will include the VMs over which the setup was done.
-2. **SQL Availability Group** SQL Availability Group must have been created over the Always ON setup. No existing listener should be present for the SQL Availability Group.
+2. **SQL Availability Group** SQL Server availability group must have been created over the Always ON setup. No existing listener should be present for the SQL Server availability group.
 3. **LoadBalancer** Internal load balancer in same location as VMs.
 4. **CNO permissions** The CNO (COmputer object for Cluster name) should have Create Computer object permissions in the OU it is placed in.
 
@@ -34,9 +34,9 @@ Before deploying the template you must have the following
 
 ## Solution overview and deployed resources
 
-This deployment will create an AG listener for a SQL Availability Group. This will also setup Load balancer rules corresponding to the Listener.
+This deployment will create an AG listener for a SQL Server availability group. This will also setup Load balancer rules corresponding to the Listener.
  Following resources will be created
- - SQL Availability Group Listener for the provided AG.
+ - SQL Server availability group listener for the provided AG.
  - Load balancer rules that will enable Listner to work in Azure.
  - Resource of type "AvailabilityGroupListener" in Microsoft.SqlVirtualMachine resource provider.
 

--- a/quickstarts/microsoft.sqlvirtualmachine/sql-vm-aglistener-setup/azuredeploy.json
+++ b/quickstarts/microsoft.sqlvirtualmachine/sql-vm-aglistener-setup/azuredeploy.json
@@ -11,19 +11,19 @@
         "existingSqlAvailabilityGroup": {
             "type": "string",
             "metadata": {
-                "description": "Specify the name of SQL Availability Group for which listener is being created"
+                "description": "Specify the name of SQL Server availability group for which listener is being created"
             }
         },
         "existingVmList": {
             "type": "string",
             "metadata": {
-                "description": "Specify the Virtual machine list participating in SQL Availability Group e.g. VM1, VM2. Maximum number is 6."
+                "description": "Specify the Virtual machine list participating in SQL Server availability group e.g. VM1, VM2. Maximum number is 6."
             }
         },
         "Listener": {
             "type": "string",
             "metadata": {
-                "description": "Specify a name for the listener for SQL Availability Group"
+                "description": "Specify a name for the listener for SQL Server availability group"
             },
             "defaultValue": "aglistener"
         },

--- a/quickstarts/microsoft.sqlvirtualmachine/sql-vm-aglistener-setup/metadata.json
+++ b/quickstarts/microsoft.sqlvirtualmachine/sql-vm-aglistener-setup/metadata.json
@@ -2,7 +2,7 @@
   "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
   "type": "QuickStart",
   "itemDisplayName": "Create SQL AvailabilityGroup listener on existing Always ON setup",
-  "description": "Deploy SQL AvailabilityGroup listener on existing Always ON setup. This creates Listener on an existing SQL Availability Group, sets up corresponding load balancer rules and probe ports on Azure Load balancer to get the listener connections working.",
+  "description": "Deploy SQL AvailabilityGroup listener on existing Always ON setup. This creates Listener on an existing SQL Server availability group, sets up corresponding load balancer rules and probe ports on Azure Load balancer to get the listener connections working.",
   "summary": "Create SQL AvailabilityGroup listener on existing Always ON setup.",
   "githubUsername": "pratraw",
   "dateUpdated": "2021-06-09"


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Replaced textual descriptions of incorrect "AlwaysOn" with "availability group"
* Replaced incorrect "SQL availability group" with "SQL Server availability group"