### PR TITLE
Enable purge protection on key-vault-create vault

### DIFF
--- a/quickstarts/microsoft.keyvault/key-vault-create/azuredeploy.json
+++ b/quickstarts/microsoft.keyvault/key-vault-create/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "9714026315215760608"
+      "templateHash": "5424899472990749957"
     }
   },
   "parameters": {
@@ -88,6 +88,7 @@
         "tenantId": "[parameters('tenantId')]",
         "enableSoftDelete": true,
         "softDeleteRetentionInDays": 90,
+        "enablePurgeProtection": true,
         "sku": {
           "name": "[parameters('skuName')]",
           "family": "A"

--- a/quickstarts/microsoft.keyvault/key-vault-create/main.bicep
+++ b/quickstarts/microsoft.keyvault/key-vault-create/main.bicep
@@ -41,6 +41,7 @@ resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
     tenantId: tenantId
     enableSoftDelete: true
     softDeleteRetentionInDays: 90
+    enablePurgeProtection: true
     sku: {
       name: skuName
       family: 'A'

--- a/quickstarts/microsoft.keyvault/key-vault-create/metadata.json
+++ b/quickstarts/microsoft.keyvault/key-vault-create/metadata.json
@@ -6,5 +6,13 @@
   "summary": "This template creates a Key Vault with Azure RBAC authorization and a secret stored inside the key vault.",
   "githubUsername": "seanbamsft",
   "docOwner": "mumian",
-  "dateUpdated": "2026-04-10"
+  "dateUpdated": "2026-05-13",
+  "validationType": "Manual",
+  "testResult": {
+    "deployments": {
+      "templateFileName": "main.bicep",
+      "correlationId": "08a19c7d-365d-455d-bbac-4de41d42a718",
+      "deploymentName": "kvc-deploy-2b2b8b3f"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds `enablePurgeProtection: true` to the vault in `key-vault-create/main.bicep` (and the regenerated `azuredeploy.json`).

## Why

Without purge protection, soft-deleted secrets, keys, and certificates can be permanently destroyed during the soft-delete retention window — either by an attacker with delete permissions or by an accidental `az keyvault purge`. Enabling purge protection guarantees the configured retention window is honored, which is the recommended Key Vault security baseline (and a hard requirement for several Azure compliance offerings, e.g. for vaults that hold storage account or disk encryption keys). Soft delete + purge protection should both be on by default for a sample that's billed as a quickstart.

The change is minimal: one line added to the `properties` block. `softDeleteRetentionInDays: 90` was already present.

## Validation

Per the contribution guide, deployed the updated `main.bicep` to my subscription:
- `correlationId`: 08a19c7d-365d-455d-bbac-4de41d42a718
- `deploymentName`: kvc-deploy-2b2b8b3f
- `provisioningState`: Succeeded
- region: eastus

`metadata.json` updated with `validationType: Manual` and the `testResult.deployments` block.