### PR TITLE
Change Event Hub capture ADLS output types to securestring

### DIFF
--- a/quickstarts/microsoft.eventhub/eventhubs-create-namespace-and-enable-capture-for-adls/azuredeploy.json
+++ b/quickstarts/microsoft.eventhub/eventhubs-create-namespace-and-enable-capture-for-adls/azuredeploy.json
@@ -139,11 +139,11 @@
   ],
   "outputs": {
     "NamespaceConnectionString": {
-      "type": "string",
+      "type": "securestring",
       "value": "[listkeys(variables('authRuleResourceId'), '2017-04-01').primaryConnectionString]"
     },
     "SharedAccessPolicyPrimaryKey": {
-      "type": "string",
+      "type": "securestring",
       "value": "[listkeys(variables('authRuleResourceId'), '2017-04-01').primaryKey]"
     }
   }


### PR DESCRIPTION
## Summary

Change the output types for `NamespaceConnectionString` and `SharedAccessPolicyPrimaryKey` from `string` to `securestring` in the Event Hub namespace with ADLS capture template.

## Motivation

These outputs expose sensitive values (namespace connection strings and shared access policy keys). Using `securestring` prevents them from being logged in deployment outputs, improving security posture.

## Changes

- `quickstarts/microsoft.eventhub/eventhubs-create-namespace-and-enable-capture-for-adls/azuredeploy.json`: Changed both output types from `string` to `securestring`.