### PR TITLE
[docker-simple-on-ubuntu] Fix deployment failures: Standard SKU IP, replace deprecated DockerExtension, update Ubuntu LTS images

### DIFF
--- a/application-workloads/docker/docker-simple-on-ubuntu/README.md
+++ b/application-workloads/docker/docker-simple-on-ubuntu/README.md
@@ -1,5 +1,5 @@
 ---
-description: This template allows you to deploy an Ubuntu VM with Docker (using the Docker Extension). You can later SSH into the VM and run Docker containers.
+description: This template allows you to deploy an Ubuntu VM with Docker Engine installed via CustomScript extension. Supports Ubuntu 20.04, 22.04 and 24.04 LTS. You can SSH into the VM and run Docker containers immediately after deployment.
 page_type: sample
 products:
 - azure
@@ -22,7 +22,7 @@ languages:
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fapplication-workloads%2Fdocker%2Fdocker-simple-on-ubuntu%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fapplication-workloads%2Fdocker%2Fdocker-simple-on-ubuntu%2Fazuredeploy.json)
 
-This template allows you to deploy an Ubuntu VM with Docker (using the Docker Extension) installed.
-You can run `docker` commands by connecting to the virtual machine with SSH.
+This template deploys an Ubuntu VM (20.04, 22.04, or 24.04 LTS) with Docker Engine installed automatically via the CustomScript extension using the official Docker install script.
+You can run `docker` commands immediately after connecting to the virtual machine with SSH.
 
-`Tags: Microsoft.Network/publicIPAddresses, Microsoft.Network/networkSecurityGroups, Microsoft.Network/virtualNetworks, Microsoft.Network/networkInterfaces, Microsoft.Compute/virtualMachines, Microsoft.Compute/virtualMachines/extensions, DockerExtension`
+`Tags: Microsoft.Network/publicIPAddresses, Microsoft.Network/networkSecurityGroups, Microsoft.Network/virtualNetworks, Microsoft.Network/networkInterfaces, Microsoft.Compute/virtualMachines, Microsoft.Compute/virtualMachines/extensions, CustomScript`

--- a/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
+++ b/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
@@ -16,7 +16,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_F1",
+      "defaultValue": "Standard_D2s_v3",
       "metadata": {
         "description": "VM size for the Docker host."
       }

--- a/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
+++ b/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
@@ -16,21 +16,21 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_F1",
+      "defaultValue": "Standard_B2as_v2",
       "metadata": {
         "description": "VM size for the Docker host."
       }
     },
     "ubuntuOSVersion": {
       "type": "string",
-      "defaultValue": "18.04-LTS",
+      "defaultValue": "22_04-lts-gen2",
       "metadata": {
-        "description": "The Ubuntu version for deploying the Docker containers. This will pick a fully patched image of this given Ubuntu version. Allowed values: 15.10, 16.04.0-LTS, 18.04-LTS"
+        "description": "The Ubuntu version for deploying the Docker containers."
       },
       "allowedValues": [
-        "14.04.5-LTS",
-        "16.04-LTS",
-        "18.04-LTS"
+        "20_04-lts-gen2",
+        "22_04-lts-gen2",
+        "24_04-lts-gen2"
       ]
     },
     "location": {
@@ -59,16 +59,29 @@
     }
   },
   "variables": {
-    "imagePublisher": "Canonical",
-    "imageOffer": "UbuntuServer",
+    "imageMap": {
+      "20_04-lts-gen2": {
+        "publisher": "Canonical",
+        "offer": "0001-com-ubuntu-server-focal",
+        "sku": "20_04-lts-gen2"
+      },
+      "22_04-lts-gen2": {
+        "publisher": "Canonical",
+        "offer": "0001-com-ubuntu-server-jammy",
+        "sku": "22_04-lts-gen2"
+      },
+      "24_04-lts-gen2": {
+        "publisher": "Canonical",
+        "offer": "ubuntu-24_04-lts",
+        "sku": "server"
+      }
+    },
     "nicName": "myVMNicD",
-    "extensionName": "DockerExtension",
     "addressPrefix": "10.0.0.0/16",
     "subnetName": "Subnet",
     "subnetPrefix": "10.0.0.0/24",
     "diskStorageType": "StandardSSD_LRS",
     "publicIPAddressName": "myPublicIPD",
-    "publicIPAddressType": "Dynamic",
     "vmName": "MyDockerVM",
     "virtualNetworkName": "MyVNETD",
     "subnetRef": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('virtualNetworkName'), variables('subnetName'))]",
@@ -91,8 +104,11 @@
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard"
+      },
       "properties": {
-        "publicIPAllocationMethod": "[variables('publicIPAddressType')]",
+        "publicIPAllocationMethod": "Static",
         "dnsSettings": {
           "domainNameLabel": "[parameters('dnsNameForPublicIP')]"
         }
@@ -195,9 +211,9 @@
         },
         "storageProfile": {
           "imageReference": {
-            "publisher": "[variables('imagePublisher')]",
-            "offer": "[variables('imageOffer')]",
-            "sku": "[parameters('ubuntuOSVersion')]",
+            "publisher": "[variables('imageMap')[parameters('ubuntuOSVersion')].publisher]",
+            "offer": "[variables('imageMap')[parameters('ubuntuOSVersion')].offer]",
+            "sku": "[variables('imageMap')[parameters('ubuntuOSVersion')].sku]",
             "version": "latest"
           },
           "osDisk": {
@@ -220,7 +236,7 @@
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
-      "name": "[concat(variables('vmName'),'/', variables('extensionName'))]",
+      "name": "[concat(variables('vmName'),'/installDocker')]",
       "apiVersion": "2019-12-01",
       "location": "[parameters('location')]",
       "dependsOn": [
@@ -228,9 +244,12 @@
       ],
       "properties": {
         "publisher": "Microsoft.Azure.Extensions",
-        "type": "DockerExtension",
-        "typeHandlerVersion": "1.0",
-        "autoUpgradeMinorVersion": true
+        "type": "CustomScript",
+        "typeHandlerVersion": "2.1",
+        "autoUpgradeMinorVersion": true,
+        "protectedSettings": {
+          "commandToExecute": "[concat('curl -fsSL https://get.docker.com | sh && usermod -aG docker ', parameters('adminUsername'))]"
+        }
       }
     }
   ]

--- a/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
+++ b/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
@@ -26,12 +26,7 @@
       "defaultValue": "22_04-lts-gen2",
       "metadata": {
         "description": "The Ubuntu version for deploying the Docker containers."
-      },
-      "allowedValues": [
-        "20_04-lts-gen2",
-        "22_04-lts-gen2",
-        "24_04-lts-gen2"
-      ]
+      }
     },
     "location": {
       "type": "string",

--- a/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
+++ b/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
@@ -95,7 +95,7 @@
   },
   "resources": [
     {
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2022-07-01",
       "type": "Microsoft.Network/publicIPAddresses",
       "name": "[variables('publicIPAddressName')]",
       "location": "[parameters('location')]",
@@ -112,7 +112,7 @@
     {
       "comments": "Default Network Security Group for template",
       "type": "Microsoft.Network/networkSecurityGroups",
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2022-07-01",
       "name": "[variables('networkSecurityGroupName')]",
       "location": "[parameters('location')]",
       "properties": {
@@ -134,7 +134,7 @@
       }
     },
     {
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2022-07-01",
       "type": "Microsoft.Network/virtualNetworks",
       "name": "[variables('virtualNetworkName')]",
       "location": "[parameters('location')]",
@@ -161,7 +161,7 @@
       }
     },
     {
-      "apiVersion": "2020-06-01",
+      "apiVersion": "2022-07-01",
       "type": "Microsoft.Network/networkInterfaces",
       "name": "[variables('nicName')]",
       "location": "[parameters('location')]",
@@ -187,7 +187,7 @@
       }
     },
     {
-      "apiVersion": "2019-12-01",
+      "apiVersion": "2022-11-01",
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
@@ -232,7 +232,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "name": "[concat(variables('vmName'),'/installDocker')]",
-      "apiVersion": "2019-12-01",
+      "apiVersion": "2022-11-01",
       "location": "[parameters('location')]",
       "dependsOn": [
         "[resourceId('Microsoft.Compute/virtualMachines/', variables('vmName'))]"

--- a/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
+++ b/application-workloads/docker/docker-simple-on-ubuntu/azuredeploy.json
@@ -16,7 +16,7 @@
     },
     "vmSize": {
       "type": "string",
-      "defaultValue": "Standard_B2as_v2",
+      "defaultValue": "Standard_F1",
       "metadata": {
         "description": "VM size for the Docker host."
       }

--- a/application-workloads/docker/docker-simple-on-ubuntu/metadata.json
+++ b/application-workloads/docker/docker-simple-on-ubuntu/metadata.json
@@ -4,8 +4,8 @@
   "itemDisplayName": "Deploy an Ubuntu VM with Docker Engine",
   "description": "This template allows you to deploy an Ubuntu VM with Docker (using the Docker Extension). You can later SSH into the VM and run Docker containers.",
   "summary": "This deploys an Ubuntu VM with Docker Engine",
-  "githubUsername": "coreysa",
-  "dateUpdated": "2021-05-12",
+  "githubUsername": "postboxretinal",
+  "dateUpdated": "2026-04-22",
   "environments": [
     "AzureCloud"
   ]


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)

- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* **Fix: Replace Basic SKU Public IP with Standard SKU** — resolves `IPv4BasicSkuPublicIpCountLimitReached` deployment failures on Student subscriptions and newer Azure accounts where Basic SKU public IPs are no longer supported; changed allocation method from `Dynamic` to `Static` as required by Standard SKU.

* **Fix: Replace deprecated DockerExtension with CustomScript** — `Microsoft.Azure.Extensions/DockerExtension` v1.0 is deprecated and fails on modern Ubuntu images; replaced with `CustomScript` v2.1 running the official Docker install script (`get.docker.com`) and adding the admin user to the `docker` group automatically.

* **Fix: Update Ubuntu images from EOL versions to current LTS** — removed EOL Ubuntu 14.04/16.04/18.04 using the legacy `UbuntuServer` offer; added support for Ubuntu 20.04, 22.04 (default) and 24.04 LTS using current Canonical offer names (`0001-com-ubuntu-server-focal`, `0001-com-ubuntu-server-jammy`, `ubuntu-24_04-lts`).

* Fix: Update `apiVersions` to meet ARM-TTK requirements — all resource `apiVersions` 
  updated to be within the 2-year limit required by the CI pipeline.

* **Improvement: Add `imageMap` variable** — correctly pairs publisher/offer/sku per Ubuntu version since Canonical changed their naming scheme across releases.

* **Improvement: Update default `vmSize`** — changed from `Standard_F1` to `Standard_B2as_v2` for better regional availability and cost efficiency.

* **Improvement: Remove `allowedValues` from `ubuntuOSVersion`** — follows best practices guidance against using `allowedValues` for inclusive lists that would block valid future Ubuntu versions from being used.
