### PR TITLE
Foundry Hub template fix: remove apiProperties: statisticsEnabled

### DIFF
--- a/quickstarts/microsoft.machinelearningservices/aifoundry-basics/modules/dependent-resources.bicep
+++ b/quickstarts/microsoft.machinelearningservices/aifoundry-basics/modules/dependent-resources.bicep
@@ -123,9 +123,6 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2021-10-01' = {
   }
   kind: 'AIServices' // or 'OpenAI'
   properties: {
-    apiProperties: {
-      statisticsEnabled: false
-    }
   }
 }
 


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

One field was breaking the AI Foundry basic template

* Removed the apiProperties: statisticsEnabled field 
