### PR TITLE
Enable purge protection on key-vault-key-create vault

### DIFF
--- a/quickstarts/microsoft.keyvault/key-vault-key-create/azuredeploy.json
+++ b/quickstarts/microsoft.keyvault/key-vault-key-create/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "4335991112049834035"
+      "templateHash": "9113739717796369919"
     }
   },
   "parameters": {
@@ -91,6 +91,7 @@
         "enableRbacAuthorization": true,
         "enableSoftDelete": true,
         "softDeleteRetentionInDays": 90,
+        "enablePurgeProtection": true,
         "enabledForDeployment": false,
         "enabledForDiskEncryption": false,
         "enabledForTemplateDeployment": false,

--- a/quickstarts/microsoft.keyvault/key-vault-key-create/main.bicep
+++ b/quickstarts/microsoft.keyvault/key-vault-key-create/main.bicep
@@ -46,6 +46,7 @@ resource vault 'Microsoft.KeyVault/vaults@2023-07-01' = {
     enableRbacAuthorization: true
     enableSoftDelete: true
     softDeleteRetentionInDays: 90
+    enablePurgeProtection: true
     enabledForDeployment: false
     enabledForDiskEncryption: false
     enabledForTemplateDeployment: false

--- a/quickstarts/microsoft.keyvault/key-vault-key-create/metadata.json
+++ b/quickstarts/microsoft.keyvault/key-vault-key-create/metadata.json
@@ -6,5 +6,13 @@
   "summary": "This template creates a Key Vault with Azure RBAC authorization and a key stored inside the key vault.",
   "githubUsername": "msmbaldwin",
   "docOwner": "msmbaldwin",
-  "dateUpdated": "2026-04-10"
+  "dateUpdated": "2026-05-13",
+  "validationType": "Manual",
+  "testResult": {
+    "deployments": {
+      "templateFileName": "main.bicep",
+      "correlationId": "7347912a-341a-4d51-b344-9463a89d7a19",
+      "deploymentName": "kvk-deploy-e0068887"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds `enablePurgeProtection: true` to the vault in `key-vault-key-create/main.bicep` (and the regenerated `azuredeploy.json`).

## Why

Without purge protection, a soft-deleted key can be permanently destroyed during the soft-delete retention window. For a quickstart that demonstrates creating a key, the recommended baseline is soft delete + purge protection both on. `softDeleteRetentionInDays: 90` was already present.

## Validation

Deployed the updated `main.bicep` to my subscription:
- `correlationId`: 7347912a-341a-4d51-b344-9463a89d7a19
- `deploymentName`: kvk-deploy-e0068887
- `provisioningState`: Succeeded
- region: eastus

`metadata.json` updated with `validationType: Manual` and the `testResult.deployments` block.