### PR TITLE
Remove zonal usage and port 22 NSG rule from AZFW Template

### DIFF
--- a/quickstarts/microsoft.network/azurefirewall-sandbox-linux/azuredeploy.json
+++ b/quickstarts/microsoft.network/azurefirewall-sandbox-linux/azuredeploy.json
@@ -40,18 +40,7 @@
       "type": "string",
       "defaultValue": "[resourceGroup().location]",
       "metadata": {
-        "description": "Location for all resources, the location must support Availability Zones if required."
-      }
-    },
-    "availabilityZones": {
-      "type": "array",
-      "defaultValue": [
-        "1",
-        "2",
-        "3"
-      ],
-      "metadata": {
-        "description": "Zone numbers e.g. 1,2,3."
+        "description": "Location for all resources."
       }
     },
     "privateRanges": {
@@ -65,7 +54,7 @@
       "type": "string",
       "defaultValue": "Standard_D2s_v3",
       "metadata": {
-        "description": "Zone numbers e.g. 1,2,3."
+        "description": "Size of the Virtual Machine."
       }
     },
     "numberOfFirewallPublicIPAddresses": {
@@ -260,7 +249,6 @@
       "apiVersion": "2023-09-01",
       "name": "[format('{0}{1}', variables('publicIPNamePrefix'), add(range(0, parameters('numberOfFirewallPublicIPAddresses'))[copyIndex()], 1))]",
       "location": "[parameters('location')]",
-      "zones": "[if(equals(length(parameters('availabilityZones')), 0), null(), parameters('availabilityZones'))]",
       "sku": {
         "name": "Standard"
       },
@@ -284,21 +272,7 @@
       "name": "[variables('jumpBoxNsgName')]",
       "location": "[parameters('location')]",
       "properties": {
-        "securityRules": [
-          {
-            "name": "myNetworkSecurityGroupRuleSSH",
-            "properties": {
-              "protocol": "Tcp",
-              "sourcePortRange": "*",
-              "destinationPortRange": "22",
-              "sourceAddressPrefix": "*",
-              "destinationAddressPrefix": "*",
-              "access": "Allow",
-              "priority": 1000,
-              "direction": "Inbound"
-            }
-          }
-        ]
+        "securityRules": []
       }
     },
     {
@@ -524,7 +498,6 @@
       "apiVersion": "2023-09-01",
       "name": "[variables('firewallName')]",
       "location": "[parameters('location')]",
-      "zones": "[if(equals(length(parameters('availabilityZones')), 0), null(), parameters('availabilityZones'))]",
       "properties": {
         "ipConfigurations": "[variables('azureFirewallIpConfigurations')]",
         "applicationRuleCollections": [


### PR DESCRIPTION
# PR Checklist

Check these items before submitting a PR... 

[Contribution Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/README.md)

[Best Practice Guide](https://github.com/Azure/azure-quickstart-templates/blob/master/1-CONTRIBUTION-GUIDE/best-practices.md)


- [x] - Please check this box once you've submitted the PR if you've read through the Contribution Guide and best practices checklist.

## Changelog
Remove port 22 rule from commonly used template in Az Firewall team as it is security risk and disallowed by default.
Remove zonal usage as its no longer directly supported by Az Firewall and breaks in certain regions.
*
*
*
