### PR TITLE
Update Azure deployment template for Minecraft

### DIFF
--- a/application-workloads/minecraft/minecraft-on-ubuntu/azuredeploy.json
+++ b/application-workloads/minecraft/minecraft-on-ubuntu/azuredeploy.json
@@ -5,7 +5,7 @@
     "_artifactsLocation": {
       "type": "string",
       "metadata": {
-        "description": "The base URI where artifacts required by this template are located. For example, if stored on a public GitHub repo, you'd use the following URI: https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/minecraft-on-ubuntu/."
+        "description": "The base URI where artifacts required by this template are located. For example, if stored on a public GitHub repo, you'd use the following URI: https://github.com/Azure/azure-quickstart-templates/blob/master/application-workloads/minecraft/minecraft-on-ubuntu/."
       },
       "defaultValue": "[deployment().properties.templateLink.uri]"
     },
@@ -159,7 +159,7 @@
   },
   "variables": {
     "addressPrefix": "10.0.0.0/16",
-    "imageOffer": "UbuntuServer",
+    "imageOffer": "0001-com-ubuntu-server-jammy",
     "imagePublisher": "Canonical",
     "linuxConfiguration": {
       "disablePasswordAuthentication": true,
@@ -180,7 +180,7 @@
     "subnetName": "subnet",
     "subnetPrefix": "10.0.0.0/24",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
-    "ubuntuOSVersion": "18.04-LTS",
+    "ubuntuOSVersion": "22_04-lts-gen2",
     "virtualNetworkName": "minecraftvnet",
     "vmName": "minecraftvm"
   },


### PR DESCRIPTION
Updated ubuntu "imageOffer" to latest and 
Updated "ubuntuOSVersion" 
for template to even get to deployment stage

Also when deploying the template the _artifactsLocation should follow the pattern by looking at the raw `install_minecraft.sh` file location which follows the pattern of 
> https://raw.githubusercontent.com/Azure/azure-quickstart-templates/refs/heads/master/application-workloads/minecraft/minecraft-on-ubuntu/install_minecraft.sh

Also in the default template make sure you include a `/` at the end of the _artifactsLocation or else template will fail. 

I used `https://raw.githubusercontent.com/Azure/azure-quickstart-templates/refs/heads/master/application-workloads/minecraft/minecraft-on-ubuntu/` and template worked.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [ ] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

*
*
*
