### PR TITLE
Replaced Ubuntu 18.04 references with Ubuntu 22.04 references - vmss-with-public-ip-prefix (6/9)

### DIFF
--- a/quickstarts/microsoft.compute/vmss-with-public-ip-prefix/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vmss-with-public-ip-prefix/azuredeploy.json
@@ -54,35 +54,16 @@
     },
     "imageOffer": {
       "type": "string",
-      "defaultValue": "0001-com-ubuntu-server-lunar",
-      "allowedValues": [
-        "0001-com-ubuntu-minimal-bionic",
-        "0001-com-ubuntu-minimal-lunar-daily",
-        "0001-com-ubuntu-server-focal",
-        "0001-com-ubuntu-server-jammy",
-        "0001-com-ubuntu-server-lunar",
-        "0001-com-ubuntu-server-lunar-daily",
-        "0003-com-ubuntu-server-trusted-vm"
-      ],
+      "defaultValue": "0001-com-ubuntu-server-jammy",
       "metadata": {
-        "description": "Windows Server and SQL Offer"
+        "description": "The offer of the Ubuntu image from which to launch the Virtual Machine."
       }
     },
-    "sqlSku": {
+    "imageSku": {
       "type": "string",
-      "defaultValue": "23_04-gen2",
-      "allowedValues": [
-        "22_10-minimal-gen2",
-        "18_04-lts-gen2",
-        "minimal-20_04-daily-lts-gen2",
-        "minimal-23_04-daily-gen2",
-        "minimal-23_04-gen2",
-        "20_04-daily-lts-gen2",
-        "23_04-daily-gen2",
-        "23_04-gen2"
-      ],
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
-        "description": "SQL Server Sku"
+        "description": "The SKU of the Ubuntu image from which to launch the Virtual Machine."
       }
     },
     "location": {
@@ -150,7 +131,7 @@
     "osType": {
       "publisher": "Canonical",
       "offer": "[parameters('imageOffer')]",
-      "sku": "[parameters('sqlSku')]",
+      "sku": "[parameters('imageSku')]",
       "version": "latest"
     },
     "imageReference": "[variables('osType')]",

--- a/quickstarts/microsoft.compute/vmss-with-public-ip-prefix/main.bicep
+++ b/quickstarts/microsoft.compute/vmss-with-public-ip-prefix/main.bicep
@@ -32,30 +32,11 @@ var securityProfileJson = {
   securityType: securityType
 }
 
-@description('Windows Server and SQL Offer')
-@allowed([
-  '0001-com-ubuntu-minimal-bionic'
-  '0001-com-ubuntu-minimal-lunar-daily'
-  '0001-com-ubuntu-server-focal'
-  '0001-com-ubuntu-server-jammy'
-  '0001-com-ubuntu-server-lunar'
-  '0001-com-ubuntu-server-lunar-daily'
-  '0003-com-ubuntu-server-trusted-vm'
-])
-param imageOffer string = '0001-com-ubuntu-server-lunar'
+@description('The offer of the Ubuntu image from which to launch the Virtual Machine.')
+param imageOffer string = '0001-com-ubuntu-server-jammy'
 
-@description('SQL Server Sku')
-@allowed([
-  '22_10-minimal-gen2'
-  '18_04-lts-gen2'
-  'minimal-20_04-daily-lts-gen2'
-  'minimal-23_04-daily-gen2'
-  'minimal-23_04-gen2'
-  '20_04-daily-lts-gen2'
-  '23_04-daily-gen2'
-  '23_04-gen2'
-])
-param sqlSku string = '23_04-gen2'
+@description('The SKU of the Ubuntu image from which to launch the Virtual Machine.')
+param imageSku string = '22_04-lts-gen2'
 
 @description('Location for resources. Default is the current resource group location.')
 param location string = resourceGroup().location
@@ -95,7 +76,7 @@ var linuxConfiguration = {
 var osType = {
   publisher: 'Canonical'
   offer: imageOffer
-  sku: sqlSku
+  sku: imageSku
   version: 'latest'
 }
 var imageReference = osType


### PR DESCRIPTION
Ubuntu 18.04 will reach end-of-life in April of 2028, and is soon to be the fourth-most-current Ubuntu LTS release. In the interest of promoting Ubuntu release currency within the templates in this repository, this pull request is one of nine that endeavour to replace all references to Ubuntu 18.04 with references to Ubuntu 22.04. Prior to the changes, 18.04 was the oldest Ubuntu release referenced in this repository. This pull request concerns only the `vmss-with-public-ip-prefix` scenario folder.

Pull requests in series:

* https://github.com/Azure/azure-quickstart-templates/pull/13866
* https://github.com/Azure/azure-quickstart-templates/pull/13867
* https://github.com/Azure/azure-quickstart-templates/pull/13868
* https://github.com/Azure/azure-quickstart-templates/pull/13869
* https://github.com/Azure/azure-quickstart-templates/pull/13870
* https://github.com/Azure/azure-quickstart-templates/pull/13871
* https://github.com/Azure/azure-quickstart-templates/pull/13872
* https://github.com/Azure/azure-quickstart-templates/pull/13873
* https://github.com/Azure/azure-quickstart-templates/pull/13874

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Removed allow-value constraints from offer and SKU template parameters
* Updated offer and SKU template parameter default values
* Renamed SKU template parameter from sqlSku to imageSku
