### PR TITLE
Replaced Ubuntu 18.04 references with Ubuntu 22.04 references - vm-trustedlaunch-linux (4/9)

### DIFF
--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/azuredeploy.json
@@ -18,10 +18,8 @@
     },
     "sku": {
       "type": "string",
-      "defaultValue": "Ubuntu-2004",
+      "defaultValue": "Ubuntu-2204",
       "allowedValues": [
-        "Ubuntu-1804",
-        "Ubuntu-2004",
         "Ubuntu-2204",
         "RHEL-83",
         "SUSE-15-SP2"
@@ -148,18 +146,6 @@
   },
   "variables": {
     "imageReference": {
-      "Ubuntu-1804": {
-        "publisher": "Canonical",
-        "offer": "UbuntuServer",
-        "sku": "18_04-lts-gen2",
-        "version": "latest"
-      },
-      "Ubuntu-2004": {
-        "publisher": "Canonical",
-        "offer": "0001-com-ubuntu-server-focal",
-        "sku": "20_04-lts-gen2",
-        "version": "latest"
-      },
       "Ubuntu-2204": {
         "publisher": "Canonical",
         "offer": "0001-com-ubuntu-server-jammy",

--- a/quickstarts/microsoft.compute/vm-trustedlaunch-linux/main.bicep
+++ b/quickstarts/microsoft.compute/vm-trustedlaunch-linux/main.bicep
@@ -3,13 +3,11 @@ param vmName string = 'myTVM'
 
 @description('The OS for the virtual machine. This will pick the latest fully patched image of the given OS.')
 @allowed([
-  'Ubuntu-1804'
-  'Ubuntu-2004'
   'Ubuntu-2204'
   'RHEL-83'
   'SUSE-15-SP2'
 ])
-param sku string = 'Ubuntu-2004'
+param sku string = 'Ubuntu-2204'
 
 @description('The size of the virtual machine')
 param vmSize string = 'Standard_D2s_v3'
@@ -70,18 +68,6 @@ param networkSecurityGroupName string = 'nsg'
 param maaEndpoint string = ''
 
 var imageReference = {
-  'Ubuntu-1804': {
-    publisher: 'Canonical'
-    offer: 'UbuntuServer'
-    sku: '18_04-lts-gen2'
-    version: 'latest'
-  }
-  'Ubuntu-2004': {
-    publisher: 'Canonical'
-    offer: '0001-com-ubuntu-server-focal'
-    sku: '20_04-lts-gen2'
-    version: 'latest'
-  }
   'Ubuntu-2204': {
     publisher: 'Canonical'
     offer: '0001-com-ubuntu-server-jammy'


### PR DESCRIPTION
Ubuntu 18.04 will reach end-of-life in April of 2028, and is soon to be the fourth-most-current Ubuntu LTS release. In the interest of promoting Ubuntu release currency within the templates in this repository, this pull request is one of nine that endeavour to replace all references to Ubuntu 18.04 with references to Ubuntu 22.04. Prior to the changes, 18.04 was the oldest Ubuntu release referenced in this repository. This pull request concerns only the `vm-trustedlaunch-linux` scenario folder.

Pull requests in series:

* https://github.com/Azure/azure-quickstart-templates/pull/13866
* https://github.com/Azure/azure-quickstart-templates/pull/13867
* https://github.com/Azure/azure-quickstart-templates/pull/13868
* https://github.com/Azure/azure-quickstart-templates/pull/13869
* https://github.com/Azure/azure-quickstart-templates/pull/13870
* https://github.com/Azure/azure-quickstart-templates/pull/13871
* https://github.com/Azure/azure-quickstart-templates/pull/13872
* https://github.com/Azure/azure-quickstart-templates/pull/13873
* https://github.com/Azure/azure-quickstart-templates/pull/13874

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Removed Ubuntu 18.04 and Ubuntu 20.04 from allowed values associated with image template parameter
* Updated image template parameter default value
* Removed Ubuntu 18.04 and Ubuntu 20.04 from map associated with `imageReference` template variable
