### PR TITLE
FHIR Service: Updated import deployment to allow for both modes

### DIFF
--- a/quickstarts/microsoft.healthcareapis/fhir-import/README.md
+++ b/quickstarts/microsoft.healthcareapis/fhir-import/README.md
@@ -25,5 +25,5 @@ languages:
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.healthcareapis%2Ffhir-import%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.healthcareapis%2Ffhir-import%2Fazuredeploy.json)
 
-This template will allow you to toggle the [$import operation](https://docs.microsoft.com/azure/healthcare-apis/fhir/import-data) on a FHIR service inside a Azure Health Data Services workspace.
+This template will allow you to change the [$import operation mode](https://docs.microsoft.com/azure/healthcare-apis/fhir/import-data) on a FHIR service inside a Azure Health Data Services workspace. You can select between "Disabled", "Initial", or "Incremental" import.
 `Tags: `

--- a/quickstarts/microsoft.healthcareapis/fhir-import/azuredeploy.json
+++ b/quickstarts/microsoft.healthcareapis/fhir-import/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.13.1.58284",
-      "templateHash": "17241932705120126845"
+      "version": "0.21.1.54444",
+      "templateHash": "16954011609398821360"
     }
   },
   "parameters": {
@@ -46,10 +46,15 @@
         "description": "Name of storage account to use for import. Needs to be an existing storage account. Leave blank if this has already been configured."
       }
     },
-    "enableImport": {
-      "type": "bool",
+    "importMode": {
+      "type": "string",
+      "allowedValues": [
+        "Initial Import",
+        "Incremental Import",
+        "Disabled"
+      ],
       "metadata": {
-        "description": "Flag to enable or disable $import"
+        "description": "FHIR Service Import mode to enable (or disable import)"
       }
     },
     "newOrExisting": {
@@ -62,9 +67,14 @@
     }
   },
   "variables": {
-    "enableConfiguration": {
+    "initialImport": {
       "enabled": true,
       "initialImportMode": true,
+      "integrationDataStore": "[parameters('storageName')]"
+    },
+    "incrementalImport": {
+      "enabled": true,
+      "initialImportMode": false,
       "integrationDataStore": "[parameters('storageName')]"
     },
     "disableConfiguration": {
@@ -84,7 +94,7 @@
       "identity": {
         "type": "SystemAssigned"
       },
-      "properties": "[union(if(equals(parameters('newOrExisting'), 'existing'), reference(resourceId('Microsoft.Resources/deployments', variables('existingDeployName')), '2020-10-01').outputs.properties.value, reference(resourceId('Microsoft.Resources/deployments', variables('newDeployName')), '2020-10-01').outputs.properties.value), createObject('importConfiguration', if(parameters('enableImport'), variables('enableConfiguration'), variables('disableConfiguration'))))]",
+      "properties": "[union(if(equals(parameters('newOrExisting'), 'existing'), reference(resourceId('Microsoft.Resources/deployments', variables('existingDeployName')), '2022-09-01').outputs.properties.value, reference(resourceId('Microsoft.Resources/deployments', variables('newDeployName')), '2022-09-01').outputs.properties.value), createObject('importConfiguration', if(equals(parameters('importMode'), 'Initial Import'), variables('initialImport'), if(equals(parameters('importMode'), 'Incremental Import'), variables('incrementalImport'), variables('disableConfiguration')))))]",
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', variables('existingDeployName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('newDeployName'))]"
@@ -96,7 +106,7 @@
     {
       "condition": "[equals(parameters('newOrExisting'), 'existing')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('existingDeployName')]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -117,8 +127,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.13.1.58284",
-              "templateHash": "8027949065940780632"
+              "version": "0.21.1.54444",
+              "templateHash": "1378819859420502483"
             }
           },
           "parameters": {
@@ -139,7 +149,7 @@
           "outputs": {
             "properties": {
               "type": "object",
-              "value": "[reference(resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', parameters('workspaceName'), parameters('fhirName')), '2022-06-01')]"
+              "value": "[reference(resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', parameters('workspaceName'), parameters('fhirName')), '2023-02-28')]"
             }
           }
         }
@@ -151,7 +161,7 @@
     {
       "condition": "[equals(parameters('newOrExisting'), 'new')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2020-10-01",
+      "apiVersion": "2022-09-01",
       "name": "[variables('newDeployName')]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -175,8 +185,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.13.1.58284",
-              "templateHash": "736950215381405193"
+              "version": "0.21.1.54444",
+              "templateHash": "9540714951106146551"
             }
           },
           "parameters": {
@@ -230,10 +240,10 @@
   "outputs": {
     "storageAccountName": {
       "type": "string",
-      "value": "[if(parameters('enableImport'), parameters('storageName'), '')]",
       "metadata": {
         "description": "Used to validate that the storage account exists when enabling import"
-      }
+      },
+      "value": "[if(not(equals(parameters('importMode'), 'Disabled')), parameters('storageName'), '')]"
     }
   }
 }

--- a/quickstarts/microsoft.healthcareapis/fhir-import/azuredeploy.json
+++ b/quickstarts/microsoft.healthcareapis/fhir-import/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.21.1.54444",
-      "templateHash": "16954011609398821360"
+      "version": "0.13.1.58284",
+      "templateHash": "17241932705120126845"
     }
   },
   "parameters": {
@@ -46,15 +46,10 @@
         "description": "Name of storage account to use for import. Needs to be an existing storage account. Leave blank if this has already been configured."
       }
     },
-    "importMode": {
-      "type": "string",
-      "allowedValues": [
-        "Initial Import",
-        "Incremental Import",
-        "Disabled"
-      ],
+    "enableImport": {
+      "type": "bool",
       "metadata": {
-        "description": "FHIR Service Import mode to enable (or disable import)"
+        "description": "Flag to enable or disable $import"
       }
     },
     "newOrExisting": {
@@ -67,14 +62,9 @@
     }
   },
   "variables": {
-    "initialImport": {
+    "enableConfiguration": {
       "enabled": true,
       "initialImportMode": true,
-      "integrationDataStore": "[parameters('storageName')]"
-    },
-    "incrementalImport": {
-      "enabled": true,
-      "initialImportMode": false,
       "integrationDataStore": "[parameters('storageName')]"
     },
     "disableConfiguration": {
@@ -94,7 +84,7 @@
       "identity": {
         "type": "SystemAssigned"
       },
-      "properties": "[union(if(equals(parameters('newOrExisting'), 'existing'), reference(resourceId('Microsoft.Resources/deployments', variables('existingDeployName')), '2022-09-01').outputs.properties.value, reference(resourceId('Microsoft.Resources/deployments', variables('newDeployName')), '2022-09-01').outputs.properties.value), createObject('importConfiguration', if(equals(parameters('importMode'), 'Initial Import'), variables('initialImport'), if(equals(parameters('importMode'), 'Incremental Import'), variables('incrementalImport'), variables('disableConfiguration')))))]",
+      "properties": "[union(if(equals(parameters('newOrExisting'), 'existing'), reference(resourceId('Microsoft.Resources/deployments', variables('existingDeployName')), '2020-10-01').outputs.properties.value, reference(resourceId('Microsoft.Resources/deployments', variables('newDeployName')), '2020-10-01').outputs.properties.value), createObject('importConfiguration', if(parameters('enableImport'), variables('enableConfiguration'), variables('disableConfiguration'))))]",
       "dependsOn": [
         "[resourceId('Microsoft.Resources/deployments', variables('existingDeployName'))]",
         "[resourceId('Microsoft.Resources/deployments', variables('newDeployName'))]"
@@ -106,7 +96,7 @@
     {
       "condition": "[equals(parameters('newOrExisting'), 'existing')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2020-10-01",
       "name": "[variables('existingDeployName')]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -127,8 +117,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "1378819859420502483"
+              "version": "0.13.1.58284",
+              "templateHash": "8027949065940780632"
             }
           },
           "parameters": {
@@ -149,7 +139,7 @@
           "outputs": {
             "properties": {
               "type": "object",
-              "value": "[reference(resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', parameters('workspaceName'), parameters('fhirName')), '2023-02-28')]"
+              "value": "[reference(resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', parameters('workspaceName'), parameters('fhirName')), '2022-06-01')]"
             }
           }
         }
@@ -161,7 +151,7 @@
     {
       "condition": "[equals(parameters('newOrExisting'), 'new')]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2022-09-01",
+      "apiVersion": "2020-10-01",
       "name": "[variables('newDeployName')]",
       "properties": {
         "expressionEvaluationOptions": {
@@ -185,8 +175,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.21.1.54444",
-              "templateHash": "9540714951106146551"
+              "version": "0.13.1.58284",
+              "templateHash": "736950215381405193"
             }
           },
           "parameters": {
@@ -240,10 +230,10 @@
   "outputs": {
     "storageAccountName": {
       "type": "string",
+      "value": "[if(parameters('enableImport'), parameters('storageName'), '')]",
       "metadata": {
         "description": "Used to validate that the storage account exists when enabling import"
-      },
-      "value": "[if(not(equals(parameters('importMode'), 'Disabled')), parameters('storageName'), '')]"
+      }
     }
   }
 }

--- a/quickstarts/microsoft.healthcareapis/fhir-import/azuredeploy.parameters.json
+++ b/quickstarts/microsoft.healthcareapis/fhir-import/azuredeploy.parameters.json
@@ -8,7 +8,7 @@
     "fhirName": {
       "value": "GEN-UNIQUE"
     },
-    "enableImport": {
+    "importMode": {
       "value": "Initial Import"
     },
     "resourceLocation": {

--- a/quickstarts/microsoft.healthcareapis/fhir-import/azuredeploy.parameters.json
+++ b/quickstarts/microsoft.healthcareapis/fhir-import/azuredeploy.parameters.json
@@ -9,7 +9,7 @@
       "value": "GEN-UNIQUE"
     },
     "enableImport": {
-      "value": true
+      "value": "Initial Import"
     },
     "resourceLocation": {
       "value": "westus2"

--- a/quickstarts/microsoft.healthcareapis/fhir-import/main.bicep
+++ b/quickstarts/microsoft.healthcareapis/fhir-import/main.bicep
@@ -2,9 +2,11 @@
 param resourceLocation string = resourceGroup().location
 
 @description('Workspace containing the Azure Health Data Services workspace')
+@minLength(3)
 param workspaceName string
 
 @description('Name of FHIR service')
+@minLength(3)
 param fhirName string
 
 @description('Kind of the FHIR service to update')
@@ -47,7 +49,6 @@ var disableConfiguration = {
   enabled: false
   initialImportMode: false
 }
-
 
 var newDeployName = 'newdeploy${uniqueString(resourceGroup().id, fhirName)}'
 var existingDeployName = 'existingdeploy${uniqueString(resourceGroup().id, fhirName)}'

--- a/quickstarts/microsoft.healthcareapis/fhir-import/metadata.json
+++ b/quickstarts/microsoft.healthcareapis/fhir-import/metadata.json
@@ -3,8 +3,8 @@
   "itemDisplayName": "Configure FHIR service to enable $import",
   "description": "This template provisions FHIR service to enable $import for initial data loading",
   "summary": "This template provisions FHIR service to enable $import for initial data loading",
-  "githubUsername": "RuiyiC",
-  "docOwner": "RuiyiC",
+  "githubUsername": "expekesheth",
+  "docOwner": "expekesheth",
   "dateUpdated": "2023-01-11",
   "type": "QuickStart",
   "environments": [

--- a/quickstarts/microsoft.healthcareapis/fhir-import/nested_existingdeployname.bicep
+++ b/quickstarts/microsoft.healthcareapis/fhir-import/nested_existingdeployname.bicep
@@ -4,4 +4,4 @@ param workspaceName string
 @description('Name of the existing FHIR service')
 param fhirName string
 
-output properties object = reference(resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', workspaceName, fhirName), '2022-06-01')
+output properties object = reference(resourceId('Microsoft.HealthcareApis/workspaces/fhirservices', workspaceName, fhirName), '2023-02-28')


### PR DESCRIPTION
# PR Checklist
- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

- Updated the Azure Healthcare APIs FHIR Service deployment template to work with both versions of import. We've added a new version of import which needs to be enabled by this template.