### PR TITLE
Anbox: Use ARM64 images

### DIFF
--- a/quickstarts/canonical/anbox/README.md
+++ b/quickstarts/canonical/anbox/README.md
@@ -54,10 +54,4 @@ By default, `anbox-cloud-appliance init` (see the linked instructions in the **D
 
 The template includes two parameters that allow the user to expose Anbox services running on the VM to the public internet. The first parameter, `exposeAnboxManagementService`, exposes the Anbox Management Service on port 8444. The second parameter, `exposeAnboxContainerServices`, exposes Anbox container services on the port range 10000-11000. When the default arguments for these parameters are not overriden, the Anbox Management Service and any container services will only be accessible from the VM.
 
-## Notes
-
-### Anbox Cloud on ARM
-
-ARM processors are particularly well-suited to Anbox Cloud, but Ubuntu Pro images for ARM processors are not yet available. As such, the default VM in the template runs on x86 processors and the default Ubuntu image is built for x86. Users wishing to employ ARM processors must launch a VM running on ARM processors from a non-Pro Ubuntu image built for ARM and instruct `cloud-init` to attach Pro to the VM using a token. They can accomplish this by overriding the default arguments for the template's `virtualMachineSize`, `ubuntuImageOffer`, `ubuntuImageSKU`, and `ubuntuProToken` parameters.
-
 `Tags: Anbox, Azure4Student, Microsoft.Compute/virtualMachines, Microsoft.Network/networkInterfaces, Microsoft.Network/networkSecurityGroups, Microsoft.Network/publicIPAddresses, Microsoft.Network/virtualNetworks, Microsoft.Network/virtualNetworks/subnets, Ubuntu`

--- a/quickstarts/canonical/anbox/main.bicep
+++ b/quickstarts/canonical/anbox/main.bicep
@@ -30,7 +30,7 @@ param subnetName string = 'anboxVirtualNetworkSubnet'
 param ubuntuImageOffer string = '0001-com-ubuntu-pro-jammy'
 
 @description('SKU of the Ubuntu image from which to launch the virtual machine; must be a Pro SKU if an argument is not provided for the ubuntuProToken parameter')
-param ubuntuImageSKU string = 'pro-22_04-lts-gen2'
+param ubuntuImageSKU string = 'pro-22_04-lts-arm64'
 
 @description('Ubuntu Pro token to attach to the virtual machine; will be ignored by cloud-init if the arguments provided for the ubuntuImageOffer and ubuntuImageSKU parameters correspond to a Pro image (see https://cloudinit.readthedocs.io/en/latest/reference/modules.html#ubuntu-pro)')
 param ubuntuProToken string = ''
@@ -49,7 +49,7 @@ param virtualMachineName string = 'anboxVirtualMachine'
 param virtualMachineOperatingSystemDiskSizeInGB int = 40
 
 @description('Size of the virtual machine; must comply with https://anbox-cloud.io/docs/reference/requirements#anbox-cloud-appliance-4')
-param virtualMachineSize string = 'Standard_D4s_v5'
+param virtualMachineSize string = 'Standard_D4ps_v5'
 
 @description('CIDR block of the virtual network')
 param virtualNetworkAddressPrefix string = '10.0.0.0/16'
@@ -107,7 +107,7 @@ var imagePlan = empty(ubuntuProToken) ? {
   product: ubuntuImageOffer
   publisher: 'canonical'
 } : null
-  
+
 var linuxConfiguration = {
   disablePasswordAuthentication: true
   ssh: {

--- a/quickstarts/canonical/anbox/main.bicep
+++ b/quickstarts/canonical/anbox/main.bicep
@@ -102,7 +102,7 @@ var dataDisks = addDedicatedDataDiskForLXD ? [
   }
 ] : []
 
-var imagePlan = empty(ubuntuProToken) ? {
+var imagePlan = empty(ubuntuProToken) && startsWith(ubuntuImageOffer, '0001') ? {
   name: ubuntuImageSKU
   product: ubuntuImageOffer
   publisher: 'canonical'


### PR DESCRIPTION
This updates the Anbox quickstart to use ARM64 images, now that Pro ARM64 images are available in the marketplace. Anbox runs better on ARM so this is a better default for users.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Update the Anbox quickstart defaults to arm64 images
