### PR TITLE
Updated Cloud Shell VNet sample for ACI role assignment at VNet

### DIFF
--- a/demos/cloud-shell-vnet/main.bicep
+++ b/demos/cloud-shell-vnet/main.bicep
@@ -57,6 +57,15 @@ resource existingVNET 'Microsoft.Network/virtualNetworks@2023-05-01' existing = 
   name: existingVNETName
 }
 
+resource existingVNET_roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: existingVNET
+  name: guid(networkRoleDefinitionId, azureContainerInstanceOID, vnetResourceId)
+  properties: {
+    roleDefinitionId: networkRoleDefinitionId
+    principalId: azureContainerInstanceOID
+  }
+}
+
 resource containerSubnet 'Microsoft.Network/virtualNetworks/subnets@2023-05-01' = {
   parent: existingVNET
   name: containerSubnetName

--- a/demos/cloud-shell-vnet/metadata.json
+++ b/demos/cloud-shell-vnet/metadata.json
@@ -9,8 +9,13 @@
   "testResult": {
     "deployments": [
       {
+        "templateFileName": "prereqs/prereq.main.bicep",
+        "correlationId": "5b1b6e1e-4cef-4da5-9272-649c5e5dd402",
+        "deploymentName": "harish-sbox-prereq-01"
+      },
+      {
         "templateFileName": "main.bicep",
-        "correlationId": "490338c6-6d68-408b-aa38-9a66531750d2",
+        "correlationId": "22c7e86f-dce5-4082-b2a0-1faa8f886086",
         "deploymentName": "harish-sbox-deploy-01"
       }
     ]

--- a/demos/cloud-shell-vnet/metadata.json
+++ b/demos/cloud-shell-vnet/metadata.json
@@ -7,8 +7,12 @@
   "githubUsername": "harishnarain",
   "dateUpdated": "2026-04-23",
   "testResult": {
-    "templateFileName": "main.bicep",
-    "correlationId": "490338c6-6d68-408b-aa38-9a66531750d2",
-    "deploymentName": "harish-sbox-deploy-01"
+    "deployments": [
+      {
+        "templateFileName": "main.bicep",
+        "correlationId": "490338c6-6d68-408b-aa38-9a66531750d2",
+        "deploymentName": "harish-sbox-deploy-01"
+      }
+    ]
   }
 }

--- a/demos/cloud-shell-vnet/metadata.json
+++ b/demos/cloud-shell-vnet/metadata.json
@@ -4,6 +4,11 @@
   "itemDisplayName": "Azure Cloud Shell - VNet",
   "description": "This template deploys Azure Cloud Shell resources into an Azure virtual network.",
   "summary": "This template demonstrates how to create Cloud Shell resources in a VNet. For more information, please view our documentation: https://aka.ms/cloudshell/docs/vnet ",
-  "githubUsername": "maertendMSFT",
-  "dateUpdated": "2024-12-04"
+  "githubUsername": "harishnarain",
+  "dateUpdated": "2026-04-23",
+  "testResult": {
+    "templateFileName": "main.bicep",
+    "correlationId": "490338c6-6d68-408b-aa38-9a66531750d2",
+    "deploymentName": "harish-sbox-deploy-01"
+  }
 }


### PR DESCRIPTION
In preparation to move from Network Profile to supporting Subnet ID, the Cloud Shell VNet sample bicep has been updated to include a role assignment of the Azure Container Instance application ID to the VNet with Network Contributor access.

# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [X] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog

* Added role assignment for Azure Container Instance app ID to the VNet

