### PR TITLE
[devbox-ready-to-code-image] Install VSCode extensions

### DIFF
--- a/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/images/axios.bicep
+++ b/quickstarts/microsoft.devcenter/devbox-ready-to-code-image/images/axios.bicep
@@ -70,9 +70,8 @@ var winGetPackageArtifacts = [
 // Visual Studio Code extensions
 var visualStudioCodeExtensionArtifacts = [
   for extension in [
-    // TODO: uncomment after this change is committed so the artifact can be found in master branch of the repo since this is the default location of artifactSource as defined in main.bicep
-    // 'GitHub.copilot'
-    // 'ms-azuretools.vscode-bicep'
+    'GitHub.copilot'
+    'ms-azuretools.vscode-bicep'
   ]: {
     name: 'windows-install-visualstudiocode-extension'
     parameters: {


### PR DESCRIPTION
Enable installing VSCode extension in a sample image
