### PR TITLE
Restore azuredeploy.json for ADLS backup sample (fork-PR canary for #14769)

### DIFF
--- a/quickstarts/microsoft.dataprotection/backup-create-adls-storage-account-enable-protection/main.bicep
+++ b/quickstarts/microsoft.dataprotection/backup-create-adls-storage-account-enable-protection/main.bicep
@@ -312,3 +312,4 @@ resource backupInstance 'Microsoft.DataProtection/backupVaults/backupInstances@2
     storageContainerList
   ]
 }
+

--- a/quickstarts/microsoft.dataprotection/backup-create-adls-storage-account-enable-protection/metadata.json
+++ b/quickstarts/microsoft.dataprotection/backup-create-adls-storage-account-enable-protection/metadata.json
@@ -5,5 +5,16 @@
   "description": "Template that creates Azure Datalake storage account and enable vaulted backup via Backup Vault",
   "summary": "This template creates a Azure Datalake storage account, backup vault, backup policy, grants necessary permission and enables vaulted backup",
   "githubUsername": "nilaydshah",
-  "dateUpdated": "2025-10-07"
+  "dateUpdated": "2026-05-14",
+  "validationType": "Manual",
+  "environments": [
+    "AzureCloud"
+  ],
+  "testResult": {
+    "deployments": {
+      "templateFileName": "main.bicep",
+      "correlationId": "070c2fcc-1d41-4289-84f9-f8ae46cf981b",
+      "deploymentName": "adls-backup-canary-20260513-142256"
+    }
+  }
 }


### PR DESCRIPTION
## Why

Two purposes:

1. **Restore `azuredeploy.json` for `backup-create-adls-storage-account-enable-protection`.** This sample was merged in September/November 2025 (PRs #14616, #14631) before the new pipeline contract existed. It has no `azuredeploy.json` on master and no `testResult` in its `metadata.json`, so its "Deploy to Azure" button is broken today.

2. **Verify the fork-PR end-to-end path** through `commit-generated-on-merge` (the path discussed in #14769). This PR is from `alex-frankel/azure-quickstart-templates` (a fork), so on merge we'll learn empirically whether `commit-generated-on-merge` fires for fork PRs or skips them per the same-repo guard.

## What's in this PR

- `main.bicep`: trailing newline only (no semantic change). Classifies the PR as deploy-affecting for `selected-pipeline`'s preflight.
- `metadata.json`: adds `testResult.deployments` with `correlationId` and `deploymentName` from a verified deployment (`templateHash` `13943866408139100773`, `executionStatus` `Succeeded`).

`azuredeploy.json` is intentionally **not** committed — letting CI compile and commit it via `commit-generated-on-merge` is the whole point of the canary.

## Deployment details

- `correlationId`: `070c2fcc-1d41-4289-84f9-f8ae46cf981b`
- `deploymentName`: `adls-backup-canary-20260513-142256`
- Region: `southcentralus`
- Bicep version: v0.42.1 (CI will re-derive and recompile per `b7d5acb`, so version match isn't required)
- ADX record visible in `armprodeus` (verified via direct Kusto probe)

## Expected behavior

1. `validate-samples-results` passes (early gate: template + metadata both updated in diff).
2. Maintainer comments `/validate`.
3. `selected-pipeline` compiles `main.bicep` → `azuredeploy.json` (file is absent from PR diff because it's absent from master), reads `generatorVersion` from ADX, recompiles with matching Bicep, hashes, compares — should match.
4. On merge: this is the open question. Either:
   - `commit-generated-on-merge` fires for the fork PR (per @ouldsid's read) → master gets `azuredeploy.json` and #14769 closes as "won't fix / misread."
   - Or `commit-generated-on-merge` skips due to the same-repo gate (per the YAML I read) → master is left without `azuredeploy.json` and #14769 stays open with concrete evidence.

Either outcome is informative.

## Related

- #14769 (fork-PR commit-back gate) — this PR is the empirical test.
- #14765 / #14754 / #14753 (recent pipeline fixes that should all work in this PR).

cc @ouldsid