### PR TITLE
Update Discovery chat model default to gpt-5.2

### DIFF
--- a/quickstarts/microsoft.discovery/discovery-infra-deployment/main.bicep
+++ b/quickstarts/microsoft.discovery/discovery-infra-deployment/main.bicep
@@ -25,7 +25,7 @@ param workspaceName string = 'ws-${uniqueString(resourceGroup().id)}'
 @description('Name of the Chat Model Deployment created under the Workspace.')
 @minLength(3)
 @maxLength(24)
-param chatModelDeploymentName string = 'gpt-5-1'
+param chatModelDeploymentName string = 'gpt-5-2'
 
 @description('Name of the Microsoft Discovery Storage Container resource. Must be 3-24 characters, alphanumeric and hyphens only.')
 @minLength(3)
@@ -91,7 +91,7 @@ param nodePoolScaleSetPriority string = 'Regular'
 param chatModelFormat string = 'OpenAI'
 
 @description('Chat model name to deploy.')
-param chatModelName string = 'gpt-5.1'
+param chatModelName string = 'gpt-5.2'
 
 // Built-in role definition IDs
 var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'


### PR DESCRIPTION
The Discovery Engine requires a chat model deployment named gpt-5-2 (model: gpt-5.2) for task validation. Update the default from gpt-5.1 to gpt-5.2 so new deployments work with the Discovery Engine out of the box.