### PR TITLE
Enable purge protection on key-vault-secret-create vault

### DIFF
--- a/quickstarts/microsoft.keyvault/key-vault-secret-create/azuredeploy.json
+++ b/quickstarts/microsoft.keyvault/key-vault-secret-create/azuredeploy.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.42.1.51946",
-      "templateHash": "11014436081704906064"
+      "templateHash": "10998800669048245550"
     }
   },
   "parameters": {
@@ -82,6 +82,7 @@
         "tenantId": "[parameters('tenantId')]",
         "enableSoftDelete": true,
         "softDeleteRetentionInDays": 90,
+        "enablePurgeProtection": true,
         "sku": {
           "name": "[parameters('skuName')]",
           "family": "A"

--- a/quickstarts/microsoft.keyvault/key-vault-secret-create/main.bicep
+++ b/quickstarts/microsoft.keyvault/key-vault-secret-create/main.bicep
@@ -38,6 +38,7 @@ resource kv 'Microsoft.KeyVault/vaults@2023-07-01' = {
     tenantId: tenantId
     enableSoftDelete: true
     softDeleteRetentionInDays: 90
+    enablePurgeProtection: true
     sku: {
       name: skuName
       family: 'A'

--- a/quickstarts/microsoft.keyvault/key-vault-secret-create/metadata.json
+++ b/quickstarts/microsoft.keyvault/key-vault-secret-create/metadata.json
@@ -5,5 +5,13 @@
   "description": "This template creates a Key Vault with RBAC authorization enabled and a list of secrets within the key vault as passed along with the parameters",
   "summary": "Creates a Key Vault with Azure RBAC authorization and a list of secrets",
   "githubUsername": "rahulpnath",
-  "dateUpdated": "2026-04-10"
+  "dateUpdated": "2026-05-13",
+  "validationType": "Manual",
+  "testResult": {
+    "deployments": {
+      "templateFileName": "main.bicep",
+      "correlationId": "36fa8201-9ac1-4932-8c3c-7d4c1dbf36d6",
+      "deploymentName": "kvs-deploy-99a79900"
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds `enablePurgeProtection: true` to the vault in `key-vault-secret-create/main.bicep` (and the regenerated `azuredeploy.json`).

## Why

Without purge protection, a soft-deleted secret can be permanently destroyed during the soft-delete retention window. For a quickstart that demonstrates creating secrets, the recommended baseline is soft delete + purge protection both on. `softDeleteRetentionInDays: 90` was already present.

## Validation

Deployed the updated `main.bicep` to my subscription:
- `correlationId`: 36fa8201-9ac1-4932-8c3c-7d4c1dbf36d6
- `deploymentName`: kvs-deploy-99a79900
- `provisioningState`: Succeeded
- region: eastus

`metadata.json` updated with `validationType: Manual` and the `testResult.deployments` block.