### PR TITLE
Update SF Linux extension to use Version 2.0 + auto upgrade. 1.1 has been deprecated

### DIFF
--- a/quickstarts/microsoft.servicefabric/5-vm-ubuntu-1-nodetypes-secure/azuredeploy.json
+++ b/quickstarts/microsoft.servicefabric/5-vm-ubuntu-1-nodetypes-secure/azuredeploy.json
@@ -457,7 +457,7 @@
                   "settings": {
                     "clusterEndpoint": "[reference(parameters('clusterName')).clusterEndpoint]",
                     "nodeTypeRef": "[variables('vmNodeType0Name')]",
-                    "durabilityLevel": "Bronze",
+                    "durabilityLevel": "Silver",
                     "enableParallelJobs": true,
                     "nicPrefixOverride": "[variables('subnet0Prefix')]",
                     "certificate": {
@@ -465,7 +465,7 @@
                       "x509StoreName": "[parameters('certificateStoreValue')]"
                     }
                   },
-                  "typeHandlerVersion": "1.1",
+                  "typeHandlerVersion": "2.0",
                   "enableAutomaticUpgrade": true
                 }
               }
@@ -590,7 +590,7 @@
               "startPort": "[variables('nt0applicationStartPort')]"
             },
             "clientConnectionEndpointPort": "[variables('nt0fabricTcpGatewayPort')]",
-            "durabilityLevel": "Bronze",
+            "durabilityLevel": "Silver",
             "ephemeralPorts": {
               "endPort": "[variables('nt0ephemeralEndPort')]",
               "startPort": "[variables('nt0ephemeralStartPort')]"


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Update SF Linux extension to use Version 2.0 + auto upgrade. 1.1 has been deprecated
* Use silver durability instead of bronze
