### PR TITLE
Replaced Ubuntu 18.04 references with Ubuntu 22.04 references - vm-new-or-existing-conditions

### DIFF
--- a/quickstarts/microsoft.compute/vm-new-or-existing-conditions/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-new-or-existing-conditions/azuredeploy.json
@@ -171,35 +171,16 @@
     },
     "imageOffer": {
       "type": "string",
-      "defaultValue": "0001-com-ubuntu-server-lunar",
-      "allowedValues": [
-        "0001-com-ubuntu-minimal-bionic",
-        "0001-com-ubuntu-minimal-lunar-daily",
-        "0001-com-ubuntu-server-focal",
-        "0001-com-ubuntu-server-jammy",
-        "0001-com-ubuntu-server-lunar",
-        "0001-com-ubuntu-server-lunar-daily",
-        "0003-com-ubuntu-server-trusted-vm"
-      ],
+      "defaultValue": "0001-com-ubuntu-server-jammy",
       "metadata": {
-        "description": "Windows Server and SQL Offer"
+        "description": "The offer of the Ubuntu image from which to launch the Virtual Machine."
       }
     },
-    "sqlSku": {
+    "imageSku": {
       "type": "string",
-      "defaultValue": "23_04-gen2",
-      "allowedValues": [
-        "22_10-minimal-gen2",
-        "18_04-lts-gen2",
-        "minimal-20_04-daily-lts-gen2",
-        "minimal-23_04-daily-gen2",
-        "minimal-23_04-gen2",
-        "20_04-daily-lts-gen2",
-        "23_04-daily-gen2",
-        "23_04-gen2"
-      ],
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
-        "description": "SQL Server Sku"
+        "description": "The SKU of the Ubuntu image from which to launch the Virtual Machine."
       }
     }
   },
@@ -350,7 +331,7 @@
           "imageReference": {
             "publisher": "Canonical",
             "offer": "[parameters('imageOffer')]",
-            "sku": "[parameters('sqlSku')]",
+            "sku": "[parameters('imageSku')]",
             "version": "latest"
           },
           "osDisk": {

--- a/quickstarts/microsoft.compute/vm-new-or-existing-conditions/main.bicep
+++ b/quickstarts/microsoft.compute/vm-new-or-existing-conditions/main.bicep
@@ -77,30 +77,11 @@ param publicIpResourceGroupName string = resourceGroup().name
 ])
 param securityType string = 'TrustedLaunch'
 
-@description('Windows Server and SQL Offer')
-@allowed([
-  '0001-com-ubuntu-minimal-bionic'
-  '0001-com-ubuntu-minimal-lunar-daily'
-  '0001-com-ubuntu-server-focal'
-  '0001-com-ubuntu-server-jammy'
-  '0001-com-ubuntu-server-lunar'
-  '0001-com-ubuntu-server-lunar-daily'
-  '0003-com-ubuntu-server-trusted-vm'
-])
-param imageOffer string = '0001-com-ubuntu-server-lunar'
+@description('The offer of the Ubuntu image from which to launch the Virtual Machine.')
+param imageOffer string = '0001-com-ubuntu-server-jammy'
 
-@description('SQL Server Sku')
-@allowed([
-  '22_10-minimal-gen2'
-  '18_04-lts-gen2'
-  'minimal-20_04-daily-lts-gen2'
-  'minimal-23_04-daily-gen2'
-  'minimal-23_04-gen2'
-  '20_04-daily-lts-gen2'
-  '23_04-daily-gen2'
-  '23_04-gen2'
-])
-param sqlSku string = '23_04-gen2'
+@description('The SKU of the Ubuntu image from which to launch the Virtual Machine.')
+param imageSku string = '22_04-lts-gen2'
 
 var securityProfileJson = {
   uefiSettings: {
@@ -233,7 +214,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2023-07-01' = {
       imageReference: {
         publisher: 'Canonical'
         offer: imageOffer
-        sku: sqlSku
+        sku: imageSku
         version: 'latest'
       }
       osDisk: {


### PR DESCRIPTION
Ubuntu 18.04 will reach end-of-life in April of 2028, and is soon to be the fourth-most-current Ubuntu LTS release. In the interest of promoting Ubuntu release currency within the templates in this repository, this pull request is one of nine that endeavour to replace all references to Ubuntu 18.04 with references to Ubuntu 22.04. Prior to the changes, 18.04 was the oldest Ubuntu release referenced in this repository. This pull request concerns only the `vm-new-or-existing-conditions` scenario folder.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Removed allow-value constraints from offer and SKU template parameters
* Updated offer and SKU template parameter default values
* Renamed SKU template parameter from `sqlSku` to `imageSku`
