### PR TITLE
Replaced Ubuntu 18.04 references with Ubuntu 22.04 references - vm-msi-storage (1/9)

### DIFF
--- a/quickstarts/microsoft.compute/vm-msi-storage/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-msi-storage/azuredeploy.json
@@ -48,11 +48,7 @@
     },
     "ubuntuOSVersion": {
       "type": "string",
-      "defaultValue": "18_04-lts-gen2",
-      "allowedValues": [
-        "18_04-daily-lts-gen2",
-        "18_04-lts-gen2"
-      ],
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
         "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
       }

--- a/quickstarts/microsoft.compute/vm-msi-storage/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-msi-storage/azuredeploy.json
@@ -46,11 +46,18 @@
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }
     },
-    "ubuntuOSVersion": {
+    "imageOffer": {
+      "type": "string",
+      "defaultValue": "0001-com-ubuntu-server-jammy",
+      "metadata": {
+        "description": "The offer of the Ubuntu image from which to launch the Virtual Machine."
+      }
+    },
+    "imageSku": {
       "type": "string",
       "defaultValue": "22_04-lts-gen2",
       "metadata": {
-        "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
+        "description": "The SKU of the Ubuntu image from which to launch the Virtual Machine."
       }
     },
     "location": {
@@ -281,8 +288,8 @@
           },
           "imageReference": {
             "publisher": "Canonical",
-            "offer": "UbuntuServer",
-            "sku": "[parameters('ubuntuOSVersion')]",
+            "offer": "[parameters('imageOffer')]",
+            "sku": "[parameters('imageSku')]",
             "version": "latest"
           }
         },

--- a/quickstarts/microsoft.compute/vm-msi-storage/main.bicep
+++ b/quickstarts/microsoft.compute/vm-msi-storage/main.bicep
@@ -18,8 +18,11 @@ param adminPasswordOrKey string
 @description('Unique DNS Name for the Public IP used to access the Virtual Machine.')
 param dnsLabelPrefix string = toLower('vm-msi-${uniqueString(resourceGroup().id)}')
 
-@description('The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version.')
-param ubuntuOSVersion string = '22_04-lts-gen2'
+@description('The offer of the Ubuntu image from which to launch the Virtual Machine.')
+param imageOffer string = '0001-com-ubuntu-server-jammy'
+
+@description('The SKU of the Ubuntu image from which to launch the Virtual Machine.')
+param imageSku string = '22_04-lts-gen2'
 
 @description('Location for all resources.')
 param location string = resourceGroup().location
@@ -206,8 +209,8 @@ resource vm 'Microsoft.Compute/virtualMachines@2023-03-01' = {
       }
       imageReference: {
         publisher: 'Canonical'
-        offer: 'UbuntuServer'
-        sku: ubuntuOSVersion
+        offer: imageOffer
+        sku: imageSku
         version: 'latest'
       }
     }

--- a/quickstarts/microsoft.compute/vm-msi-storage/main.bicep
+++ b/quickstarts/microsoft.compute/vm-msi-storage/main.bicep
@@ -19,11 +19,7 @@ param adminPasswordOrKey string
 param dnsLabelPrefix string = toLower('vm-msi-${uniqueString(resourceGroup().id)}')
 
 @description('The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version.')
-@allowed([
-  '18_04-daily-lts-gen2'
-  '18_04-lts-gen2'
-])
-param ubuntuOSVersion string = '18_04-lts-gen2'
+param ubuntuOSVersion string = '22_04-lts-gen2'
 
 @description('Location for all resources.')
 param location string = resourceGroup().location


### PR DESCRIPTION
Ubuntu 18.04 will reach end-of-life in April of 2028, and is soon to be the fourth-most-current Ubuntu LTS release. In the interest of promoting Ubuntu release currency within the templates in this repository, this pull request is one of nine that endeavour to replace all references to Ubuntu 18.04 with references to Ubuntu 22.04. Prior to the changes, 18.04 was the oldest Ubuntu release referenced in this repository. This pull request concerns only the `vm-msi-storage` scenario folder.

Pull requests in series:

* https://github.com/Azure/azure-quickstart-templates/pull/13866
* https://github.com/Azure/azure-quickstart-templates/pull/13867
* https://github.com/Azure/azure-quickstart-templates/pull/13868
* https://github.com/Azure/azure-quickstart-templates/pull/13869
* https://github.com/Azure/azure-quickstart-templates/pull/13870
* https://github.com/Azure/azure-quickstart-templates/pull/13871
* https://github.com/Azure/azure-quickstart-templates/pull/13872
* https://github.com/Azure/azure-quickstart-templates/pull/13873
* https://github.com/Azure/azure-quickstart-templates/pull/13874

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Replaced all references to Ubuntu 18.04 with references to Ubuntu 22.04
* Removed allowed-value constraint from SKU template parameter
* Replaced hard-coded `UbuntuServer` offer with `imageOffer` parameter
