### PR TITLE
GitHub Enterprise Template - set storage account's minimum TLS version to TLSv1.2

### DIFF
--- a/application-workloads/github-enterprise/github-enterprise/azuredeploy.json
+++ b/application-workloads/github-enterprise/github-enterprise/azuredeploy.json
@@ -101,7 +101,10 @@
       "sku": {
         "name": "[variables('storageAccountType')]"
       },
-      "kind": "StorageV2"
+      "kind": "StorageV2",
+      "properties": {
+        "minimumTlsVersion": "TLS1_2"
+      }
     },
     {
       "apiVersion": "2020-05-01",


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Add `minimumTlsVersion` to specify TLS 1.2 as the minimum TLS version of the created storage account

Considering [IETF officially deprecates TLS 1.0 and TLS 1.1](https://therecord.media/ietf-officially-deprecates-tls-1-0-and-tls-1-1) ([RFC 8996 Deprecating TLS 1.0 and TLS 1.1](https://www.ietf.org/rfc/rfc8996.html)) and [Microsoft Azure will stop supporting TLS 1.0 and 1.1 on 2025-08-31](https://learn.microsoft.com/en-us/lifecycle/announcements/tls-support-ending-10-31-2024), there is no valid reason to deploy a GitHub Enterprise Server to Azure with storage account that uses TLS 1.0 ([default value](https://learn.microsoft.com/en-us/azure/templates/microsoft.storage/storageaccounts?pivots=deployment-language-arm-template)) as the minimum TLS version.

This pull request adds a property to specify TLS 1.2 as the minimum TLS version of the created storage account.