### PR TITLE
[devbox-ready-to-code-image] Provide explicit default values for complex params; add blog post link

### DIFF
--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/README.md
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/README.md
@@ -28,6 +28,8 @@ languages:
 
 This sample demonstrates building `Ready-To-Code` images containing everything a developer needs (configuration, source, packages, binaries) to minimize the time used for setting up a new Dev Box. The sample relies on Dev Box Image Template to provide flexible approach for building images using Azure Image Builder.
 
+For more details see as well [Dev Box Ready-To-Code Dev Box images template](https://devblogs.microsoft.com/engineering-at-microsoft/dev-box-ready-to-code-dev-box-images-template/) blog post.
+
 ## Deployed Resources
 The sample builds 3 images to demonstrate various configuration options of the Dev Box Image Template. For each image the template creates the following Azure resources:
 - **Azure Image Builder Template**: the image factory used for building an image version.

--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/main.bicep
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/main.bicep
@@ -30,7 +30,10 @@ param createDevDrive bool = true
 param osDriveMinSizeGB int = 160
 
 @description('Custom VS SKU to use when allocating the VM for image creation')
-param imageBuildProfile object = {}
+// The default SKU value allows building images with in PR validation pipelines (https://dev.azure.com/azurequickstarts/azure-quickstart-templates/_build).
+param imageBuildProfile object = {
+  sku: 'Standard_D2_v4'
+}
 
 @description('Specifies whether the image is a base image, i.e. that is not meant to be used directly by users but as a base for other images. Base images cannot be used with Dev Box service at the moment.')
 param isBaseImage bool = false
@@ -39,7 +42,11 @@ param isBaseImage bool = false
 param imageBuildTimeoutInMinutes int = 180
 
 @description('Git repository containing artifacts to be used in the image build')
-param artifactSource types.artifactSource?
+param artifactSource types.artifactSource = {
+  Url: 'https://github.com/Azure/azure-quickstart-templates'
+  Path: 'quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts'
+  Branch: 'master'
+}
 
 @description('''
 In the case of an error do not fail the deployment but rather return the tail of the customization log.
@@ -67,15 +74,6 @@ var defaultImages = {
 
 var imagesWithDefaults = union(defaultImages, images)
 
-var artifactSourceWithDefaults = union(
-  {
-    Url: 'https://github.com/Azure/azure-quickstart-templates'
-    Path: 'quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts'
-    Branch: 'master'
-  },
-  artifactSource ?? {}
-)
-
 module eShop 'images/eShop.bicep' = if (imagesWithDefaults.eShop.shouldBuild) {
   name: 'eShopImg-${uniqueString(deployment().name, resourceGroup().name)}'
   params: {
@@ -88,7 +86,7 @@ module eShop 'images/eShop.bicep' = if (imagesWithDefaults.eShop.shouldBuild) {
     galleryName: galleryName
     galleryResourceGroup: galleryResourceGroup
     gallerySubscriptionId: gallerySubscriptionId
-    artifactSource: artifactSourceWithDefaults
+    artifactSource: artifactSource
     ignoreBuildFailure: ignoreBuildFailure
     createDevDrive: createDevDrive
     osDriveMinSizeGB: osDriveMinSizeGB
@@ -109,7 +107,7 @@ module axios 'images/axios.bicep' = if (imagesWithDefaults.axios.shouldBuild) {
     galleryName: galleryName
     galleryResourceGroup: galleryResourceGroup
     gallerySubscriptionId: gallerySubscriptionId
-    artifactSource: artifactSourceWithDefaults
+    artifactSource: artifactSource
     ignoreBuildFailure: ignoreBuildFailure
     createDevDrive: createDevDrive
     osDriveMinSizeGB: osDriveMinSizeGB
@@ -126,7 +124,7 @@ module MSBuildSdks 'images/MSBuildSdks.bicep' = if (imagesWithDefaults.MSBuildSd
     builderIdentity: builderIdentity
     imageIdentity: imageIdentity
     galleryName: galleryName
-    artifactSource: artifactSourceWithDefaults
+    artifactSource: artifactSource
     ignoreBuildFailure: ignoreBuildFailure
     imageBuildProfile: imageBuildProfile
     imageBuildTimeoutInMinutes: imageBuildTimeoutInMinutes


### PR DESCRIPTION
Provided explicit sample values for complex objects like imageBuildProfile and artifactSource to make it easier to use 'Deploy To Azure' experience at https://github.com/Azure/azure-quickstart-templates/tree/master/quickstarts/microsoft.devcenter/devbox-ready-to-code-image

Linked to the related blog post: https://devblogs.microsoft.com/engineering-at-microsoft/dev-box-ready-to-code-dev-box-images-template/