### PR TITLE
Update documentation link to the new Azure Resource Manager URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See the [**Contribution guide**](/1-CONTRIBUTION-GUIDE/README.md#contribution-gu
 
 We will reject PRs or remove samples that contain links to non-Microsoft controlled assets, to avoid the risk of potential domain spoofing or hostile takeover. Examples include S3 buckets, non-Microsoft owned Azure storage accounts or non-Azure git repositories.
 
-To fix this, either use Bicep with [modules](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/modules) & [file functions](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/bicep-functions-files), or parameterize links to external content.
+To fix this, either use Bicep with [modules](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/modules) & [file functions](https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-functions-files), or parameterize links to external content.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Resource Manager QuickStart Templates
 
-This repo contains all currently available Azure Resource Manager templates contributed by the community. A searchable template index is maintained at [azure.com](https://azure.microsoft.com/documentation/templates).
+This repo contains all currently available Azure Resource Manager templates contributed by the community. A searchable template index is maintained at [azure.com](https://learn.microsoft.com/en-us/samples/browse/?expanded=azure&products=azure-resource-manager).
 
 See the [**Contribution guide**](/1-CONTRIBUTION-GUIDE/README.md#contribution-guide) for how to use or contribute to this repo.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure Resource Manager QuickStart Templates
 
-This repo contains all currently available Azure Resource Manager templates contributed by the community. A searchable template index is maintained at [azure.com](https://learn.microsoft.com/en-us/samples/browse/?expanded=azure&products=azure-resource-manager).
+This repo contains all currently available Azure Resource Manager templates contributed by the community. A searchable template index is maintained at [azure.com](https://learn.microsoft.com/samples/browse/?expanded=azure&products=azure-resource-manager).
 
 See the [**Contribution guide**](/1-CONTRIBUTION-GUIDE/README.md#contribution-guide) for how to use or contribute to this repo.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ See the [**Contribution guide**](/1-CONTRIBUTION-GUIDE/README.md#contribution-gu
 
 We will reject PRs or remove samples that contain links to non-Microsoft controlled assets, to avoid the risk of potential domain spoofing or hostile takeover. Examples include S3 buckets, non-Microsoft owned Azure storage accounts or non-Azure git repositories.
 
-To fix this, either use Bicep with [modules](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/modules) & [file functions](https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-functions-files), or parameterize links to external content.
+To fix this, either use Bicep with [modules](https://learn.microsoft.com/azure/azure-resource-manager/bicep/modules) & [file functions](https://learn.microsoft.com/azure/azure-resource-manager/bicep/bicep-functions-files), or parameterize links to external content.
 
 ## Code of Conduct
 


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR...

- [x] **I have read through the [Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md) and [Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md).**

## Changelog

### Updated
- **Documentation Link**: Replaced outdated Azure Resource Manager documentation link:
  - **Old URL**: `https://azure.microsoft.com/en-us/documentation/templates`
  - **New URL**: `https://learn.microsoft.com/en-us/samples/browse/?expanded=azure&products=azure-resource-manager`

### Reason
- **Link Update**: The previous link was deprecated and redirected to the new Microsoft Learn samples page. Updating ensures the documentation remains accurate and up-to-date.
