### PR TITLE
Correcting spelling misstake in header

### DIFF
--- a/quickstarts/microsoft.containerservice/azure-kubernetes-monitoring-with-prometheus-and-grafana/README.md
+++ b/quickstarts/microsoft.containerservice/azure-kubernetes-monitoring-with-prometheus-and-grafana/README.md
@@ -9,7 +9,7 @@ languages:
 - bicep
 - json
 ---
-# Create AKS with Prometheus and Grafana with privae link
+# Create AKS with Prometheus and Grafana with private link
 
 ![Azure Public Test Date](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.containerservice/azure-kubernetes-monitoring-with-prometheus-and-grafana/PublicLastTestDate.svg)
 ![Azure Public Test Result](https://azurequickstartsservice.blob.core.windows.net/badges/quickstarts/microsoft.containerservice/azure-kubernetes-monitoring-with-prometheus-and-grafana/PublicDeployment.svg)


### PR DESCRIPTION
Changed from "privae" to "private".


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Updated header to private instead of privae
