### PR TITLE
Replaced Ubuntu 18.04 references with Ubuntu 22.04 references

### DIFF
--- a/quickstarts/microsoft.compute/vm-msi-storage/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-msi-storage/azuredeploy.json
@@ -48,11 +48,7 @@
     },
     "ubuntuOSVersion": {
       "type": "string",
-      "defaultValue": "18_04-lts-gen2",
-      "allowedValues": [
-        "18_04-daily-lts-gen2",
-        "18_04-lts-gen2"
-      ],
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
         "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
       }

--- a/quickstarts/microsoft.compute/vm-msi-storage/main.bicep
+++ b/quickstarts/microsoft.compute/vm-msi-storage/main.bicep
@@ -19,11 +19,7 @@ param adminPasswordOrKey string
 param dnsLabelPrefix string = toLower('vm-msi-${uniqueString(resourceGroup().id)}')
 
 @description('The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version.')
-@allowed([
-  '18_04-daily-lts-gen2'
-  '18_04-lts-gen2'
-])
-param ubuntuOSVersion string = '18_04-lts-gen2'
+param ubuntuOSVersion string = '22_04-lts-gen2'
 
 @description('Location for all resources.')
 param location string = resourceGroup().location

--- a/quickstarts/microsoft.compute/vm-new-or-existing-conditions/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-new-or-existing-conditions/azuredeploy.json
@@ -171,33 +171,14 @@
     },
     "imageOffer": {
       "type": "string",
-      "defaultValue": "0001-com-ubuntu-server-lunar",
-      "allowedValues": [
-        "0001-com-ubuntu-minimal-bionic",
-        "0001-com-ubuntu-minimal-lunar-daily",
-        "0001-com-ubuntu-server-focal",
-        "0001-com-ubuntu-server-jammy",
-        "0001-com-ubuntu-server-lunar",
-        "0001-com-ubuntu-server-lunar-daily",
-        "0003-com-ubuntu-server-trusted-vm"
-      ],
+      "defaultValue": "0001-com-ubuntu-server-jammy",
       "metadata": {
         "description": "Windows Server and SQL Offer"
       }
     },
     "sqlSku": {
       "type": "string",
-      "defaultValue": "23_04-gen2",
-      "allowedValues": [
-        "22_10-minimal-gen2",
-        "18_04-lts-gen2",
-        "minimal-20_04-daily-lts-gen2",
-        "minimal-23_04-daily-gen2",
-        "minimal-23_04-gen2",
-        "20_04-daily-lts-gen2",
-        "23_04-daily-gen2",
-        "23_04-gen2"
-      ],
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
         "description": "SQL Server Sku"
       }

--- a/quickstarts/microsoft.compute/vm-new-or-existing-conditions/main.bicep
+++ b/quickstarts/microsoft.compute/vm-new-or-existing-conditions/main.bicep
@@ -78,29 +78,10 @@ param publicIpResourceGroupName string = resourceGroup().name
 param securityType string = 'TrustedLaunch'
 
 @description('Windows Server and SQL Offer')
-@allowed([
-  '0001-com-ubuntu-minimal-bionic'
-  '0001-com-ubuntu-minimal-lunar-daily'
-  '0001-com-ubuntu-server-focal'
-  '0001-com-ubuntu-server-jammy'
-  '0001-com-ubuntu-server-lunar'
-  '0001-com-ubuntu-server-lunar-daily'
-  '0003-com-ubuntu-server-trusted-vm'
-])
-param imageOffer string = '0001-com-ubuntu-server-lunar'
+param imageOffer string = '0001-com-ubuntu-server-jammy'
 
 @description('SQL Server Sku')
-@allowed([
-  '22_10-minimal-gen2'
-  '18_04-lts-gen2'
-  'minimal-20_04-daily-lts-gen2'
-  'minimal-23_04-daily-gen2'
-  'minimal-23_04-gen2'
-  '20_04-daily-lts-gen2'
-  '23_04-daily-gen2'
-  '23_04-gen2'
-])
-param sqlSku string = '23_04-gen2'
+param sqlSku string = '22_04-lts-gen2'
 
 var securityProfileJson = {
   uefiSettings: {

--- a/quickstarts/microsoft.compute/vm-sshkey/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-sshkey/azuredeploy.json
@@ -192,7 +192,7 @@
           "imageReference": {
             "publisher": "Canonical",
             "offer": "UbuntuServer",
-            "sku": "18_04-lts-gen2",
+            "sku": "22_04-lts-gen2",
             "version": "latest"
           },
           "osDisk": {

--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
@@ -18,10 +18,8 @@
     },
     "sku": {
       "type": "string",
-      "defaultValue": "Ubuntu-2004",
+      "defaultValue": "Ubuntu-2204",
       "allowedValues": [
-        "Ubuntu-1804",
-        "Ubuntu-2004",
         "Ubuntu-2204",
         "RHEL-83",
         "SUSE-15-SP2"
@@ -148,18 +146,6 @@
   },
   "variables": {
     "imageReference": {
-      "Ubuntu-1804": {
-        "publisher": "Canonical",
-        "offer": "UbuntuServer",
-        "sku": "18_04-lts-gen2",
-        "version": "latest"
-      },
-      "Ubuntu-2004": {
-        "publisher": "Canonical",
-        "offer": "0001-com-ubuntu-server-focal",
-        "sku": "20_04-lts-gen2",
-        "version": "latest"
-      },
       "Ubuntu-2204": {
         "publisher": "Canonical",
         "offer": "0001-com-ubuntu-server-jammy",

--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/main.bicep
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/main.bicep
@@ -3,13 +3,11 @@ param vmName string = 'myTVM'
 
 @description('The OS for the virtual machine. This will pick the latest fully patched image of the given OS.')
 @allowed([
-  'Ubuntu-1804'
-  'Ubuntu-2004'
   'Ubuntu-2204'
   'RHEL-83'
   'SUSE-15-SP2'
 ])
-param sku string = 'Ubuntu-2004'
+param sku string = 'Ubuntu-2204'
 
 @description('The size of the virtual machine')
 param vmSize string = 'Standard_D2s_v3'
@@ -70,18 +68,6 @@ param networkSecurityGroupName string = 'nsg'
 param maaEndpoint string = ''
 
 var imageReference = {
-  'Ubuntu-1804': {
-    publisher: 'Canonical'
-    offer: 'UbuntuServer'
-    sku: '18_04-lts-gen2'
-    version: 'latest'
-  }
-  'Ubuntu-2004': {
-    publisher: 'Canonical'
-    offer: '0001-com-ubuntu-server-focal'
-    sku: '20_04-lts-gen2'
-    version: 'latest'
-  }
   'Ubuntu-2204': {
     publisher: 'Canonical'
     offer: '0001-com-ubuntu-server-jammy'

--- a/quickstarts/microsoft.compute/vmss-azure-files-linux/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-azure-files-linux/azuredeploy.json
@@ -136,7 +136,7 @@
     "osType": {
       "publisher": "Canonical",
       "offer": "UbuntuServer",
-      "sku": "18_04-lts-gen2",
+      "sku": "22_04-lts-gen2",
       "version": "latest"
     },
     "imageReference": "[variables('osType')]",

--- a/quickstarts/microsoft.compute/vmss-azure-files-linux/main.bicep
+++ b/quickstarts/microsoft.compute/vmss-azure-files-linux/main.bicep
@@ -77,7 +77,7 @@ var ipConfigName = '${vmssName}ipconfig'
 var osType = {
   publisher: 'Canonical'
   offer: 'UbuntuServer'
-  sku: '18_04-lts-gen2'
+  sku: '22_04-lts-gen2'
   version: 'latest'
 }
 var imageReference = osType

--- a/quickstarts/microsoft.compute/vmss-with-public-ip-prefix/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-with-public-ip-prefix/azuredeploy.json
@@ -54,33 +54,14 @@
     },
     "imageOffer": {
       "type": "string",
-      "defaultValue": "0001-com-ubuntu-server-lunar",
-      "allowedValues": [
-        "0001-com-ubuntu-minimal-bionic",
-        "0001-com-ubuntu-minimal-lunar-daily",
-        "0001-com-ubuntu-server-focal",
-        "0001-com-ubuntu-server-jammy",
-        "0001-com-ubuntu-server-lunar",
-        "0001-com-ubuntu-server-lunar-daily",
-        "0003-com-ubuntu-server-trusted-vm"
-      ],
+      "defaultValue": "0001-com-ubuntu-server-jammy",
       "metadata": {
         "description": "Windows Server and SQL Offer"
       }
     },
     "sqlSku": {
       "type": "string",
-      "defaultValue": "23_04-gen2",
-      "allowedValues": [
-        "22_10-minimal-gen2",
-        "18_04-lts-gen2",
-        "minimal-20_04-daily-lts-gen2",
-        "minimal-23_04-daily-gen2",
-        "minimal-23_04-gen2",
-        "20_04-daily-lts-gen2",
-        "23_04-daily-gen2",
-        "23_04-gen2"
-      ],
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
         "description": "SQL Server Sku"
       }

--- a/quickstarts/microsoft.compute/vmss-with-public-ip-prefix/main.bicep
+++ b/quickstarts/microsoft.compute/vmss-with-public-ip-prefix/main.bicep
@@ -33,29 +33,10 @@ var securityProfileJson = {
 }
 
 @description('Windows Server and SQL Offer')
-@allowed([
-  '0001-com-ubuntu-minimal-bionic'
-  '0001-com-ubuntu-minimal-lunar-daily'
-  '0001-com-ubuntu-server-focal'
-  '0001-com-ubuntu-server-jammy'
-  '0001-com-ubuntu-server-lunar'
-  '0001-com-ubuntu-server-lunar-daily'
-  '0003-com-ubuntu-server-trusted-vm'
-])
-param imageOffer string = '0001-com-ubuntu-server-lunar'
+param imageOffer string = '0001-com-ubuntu-server-jammy'
 
 @description('SQL Server Sku')
-@allowed([
-  '22_10-minimal-gen2'
-  '18_04-lts-gen2'
-  'minimal-20_04-daily-lts-gen2'
-  'minimal-23_04-daily-gen2'
-  'minimal-23_04-gen2'
-  '20_04-daily-lts-gen2'
-  '23_04-daily-gen2'
-  '23_04-gen2'
-])
-param sqlSku string = '23_04-gen2'
+param sqlSku string = '22_04-lts-gen2'
 
 @description('Location for resources. Default is the current resource group location.')
 param location string = resourceGroup().location

--- a/quickstarts/microsoft.network/aks-application-gateway-ingress-controller/azuredeploy.json
+++ b/quickstarts/microsoft.network/aks-application-gateway-ingress-controller/azuredeploy.json
@@ -635,11 +635,7 @@
     },
     "imageSku": {
       "type": "string",
-      "defaultValue": "18_04-lts-gen2",
-      "allowedValues": [
-          "18_04-daily-lts-gen2",
-          "18_04-lts-gen2"
-      ],            
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
         "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
       }

--- a/quickstarts/microsoft.network/azure-firewall-dns-proxy/azuredeploy.json
+++ b/quickstarts/microsoft.network/azure-firewall-dns-proxy/azuredeploy.json
@@ -128,11 +128,7 @@
     },
     "imageSku": {
       "type": "string",
-      "defaultValue": "18_04-lts-gen2",
-      "allowedValues": [
-        "18_04-daily-lts-gen2",
-        "18_04-lts-gen2"
-      ],
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
         "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
       }

--- a/quickstarts/microsoft.network/azure-firewall-dns-proxy/main.bicep
+++ b/quickstarts/microsoft.network/azure-firewall-dns-proxy/main.bicep
@@ -56,11 +56,7 @@ param imagePublisher string = 'Canonical'
 param imageOffer string = 'UbuntuServer'
 
 @description('The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version.')
-@allowed([
-  '18_04-daily-lts-gen2'
-  '18_04-lts-gen2'
-])
-param imageSku string = '18_04-lts-gen2'
+param imageSku string = '22_04-lts-gen2'
 
 @description('Specifies the type of authentication when accessing the Virtual Machine. SSH key is recommended.')
 @allowed([

--- a/quickstarts/microsoft.network/azurefirewall-client-server-sandbox/azuredeploy.json
+++ b/quickstarts/microsoft.network/azurefirewall-client-server-sandbox/azuredeploy.json
@@ -198,7 +198,7 @@
           "imageReference": {
             "publisher": "Canonical",
             "offer": "UbuntuServer",
-            "sku": "18_04-lts-gen2",
+            "sku": "22_04-lts-gen2",
             "version": "latest"
           },
           "osDisk": {
@@ -248,7 +248,7 @@
           "imageReference": {
             "publisher": "Canonical",
             "offer": "UbuntuServer",
-            "sku": "18_04-lts-gen2",
+            "sku": "22_04-lts-gen2",
             "version": "latest"
           },
           "osDisk": {

--- a/quickstarts/microsoft.network/azurefirewall-client-server-sandbox/main.bicep
+++ b/quickstarts/microsoft.network/azurefirewall-client-server-sandbox/main.bicep
@@ -131,7 +131,7 @@ resource clientVirtualMachine 'Microsoft.Compute/virtualMachines@2023-09-01' = {
       imageReference: {
         publisher: 'Canonical'
         offer: 'UbuntuServer'
-        sku: '18_04-lts-gen2'
+        sku: '22_04-lts-gen2'
         version: 'latest'
       }
       osDisk: {
@@ -177,7 +177,7 @@ resource serverVirtualMachine 'Microsoft.Compute/virtualMachines@2023-09-01' = {
       imageReference: {
         publisher: 'Canonical'
         offer: 'UbuntuServer'
-        sku: '18_04-lts-gen2'
+        sku: '22_04-lts-gen2'
         version: 'latest'
       }
       osDisk: {


### PR DESCRIPTION
Ubuntu 18.04 will reach end-of-life in April of 2028, and is soon to be the fourth-most-current Ubuntu LTS release. In the interest of promoting Ubuntu release currency within the templates in this repository, this commit replaces all references to Ubuntu 18.04 with references to Ubuntu 22.04. Prior to the changes, 18.04 was the oldest Ubuntu release referenced in this repository.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Replaced all references to Ubuntu 18.04 with references to Ubuntu 22.04
* Removed allowed-value constraints from select offer and SKU template parameters
* Updated the default values associated with select offer and SKU template parameters
