### PR TITLE
Basic Public IP sku no longer allowed

### DIFF
--- a/quickstarts/microsoft.compute/vm-simple-windows/azuredeploy.json
+++ b/quickstarts/microsoft.compute/vm-simple-windows/azuredeploy.json
@@ -38,22 +38,14 @@
     },
     "publicIPAllocationMethod": {
       "type": "string",
-      "defaultValue": "Dynamic",
-      "allowedValues": [
-        "Dynamic",
-        "Static"
-      ],
+      "defaultValue": "Static",
       "metadata": {
         "description": "Allocation method for the Public IP used to access the Virtual Machine."
       }
     },
     "publicIpSku": {
       "type": "string",
-      "defaultValue": "Basic",
-      "allowedValues": [
-        "Basic",
-        "Standard"
-      ],
+      "defaultValue": "Standard",
       "metadata": {
         "description": "SKU for the Public IP used to access the Virtual Machine."
       }

--- a/quickstarts/microsoft.compute/vm-simple-windows/main.bicep
+++ b/quickstarts/microsoft.compute/vm-simple-windows/main.bicep
@@ -13,18 +13,10 @@ param dnsLabelPrefix string = toLower('${vmName}-${uniqueString(resourceGroup().
 param publicIpName string = 'myPublicIP'
 
 @description('Allocation method for the Public IP used to access the Virtual Machine.')
-@allowed([
-  'Dynamic'
-  'Static'
-])
-param publicIPAllocationMethod string = 'Dynamic'
+param publicIPAllocationMethod string = 'Static'
 
 @description('SKU for the Public IP used to access the Virtual Machine.')
-@allowed([
-  'Basic'
-  'Standard'
-])
-param publicIpSku string = 'Basic'
+param publicIpSku string = 'Standard'
 
 @description('The Windows version for the VM. This will pick a fully patched image of this given Windows version.')
 @allowed([


### PR DESCRIPTION
nor is its Dynamic property.
https://azure.microsoft.com/en-us/updates?id=upgrade-to-standard-sku-public-ip-addresses-in-azure-by-30-september-2025-basic-sku-will-be-retired
`On 30 September 2025, Basic SKU public IP addresses will be retired in Azure. You can continue to use your existing Basic SKU public IP addresses until then, however, you'll no longer be able to create new ones after 31 March 2025.`

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Removed Basic SKU from Public IP Address in Simple Windows VM ARM and Bicep
* Removed Dynamic property from Public IP Address in Simple Windows VM ARM and Bicep
*
