### PR TITLE
Remove Azure Stack HCI 22H2 VM Creation Templates

### DIFF
--- a/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/README.md
+++ b/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/README.md
@@ -1,0 +1,42 @@
+---
+description: This template creates a simple Windows VM from the referenced image on Azure Stack HCI
+page_type: sample
+products:
+- azure
+- azure-resource-manager
+urlFragment: vm-windows-storage-container
+languages:
+- bicep
+- json
+---
+# Create a VM from the referenced image on Azure Stack HCI
+
+![Azure Public Test Date](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/PublicLastTestDate.svg)
+![Azure Public Test Result](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/PublicDeployment.svg)
+
+![Azure US Gov Last Test Date](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/FairfaxLastTestDate.svg)
+![Azure US Gov Last Test Result](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/FairfaxDeployment.svg)
+
+![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/BestPracticeResult.svg)
+![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/CredScanResult.svg)
+
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/BicepVersion.svg)
+
+This template allows you to deploy a new Windows Virtual Machine on an on-premises Azure Stack HCI cluster using the referenced image. The [article](/azure-stack/hci/manage/manage-virtual-machines-in-azure-portal?tabs=arm) walks you through the process and prerequisites.
+
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.azurestackhci%2Fvm-windows-storage-container%2Fazuredeploy.json)
+[![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.azurestackhci%2Fvm-windows-storage-container%2Fazuredeploy.json)
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fmicrosoft.azurestackhci%2Fvm-windows-storage-container%2Fazuredeploy.json)
+
+## Prerequisites
+
+In order to deploy this template, there must be an operational ARC Resource Bridge associated with your Azure Stack HCI cluster. Further, the resources below must be deployed before running this template:
+
+- Custom Location: This is the custom location resource representing your Azure Stack HCI Cluster in Azure. The following Virtual Network and Image resources must be associated with this custom location.
+- Azure Stack HCI Virtual Network: This resource is the Azure representation of your Hyper-v virtual switch and related network configuration used for the Network Interface created for the new VM. See [Azure Stack HCI Virtual Networks](/azure-stack/hci/manage/create-virtual-networks)
+- Azure Stack HCI Image: This is a virtual machine image, created either through a custom image build process and generalized or from an Azure marketplace gallery image. See [Azure Stack HCI Images](/azure-stack/hci/manage/virtual-machine-image-azure-marketplace)
+
+> [!NOTE]
+> For simplicity, this template assumes the Custom Location, Virtual Network, and Image all reside in the same Resource Group as where the Virtual Machine is being created. 
+
+`Tags: Microsoft.AzureStackHCI/virtualmachines, hci`

--- a/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/azuredeploy.json
+++ b/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/azuredeploy.json
@@ -1,0 +1,141 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "metadata": {
+    "_generator": {
+      "name": "bicep",
+      "version": "0.21.1.54444",
+      "templateHash": "1564156715074656915"
+    }
+  },
+  "parameters": {
+    "name": {
+      "type": "string",
+      "maxLength": 15
+    },
+    "location": {
+      "type": "string"
+    },
+    "vCPUCount": {
+      "type": "int",
+      "defaultValue": 2
+    },
+    "memoryGB": {
+      "type": "int",
+      "defaultValue": 4
+    },
+    "adminUsername": {
+      "type": "string"
+    },
+    "imageName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure Stack HCI image to use for the virtual machine. This can be either a marketplace image or a custom image."
+      }
+    },
+    "imageType": {
+      "type": "string",
+      "allowedValues": [
+        "Marketplace",
+        "Custom"
+      ],
+      "metadata": {
+        "description": "If the source image was created directly from the Azure Marketpace, use \"Marketplace\"; otherwise, if it was created from a custom image, use \"Custom\"."
+      }
+    },
+    "hciVirtualNetworkName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure Stack HCI virtual network to use for the virtual machine. This must already exist."
+      }
+    },
+    "customLocationName": {
+      "type": "string"
+    },
+    "storageContainerName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the Azure Stack HCI storage container to use for the virtual machine. This is sometimes called a Storage Path and must already exist--see the prerequ.main.bicep file for an example."
+      }
+    },
+    "adminPassword": {
+      "type": "securestring"
+    }
+  },
+  "variables": {
+    "nicName": "[format('nic-{0}', parameters('name'))]",
+    "customLocationId": "[resourceId('Microsoft.ExtendedLocation/customLocations', parameters('customLocationName'))]",
+    "fullImageType": "[if(equals(parameters('imageType'), 'Marketplace'), 'microsoft.azurestackhci/marketplaceGalleryImages', 'microsoft.azurestackhci/galleryImages')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.AzureStackHCI/virtualmachines",
+      "apiVersion": "2021-09-01-preview",
+      "name": "[parameters('name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "resourceName": "[parameters('name')]",
+        "hardwareProfile": {
+          "processors": "[parameters('vCPUCount')]",
+          "memoryGB": "[parameters('memoryGB')]"
+        },
+        "osProfile": {
+          "adminUsername": "[parameters('adminUsername')]",
+          "adminPassword": "[parameters('adminPassword')]",
+          "osType": "Windows",
+          "computerName": "[parameters('name')]",
+          "windowsConfiguration": {
+            "provisionVMAgent": true
+          }
+        },
+        "storageProfile": {
+          "imageReference": {
+            "name": "[resourceId(variables('fullImageType'), parameters('imageName'))]"
+          },
+          "vmConfigContainerName": "[parameters('storageContainerName')]"
+        },
+        "networkProfile": {
+          "networkInterfaces": [
+            {
+              "id": "[resourceId('Microsoft.AzureStackHCI/networkinterfaces', variables('nicName'))]"
+            }
+          ]
+        }
+      },
+      "extendedLocation": {
+        "type": "CustomLocation",
+        "name": "[variables('customLocationId')]"
+      },
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.AzureStackHCI/networkinterfaces', variables('nicName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.AzureStackHCI/networkinterfaces",
+      "apiVersion": "2021-09-01-preview",
+      "name": "[variables('nicName')]",
+      "location": "[parameters('location')]",
+      "extendedLocation": {
+        "type": "CustomLocation",
+        "name": "[variables('customLocationId')]"
+      },
+      "properties": {
+        "resourceName": "[variables('nicName')]",
+        "ipConfigurations": [
+          {
+            "name": "ipconfig1",
+            "properties": {
+              "privateIPAllocationMethod": "Dynamic",
+              "subnet": {
+                "id": "[resourceId('microsoft.azurestackhci/virtualnetworks', parameters('hciVirtualNetworkName'))]"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/azuredeploy.parameters.json
+++ b/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/azuredeploy.parameters.json
@@ -1,0 +1,39 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "name": {
+            "value": "vm-sampledeploy"
+        },
+        "location": {
+            "value": "eastus"
+        },
+        "adminUsername": {
+            "value": "admin-quickstart"
+        },
+        "adminPassword": {
+            "value": "GEN-PASSWORD"
+        },
+        "vCPUCount": {
+            "value": 2
+        },
+        "memoryGB": {
+            "value": 4
+        },
+        "imageName": {
+            "value": "GEN-UNIQUE" 
+        },
+        "imageType": {
+            "value": "Marketplace"
+        },
+        "hciVirtualNetworkName": {
+            "value": "GEN-UNIQUE"
+        },
+        "customLocationName": {
+            "value": "GEN-UNIQUE"
+        },
+        "storageContainerName": {
+            "value": "GEN-UNIQUE"
+        }
+    }
+}

--- a/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/main.bicep
+++ b/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/main.bicep
@@ -1,0 +1,86 @@
+@maxLength(15) // maxlength 15 for Windows
+param name string
+param location string
+param vCPUCount int = 2
+param memoryGB int = 4
+param adminUsername string
+@description('The name of the Azure Stack HCI image to use for the virtual machine. This can be either a marketplace image or a custom image.')
+param imageName string
+@description('If the source image was created directly from the Azure Marketpace, use "Marketplace"; otherwise, if it was created from a custom image, use "Custom".')
+@allowed(['Marketplace', 'Custom'])
+param imageType string
+@description('The name of the Azure Stack HCI virtual network to use for the virtual machine. This must already exist.')
+param hciVirtualNetworkName string
+param customLocationName string
+@description('The name of the Azure Stack HCI storage container to use for the virtual machine. This is sometimes called a Storage Path and must already exist--see the prerequ.main.bicep file for an example.')
+param storageContainerName string
+@secure()
+param adminPassword string
+
+var nicName = 'nic-${name}'
+var customLocationId = resourceId('Microsoft.ExtendedLocation/customLocations', customLocationName)
+var fullImageType = imageType == 'Marketplace' ? 'microsoft.azurestackhci/marketplaceGalleryImages' : 'microsoft.azurestackhci/galleryImages'
+
+resource virtualMachine 'Microsoft.AzureStackHCI/virtualmachines@2021-09-01-preview' = {
+  name: name
+  location: location
+  properties: {
+    resourceName: name
+    hardwareProfile: {
+      processors: vCPUCount
+      memoryGB: memoryGB
+    }
+    osProfile: {
+      adminUsername: adminUsername
+      adminPassword: adminPassword
+      osType: 'Windows'
+      computerName: name
+      windowsConfiguration: {
+        provisionVMAgent: true
+      }
+    }
+    storageProfile: {
+      imageReference: {
+        name: resourceId(fullImageType, imageName)
+      }
+      vmConfigContainerName: storageContainerName
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: nic.id
+        }
+      ]
+    }
+  }
+  extendedLocation: {
+    type: 'CustomLocation'
+    name: customLocationId
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+}
+
+resource nic 'Microsoft.AzureStackHCI/networkinterfaces@2021-09-01-preview' = {
+  name: nicName
+  location: location
+  extendedLocation: {
+    type: 'CustomLocation'
+    name: customLocationId
+  }
+  properties: {
+    resourceName: nicName
+    ipConfigurations: [
+      {
+        name: 'ipconfig1'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          subnet: {
+            id: resourceId('microsoft.azurestackhci/virtualnetworks', hciVirtualNetworkName)
+          }
+        }
+      }
+    ]
+  }
+}

--- a/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/metadata.json
+++ b/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/metadata.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
+  "type": "QuickStart",
+  "itemDisplayName": "Create a VM from the referenced image on Azure Stack HCI",
+  "description": "This template creates a simple Windows VM from the referenced image on Azure Stack HCI",
+  "summary": "Create a VM from the referenced image on Azure Stack HCI",
+  "githubUsername": "mbrat2005",
+  "validationType": "Manual",
+  "dateUpdated": "2023-09-25"
+}

--- a/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/prereq.azuredeploy.parameters.json
+++ b/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/prereq.azuredeploy.parameters.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "storageContainerName": {
+            "value": "GEN-UNIQUE"
+        },
+        "hciLocalPath": {
+            "value": "C:\\ClusterStorage\\CSV-DefaultVMs"
+        },
+        "location": {
+            "value": "eastus"
+        },
+        "customLocationName": {
+            "value": "GEN-UNIQUE"
+        },
+        "virtualNetworkName": {
+            "value":  "vnet-vlan240"
+        },
+        "vmSwitchName": {
+            "value": "ConvergedSwitch"
+        }
+    }
+}

--- a/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/prereq.main.bicep
+++ b/quickstarts/microsoft.azurestackhci/vm-windows-storage-container/prereq.main.bicep
@@ -1,0 +1,36 @@
+param storageContainerName string
+param hciLocalPath string
+param virtualNetworkName string
+param vmSwitchName string
+param location string = 'eastus'
+param customLocationName string = 'hcicluster-cl'
+
+var customLocationId = resourceId('Microsoft.ExtendedLocation/customLocations', customLocationName)
+
+resource storageContainer 'Microsoft.AzureStackHCI/storageContainers@2021-09-01-preview' = {
+  name: storageContainerName
+  location: location
+  extendedLocation: {
+    type: 'CustomLocation'
+    name: customLocationId
+  }
+  properties: {
+    path: hciLocalPath
+    resourceName: storageContainerName
+  }
+}
+
+resource virtualNetwork 'Microsoft.AzureStackHCI/virtualNetworks@2022-12-15-preview' = {
+  name: virtualNetworkName
+  location: location
+  extendedLocation: {
+    type: 'CustomLocation'
+    name: customLocationId
+  }
+  properties: {
+    networkType: 'Transparent'
+    subnets: []
+    vmSwitchName: vmSwitchName
+    dhcpOptions: {}
+  }
+}


### PR DESCRIPTION
These templates are no longer functional with the deprecation of the Azure Stack HCI 22H2 Resource Bridge preview and are replaced by new templates supporting 23H2+

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* removed vm-simple-hci-windows
* removed vm-windows-storage-container*
