### PR TITLE
Update outdated App Gateway SKU for vmss-app-gateway

### DIFF
--- a/quickstarts/microsoft.compute/vmss-ubuntu-app-gateway/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-ubuntu-app-gateway/azuredeploy.json
@@ -138,7 +138,7 @@
       ],
       "properties": {
         "sku": {
-          "name": "Standard_Large",
+          "name": "Standard_v2",
           "tier": "Standard_v2",
           "capacity": "10"
         },

--- a/quickstarts/microsoft.compute/vmss-ubuntu-app-gateway/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-ubuntu-app-gateway/azuredeploy.json
@@ -139,7 +139,7 @@
       "properties": {
         "sku": {
           "name": "Standard_Large",
-          "tier": "Standard",
+          "tier": "Standard_v2",
           "capacity": "10"
         },
         "gatewayIPConfigurations": [


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Using Standard sku causes error while creating resources with `vmss-ubuntu-app-gateway`
* Updated App GW tier to Standard_v2 due to outdate of Standard tier.
* Changed both name and tier.
