### PR TITLE
Replaced Ubuntu 18.04 references with Ubuntu 22.04 references - vm-sshkey (3/9)

### DIFF
--- a/quickstarts/microsoft.compute/vm-sshkey/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-sshkey/azuredeploy.json
@@ -191,8 +191,8 @@
         "storageProfile": {
           "imageReference": {
             "publisher": "Canonical",
-            "offer": "UbuntuServer",
-            "sku": "18_04-lts-gen2",
+            "offer": "0001-com-ubuntu-server-jammy",
+            "sku": "22_04-lts-gen2",
             "version": "latest"
           },
           "osDisk": {


### PR DESCRIPTION
Ubuntu 18.04 will reach end-of-life in April of 2028, and is soon to be the fourth-most-current Ubuntu LTS release. In the interest of promoting Ubuntu release currency within the templates in this repository, this pull request is one of nine that endeavour to replace all references to Ubuntu 18.04 with references to Ubuntu 22.04. Prior to the changes, 18.04 was the oldest Ubuntu release referenced in this repository. This pull request concerns only the `vm-sshkey` scenario folder.

Pull requests in series:

* https://github.com/Azure/azure-quickstart-templates/pull/13866
* https://github.com/Azure/azure-quickstart-templates/pull/13867
* https://github.com/Azure/azure-quickstart-templates/pull/13868
* https://github.com/Azure/azure-quickstart-templates/pull/13869
* https://github.com/Azure/azure-quickstart-templates/pull/13870
* https://github.com/Azure/azure-quickstart-templates/pull/13871
* https://github.com/Azure/azure-quickstart-templates/pull/13872
* https://github.com/Azure/azure-quickstart-templates/pull/13873
* https://github.com/Azure/azure-quickstart-templates/pull/13874

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Replaced reference to Ubuntu 18.04 with reference to Ubuntu 22.04
