### PR TITLE
[devbox-ready-to-code-image] Support installing VSCode extensions during image creation

### DIFF
--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/images/axios.bicep
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/images/axios.bicep
@@ -58,7 +58,7 @@ var winGetPackageIds = [
   'Microsoft.Azure.AZCopy.10'
 ]
 
-var additionalArtifacts = [
+var winGetPackageArtifacts = [
   {
     name: 'windows-install-winget-packages'
     parameters: {
@@ -66,6 +66,21 @@ var additionalArtifacts = [
     }
   }
 ]
+
+// Visual Studio Code extensions
+var visualStudioCodeExtensionArtifacts = [
+  for extension in [
+    'GitHub.copilot'
+    'ms-azuretools.vscode-bicep'
+  ]: {
+    name: 'windows-install-visualstudiocode-extension'
+    parameters: {
+      ExtensionName: extension
+    }
+  }
+]
+
+var additionalArtifacts = concat(winGetPackageArtifacts, visualStudioCodeExtensionArtifacts)
 
 module devBoxImage '../modules/devbox-image.bicep' = {
   name: 'axios-${uniqueString(deployment().name, resourceGroup().name)}'

--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/images/axios.bicep
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/images/axios.bicep
@@ -70,8 +70,9 @@ var winGetPackageArtifacts = [
 // Visual Studio Code extensions
 var visualStudioCodeExtensionArtifacts = [
   for extension in [
-    'GitHub.copilot'
-    'ms-azuretools.vscode-bicep'
+    // TODO: uncomment after this change is committed so the artifact can be found in master branch of the repo since this is the default location of artifactSource as defined in main.bicep
+    // 'GitHub.copilot'
+    // 'ms-azuretools.vscode-bicep'
   ]: {
     name: 'windows-install-visualstudiocode-extension'
     parameters: {

--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/modules/resource-aib.bicep
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/modules/resource-aib.bicep
@@ -171,7 +171,7 @@ resource buildImageTemplateScript 'Microsoft.Resources/deploymentScripts@2020-10
   ]
   properties: {
     forceUpdateTag: guidId
-    azPowerShellVersion: '9.7'
+    azPowerShellVersion: '13.0'
     environmentVariables: [
       {
         name: 'imageTemplateName'

--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts/_common/windows-visual-studio-marketplace-utils.Tests.ps1
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts/_common/windows-visual-studio-marketplace-utils.Tests.ps1
@@ -1,0 +1,403 @@
+# In PowerShell 5.1 or later, run:
+# - To install Pester: Install-Module Pester -Force
+# - To execute tests:  Invoke-Pester -Path <path to test file>
+# More is at https://pester.dev/docs/quick-start
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $global:IsUnderTest = $true
+    $retryModuleName = 'windows-retry-utils'
+    Import-Module -Force -Name (Join-Path $(Split-Path -Parent $PSScriptRoot) "_common/$retryModuleName.psm1")
+    
+    $marketplaceModuleName = 'windows-visual-studio-marketplace-utils'  
+    Import-Module -Force -Name (Join-Path $(Split-Path -Parent $PSScriptRoot) "_common/$marketplaceModuleName.psm1")
+    
+    # Mock a x64 processor by default
+    function Get-CimInstance { }
+    Mock Get-CimInstance {
+        [pscustomobject]@{ Architecture = 9 }
+    } -Verifiable -ModuleName $marketplaceModuleName
+
+    $script:currentAttempt = 0
+    $script:sleepTimes = @()
+    Mock -CommandName Start-Sleep -ModuleName $retryModuleName `
+        -MockWith { param ($seconds) $script:sleepTimes += $seconds; }
+
+    Mock Write-Host {} -ModuleName $marketplaceModuleName
+    Mock Write-Host {} -ModuleName $retryModuleName
+}
+
+Describe "Get-ApiHeaders Tests" {
+    It "Should return the correct headers" {
+        $headers = Get-ApiHeaders
+
+        $headers | Should -Not -BeNullOrEmpty
+        $headers["Accept"] | Should -Be "application/json;api-version=3.0-preview.1"
+        $headers["Content-Type"] | Should -Be "application/json"
+    }
+}
+
+Describe "Get-ApiFlags Tests" {
+    It "Should be 402" {
+        $flags = Get-ApiFlags -VersionNumber $null
+
+        ($flags -band 402) | Should -Be 402
+    }
+}
+
+Describe "Get-RequestBody Tests" {
+    It "Should create a valid request body" {
+        $body = Get-RequestBody -ExtensionReference "test.extension" -Flags 402
+        $jsonBody = $body | ConvertFrom-Json
+
+        $jsonBody.filters[0].criteria[0].filterType | Should -Be 7
+        $jsonBody.filters[0].criteria[0].value | Should -Be "test.extension"
+        $jsonBody.flags | Should -Be 402
+    }
+}
+
+Describe "Import-ExtensionByMetadata Tests" {
+    Context "When the destination file does not exist" {
+        BeforeEach {
+            Mock Test-Path {
+                param($Path)
+                return $false
+            } -Verifiable -ModuleName $marketplaceModuleName
+
+            Mock Copy-Item {
+                param($Path, $Destination)
+                Write-Host "Mocked: Copying $Path to $Destination"
+            } -Verifiable -ModuleName $marketplaceModuleName
+
+            Mock Import-RemoteVisualStudioPackageToPath {
+                param($VsixUrl, $LocalFilePath)
+                Write-Host "Mocked: Downloading $VsixUrl to $LocalFilePath"
+            } -Verifiable -ModuleName $marketplaceModuleName
+        }
+
+        It "Should download and copy the file to the destination" {
+            $ExtensionMetadata = [PSCustomObject]@{
+                name    = "SampleExtension"
+                vsixUrl = "http://localhost/sampleextension.VSIXPackage"
+            }
+            $DownloadLocation = "c:\temp\"
+            $ExpectedFilePath = Join-Path -Path $DownloadLocation -ChildPath "SampleExtension.vsix"
+            $Result = Import-ExtensionByMetadata -ExtensionMetadata $ExtensionMetadata -DownloadLocation $DownloadLocation
+
+            # Assertions
+            Assert-MockCalled Import-RemoteVisualStudioPackageToPath -Exactly 1 -Scope It -ModuleName $marketplaceModuleName
+            Assert-MockCalled Copy-Item -Exactly 1 -Scope It -ModuleName $marketplaceModuleName
+            $Result | Should -Be $ExpectedFilePath
+        }
+    }
+
+    Context "When the destination file already exists" {
+        BeforeEach {
+            Mock Test-Path {
+                param($Path)
+                $true
+            } -Verifiable -ModuleName $marketplaceModuleName
+
+            Mock Copy-Item {
+                param($Path, $Destination)
+                Write-Host "Mocked: Copying $Path to $Destination"
+            } -Verifiable -ModuleName $marketplaceModuleName
+
+            Mock Import-RemoteVisualStudioPackageToPath {
+                param($VsixUrl, $LocalFilePath)
+                Write-Host "Mocked: Downloading $VsixUrl to $LocalFilePath"
+            } -Verifiable -ModuleName $marketplaceModuleName
+        }
+
+        It "Should not attempt to download or copy the file" {
+            $ExtensionMetadata = [PSCustomObject]@{
+                name    = "SampleExtension"
+                vsixUrl = "http://localhost/sampleextension.VSIXPackage"
+            }
+            $DownloadLocation = "c:\temp\"
+            $ExpectedFilePath = Join-Path -Path $DownloadLocation -ChildPath "SampleExtension.vsix"
+            $Result = Import-ExtensionByMetadata -ExtensionMetadata $ExtensionMetadata -DownloadLocation $DownloadLocation
+
+            # Assertions
+            Assert-MockCalled Import-RemoteVisualStudioPackageToPath -Exactly 0 -Scope It -ModuleName $marketplaceModuleName
+            Assert-MockCalled Copy-Item -Exactly 0 -Scope It -ModuleName $marketplaceModuleName
+            $Result | Should -Be $ExpectedFilePath
+        }
+    }
+
+    Context "Retries and error handling" {
+        BeforeEach {
+            Mock Test-Path {
+                param($Path)
+                return $false
+            } -Verifiable -ModuleName $marketplaceModuleName
+
+            Mock Import-RemoteVisualStudioPackageToPath {
+                param($VsixUrl, $LocalFilePath)
+                throw "Simulated error"
+            } -Verifiable -ModuleName $marketplaceModuleName
+        }
+
+        It "Should throw an error if all retries fail" {
+            $ExtensionMetadata = [PSCustomObject]@{
+                name    = "SampleExtension"
+                vsixUrl = "http://localhost/sampleextension.VSIXPackage"
+            }
+            $DownloadLocation = "c:\temp\"
+            { Import-ExtensionByMetadata -ExtensionMetadata $ExtensionMetadata -DownloadLocation $DownloadLocation } |
+            Should -Throw "Simulated error"
+        }
+    }
+}
+
+Describe "Get-ExtensionMetadata" {
+    BeforeEach {
+        Mock Get-ApiHeaders { return @{} } -ModuleName $marketplaceModuleName
+        Mock Get-ApiFlags { return 100 } -ModuleName $marketplaceModuleName
+        Mock Get-RequestBody {
+            param ($ExtensionReference, $Flags)
+            return @{ mockBody = "data" }
+        } -ModuleName $marketplaceModuleName
+        Mock Invoke-MarketplaceApi {
+            param ($ApiUrl, $Headers, $Body)
+            return @{
+                results = @(@{
+                        extensions = @(
+                            @{
+                                versions = @(
+                                    [PSCustomObject]@{
+                                        version        = "1.0.0";
+                                        targetPlatform = "x64";
+                                        files          = @(
+                                            @{
+                                                assetType = "Microsoft.VisualStudio.Services.VSIXPackage";
+                                                source    = "http://localhost/vsix"
+                                            }
+                                        );
+                                        properties     = @(
+                                            @{
+                                                key   = "Microsoft.VisualStudio.Code.PreRelease";
+                                                value = "false"
+                                            }
+                                        )
+                                    }
+                                )
+                            }
+                        )
+                    })
+            }
+        } -ModuleName $marketplaceModuleName
+    }
+
+    Context "Valid scenarios" {
+        It "Should return metadata for a valid extension reference" {
+            $result = Get-ExtensionMetadata -ExtensionReference "example.extension" -TargetPlatform "x64"
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.name | Should -Be "example.extension"
+            $result.vsixUrl | Should -Be "http://localhost/vsix"
+            $result.dependencies | Should -BeNullOrEmpty
+        }
+
+        It "Should return metadata for a specific version" {
+            Mock Invoke-MarketplaceApi {
+                param ($ApiUrl, $Headers, $Body)
+                return @{
+                    results = @(@{
+                            extensions = @(
+                                @{
+                                    versions = @(
+                                        [PSCustomObject]@{
+                                            version        = "2.0.0";
+                                            targetPlatform = "x64";
+                                            files          = @(
+                                                @{
+                                                    assetType = "Microsoft.VisualStudio.Services.VSIXPackage";
+                                                    source    = "http://localhost/vsix-2.0.0"
+                                                }
+                                            );
+                                            properties     = @(
+                                                @{
+                                                    key   = "Microsoft.VisualStudio.Code.PreRelease";
+                                                    value = "false"
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            )
+                        })
+                }
+            } -ModuleName $marketplaceModuleName
+
+            $result = Get-ExtensionMetadata -ExtensionReference "example.extension" -VersionNumber "2.0.0" -TargetPlatform "x64"
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.vsixUrl | Should -Be "http://localhost/vsix-2.0.0"
+        }
+
+        It "Should filter by target platform" {
+            Mock Invoke-MarketplaceApi {
+                param ($ApiUrl, $Headers, $Body)
+                return @{
+                    results = @(@{
+                            extensions = @(
+                                @{
+                                    versions = @(
+                                        [PSCustomObject]@{
+                                            version        = "1.0.0";
+                                            targetPlatform = "x64";
+                                            files          = @(
+                                                @{
+                                                    assetType = "Microsoft.VisualStudio.Services.VSIXPackage";
+                                                    source    = "http://localhost/vsix-x64"
+                                                }
+                                            );
+                                            properties     = @()
+                                        },
+                                        [PSCustomObject]@{
+                                            version        = "1.0.0";
+                                            targetPlatform = "arm64";
+                                            files          = @(
+                                                @{
+                                                    assetType = "Microsoft.VisualStudio.Services.VSIXPackage";
+                                                    source    = "http://localhost/vsix-arm64"
+                                                }
+                                            );
+                                            properties     = @()
+                                        }
+                                    )
+                                }
+                            )
+                        })
+                }
+            } -ModuleName $marketplaceModuleName
+
+            $result = Get-ExtensionMetadata -ExtensionReference "example.extension" -TargetPlatform "arm64"
+
+            $result | Should -Not -BeNullOrEmpty
+            $result.vsixUrl | Should -Be "http://localhost/vsix-arm64"
+        }
+    }
+
+    Context "Error scenarios" {
+        It "Should throw an error for missing 'versions' property" {
+            Mock Invoke-MarketplaceApi {
+                param ($ApiUrl, $Headers, $Body)
+                return @{
+                    results = @(@{
+                            extensions = @(
+                                @{
+                                    # Missing versions
+                                }
+                            )
+                        })
+                }
+            } -ModuleName $marketplaceModuleName
+
+            { Get-ExtensionMetadata -ExtensionReference "invalid.extension" -TargetPlatform "x64" } |
+            Should -Throw "Property 'versions' is missing or inaccessible in the Marketplace API response. Ensure you have provided a valid extension id. The property 'versions' cannot be found on this object. Verify that the property exists."
+        }
+
+        It "Should throw an error if no VSIXPackage is found" {
+            Mock Invoke-MarketplaceApi {
+                param ($ApiUrl, $Headers, $Body)
+                return @{
+                    results = @(@{
+                            extensions = @(
+                                @{
+                                    versions = @(
+                                        @{
+                                            version    = "1.0.0";
+                                            files      = @(
+                                                # Missing VSIXPackage
+                                            );
+                                            properties = @()
+                                        }
+                                    )
+                                }
+                            )
+                        })
+                }
+            } -ModuleName $marketplaceModuleName
+
+            { Get-ExtensionMetadata -ExtensionReference "example.extension" -TargetPlatform "x64" } |
+            Should -Throw "No VSIXPackage was found in the file list for the extension metadata. Verify the extension and version specified are correct. The property 'source' cannot be found on this object. Verify that the property exists."
+        }
+
+        It "Should throw an error if pre-release version is found but not allowed" {
+            Mock Invoke-MarketplaceApi {
+                param ($ApiUrl, $Headers, $Body)
+                return @{
+                    results = @(@{
+                            extensions = @(
+                                @{
+                                    versions = @(
+                                        [PSCustomObject]@{
+                                            version        = "2.0.0";
+                                            targetPlatform = "x64";
+                                            files          = @(
+                                                @{
+                                                    assetType = "Microsoft.VisualStudio.Services.VSIXPackage";
+                                                    source    = "http://localhost/vsix-2.0.0"
+                                                }
+                                            );
+                                            properties     = @(
+                                                @{
+                                                    key   = "Microsoft.VisualStudio.Code.PreRelease";
+                                                    value = "true"
+                                                }
+                                            )
+                                        }
+                                    )
+                                }
+                            )
+                        })
+                }
+            } -ModuleName $marketplaceModuleName
+
+            { Get-ExtensionMetadata -ExtensionReference "example.extension" -TargetPlatform "x64" -DownloadPreRelease $false } |
+            Should -Throw "Extension 'example.extension' version 'Not specified' not found for 'x64'. Latest 10 versions found: (2.0.0)"
+        }
+    }
+}
+
+Describe 'Get-CurrentPlatform' {
+    It 'Should return win32-arm64 when processor is ARM64' {
+        # Simulate an ARM64 processor
+        Mock Get-CimInstance {
+            [pscustomobject]@{ Architecture = 12 }
+        } -Verifiable -ModuleName $marketplaceModuleName
+
+        $result = Get-CurrentPlatform
+        $result | Should -Be 'win32-arm64'
+
+        Assert-MockCalled Get-CimInstance -Exactly 1 -ModuleName $marketplaceModuleName
+    }
+
+    It 'Should return win32-x64 when processor is x64' {
+        # Simulate an x64 processor
+        Mock Get-CimInstance {
+            [pscustomobject]@{ Architecture = 9 }
+        } -Verifiable -ModuleName $marketplaceModuleName
+
+        $result = Get-CurrentPlatform
+        $result | Should -Be 'win32-x64'
+
+        Assert-MockCalled Get-CimInstance -Exactly 1 -ModuleName $marketplaceModuleName
+    }
+
+    It 'Should default to win32-x64 when processor architecture is unknown' {
+        # Simulate an unknown processor architecture
+        Mock Get-CimInstance {
+            [pscustomobject]@{ Architecture = 99 }
+        } -Verifiable -ModuleName $marketplaceModuleName
+
+        $result = Get-CurrentPlatform
+        $result | Should -Be 'win32-x64'
+
+        Assert-MockCalled Get-CimInstance -Exactly 1 -ModuleName $marketplaceModuleName
+    }
+}

--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts/_common/windows-visual-studio-marketplace-utils.psm1
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts/_common/windows-visual-studio-marketplace-utils.psm1
@@ -1,0 +1,356 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$ProgressPreference = 'SilentlyContinue'
+
+Import-Module -Force (Join-Path $(Split-Path -Parent $PSScriptRoot) '_common/windows-retry-utils.psm1')
+
+# Function: Get-VisualStudioExtension
+# Description: Downloads a specified extension and all dependencies (Visual Studio or VS Code) from
+# the Marketplace and returns a list of local paths.
+function Get-VisualStudioExtension {
+    param (
+        [Parameter(Mandatory = $true)] [string]$ExtensionReference,
+        [Parameter(Mandatory = $false)] [string]$VersionNumber,
+        [Parameter(Mandatory = $true)] [string]$DownloadLocation,
+        [Parameter(Mandatory = $false)] [bool]$DownloadDependencies = $true,
+        [Parameter(Mandatory = $false)] [bool]$DownloadPreRelease = $false
+    )
+    $localPaths = [System.Collections.ArrayList]@()
+    $targetPlatform = Get-CurrentPlatform
+
+    try {
+        Get-ExtensionMetadataDependencyTree -ExtensionReference $ExtensionReference `
+            -VersionNumber $VersionNumber `
+            -TargetPlatform $targetPlatform `
+            -DownloadDependencies $DownloadDependencies `
+            -DownloadPreRelease $DownloadPreRelease | ForEach-Object {
+            $localPaths.Add((Import-ExtensionByMetadata -ExtensionMetadata $_ -DownloadLocation $DownloadLocation)) | Out-Null
+        }
+
+        return $localPaths
+    }
+    catch {
+        throw "Failed to retrieve or save VSIX file for extension '$ExtensionReference' or its dependencies: $_"
+    }
+}
+
+# Function: Get-ApiHeaders
+# Description: Constructs the headers required for the Marketplace API request.
+function Get-ApiHeaders {
+    return @{
+        "Accept"       = "application/json;api-version=3.0-preview.1"
+        "Content-Type" = "application/json"
+    }
+}
+
+# Function: Get-ApiFlags
+# Description: Constructs the flags for the Marketplace API request.
+# Flags:
+#   - 2: Include Extension Metadata
+#   - 16: Include Extension Properties
+#   - 128: Include Asset URI
+#   - 256: Include Files in the Response
+function Get-ApiFlags {
+    $flags = 2 -bor 16 -bor 128 -bor 256  # Base flags using bitwise
+    return $flags
+}
+
+# Function: Get-RequestBody
+# Description: Constructs the request body for the Marketplace API.
+function Get-RequestBody {
+    param (
+        [Parameter(Mandatory = $true)] [string]$ExtensionReference,
+        [Parameter(Mandatory = $true)] [int]$Flags
+    )
+    return @{
+        filters = @(@{
+                criteria = @(@{
+                        filterType = 7  # Filter type 7: Search by extension id
+                        value      = $ExtensionReference
+                    })
+            })
+        flags   = $Flags
+    } | ConvertTo-Json -Depth 10
+}
+
+# Function: Invoke-MarketplaceApi
+# Description: Sends a POST request to the Marketplace API and returns the response.
+function Invoke-MarketplaceApi {
+    param (
+        [Parameter(Mandatory = $true)] [string]$ApiUrl,
+        [Parameter(Mandatory = $true)] [hashtable]$Headers,
+        [Parameter(Mandatory = $true)] [string]$Body
+    )
+    return RunWithRetries -runBlock {
+        return Invoke-RestMethod -Uri $ApiUrl -Method Post -Headers $Headers -Body $Body -MaximumRedirection 10
+    } -retryAttempts 3 -waitBeforeRetrySeconds 5 -exponentialBackoff        
+}
+
+# Function: Get-ExtensionMetadataDependencyTree
+# Description: Provided with a VSIX name and version, find all metadata for the extension and its dependencies.
+function Get-ExtensionMetadataDependencyTree {
+    param (
+        [Parameter(Mandatory = $true)] [string]$ExtensionReference,
+        [Parameter(Mandatory = $false)] [string]$VersionNumber,
+        [Parameter(Mandatory = $true)] [string]$TargetPlatform,
+        [Parameter(Mandatory = $false)] [bool]$DownloadDependencies = $false,
+        [Parameter(Mandatory = $false)] [bool]$DownloadPreRelease = $false
+    )
+    $processedDependencies = @{}
+    $toProcess = @($ExtensionReference)
+    $extensionMetadataList = [System.Collections.ArrayList]@()
+
+    while ($toProcess.Count -gt 0) {
+        # Dequeue the next extension reference
+        $currentDependency = $toProcess[0]
+        $toProcess = if ($toProcess.Count -gt 1) { , @($toProcess[1..($toProcess.Count - 1)]) } else { , @() }
+
+        # Skip if already processed
+        if ($processedDependencies.ContainsKey($currentDependency)) {
+            continue
+        }
+
+        # Mark as processed
+        $processedDependencies[$currentDependency] = $true
+
+        # Fetch extension metadata
+        $extensionMetadata = Get-ExtensionMetadata -ExtensionReference $currentDependency `
+            -VersionNumber $VersionNumber `
+            -TargetPlatform $TargetPlatform `
+            -DownloadPreRelease $DownloadPreRelease
+
+        if ($extensionMetadata) {
+            $extensionMetadataList += $extensionMetadata
+        }
+
+        if (-not $DownloadDependencies) {
+            break;
+        }
+
+        # Add dependencies to the processing queue
+        if ($extensionMetadata) {
+            foreach ($dependency in $extensionMetadata.dependencies) {
+                if ($dependency -and (-not $processedDependencies.ContainsKey($dependency))) {
+                    $toProcess += $dependency
+                }
+            }
+        }
+    }
+
+    return $extensionMetadataList
+}
+
+# Function: Import-RemoteVisualStudioPackageToPath
+# Description: Download a remote VSIX to the local machine.
+function Import-RemoteVisualStudioPackageToPath {
+    param (
+        [Parameter(Mandatory = $true)] [string]$VsixUrl,
+        [Parameter(Mandatory = $true)] [string]$LocalFilePath
+    )
+    Write-Host "Downloading VSIX from URL: $vsixUrl"
+    Invoke-WebRequest -Uri $VsixUrl -OutFile $LocalFilePath -MaximumRedirection 10
+    Write-Host "Downloaded VSIX to: $localFilePath"
+
+    # Validate the downloaded file
+    if (-not (Test-Path $LocalFilePath)) {
+        throw "The file was not downloaded. Ensure the URL is correct and accessible: $VsixUrl"
+    }
+
+    $fileInfo = Get-Item -Path $LocalFilePath
+    $fileSizeBytes = $fileInfo.Length
+
+    if ($fileSizeBytes -le 0) {
+        throw "The downloaded file is empty or corrupt (size: 0 bytes): $LocalFilePath"
+    }
+
+    $fileSizeKB = [math]::Round($fileSizeBytes / 1KB, 2)
+    Write-Host "Downloaded file size: $fileSizeKB KB"
+}
+
+# Function: Get-CurrentPlatform
+# Determine the target platform of the current machine
+function Get-CurrentPlatform {
+    $processorArch = $null
+    
+    try {
+        $processorArch = (Get-CimInstance -ClassName Win32_Processor).Architecture
+    }
+    catch {
+        Write-Host "Processor architecture could not be determined, assuming x64."
+    }
+
+    if ($processorArch -eq 12) {
+        $targetPlatform = "win32-arm64"
+    }
+    else {
+        $targetPlatform = "win32-x64"
+    }
+
+    Write-Host "Current machine target platform: $targetPlatform"
+    return $targetPlatform
+}
+
+# Function: Get-ExtensionMetadata
+# Description: Fetches extension metadata for a given extension.
+function Get-ExtensionMetadata {
+    param (
+        [Parameter(Mandatory = $true)] [string]$ExtensionReference,
+        [Parameter(Mandatory = $false)] [string]$VersionNumber,
+        [Parameter(Mandatory = $true)] [string]$TargetPlatform,
+        [Parameter(Mandatory = $false)] [bool]$DownloadPreRelease = $false
+    )
+    # Define base API URL (same for both Visual Studio and VSCode)
+    $baseApiUrl = "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery"
+
+    # Call helper methods to construct headers and request body
+    $headers = Get-ApiHeaders
+    $flags = Get-ApiFlags
+    $body = Get-RequestBody -ExtensionReference $ExtensionReference -Flags $flags
+    $response = Invoke-MarketplaceApi -ApiUrl $baseApiUrl -Headers $headers -Body $body
+
+    if ((!($response.results)) -or (!$response.results[0].extensions)) {
+        Write-Host "Skipping presumably built-in extension $ExtensionReference"
+        return $null
+    }
+
+    if ($response.results.Count -gt 1) {
+        throw "Expected to receive only a single result in the metadata for '$ExtensionReference'."
+    }
+
+    $extensionVersions = @()
+    try {
+        # Extract versions of the extension from the response
+        $extensionVersions = @($response.results[0].extensions[0].versions)
+
+        if (-not $extensionVersions) {
+            throw "No versions found for extension '$ExtensionReference'."
+        }
+    }
+    catch {
+        throw "Property 'versions' is missing or inaccessible in the Marketplace API response. Ensure you have provided a valid extension id. $_"
+    }
+
+    # Filter for the versions matching the current machine's platform (e.g. x64 or ARM64)
+    # Empty or missing target platforms are considered "Universal" versions
+    $extensionVersions = $extensionVersions | Where-Object {
+        # Check if 'targetPlatform' exists dynamically
+        $hasTargetPlatform = $_.PSObject.Properties.Name -contains 'targetPlatform'
+
+        # If 'targetPlatform' exists, evaluate it; otherwise, treat as "Universal"
+        (-not $hasTargetPlatform) -or
+        ($_.targetPlatform -eq $TargetPlatform) -or
+        [string]::IsNullOrWhiteSpace($_.targetPlatform)
+    }
+
+    # Filter by version number if provided, else use the latest version
+    $versionInfos = if ($VersionNumber) {
+        $extensionVersions | Where-Object { $_.version -eq $VersionNumber }
+    }
+    else {
+        $extensionVersions
+    }
+
+    $foundVersionInfo = $null;
+    
+    foreach ($versionInfo in $versionInfos) {
+        # Find the Vsix file URL in the response
+        try {
+            $vsixUrl = ($versionInfo.files |
+                Where-Object { $_.assetType -eq "Microsoft.VisualStudio.Services.VSIXPackage" } |
+                Select-Object -First 1).source
+        }
+        catch {
+            throw "No VSIXPackage was found in the file list for the extension metadata. Verify the extension and version specified are correct. $_"
+        }
+
+        if ([string]::IsNullOrWhiteSpace($VersionNumber)) {
+            $VersionNumber = "Not specified"
+        }
+        
+        if (-not $vsixUrl) {
+            throw "VSIX download URL not found for extension '$ExtensionReference' version '$VersionNumber'. Please validate this is a VS Code extension."
+        }
+
+        $isPreReleaseRef = ($versionInfo.properties |
+            Where-Object { $_.key -eq "Microsoft.VisualStudio.Code.PreRelease" } |
+            Select-Object -First 1)
+        $isPreRelease = if ($isPreReleaseRef) { $isPreReleaseRef.value -eq "true" } else { $false }
+
+        if ($isPreRelease -and (-not $DownloadPreRelease)) {
+            continue;
+        }
+
+        $vsixDependenciesRef = ($versionInfo.properties |
+            Where-Object { $_.key -eq "Microsoft.VisualStudio.Code.ExtensionDependencies" } |
+            Select-Object -First 1)
+        $vsixDependencies = if ($vsixDependenciesRef) { $vsixDependenciesRef.value -split ',' } else { @() }
+        
+        $vsixExtensionPackRef = ($versionInfo.properties |
+            Where-Object { $_.key -eq "Microsoft.VisualStudio.Code.ExtensionPack" } |
+            Select-Object -First 1)
+        $vsixExtensionPack = if ($vsixExtensionPackRef) { $vsixExtensionPackRef.value -split ',' } else { @() }
+
+        $allDependencies = ($vsixDependencies + $vsixExtensionPack) | Select-Object -Unique
+
+        $foundVersionInfo = $versionInfo;
+        break;
+    }
+
+    if (-not $foundVersionInfo) {
+        $foundVersions = ($extensionVersions | Select-Object -First 10 | ForEach-Object { '({0})' -f $_.version }) -join ", "
+        throw "Extension '$ExtensionReference' version '$VersionNumber' not found for '$TargetPlatform'. Latest 10 versions found: $foundVersions"
+    }
+
+    # Log the version being used
+    $foundVersion = $foundVersionInfo.version
+    $foundTargetPlatform = if ($foundVersionInfo.PSObject.Properties.Match("targetPlatform").Count -gt 0) { $foundVersionInfo.targetPlatform -join "," } else { "universal" }
+    Write-Host "Found $ExtensionReference version $foundVersion, target platform: $foundTargetPlatform"
+
+    return @{
+        name         = $ExtensionReference;
+        vsixUrl      = $vsixUrl;
+        dependencies = $allDependencies;
+    }
+}
+
+# Function: Import-ExtensionByMetadata
+# Description: Processes the Marketplace API response returns a local path for the downloaded file.
+function Import-ExtensionByMetadata {
+    param (
+        [Parameter(Mandatory = $true)] [object]$ExtensionMetadata,
+        [Parameter(Mandatory = $true)] [string]$DownloadLocation
+    )
+    $tempFolder = [IO.Path]::GetTempPath()
+
+    # Rename the file during the copy process to ensure its extension is `.vsix`.
+    # For example, files downloaded from the Visual Studio Marketplace often have a `.VSIXPackage` extension,
+    # which must be renamed to `.vsix` for the VS Code bootstrapper to recognize them correctly.
+    $localFileName = $ExtensionMetadata.name + ".vsix"
+    $localFilePath = Join-Path $tempFolder $localFileName
+    $destinationFile = Join-Path -Path $DownloadLocation -ChildPath $localFileName
+
+    if (-not (Test-Path $destinationFile)) {
+        RunWithRetries -runBlock {
+            Import-RemoteVisualStudioPackageToPath -VsixUrl $ExtensionMetadata.vsixUrl -LocalFilePath $localFilePath
+        } -retryAttempts 3 -waitBeforeRetrySeconds 5 -exponentialBackoff
+
+        # Copy to the final location
+        RunWithRetries -runBlock {
+            Write-Host "Copying $localFilePath to $destinationFile"
+            Copy-Item -Path $localFilePath -Destination $destinationFile -Force
+        } -retryAttempts 3 -waitBeforeRetrySeconds 5 -exponentialBackoff
+    }
+    else {
+        Write-Host "VSIX already exists: $destinationFile"
+    }
+
+    return $destinationFile
+}
+
+if ((Test-Path variable:global:IsUnderTest) -and $global:IsUnderTest) {
+    Export-ModuleMember -Function *
+}
+else {
+    Export-ModuleMember -Function Get-VisualStudioExtension
+    Export-ModuleMember -Function Import-RemoteVisualStudioPackageToPath
+}

--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts/windows-install-visualstudiocode-extension/windows-install-visualstudiocode-extension.Tests.ps1
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts/windows-install-visualstudiocode-extension/windows-install-visualstudiocode-extension.Tests.ps1
@@ -1,0 +1,129 @@
+# In PowerShell 5.1 or later, run:
+# - To install Pester: Install-Module Pester -Force
+# - To execute tests:  Invoke-Pester -Path <path to test file>
+# More is at https://pester.dev/docs/quick-start
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+BeforeAll {
+    $global:IsUnderTest = $true
+    $retryModuleName = 'windows-retry-utils'
+    Import-Module -Force (Join-Path $(Split-Path -Parent $PSScriptRoot) "_common/$retryModuleName.psm1") -DisableNameChecking
+    
+    $marketplaceModuleName = 'windows-visual-studio-marketplace-utils'  
+    Import-Module -Force (Join-Path $(Split-Path -Parent $PSScriptRoot) "_common/$marketplaceModuleName.psm1") -DisableNameChecking
+    
+    . (Join-Path $PSScriptRoot "windows-install-visualstudiocode-extension.ps1")
+
+    $script:currentAttempt = 0
+    $script:sleepTimes = @()
+    Mock -CommandName Start-Sleep -ModuleName $retryModuleName -MockWith { param ($seconds) $script:sleepTimes += $seconds; Write-Host "Sleeping $seconds seconds" }
+
+    Mock Write-Host {}
+}
+
+Describe "Confirm-UserRequest Tests" {
+    It "Should not throw an error if only ExtensionId is provided" {
+        { Confirm-UserRequest -extensionId "test-id" } | Should -Not -Throw
+    }
+
+    It "Should not throw an error if only ExtensionName is provided" {
+        { Confirm-UserRequest -extensionName "test-name" } | Should -Not -Throw
+    }
+
+    It "Should not throw an error if only ExtensionVsixPath is provided" {
+        { Confirm-UserRequest -extensionVsixPath "https://example.com/test.vsix" } | Should -Not -Throw
+    }
+
+    It "Should throw an error if more than one parameter is provided" {
+        { Confirm-UserRequest -extensionId "test-id" -extensionName "test-name" } | Should -Throw
+        { Confirm-UserRequest -extensionId "test-id" -extensionVsixPath "https://example.com/test.vsix" } | Should -Throw
+        { Confirm-UserRequest -extensionName "test-name" -extensionVsixPath "https://example.com/test.vsix" } | Should -Throw
+    }
+
+    It "Should throw an error if ExtensionVsixPath and ExtensionVersion are both provided" {
+        { Confirm-UserRequest -extensionVsixPath "https://example.com/test.vsix" -extensionVersion "1.0.0" } | Should -Throw
+    }
+}
+
+Describe "Import-ExtensionToLocalPath Tests" {
+    BeforeEach {
+        # Mock dependencies
+        Mock Import-RemoteVisualStudioPackageToPath -MockWith {}
+        Mock Get-VisualStudioExtension -MockWith {
+            return "C:\\Temp\\mocked-extension.vsix"
+        }
+        function Copy-Item {}
+        Mock Copy-Item -MockWith {}
+    }
+
+    It "Should download the VSIX file from a URL" {
+        Mock Test-Path -MockWith { return $false }
+
+        $result = Import-ExtensionToLocalPath -extensionVsixPath "https://example.com/test.vsix" -downloadLocation "C:\\Temp"
+
+        Assert-MockCalled Copy-Item -Exactly 1
+        Assert-MockCalled Import-RemoteVisualStudioPackageToPath -Exactly 1
+    }
+
+    It "Should copy the local VSIX file to the download location" {
+        Mock Test-Path -MockWith { return $true }
+
+        $result = Import-ExtensionToLocalPath -extensionVsixPath "C:\\myext\\test.vsix" -downloadLocation "C:\\Temp"
+
+        Assert-MockCalled Copy-Item -Exactly 1
+        Assert-MockCalled Import-RemoteVisualStudioPackageToPath -Exactly 0
+    }
+
+    It "Should throw an error if file path does not exist" {
+        Mock Test-Path -MockWith { return $false }
+
+        { Import-ExtensionToLocalPath -extensionVsixPath "C:\\NonExistent\\test.vsix" -downloadLocation "C:\\Temp" } | Should -Throw
+    }
+
+    It "Should call Get-VisualStudioExtension for ExtensionName" {
+        $result = Import-ExtensionToLocalPath -extensionName "test-name" -extensionVersion "1.0.0" -downloadLocation "C:\\Temp"
+
+        $result | Should -Be "C:\\Temp\\mocked-extension.vsix"
+        Assert-MockCalled Get-VisualStudioExtension -Exactly 1 -Scope It
+    }
+
+    It "Should call Get-VisualStudioExtension for ExtensionId" {
+        $result = Import-ExtensionToLocalPath -extensionId "test-id" -extensionVersion "1.0.0" -downloadLocation "C:\\Temp"
+
+        $result | Should -Be "C:\\Temp\\mocked-extension.vsix"
+        Assert-MockCalled Get-VisualStudioExtension -Exactly 1 -Scope It
+    }
+}
+
+Describe "Main Function Tests" {
+    BeforeEach {
+        # Mock dependencies
+        Mock Confirm-UserRequest {}
+        Mock Import-ExtensionToLocalPath -MockWith {
+            return "C:\\Temp\\mocked-extension.vsix"
+        }
+        Mock Resolve-VisualStudioCodeBootstrapPath -MockWith {
+            return "C:\\Program Files\\VSCode\\extensions"
+        }
+        function Get-ChildItem {}
+        Mock Get-ChildItem -MockWith {
+            return @("mocked-extension1", "mocked-extension2")
+        }
+        Mock Test-Path -MockWith { return $true }
+    }
+
+    It "Should validate user input and download extension" {
+        Main -extensionId "test-id"
+
+        Assert-MockCalled Confirm-UserRequest -Exactly 1
+        Assert-MockCalled Import-ExtensionToLocalPath -Exactly 1
+    }
+
+    It "Should list all installed extensions if emitAllInstalledExtensions is true" {
+        Main -extensionId "test-id" -emitAllInstalledExtensions $true
+
+        Assert-MockCalled Get-ChildItem -Exactly 1
+    }
+}

--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts/windows-install-visualstudiocode-extension/windows-install-visualstudiocode-extension.ps1
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/artifacts/windows-install-visualstudiocode-extension/windows-install-visualstudiocode-extension.ps1
@@ -1,0 +1,200 @@
+<#
+.SYNOPSIS
+    Installs a Visual Studio Code extension
+.DESCRIPTION
+    Installs the provided Visual Studio Code extension by id or name to the given installation of VS Code
+.PARAMETER ExtensionId
+    Visual Studio Code Marketplace identifier for the extension. Cannot be defined if ExtensionName or ExtensionVsixPath is defined
+.PARAMETER ExtensionName
+    Visual Studio Code Marketplace name identifier for the extension. Cannot be defined if ExtensionId or ExtensionVsixPath is defined
+.PARAMETER ExtensionVsixPath
+    File path or URL to the extension VSIX file. Cannot be defined if ExtensionName or ExtensionId is defined
+.PARAMETER ExtensionVersion
+    Version of extension to install, or latest if unspecified. Only applicable when ExtensionName or ExtensionId is set.
+.PARAMETER VisualStudioCodeInstallPath
+    The location of the Visual Studio Code install (optional, defaults to the global install location)
+.PARAMETER EmitAllInstalledExtensions
+    After the install operation, emit all extensions installed globally and their versions (default: false)
+.EXAMPLE
+    Sample Bicep snippet for using the artifact:
+    {
+      name: 'windows-install-visualstudiocode-extension'
+      parameters: {
+        ExtensionName: 'GitHub.copilot'
+      }
+    }
+#>
+
+param(
+    [Parameter(Mandatory = $false)] [String] $ExtensionId,
+    [Parameter(Mandatory = $false)] [String] $ExtensionName,
+    [Parameter(Mandatory = $false)] [String] $ExtensionVsixPath,
+    [Parameter(Mandatory = $false)] [String] $ExtensionVersion,
+    [Parameter(Mandatory = $false)] [String] $VisualStudioCodeInstallPath,
+    [Parameter(Mandatory = $false)] [bool] $InstallInsiders = $false,
+    [Parameter(Mandatory = $false)] [bool] $EmitAllInstalledExtensions = $false
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+Import-Module -Force (Join-Path $(Split-Path -Parent $PSScriptRoot) '_common/windows-visual-studio-marketplace-utils.psm1')
+
+# Function: Confirm-UserRequest
+# Description: Validate that exactly one of ExtensionId, ExtensionName, or ExtensionVsixPath is provided
+function Confirm-UserRequest (
+    [Parameter(Mandatory = $false)] [String] $extensionId = $null,
+    [Parameter(Mandatory = $false)] [String] $extensionName = $null,
+    [Parameter(Mandatory = $false)] [String] $extensionVsixPath = $null,
+    [Parameter(Mandatory = $false)] [String] $extensionVersion = $null) {
+
+    $paramCount = 0
+    if (-not [string]::IsNullOrWhiteSpace($extensionId)) { $paramCount++ }
+    if (-not [string]::IsNullOrWhiteSpace($extensionName)) { $paramCount++ }
+    if (-not [string]::IsNullOrWhiteSpace($extensionVsixPath)) { $paramCount++ }
+
+    if ($paramCount -ne 1) {
+        Write-Error "You must provide either an ExtensionId, ExtensionName, or ExtensionVsixPath (but not more than one). You can find the ExtensionName in the URL of the Marketplace extension. Example: If the extension URL is https://marketplace.visualstudio.com/items?itemName=GitHub.copilot then you would use `GitHub.copilot`."
+    }
+    
+    if ((-not [string]::IsNullOrWhiteSpace($extensionVsixPath)) -and (-not [string]::IsNullOrWhiteSpace($extensionVersion))) {
+        Write-Error "You cannot specify an ExtensionVersion when installing from a direct VSIX URL or path."
+    }
+}
+
+# Function: Import-ExtensionToLocalPath
+# Description: Downloads the user requested extension from the VS Code Marketplace, remote url, or a local path.
+function Import-ExtensionToLocalPath (
+    [Parameter(Mandatory = $false)] [String] $extensionId = $null,
+    [Parameter(Mandatory = $false)] [String] $extensionName = $null,
+    [Parameter(Mandatory = $false)] [String] $extensionVsixPath = $null,
+    [Parameter(Mandatory = $false)] [String] $extensionVersion = $null,
+    [Parameter(Mandatory = $true)] [String] $downloadLocation,
+    [Parameter(Mandatory = $false)] [Bool] $downloadPreRelease) {
+
+    # Process direct URLs and local path references to extensions
+    if (-not [string]::IsNullOrWhiteSpace($extensionVsixPath)) {
+        Write-Host "ExtensionVsixPath: $extensionVsixPath"
+
+        if ($extensionVsixPath -match '^https://') {
+            try {
+                $fileName = [System.IO.Path]::GetFileName($extensionVsixPath)
+                if (-not $fileName.EndsWith(".vsix")) {
+                    $fileName += ".vsix"
+                }
+
+                $savedPath = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), $fileName)
+                Import-RemoteVisualStudioPackageToPath -VsixUrl $extensionVsixPath -LocalFilePath $savedPath
+                Copy-Item -Path $savedPath -Destination $downloadLocation
+            }
+            catch {
+                Write-Error "Failed to download the VSIX file from: $extensionVsixPath. $_"
+            }
+        }
+        elseif (-Not (Test-Path $extensionVsixPath)) {
+            Write-Error "The specified file path does not exist: $extensionVsixPath."
+        }
+        else {
+            Write-Host "Copying VSIX from local path: $extensionVsixPath"
+            Copy-Item -Path $extensionVsixPath -Destination $downloadLocation
+            Write-Host "Copied VSIX to: $downloadLocation"
+        }
+    }
+    # Process extension name
+    elseif (-not [string]::IsNullOrWhiteSpace($extensionName)) {
+        Write-Host "ExtensionName: $extensionName"
+        Get-VisualStudioExtension -ExtensionReference $extensionName `
+            -VersionNumber $extensionVersion `
+            -DownloadLocation $downloadLocation `
+            -DownloadDependencies $true `
+            -DownloadPreRelease $downloadPreRelease
+    }
+    # Process extension id
+    else {
+        Write-Host "ExtensionId: $extensionId"
+        Get-VisualStudioExtension -ExtensionReference $extensionId `
+            -VersionNumber $extensionVersion `
+            -DownloadLocation $downloadLocation `
+            -DownloadDependencies $true `
+            -DownloadPreRelease $downloadPreRelease
+    }
+}
+
+# Function: Resolve-VisualStudioCodeBootstrapPath
+# Description: Determines the location of the VS Code install's bootstrap extension directory based on user inputs.
+# Parameters:
+#   - visualStudioCodeInstallPath (string, optional): A custom VS Code install location root.
+#   - installInsiders (bool, optional): If using the default install location, request VS Code insiders.
+function Resolve-VisualStudioCodeBootstrapPath (
+    [Parameter(Mandatory = $false)] [String] $visualStudioCodeInstallPath = $null,
+    [Parameter(Mandatory = $false)] [bool] $installInsiders = $false) {
+
+    if ([string]::IsNullOrWhiteSpace($visualStudioCodeInstallPath)) {
+        if ($installInsiders) {
+            $visualStudioCodeInstallPath = "%ProgramFiles%\Microsoft VS Code Insiders"
+        }
+        else {
+            $visualStudioCodeInstallPath = "%ProgramFiles%\Microsoft VS Code"
+        }
+    }
+
+    $visualStudioCodeInstallPath = [System.Environment]::ExpandEnvironmentVariables($visualStudioCodeInstallPath)
+
+    if (-not (Test-Path $visualStudioCodeInstallPath)) {
+        Write-Error "Visual Studio Code install path was not found at $VisualStudioCodeInstallPath. Ensure the windows-vscodeinstall artifact is executed before this or manually define the install path via the property VisualStudioCodeInstallPath"
+    }
+    
+    return Join-Path -Path $visualStudioCodeInstallPath -ChildPath "bootstrap\extensions"
+}
+
+function Main (
+    [Parameter(Mandatory = $false)] [String] $extensionId = $null,
+    [Parameter(Mandatory = $false)] [String] $extensionName = $null,
+    [Parameter(Mandatory = $false)] [String] $extensionVsixPath = $null,
+    [Parameter(Mandatory = $false)] [String] $extensionVersion = $null,
+    [Parameter(Mandatory = $false)] [String] $visualStudioCodeInstallPath = $null,
+    [Parameter(Mandatory = $false)] [bool] $installInsiders = $false,
+    [Parameter(Mandatory = $false)] [bool] $emitAllInstalledExtensions = $false) {
+
+    Confirm-UserRequest -extensionId $extensionId `
+        -extensionName $extensionName `
+        -extensionVsixPath $extensionVsixPath `
+        -extensionVersion $extensionVersion
+
+    $vsCodeGlobalExtensionsPath = Resolve-VisualStudioCodeBootstrapPath
+
+    if (-not (Test-Path $vsCodeGlobalExtensionsPath)) {
+        New-Item $vsCodeGlobalExtensionsPath -ItemType Directory -ErrorAction 'SilentlyContinue' | Out-Null
+
+        if (-not (Test-Path $vsCodeGlobalExtensionsPath)) {
+            Write-Error "The folder $vsCodeGlobalExtensionsPath could not be created. Please ensure you are running as admin."
+        }
+    }
+    
+    Import-ExtensionToLocalPath -extensionId $extensionId `
+        -extensionName $extensionName `
+        -extensionVsixPath $extensionVsixPath `
+        -extensionVersion $extensionVersion `
+        -downloadLocation $vsCodeGlobalExtensionsPath `
+        -downloadPreRelease $installInsiders
+
+    if ($emitAllInstalledExtensions) {
+        Write-Host "All extensions in the bootstrap directory:"
+        Get-ChildItem -Path $vsCodeGlobalExtensionsPath -File
+    } 
+}
+
+try {
+    if (-not ((Test-Path variable:global:IsUnderTest) -and $global:IsUnderTest)) {
+        Main -extensionId $ExtensionId `
+            -extensionName $ExtensionName `
+            -extensionVsixPath $ExtensionVsixPath `
+            -extensionVersion $ExtensionVersion `
+            -visualStudioCodeInstallPath $VisualStudioCodeInstallPath `
+            -installInsiders $InstallInsiders `
+            -emitAllInstalledExtensions $EmitAllInstalledExtensions
+    }
+}
+catch {
+    Write-Error "!!! [ERROR] Unhandled exception:`n$_`n$($_.ScriptStackTrace)" -ErrorAction Stop
+}

--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/run-image-build.ps1
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/tools/run-image-build.ps1
@@ -16,7 +16,7 @@ function Log([string] $message, [switch] $asError) {
 }
 
 RunWithRetries { Connect-AzAccount -Identity | Out-Null }
-RunWithRetries { Install-Module -Name Az.ImageBuilder -AllowPrerelease -Force | Out-Null }
+RunWithRetries { Install-Module -Name Az.ImageBuilder -AllowPrerelease -Force -Verbose }
 
 $preBuildPauseSeconds = 30
 Log "=== Pausing for $preBuildPauseSeconds seconds for the template and prerequisites to complete initialization"


### PR DESCRIPTION
Added new artifact to preinstall Visual Studio Code extensions (https://code.visualstudio.com/updates/v1_96#_set-up-vs-code-with-preinstalled-extensions) 
Contributed by https://github.com/richardsondev
 
