### PR TITLE
Fix API Version on container-app-azurevote

### DIFF
--- a/quickstarts/microsoft.app/container-app-azurevote/azuredeploy.json
+++ b/quickstarts/microsoft.app/container-app-azurevote/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.177.2456",
-      "templateHash": "14648521807975445785"
+      "templateHash": "7015161032604525705"
     }
   },
   "parameters": {
@@ -44,7 +44,7 @@
     },
     "frontendContainerImage": {
       "type": "string",
-      "defaultValue": "mcr.microsoft.com/azuredocs/azure-vote-front:v1",
+      "defaultValue": "lgmorand/azure-vote-front:v1",
       "metadata": {
         "description": "Specifies the docker container image to deploy."
       }

--- a/quickstarts/microsoft.app/container-app-azurevote/azuredeploy.json
+++ b/quickstarts/microsoft.app/container-app-azurevote/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.177.2456",
-      "templateHash": "17411020582279761271"
+      "templateHash": "14648521807975445785"
     }
   },
   "parameters": {
@@ -78,7 +78,7 @@
   "resources": [
     {
       "type": "Microsoft.OperationalInsights/workspaces",
-      "apiVersion": "2021-06-01",
+      "apiVersion": "2022-10-01",
       "name": "[parameters('containerAppLogAnalyticsName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -96,8 +96,8 @@
         "appLogsConfiguration": {
           "destination": "log-analytics",
           "logAnalyticsConfiguration": {
-            "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('containerAppLogAnalyticsName')), '2021-06-01').customerId]",
-            "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('containerAppLogAnalyticsName')), '2021-06-01').primarySharedKey]"
+            "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('containerAppLogAnalyticsName')), '2022-10-01').customerId]",
+            "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('containerAppLogAnalyticsName')), '2022-10-01').primarySharedKey]"
           }
         }
       },

--- a/quickstarts/microsoft.app/container-app-azurevote/azuredeploy.json
+++ b/quickstarts/microsoft.app/container-app-azurevote/azuredeploy.json
@@ -4,8 +4,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.5.6.12127",
-      "templateHash": "5958316336517191726"
+      "version": "0.36.177.2456",
+      "templateHash": "17411020582279761271"
     }
   },
   "parameters": {
@@ -59,8 +59,8 @@
     "minReplica": {
       "type": "int",
       "defaultValue": 1,
-      "maxValue": 25,
       "minValue": 0,
+      "maxValue": 25,
       "metadata": {
         "description": "Minimum number of replicas that will be deployed"
       }
@@ -68,8 +68,8 @@
     "maxReplica": {
       "type": "int",
       "defaultValue": 3,
-      "maxValue": 25,
       "minValue": 0,
+      "maxValue": 25,
       "metadata": {
         "description": "Maximum number of replicas that will be deployed"
       }
@@ -89,14 +89,14 @@
     },
     {
       "type": "Microsoft.App/managedEnvironments",
-      "apiVersion": "2022-01-01-preview",
+      "apiVersion": "2025-02-02-preview",
       "name": "[parameters('containerAppEnvName')]",
       "location": "[parameters('location')]",
       "properties": {
         "appLogsConfiguration": {
           "destination": "log-analytics",
           "logAnalyticsConfiguration": {
-            "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('containerAppLogAnalyticsName'))).customerId]",
+            "customerId": "[reference(resourceId('Microsoft.OperationalInsights/workspaces', parameters('containerAppLogAnalyticsName')), '2021-06-01').customerId]",
             "sharedKey": "[listKeys(resourceId('Microsoft.OperationalInsights/workspaces', parameters('containerAppLogAnalyticsName')), '2021-06-01').primarySharedKey]"
           }
         }
@@ -107,7 +107,7 @@
     },
     {
       "type": "Microsoft.App/containerApps",
-      "apiVersion": "2022-01-01-preview",
+      "apiVersion": "2025-02-02-preview",
       "name": "[parameters('containerAppName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -181,7 +181,7 @@
   "outputs": {
     "containerAppFQDN": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.App/containerApps', parameters('containerAppName'))).configuration.ingress.fqdn]"
+      "value": "[reference(resourceId('Microsoft.App/containerApps', parameters('containerAppName')), '2025-02-02-preview').configuration.ingress.fqdn]"
     }
   }
 }

--- a/quickstarts/microsoft.app/container-app-azurevote/main.bicep
+++ b/quickstarts/microsoft.app/container-app-azurevote/main.bicep
@@ -42,7 +42,7 @@ resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2021-06-01' = {
   }
 }
 
-resource containerAppEnv 'Microsoft.App/managedEnvironments@2022-01-01-preview' = {
+resource containerAppEnv 'Microsoft.App/managedEnvironments@2025-02-02-preview' = {
   name: containerAppEnvName
   location: location
   properties: {
@@ -56,7 +56,7 @@ resource containerAppEnv 'Microsoft.App/managedEnvironments@2022-01-01-preview' 
   }
 }
 
-resource containerApp 'Microsoft.App/containerApps@2022-01-01-preview' = {
+resource containerApp 'Microsoft.App/containerApps@2025-02-02-preview' = {
   name: containerAppName
   location: location
   properties: {

--- a/quickstarts/microsoft.app/container-app-azurevote/main.bicep
+++ b/quickstarts/microsoft.app/container-app-azurevote/main.bicep
@@ -17,7 +17,7 @@ param containerAppLogAnalyticsName string = 'containerapp-log-${uniqueString(res
 param location string
 
 @description('Specifies the docker container image to deploy.')
-param frontendContainerImage string = 'mcr.microsoft.com/azuredocs/azure-vote-front:v1'
+param frontendContainerImage string = 'lgmorand/azure-vote-front:v1'
 
 @description('Specifies the docker container image to deploy for the Redis backend.')
 param backendContainerImage string = 'mcr.microsoft.com/oss/bitnami/redis:6.0.8'

--- a/quickstarts/microsoft.app/container-app-azurevote/main.bicep
+++ b/quickstarts/microsoft.app/container-app-azurevote/main.bicep
@@ -32,7 +32,7 @@ param minReplica int = 1
 @maxValue(25)
 param maxReplica int = 3
 
-resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2021-06-01' = {
+resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
   name: containerAppLogAnalyticsName
   location: location
   properties: {


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

> No registered resource provider found for location 'eastus' and API version '2022-01-01-preview' for type 'managedEnvironments'. The supported API versions are: '2022-03-01, 2022-06-01-preview, 2022-10-01, 2022-11-01-preview, 2023-04-01-preview, 2023-05-01, 2023-05-02-preview, 2023-08-01-preview, 2023-11-02-preview, 2024-02-02-preview, 2024-03-01, 2024-08-02-preview, 2024-10-02-preview, 2025-01-01, 2025-02-02-preview'. The supported locations are: 'northcentralusstage, westus2, southeastasia, swedencentral, canadacentral, westeurope, northeurope, eastus, eastus2, eastasia, australiaeast, germanywestcentral, japaneast, uksouth, westus, centralus, northcentralus, southcentralus, koreacentral, brazilsouth, westus3, francecentral, southafricanorth, norwayeast, switzerlandnorth, uaenorth, canadaeast, westcentralus, ukwest, centralindia, japanwest, australiasoutheast, francesouth, jioindiawest, spaincentral, italynorth, polandcentral, southindia'. (Code: NoRegisteredProviderFound)

<img width="1370" height="178" alt="image" src="https://github.com/user-attachments/assets/888ac260-1e76-4584-a353-eba1fca47183" />



This pull request updates the Azure Resource Manager templates and Bicep files for the Azure Container Apps quickstart to align with newer API versions and improve compatibility. The most important changes include upgrading API versions.

### API Version Updates:
* Updated `apiVersion` for `Microsoft.App/managedEnvironments` and `Microsoft.App/containerApps` resources from `2022-01-01-preview` to `2025-02-02-preview` in both `azuredeploy.json` and `main.bicep`. [[1]](diffhunk://#diff-b486571799563386e5e8bed0d4c42a92ef535de14a726ab0b4f6945f60c1dbb1L92-R99) [[2]](diffhunk://#diff-b486571799563386e5e8bed0d4c42a92ef535de14a726ab0b4f6945f60c1dbb1L110-R110) [[3]](diffhunk://#diff-69355befc9a4a56628951b237c240541ae956500fba556ffd1688d2ecb8059c2L45-R45) [[4]](diffhunk://#diff-69355befc9a4a56628951b237c240541ae956500fba556ffd1688d2ecb8059c2L59-R59)
