### PR TITLE
Fix doc-drift in contribution guide post Apr–May 2026 CI rewrite

### DIFF
--- a/1-CONTRIBUTION-GUIDE/README.md
+++ b/1-CONTRIBUTION-GUIDE/README.md
@@ -114,7 +114,7 @@ The target scope itself should not be created by the sample unless the creation 
 We encourage new samples to be written directly in [Bicep](https://docs.microsoft.com/azure/azure-resource-manager/bicep/overview) and encourage existing samples to be converted to support Bicep.
 
 1. The bicep file must be named **main.bicep**
-1. The **azuredeploy.json** must **not** be included in the PR as it will be built automatically when the sample is merged.
+1. The **azuredeploy.json** (compiled output of `main.bicep`) should be included in the PR alongside `main.bicep`. The "Deploy to Azure" / "Visualize" buttons in each sample's README link directly to `azuredeploy.json`, so it must exist in the sample folder. Compile locally with `az bicep build --file main.bicep --outfile azuredeploy.json` before submitting.
 1. The [**README.md**](sample-README.md) file must include a link to the bicep badge
 1. The parameter file must still be named **azuredeploy.parameters.json**
 
@@ -309,7 +309,7 @@ If only one is provided it will be used for testing in all clouds.
 
 ## GitHub Actions CI
 
-We have automated template validation through GitHub Actions.  Three workflows run as part of the PR process:
+We have automated template validation through GitHub Actions.  Two workflows run as part of the PR process:
 
 ### 1. Validate Sample Contributions (`validate-samples.yml`)
 
@@ -323,17 +323,15 @@ This workflow runs automatically on every PR to `master`. It validates:
 
 ### 2. Validate ARM Deployments (`ValidateSampleDeployments.yml`)
 
-This workflow is triggered by a repo maintainer posting a `/verify` comment on your PR.  It validates the deployment results you provided in `testResult`:
+This workflow is triggered by a repo maintainer posting a `/validate` comment on your PR.  It validates the deployment results you provided in `testResult`:
 
 + Verifies that the `correlationId` and `deploymentName` exist in the Azure deployment logs
 + Confirms the deployment `executionStatus` is `Succeeded`
 + Computes a `templateHash` from the template file in the PR and verifies it matches the hash recorded in the deployment logs — this ensures the template you deployed is the same one in the PR
 
-The `/verify` command can only be run after `validate-samples.yml` passes.
+The workflow also posts an AI-generated summary comment on the PR alongside the deployment validation, to help reviewers understand what the sample does.
 
-### 3. Summarize PR (`summarize-pr.yml`)
-
-Triggered by a `/summarize` comment on a PR, this workflow generates an AI-powered summary of the sample changes to help reviewers.
+The `/validate` command can only be run after `validate-samples.yml` passes.
 
 ### Contributor Workflow Summary
 
@@ -342,8 +340,7 @@ Triggered by a `/summarize` comment on a PR, this workflow generates an AI-power
 3. **Capture** the deployment results: `correlationId`, `deploymentName`, and `templateFileName`
 4. **Update** `metadata.json` with the `testResult` section containing the deployment results
 5. **Submit** your PR — `validate-samples.yml` runs automatically
-6. A **maintainer** runs `/verify` to validate your deployment results against Azure logs
-7. Optionally, a reviewer runs `/summarize` for an AI-generated PR summary
+6. A **maintainer** runs `/validate` to validate your deployment results against Azure logs
 
 ### Parameters File Placeholders
 
@@ -489,9 +486,9 @@ Common failure reasons:
 
 + **metadata.json missing `testResult`:** You must deploy your template and add the deployment results to metadata.json before submitting the PR.  See [testResult](#testresult) for the required format.
 + **Template changed but metadata.json not updated:** If you modify any `.bicep` or `.json` file, you must re-deploy and update the `testResult` section with fresh deployment results.
-+ **`/verify` fails with "No ADX record found":** The `correlationId` or `deploymentName` in your metadata.json does not match any Azure deployment log.  Double-check the values are correct.
-+ **`/verify` fails with templateHash mismatch:** The template you deployed is different from the template in your PR.  Re-deploy the exact template from your PR branch and update the deployment results.
-+ **`/verify` fails with executionStatus not Succeeded:** Your deployment did not succeed.  Fix the template, re-deploy, and update the deployment results.
++ **`/validate` fails with "No ADX record found":** The `correlationId` or `deploymentName` in your metadata.json does not match any Azure deployment log.  Double-check the values are correct.
++ **`/validate` fails with templateHash mismatch:** The template you deployed is different from the template in your PR.  Re-deploy the exact template from your PR branch and update the deployment results.
++ **`/validate` fails with executionStatus not Succeeded:** Your deployment did not succeed.  Fix the template, re-deploy, and update the deployment results.
 
 Keep in mind that depending on the resources allocated, it can take a few minutes for the CI system to cleanup provisioned resources.
 


### PR DESCRIPTION
## Why

The contribution guide (`1-CONTRIBUTION-GUIDE/README.md`) has drifted from what the workflows actually do, post Ould's Apr–May 2026 CI rewrite. New contributors following the doc verbatim will be told to type `/verify` (which does nothing — the workflow listens for `/validate`) and to expect a `summarize-pr.yml` workflow that doesn't exist. The Bicep section also tells contributors to omit `azuredeploy.json` from the PR, which produces broken "Deploy to Azure" buttons because customers click those button links directly to `azuredeploy.json` in master.

Surfaced while running #14752 as a canary for the new pipeline.

## What changed

- **`/verify` → `/validate`** (7 occurrences in §2, the Contributor Workflow Summary, and the Diagnosing Failures section). The workflow source is the source of truth: `ValidateSampleDeployments.yml` matches `startsWith(github.event.comment.body, '/validate')`.
- **Drop §3 "Summarize PR (`summarize-pr.yml`)"**. That workflow doesn't exist. The AI summary is a job *inside* `ValidateSampleDeployments.yml` and fires automatically alongside `/validate`. Replaced with a one-line mention at the end of §2.
- **"Three workflows" → "Two workflows"** in the section opener. Matches the two workflows that actually drive the contributor PR flow (`validate-samples.yml` and `ValidateSampleDeployments.yml`). `auto-fix.yml` exists but is maintainer-only `workflow_dispatch`, not part of the contributor flow.
- **Drop step 7 from the Contributor Workflow Summary** (`/summarize` reference).
- **Bicep section**: change "must **not** be included in the PR as it will be built automatically when the sample is merged" to "should be included in the PR (compiled output of `main.bicep`)". The "Deploy to Azure" / "Visualize" buttons in each sample's README link directly to `azuredeploy.json`, so it must exist in the sample folder on master. Without it, the buttons 404 — which is exactly the breakage #14704–#14707 introduced and which @msmbaldwin's restore PRs (#14739–#14742, merged today) just fixed.

## Notes for @ouldsid

- The `commit-generated-on-merge` job in `ValidateSampleDeployments.yml` is the design path that would let contributors omit `azuredeploy.json` and have CI commit it for them. That's a great destination. Until #14754 (path-stripping bug) is fixed and the flow is reliable, the doc should describe what works today, which is "compile + commit it yourself." Once #14754 lands, this section can be updated again to mention the auto-gen path as a contributor option.
- This PR doesn't claim to be exhaustive on doc drift — there may be other doc files (sample-README.md, best-practices.md, the GH Actions wiki) that also need updating. Limited scope to the main contribution README.

cc @ouldsid