### PR TITLE
Fix the targetDNS array in the Private DNS Resolver example

### DIFF
--- a/quickstarts/microsoft.network/azure-dns-private-resolver/main.bicep
+++ b/quickstarts/microsoft.network/azure-dns-private-resolver/main.bicep
@@ -67,11 +67,11 @@ param DomainName string = 'contoso.com.'
 @description('the list of target DNS servers ip address and the port number for conditional forwarding')
 param targetDNS array = [
   {
-    ipaddress: '10.0.0.4'
+    ipAddress: '10.0.0.4'
     port: 53
   }
   {
-    ipaddress: '10.0.0.5'
+    ipAddress: '10.0.0.5'
     port: 53
   }
 ]


### PR DESCRIPTION
The correct property key is `ipAddress` ([source](https://learn.microsoft.com/en-us/azure/templates/microsoft.network/dnsforwardingrulesets/forwardingrules?pivots=deployment-language-bicep#targetdnsserver)).

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

- Fixed a syntax error in the Private DNS Resolver bicep template example
