### PR TITLE
Added Anbox Cloud quick-start template

### DIFF
--- a/quickstarts/canonical/anbox/README.md
+++ b/quickstarts/canonical/anbox/README.md
@@ -31,6 +31,18 @@ By default, the template will launch a VM from an Ubuntu Pro image. If you would
 
 Once the deployment is complete, follow [these instructions](https://anbox-cloud.io/docs/tutorial/installing-appliance#initialise-the-appliance-6) to initialize the Anbox Cloud Appliance and register your Ubuntu SSO account with the Appliance. The machine (VM) IP address referenced in the instructions is available as the `virtualMachinePublicIPAddress` output from the template. Note that the SSH command presented to you in your browser during Appliance initialization reflects certain assumptions regarding the location of the VM administrator's private SSH key. If you would like to point the `ssh` command to a private key at a particular location in your filesystem, the `sshCommand` output from the template provides an example of how to do so (replace `$PATH_TO_ADMINISTRATOR_PRIVATE_SSH_KEY` with the filesystem location).
 
+### Advanced configuration
+
+The template allows users to attach a dedicated data disk for LXD to the VM and to expose both the Anbox Management Service and services running on Anbox containers to the public internet.
+
+#### Dedicated disk for LXD
+
+By default, `anbox-cloud-appliance init` (see the linked instructions in the **Deployment steps** section above) will deploy the LXD storage pool to a dedicated data disk. Users wishing to instead host the LXD storage pool on the operating system disk can override the default argument for the template's `addDedicatedDataDiskForLXD` parameter. Note that when a dedicated data disk is attached to the VM, `anbox-cloud-appliance init` will automatically detect the disk's presence and deploy the LXD storage pool to the disk, so the user need not override any of the default answers to the questions that `anbox-cloud-appliance init` presents.
+
+#### Exposing Anbox services to the public internet
+
+The template includes two parameters that allow the user to expose Anbox services running on the VM to the public internet. The first parameter, `exposeAnboxManagementService`, exposes the Anbox Management Service on port 8444. The second parameter, `exposeAnboxContainerServices`, exposes Anbox container services on the port range 10000-11000. When the default arguments for these parameters are not overriden, the Anbox Management Service and any container services will only be accessible from the VM.
+
 ## Notes
 
 ### Anbox Cloud on ARM

--- a/quickstarts/canonical/anbox/README.md
+++ b/quickstarts/canonical/anbox/README.md
@@ -1,0 +1,40 @@
+# Deploy Anbox Cloud
+
+![Azure Public Test Date](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/canonical/anbox/PublicLastTestDate.svg)
+![Azure Public Test Result](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/canonical/anbox/PublicDeployment.svg)
+
+![Azure US Gov Last Test Date](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/canonical/anbox/FairfaxLastTestDate.svg)
+![Azure US Gov Last Test Result](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/canonical/anbox/FairfaxDeployment.svg)
+
+![Best Practice Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/canonical/anbox/BestPracticeResult.svg)
+![Cred Scan Check](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/canonical/anbox/CredScanResult.svg)
+
+![Bicep Version](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/canonical/anbox/BicepVersion.svg)
+
+[![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fcanonical%2Fanbox%2Fmain.bicep)
+[![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fcanonical%2Fanbox%2Fmain.bicep)
+[![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fquickstarts%2Fcanonical%2Fanbox%2Fmain.bicep)
+
+This template deploys [Anbox Cloud](https://anbox-cloud.io/) on an Ubuntu VM. Completing the installation of Anbox Cloud requires user interaction following the deployment; please follow the instructions in the **Deployment steps** section below when deploying.
+
+## Prerequisites
+
+The template supports both launching of a VM from an Ubuntu Pro image and association of an Ubuntu Pro token with a VM launched from a non-Pro image. Users seeking the latter behaviour must [obtain a Pro token](https://canonical-ubuntu-pro-client.readthedocs-hosted.com/en/latest/howtoguides/get_token_and_attach/#get-an-ubuntu-pro-token) before proceeding with deployment.
+
+The template is also parametric in the public SSH key of the VM administrator. To create a new key pair for this purpose, please follow [these instructions](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/mac-create-ssh-keys#create-an-ssh-key-pair).
+
+## Deployment steps
+
+To begin the deployment, either click the **Deploy to Azure** button at the beginning of this document or follow the instructions for command-line deployment using the scripts in the root of this repository. You will be prompted for the VM administrator's username and public SSH key (see the **Prerequisites** section above for more information regarding the latter).
+
+By default, the template will launch a VM from an Ubuntu Pro image. If you would rather associate an Ubuntu Pro token with a VM launched from a non-Pro image, then you will need to override the default arguments for the template's `ubuntuImageOffer`, `ubuntuImageSKU` and `ubuntuProToken` parameters. Note that any Pro token supplied as an argument will be [ignored by cloud-init](https://cloudinit.readthedocs.io/en/latest/reference/modules.html#ubuntu-pro) if the arguments provided for the `ubuntuImageOffer` and `ubuntuImageSKU` parameters correspond to a Pro image.
+
+Once the deployment is complete, follow [these instructions](https://anbox-cloud.io/docs/tutorial/installing-appliance#initialise-the-appliance-6) to initialize the Anbox Cloud Appliance and register your Ubuntu SSO account with the Appliance. The machine (VM) IP address referenced in the instructions is available as the `virtualMachinePublicIPAddress` output from the template. Note that the SSH command presented to you in your browser during Appliance initialization reflects certain assumptions regarding the location of the VM administrator's private SSH key. If you would like to point the `ssh` command to a private key at a particular location in your filesystem, the `sshCommand` output from the template provides an example of how to do so (replace `$PATH_TO_ADMINISTRATOR_PRIVATE_SSH_KEY` with the filesystem location).
+
+## Notes
+
+### Anbox Cloud on ARM
+
+ARM processors are particularly well-suited to Anbox Cloud, but Ubuntu Pro images for ARM processors are not yet available. As such, the default VM in the template runs on x86 processors and the default Ubuntu image is built for x86. Users wishing to employ ARM processors must launch a VM running on ARM processors from a non-Pro Ubuntu image built for ARM and instruct `cloud-init` to attach Pro to the VM using a token. They can accomplish this by overriding the default arguments for the template's `virtualMachineSize`, `ubuntuImageOffer`, `ubuntuImageSKU`, and `ubuntuProToken` parameters.
+
+`Tags: Anbox, Azure4Student, Microsoft.Compute/virtualMachines, Microsoft.Network/networkInterfaces, Microsoft.Network/networkSecurityGroups, Microsoft.Network/publicIPAddresses, Microsoft.Network/virtualNetworks, Microsoft.Network/virtualNetworks/subnets, Ubuntu`

--- a/quickstarts/canonical/anbox/azuredeploy.parameters.json
+++ b/quickstarts/canonical/anbox/azuredeploy.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "administratorPublicSSHKey": {
+      "value": "GEN-SSH-PUB-KEY"
+    },
+    "administratorUsername": {
+      "value": "GEN-UNIQUE"
+    }
+  }
+}

--- a/quickstarts/canonical/anbox/main.bicep
+++ b/quickstarts/canonical/anbox/main.bicep
@@ -1,0 +1,240 @@
+@description('Public SSH key of the virtual machine administrator')
+@secure()
+param administratorPublicSSHKey string
+
+@description('Virtual machine administrator username')
+param administratorUsername string
+
+@description('Location of all resources')
+param location string = resourceGroup().location
+
+@description('Name of the virtual machine network interface security group')
+param networkSecurityGroupName string = 'anboxVirtualMachineNetworkInterfaceSecurityGroup'
+
+@description('CIDR block of the virtual network subnet')
+param subnetAddressPrefix string = '10.0.0.0/24'
+
+@description('Name of the virtual network subnet')
+param subnetName string = 'anboxVirtualNetworkSubnet'
+
+@description('Offer of the Ubuntu image from which to launch the virtual machine; must be a Pro offer if an argument is not provided for the ubuntuProToken parameter')
+param ubuntuImageOffer string = '0001-com-ubuntu-pro-jammy'
+
+@description('SKU of the Ubuntu image from which to launch the virtual machine; must be a Pro SKU if an argument is not provided for the ubuntuProToken parameter')
+param ubuntuImageSKU string = 'pro-22_04-lts-gen2'
+
+@description('Ubuntu Pro token to attach to the virtual machine; will be ignored by cloud-init if the arguments provided for the ubuntuImageOffer and ubuntuImageSKU parameters correspond to a Pro image (see https://cloudinit.readthedocs.io/en/latest/reference/modules.html#ubuntu-pro)')
+param ubuntuProToken string = ''
+
+@description('Size of the virtual machine data disk; must comply with https://anbox-cloud.io/docs/reference/requirements#anbox-cloud-appliance-4')
+@minValue(100)
+@maxValue(1023)
+param virtualMachineDataDiskSizeInGB int = 100
+
+@description('Name of the virtual machine')
+param virtualMachineName string = 'anboxVirtualMachine'
+
+@description('Size of the virtual machine data disk; must comply with https://anbox-cloud.io/docs/reference/requirements#anbox-cloud-appliance-4')
+@minValue(40)
+@maxValue(1023)
+param virtualMachineOperatingSystemDiskSizeInGB int = 40
+
+@description('Size of the virtual machine; must comply with https://anbox-cloud.io/docs/reference/requirements#anbox-cloud-appliance-4')
+param virtualMachineSize string = 'Standard_D4s_v5'
+
+@description('CIDR block of the virtual network')
+param virtualNetworkAddressPrefix string = '10.0.0.0/16'
+
+@description('Name of the virtual network')
+param virtualNetworkName string = 'anboxVirtualNetwork'
+
+var cloudConfigWithToken = '''
+#cloud-config
+
+package_upgrade: true
+
+ubuntu_advantage:
+  token: ubuntuProToken
+  enable:
+    - anbox-cloud'''
+
+var cloudConfigWithoutToken = '''
+#cloud-config
+
+package_upgrade: true
+
+ubuntu_advantage:
+  enable:
+    - anbox-cloud'''
+
+var cloudConfig = base64(empty(ubuntuProToken) ? cloudConfigWithoutToken : replace(cloudConfigWithToken, 'ubuntuProToken', ubuntuProToken))
+
+var imagePlan = empty(ubuntuProToken) ? {
+  name: ubuntuImageSKU
+  product: ubuntuImageOffer
+  publisher: 'canonical'
+} : null
+  
+var linuxConfiguration = {
+  disablePasswordAuthentication: true
+  ssh: {
+    publicKeys: [
+      {
+        path: '/home/${administratorUsername}/.ssh/authorized_keys'
+        keyData: administratorPublicSSHKey
+      }
+    ]
+  }
+}
+
+var networkInterfaceName = '${virtualMachineName}NetworkInterface'
+
+var publicIPAddressName = '${virtualMachineName}PublicIP'
+
+resource virtualNetwork 'Microsoft.Network/virtualNetworks@2023-09-01' = {
+  name: virtualNetworkName
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        virtualNetworkAddressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: subnetName
+        properties: {
+          addressPrefix: subnetAddressPrefix
+        }
+      }
+    ]
+  }
+}
+
+resource networkSecurityGroup 'Microsoft.Network/networkSecurityGroups@2023-09-01' = {
+  name: networkSecurityGroupName
+  location: location
+  properties: {
+    securityRules: [
+      {
+        name: 'SSH'
+        properties: {
+          priority: 1000
+          protocol: 'Tcp'
+          access: 'Allow'
+          direction: 'Inbound'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRange: '22'
+        }
+      }
+      {
+        name: 'Anbox'
+        properties: {
+          priority: 1010
+          protocol: '*'
+          access: 'Allow'
+          direction: 'Inbound'
+          sourceAddressPrefix: '*'
+          sourcePortRange: '*'
+          destinationAddressPrefix: '*'
+          destinationPortRanges: [
+            '80'
+            '443'
+            '5349'
+            '8444'
+            '10000-11000'
+            '60000-60100'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource publicIPAddress 'Microsoft.Network/publicIPAddresses@2023-09-01' = {
+  name: publicIPAddressName
+  location: location
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+  }
+}
+
+resource networkInterface 'Microsoft.Network/networkInterfaces@2023-09-01' = {
+  name: networkInterfaceName
+  location: location
+  properties: {
+    ipConfigurations: [
+      {
+        name: '${networkInterfaceName}IPConfiguration'
+        properties: {
+          subnet: {
+            id: virtualNetwork.properties.subnets[0].id
+          }
+          privateIPAllocationMethod: 'Dynamic'
+          publicIPAddress: {
+            id: publicIPAddress.id
+          }
+        }
+      }
+    ]
+    networkSecurityGroup: {
+      id: networkSecurityGroup.id
+    }
+  }
+}
+
+resource virtualMachine 'Microsoft.Compute/virtualMachines@2023-09-01' = {
+  name: virtualMachineName
+  location: location
+  plan: imagePlan
+  properties: {
+    hardwareProfile: {
+      vmSize: virtualMachineSize
+    }
+    storageProfile: {
+      osDisk: {
+        createOption: 'FromImage'
+        diskSizeGB: virtualMachineOperatingSystemDiskSizeInGB
+        managedDisk: {
+          storageAccountType: 'Standard_LRS'
+        }
+      }
+      imageReference: {
+        publisher: 'Canonical'
+        offer: ubuntuImageOffer
+        sku: ubuntuImageSKU
+        version: 'latest'
+      }
+      dataDisks: [
+        {
+          createOption: 'Empty'
+          diskSizeGB: virtualMachineDataDiskSizeInGB
+          lun: 0
+          managedDisk: {
+            storageAccountType: 'Premium_LRS'
+          }
+        }
+      ]
+    }
+    networkProfile: {
+      networkInterfaces: [
+        {
+          id: networkInterface.id
+        }
+      ]
+    }
+    osProfile: {
+      computerName: virtualMachineName
+      adminUsername: administratorUsername
+      adminPassword: administratorPublicSSHKey
+      linuxConfiguration: linuxConfiguration
+      customData: cloudConfig
+    }
+  }
+}
+
+output sshCommand string = 'ssh -i $PATH_TO_ADMINISTRATOR_PRIVATE_SSH_KEY ${administratorUsername}@${publicIPAddress.properties.ipAddress}'
+output virtualMachinePublicIPAddress string = publicIPAddress.properties.ipAddress

--- a/quickstarts/canonical/anbox/metadata.json
+++ b/quickstarts/canonical/anbox/metadata.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://aka.ms/azure-quickstart-templates-metadata-schema#",
+  "itemDisplayName": "Deploy Anbox Cloud",
+  "description": "This template deploys Anbox Cloud on an Ubuntu VM. Completing the installation of Anbox Cloud requires user interaction following the deployment; please consult the README for instructions. The template supports both launching of a VM from an Ubuntu Pro image and association of an Ubuntu Pro token with a VM launched from a non-Pro image. The former is the default behaviour; users seeking to attach a token to a VM launched from a non-Pro image must override the default arguments for the ubuntuImageOffer, ubuntuImageSKU, and ubuntuProToken parameters. The template is also parametric in the VM size and disk sizes. Non-default argument values for these parameters must comply with https://anbox-cloud.io/docs/reference/requirements#anbox-cloud-appliance-4.",
+  "summary": "This template deploys Anbox Cloud on an Ubuntu VM. The template supports both launching of a VM from an Ubuntu Pro image and association of an Ubuntu Pro token with a VM launched from a non-Pro image.",
+  "githubUsername": "danpdraper",
+  "dateUpdated": "2024-03-15",
+  "type": "QuickStart"
+}


### PR DESCRIPTION
The commits in this pull request introduce a quick-start template that facilitates deployment of an [Anbox Cloud](https://anbox-cloud.io/) instance. The template allows users to launch the VM from an Ubuntu Pro image or attach an existing Ubuntu Pro token to a VM launched from a non-Pro image. The template also supports both the x86 and ARM processor architectures.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Added Anbox Cloud Bicep template and associated `README`, `azuredeploy.parameters.json`, and `metadata.json` files.
