### PR TITLE
Fix tiny typo in vm-simple-linux main.bicep

### DIFF
--- a/quickstarts/microsoft.compute/vm-simple-linux/main.bicep
+++ b/quickstarts/microsoft.compute/vm-simple-linux/main.bicep
@@ -1,4 +1,4 @@
-@description('The name of you Virtual Machine.')
+@description('The name of your Virtual Machine.')
 param vmName string = 'simpleLinuxVM'
 
 @description('Username for the Virtual Machine.')


### PR DESCRIPTION
- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Fixes a typo in `vm-simple-linux/main.bicep`