### PR TITLE
Replaced Ubuntu 18.04 references with Ubuntu 22.04 references - azure-firewall-dns-proxy (8/9)

### DIFF
--- a/quickstarts/microsoft.network/azure-firewall-dns-proxy/azuredeploy.json
+++ b/quickstarts/microsoft.network/azure-firewall-dns-proxy/azuredeploy.json
@@ -1359,7 +1359,7 @@
       "properties": {
         "publisher": "Microsoft.EnterpriseCloud.Monitoring",
         "type": "OmsAgentForLinux",
-        "typeHandlerVersion": "1.12",
+        "typeHandlerVersion": "1.16",
         "settings": {
           "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2023-09-01').customerId]",
           "stopOnMultipleConnections": false

--- a/quickstarts/microsoft.network/azure-firewall-dns-proxy/azuredeploy.json
+++ b/quickstarts/microsoft.network/azure-firewall-dns-proxy/azuredeploy.json
@@ -1353,45 +1353,19 @@
     {
       "condition": "[parameters('deployCustomDnsForwarder')]",
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "apiVersion": "2023-09-01",
-      "name": "[format('{0}/{1}', parameters('dnsVmName'), 'LogAnalytics')]",
+      "apiVersion": "2021-11-01",
+      "name": "[format('{0}/AzureMonitorLinuxAgent', parameters('dnsVmName'))]",
       "location": "[parameters('location')]",
-      "properties": {
-        "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-        "type": "OmsAgentForLinux",
-        "typeHandlerVersion": "1.16",
-        "settings": {
-          "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2023-09-01').customerId]",
-          "stopOnMultipleConnections": false
-        },
-        "protectedSettings": {
-          "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2023-09-01').primarySharedKey]"
-        }
-      },
       "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('dnsVmName'))]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('dnsVmName'), 'CustomScript')]",
-        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      ]
-    },
-    {
-      "condition": "[parameters('deployCustomDnsForwarder')]",
-      "type": "Microsoft.Compute/virtualMachines/extensions",
-      "apiVersion": "2023-09-01",
-      "name": "[format('{0}/{1}', parameters('dnsVmName'), 'DependencyAgent')]",
-      "location": "[parameters('location')]",
+        "[resourceId('Microsoft.Compute/virtualMachines', parameters('dnsVmName'))]"
+      ],
       "properties": {
-        "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
-        "type": "DependencyAgentLinux",
-        "typeHandlerVersion": "9.10",
-        "autoUpgradeMinorVersion": true
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('dnsVmName'))]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('dnsVmName'), 'CustomScript')]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('dnsVmName'), 'LogAnalytics')]",
-        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      ]
+        "publisher": "Microsoft.Azure.Monitor",
+        "type": "AzureMonitorLinuxAgent",
+        "typeHandlerVersion": "1.21",
+        "autoUpgradeMinorVersion": true,
+        "enableAutomaticUpgrade": true
+      }
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
@@ -1574,44 +1548,19 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "apiVersion": "2023-09-01",
-      "name": "[format('{0}/{1}', parameters('devVmName'), 'LogAnalytics')]",
+      "apiVersion": "2021-11-01",
+      "name": "[format('{0}/AzureMonitorLinuxAgent', parameters('devVmName'))]",
       "location": "[parameters('location')]",
-      "properties": {
-        "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-        "type": "OmsAgentForLinux",
-        "typeHandlerVersion": "1.12",
-        "settings": {
-          "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2023-09-01').customerId]",
-          "stopOnMultipleConnections": false
-        },
-        "protectedSettings": {
-          "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2023-09-01').primarySharedKey]"
-        }
-      },
       "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('devVmName'))]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('devVmName'), 'CustomScript')]",
-        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Compute/virtualMachines/extensions",
-      "apiVersion": "2023-09-01",
-      "name": "[format('{0}/{1}', parameters('devVmName'), 'DependencyAgent')]",
-      "location": "[parameters('location')]",
+        "[resourceId('Microsoft.Compute/virtualMachines', parameters('devVmName'))]"
+      ],
       "properties": {
-        "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
-        "type": "DependencyAgentLinux",
-        "typeHandlerVersion": "9.10",
-        "autoUpgradeMinorVersion": true
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('devVmName'))]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('devVmName'), 'CustomScript')]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('devVmName'), 'LogAnalytics')]",
-        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      ]
+        "publisher": "Microsoft.Azure.Monitor",
+        "type": "AzureMonitorLinuxAgent",
+        "typeHandlerVersion": "1.21",
+        "autoUpgradeMinorVersion": true,
+        "enableAutomaticUpgrade": true
+      }
     },
     {
       "type": "Microsoft.Network/networkInterfaces",
@@ -1794,44 +1743,19 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "apiVersion": "2023-09-01",
-      "name": "[format('{0}/{1}', parameters('prodVmName'), 'LogAnalytics')]",
+      "apiVersion": "2021-11-01",
+      "name": "[format('{0}/AzureMonitorLinuxAgent', parameters('prodVmName'))]",
       "location": "[parameters('location')]",
-      "properties": {
-        "publisher": "Microsoft.EnterpriseCloud.Monitoring",
-        "type": "OmsAgentForLinux",
-        "typeHandlerVersion": "1.12",
-        "settings": {
-          "workspaceId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2023-09-01').customerId]",
-          "stopOnMultipleConnections": false
-        },
-        "protectedSettings": {
-          "workspaceKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName')), '2023-09-01').primarySharedKey]"
-        }
-      },
       "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('prodVmName'))]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('prodVmName'), 'CustomScript')]",
-        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      ]
-    },
-    {
-      "type": "Microsoft.Compute/virtualMachines/extensions",
-      "apiVersion": "2023-09-01",
-      "name": "[format('{0}/{1}', parameters('prodVmName'), 'DependencyAgent')]",
-      "location": "[parameters('location')]",
+        "[resourceId('Microsoft.Compute/virtualMachines', parameters('prodVmName'))]"
+      ],
       "properties": {
-        "publisher": "Microsoft.Azure.Monitoring.DependencyAgent",
-        "type": "DependencyAgentLinux",
-        "typeHandlerVersion": "9.10",
-        "autoUpgradeMinorVersion": true
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('prodVmName'))]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('prodVmName'), 'CustomScript')]",
-        "[resourceId('Microsoft.Compute/virtualMachines/extensions', parameters('prodVmName'), 'LogAnalytics')]",
-        "[resourceId('Microsoft.OperationalInsights/workspaces', parameters('workspaceName'))]"
-      ]
+        "publisher": "Microsoft.Azure.Monitor",
+        "type": "AzureMonitorLinuxAgent",
+        "typeHandlerVersion": "1.21",
+        "autoUpgradeMinorVersion": true,
+        "enableAutomaticUpgrade": true
+      }
     },
     {
       "copy": {

--- a/quickstarts/microsoft.network/azure-firewall-dns-proxy/azuredeploy.json
+++ b/quickstarts/microsoft.network/azure-firewall-dns-proxy/azuredeploy.json
@@ -116,25 +116,21 @@
       "type": "string",
       "defaultValue": "Canonical",
       "metadata": {
-        "description": "Specifies the image publisher of the disk image used to create the virtual machine."
+        "description": "The publisher of the image from which to launch the virtual machine."
       }
     },
     "imageOffer": {
       "type": "string",
-      "defaultValue": "UbuntuServer",
+      "defaultValue": "0001-com-ubuntu-server-jammy",
       "metadata": {
-        "description": "Specifies the offer of the platform image or marketplace image used to create the virtual machine."
+        "description": "The offer of the image from which to launch the virtual machine."
       }
     },
     "imageSku": {
       "type": "string",
-      "defaultValue": "18_04-lts-gen2",
-      "allowedValues": [
-        "18_04-daily-lts-gen2",
-        "18_04-lts-gen2"
-      ],
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
-        "description": "The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version."
+        "description": "The SKU of the image from which to launch the virtual machine."
       }
     },
     "authenticationType": {

--- a/quickstarts/microsoft.network/azure-firewall-dns-proxy/main.bicep
+++ b/quickstarts/microsoft.network/azure-firewall-dns-proxy/main.bicep
@@ -49,18 +49,14 @@ param prodVmName string = 'ProdVm'
 @description('Specifies the size of the virtual machine.')
 param vmSize string = 'Standard_D4s_v3'
 
-@description('Specifies the image publisher of the disk image used to create the virtual machine.')
+@description('The publisher of the image from which to launch the virtual machine.')
 param imagePublisher string = 'Canonical'
 
-@description('Specifies the offer of the platform image or marketplace image used to create the virtual machine.')
-param imageOffer string = 'UbuntuServer'
+@description('The offer of the image from which to launch the virtual machine.')
+param imageOffer string = '0001-com-ubuntu-server-jammy'
 
-@description('The Ubuntu version for the VM. This will pick a fully patched image of this given Ubuntu version.')
-@allowed([
-  '18_04-daily-lts-gen2'
-  '18_04-lts-gen2'
-])
-param imageSku string = '18_04-lts-gen2'
+@description('The SKU of the image from which to launch the virtual machine.')
+param imageSku string = '22_04-lts-gen2'
 
 @description('Specifies the type of authentication when accessing the Virtual Machine. SSH key is recommended.')
 @allowed([

--- a/quickstarts/microsoft.network/azure-firewall-dns-proxy/main.bicep
+++ b/quickstarts/microsoft.network/azure-firewall-dns-proxy/main.bicep
@@ -1013,42 +1013,17 @@ resource dnsVmCustomScript 'Microsoft.Compute/virtualMachines/extensions@2023-09
   }
 }
 
-resource dnsVmLogAnalytics 'Microsoft.Compute/virtualMachines/extensions@2023-09-01' = if (deployCustomDnsForwarder) {
+resource dnsVmAzureMonitorAgent 'Microsoft.Compute/virtualMachines/extensions@2023-09-01' = if (deployCustomDnsForwarder) {
   parent: dnsVm
-  name: 'LogAnalytics'
+  name: '${dnsVmName}-AzureMonitorLinuxAgent'
   location: location
   properties: {
-    publisher: 'Microsoft.EnterpriseCloud.Monitoring'
-    type: 'OmsAgentForLinux'
-    typeHandlerVersion: '1.12'
-    settings: {
-      workspaceId: workspace.properties.customerId
-      stopOnMultipleConnections: false
-    }
-    protectedSettings: {
-      workspaceKey: workspace.listKeys().primarySharedKey
-    }
-  }
-  dependsOn: [
-    dnsVmCustomScript
-  ]
-}
-
-resource dnsVmDependencyAgent 'Microsoft.Compute/virtualMachines/extensions@2023-09-01' = if (deployCustomDnsForwarder) {
-  parent: dnsVm
-  name: 'DependencyAgent'
-  location: location
-  properties: {
-    publisher: 'Microsoft.Azure.Monitoring.DependencyAgent'
-    type: 'DependencyAgentLinux'
-    typeHandlerVersion: '9.10'
+    publisher: 'Microsoft.Azure.Monitor'
+    type: 'AzureMonitorLinuxAgent'
+    typeHandlerVersion: '1.21'
     autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
   }
-  dependsOn: [
-    workspace
-    dnsVmCustomScript
-    dnsVmLogAnalytics
-  ]
 }
 
 resource devVmNic 'Microsoft.Network/networkInterfaces@2023-09-01' = {
@@ -1207,42 +1182,17 @@ resource devVmCustomScript 'Microsoft.Compute/virtualMachines/extensions@2023-09
   ]
 }
 
-resource devVmLogAnalytics 'Microsoft.Compute/virtualMachines/extensions@2023-09-01' = {
+resource devVmAzureMonitorAgent 'Microsoft.Compute/virtualMachines/extensions@2023-09-01' = {
   parent: devVm
-  name: 'LogAnalytics'
+  name: '${devVmName}-AzureMonitorLinuxAgent'
   location: location
   properties: {
-    publisher: 'Microsoft.EnterpriseCloud.Monitoring'
-    type: 'OmsAgentForLinux'
-    typeHandlerVersion: '1.12'
-    settings: {
-      workspaceId: workspace.properties.customerId
-      stopOnMultipleConnections: false
-    }
-    protectedSettings: {
-      workspaceKey: workspace.listKeys().primarySharedKey
-    }
-  }
-  dependsOn: [
-    devVmCustomScript
-  ]
-}
-
-resource devVmDependencyAgent 'Microsoft.Compute/virtualMachines/extensions@2023-09-01' = {
-  parent: devVm
-  name: 'DependencyAgent'
-  location: location
-  properties: {
-    publisher: 'Microsoft.Azure.Monitoring.DependencyAgent'
-    type: 'DependencyAgentLinux'
-    typeHandlerVersion: '9.10'
+    publisher: 'Microsoft.Azure.Monitor'
+    type: 'AzureMonitorLinuxAgent'
+    typeHandlerVersion: '1.21'
     autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
   }
-  dependsOn: [
-    workspace
-    devVmCustomScript
-    devVmLogAnalytics
-  ]
 }
 
 resource prodVmNic 'Microsoft.Network/networkInterfaces@2023-09-01' = {
@@ -1401,42 +1351,17 @@ resource prodVmCustomScript 'Microsoft.Compute/virtualMachines/extensions@2023-0
   ]
 }
 
-resource prodVmLogAnalytics 'Microsoft.Compute/virtualMachines/extensions@2023-09-01' = {
+resource prodVmAzureMonitorAgent 'Microsoft.Compute/virtualMachines/extensions@2023-09-01' = {
   parent: prodVm
-  name: 'LogAnalytics'
+  name: '${prodVmName}-AzureMonitorLinuxAgent'
   location: location
   properties: {
-    publisher: 'Microsoft.EnterpriseCloud.Monitoring'
-    type: 'OmsAgentForLinux'
-    typeHandlerVersion: '1.12'
-    settings: {
-      workspaceId: workspace.properties.customerId
-      stopOnMultipleConnections: false
-    }
-    protectedSettings: {
-      workspaceKey: workspace.listKeys().primarySharedKey
-    }
-  }
-  dependsOn: [
-    prodVmCustomScript
-  ]
-}
-
-resource prodVmDependencyAgent 'Microsoft.Compute/virtualMachines/extensions@2023-09-01' = {
-  parent: prodVm
-  name: 'DependencyAgent'
-  location: location
-  properties: {
-    publisher: 'Microsoft.Azure.Monitoring.DependencyAgent'
-    type: 'DependencyAgentLinux'
-    typeHandlerVersion: '9.10'
+    publisher: 'Microsoft.Azure.Monitor'
+    type: 'AzureMonitorLinuxAgent'
+    typeHandlerVersion: '1.21'
     autoUpgradeMinorVersion: true
+    enableAutomaticUpgrade: true
   }
-  dependsOn: [
-    workspace
-    prodVmCustomScript
-    prodVmLogAnalytics
-  ]
 }
 
 resource firewallPublicIp 'Microsoft.Network/publicIPAddresses@2023-09-01' = [for i in range(0, numberOfFirewallPublicIPAddresses): {


### PR DESCRIPTION
Ubuntu 18.04 will reach end-of-life in April of 2028, and is soon to be the fourth-most-current Ubuntu LTS release. In the interest of promoting Ubuntu release currency within the templates in this repository, this pull request is one of nine that endeavour to replace all references to Ubuntu 18.04 with references to Ubuntu 22.04. Prior to the changes, 18.04 was the oldest Ubuntu release referenced in this repository. This pull request concerns only the `azure-firewall-dns-proxy` scenario folder.

Pull requests in series:

* https://github.com/Azure/azure-quickstart-templates/pull/13866
* https://github.com/Azure/azure-quickstart-templates/pull/13867
* https://github.com/Azure/azure-quickstart-templates/pull/13868
* https://github.com/Azure/azure-quickstart-templates/pull/13869
* https://github.com/Azure/azure-quickstart-templates/pull/13870
* https://github.com/Azure/azure-quickstart-templates/pull/13871
* https://github.com/Azure/azure-quickstart-templates/pull/13872
* https://github.com/Azure/azure-quickstart-templates/pull/13873
* https://github.com/Azure/azure-quickstart-templates/pull/13874

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Removed allowed-value constraint from image SKU template parameter
* Updated offer and SKU template parameter default values
* Updated publisher, offer, and SKU template parameter descriptions
* Replaced OMS Agent for Linux and Dependency Agent with Azure Monitor Agent for Linux
