### PR TITLE
docs: fix typos and grammar in GettingStarted guides

### DIFF
--- a/application-workloads/datascience/vm-ubuntu-DSVM-GPU-or-CPU/GettingStarted.md
+++ b/application-workloads/datascience/vm-ubuntu-DSVM-GPU-or-CPU/GettingStarted.md
@@ -4,9 +4,9 @@ The purpose of this ARM Template is to deploy a **Linux Virtual Machine with som
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template, most of them are already with the values, the ones that you need to inform are: **adminUsername**, **adminPassword** and **resourceGroup**. All the other parameters will be already informed.
+Those are the parameters on the template, most of them are already filled with values, the ones that you need to inform are: **adminUsername**, **adminPassword** and **resourceGroup**. All the other parameters will be already informed.
 
 Don't worry about changing anything on the file, either on the portal or using Azure CLI, you need to inform just the following parameters.
 
@@ -27,7 +27,7 @@ You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager
 
 For this task, we going to deploy using Visual Code and the portal and a little surprise for you at the end. :D
 
-For Azure CLI I choose to use the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**.
+For Azure CLI I choose to use the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -37,15 +37,15 @@ type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/application-workloads/jupyter/jupyterhub-classroom/GettingStarted.md
+++ b/application-workloads/jupyter/jupyterhub-classroom/GettingStarted.md
@@ -4,9 +4,9 @@ The purpose of this ARM Template is to deploy a **Jupyter Server using an Ubuntu
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template, most of them are already with the values, the ones that you need to inform are: **adminUsername**, **adminPassword**, **resourceGroup** and select between **CPU or GPU based virtual machine**. All the other parameters will be already informed.
+Those are the parameters on the template, most of them are already filled with values, the ones that you need to inform are: **adminUsername**, **adminPassword**, **resourceGroup** and select between **CPU or GPU based virtual machine**. All the other parameters will be already informed.
 
 Don't worry about changing anything on the file, either on the portal or using Azure CLI, you need to inform just the following parameters.
 
@@ -39,7 +39,7 @@ You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager
 
 For this task, we going to deploy using Visual Code and the portal and a little surprise for you at the end. :D
 
-For Azure CLI I choose to use the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**.
+For Azure CLI I choose to use the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -49,15 +49,15 @@ type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/application-workloads/mongo/mongodb-nodejs-high-availability/README.md
+++ b/application-workloads/mongo/mongodb-nodejs-high-availability/README.md
@@ -35,7 +35,7 @@ A Node.js (Express) service is installed on it, exposes a REST GET endpoint that
 SSH into the Ubuntu VM (using Putty www.putty.org), navigate to /opt/app.js and modify the workload as needed.
 
 Credentials -
-The adminUsername and adminPassword are administrators of all the VM's, the MongoDB database and the Tasks database.
+The adminUsername and adminPassword are administrators of all the VMs, the MongoDB database and the Tasks database.
 These credentials are hard coded in the connection string in the Node js server, in /opt/app.js. Modify according to adminUsername:adminPassword you entered in the parameters.
 Please do not use a question mark in the adminUsername and/or the adminPassword.
 

--- a/application-workloads/postgre/postgresql-standalone-server-ubuntu/GettingStarted.md
+++ b/application-workloads/postgre/postgresql-standalone-server-ubuntu/GettingStarted.md
@@ -4,7 +4,7 @@ The purpose of this ARM Template is **PostgreSQL Server on Ubuntu VM** inserting
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
 
 These are the parameters on the template, most of them already have values inserted, the ones that you need to inform are: **adminUsername**, **adminPassword** and **resourceGroup**.
 
@@ -28,7 +28,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
+For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -40,7 +40,7 @@ You will be redirected to the Azure Portal in your web browser where you can ins
 
 After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -48,7 +48,7 @@ To set the right subscription, type following command:
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/application-workloads/tomcat/openjdk-tomcat-ubuntu-vm/gettingstarted.md
+++ b/application-workloads/tomcat/openjdk-tomcat-ubuntu-vm/gettingstarted.md
@@ -4,9 +4,9 @@ The purpose of this ARM Template is **simple Ubuntu Server Virtual Machine** ins
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template, most of them are already with the values, the ones that you need to inform are: **adminUsername**, **adminPassword** and **resourceGroup**. All the other parameters will be already informed.
+Those are the parameters on the template, most of them are already filled with values, the ones that you need to inform are: **adminUsername**, **adminPassword** and **resourceGroup**. All the other parameters will be already informed.
 
 Don't worry about changing anything on the file, either on the portal or using Azure CLI, you need to inform just the following parameters.
 
@@ -25,7 +25,7 @@ You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager
 
 For this task, we going to deploy using Visual Code and the portal and a little surprise for you at the end. :D
 
-For Azure CLI I choose to use the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**.
+For Azure CLI I choose to use the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -35,9 +35,9 @@ type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -45,7 +45,7 @@ To set the right subscription, type following command:
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/application-workloads/visualstudio/ubuntu-mate-desktop-vscode/GettingStarted.md
+++ b/application-workloads/visualstudio/ubuntu-mate-desktop-vscode/GettingStarted.md
@@ -4,7 +4,7 @@ The purpose of this ARM Template is **Deploy an Ubuntu Mate Desktop VM with VS C
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
 
 These are the parameters on the template, most of them already have values inserted, the ones that you need to inform are: **adminUsername**, **adminPassword** and **resourceGroup**.
 
@@ -28,7 +28,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
+For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -40,7 +40,7 @@ You will be redirected to the Azure Portal in your web browser where you can ins
 
 After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -48,7 +48,7 @@ To set the right subscription, type following command:
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/demos/azmgmt-demo/README.md
+++ b/demos/azmgmt-demo/README.md
@@ -23,7 +23,7 @@ languages:
 [![Deploy To Azure US Gov](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazuregov.svg?sanitize=true)](https://portal.azure.us/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fazmgmt-demo%2Fazuredeploy.json)
 [![Visualize](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/visualizebutton.svg?sanitize=true)](http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Fdemos%2Fazmgmt-demo%2Fazuredeploy.json)
 
->Note: The purpose of these templates, is to give you a kick-start, instantiating all of the Azure mgmt services in Azure.
+>Note: The purpose of these templates is to give you a kick-start, instantiating all of the Azure mgmt services in Azure.
 The mgmt. services will be fully integrated, and you will have VM workloads (Windows or Linux) which will be attached - and fully managed as part of the deployment.
 **Please note that this sample is for demo purposes only**
 

--- a/demos/ubuntu-desktop-gnome-rdp/GettingStarted.md
+++ b/demos/ubuntu-desktop-gnome-rdp/GettingStarted.md
@@ -4,7 +4,7 @@ The purpose of this ARM Template is **Deploy Ubuntu Desktop VM with VS Code, Azu
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
 
 These are the parameters on the template, most of them already have values inserted, the ones that you need to inform are: **adminUsername**, **adminPassword** and **resourceGroup**.
 
@@ -28,7 +28,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
+For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -40,7 +40,7 @@ You will be redirected to the Azure Portal in your web browser where you can ins
 
 After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -48,7 +48,7 @@ To set the right subscription, type following command:
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/quickstarts/microsoft.blockchain/blockchain-asaservice/GettingStarted-blockchain.md
+++ b/quickstarts/microsoft.blockchain/blockchain-asaservice/GettingStarted-blockchain.md
@@ -57,7 +57,7 @@ Now that you got a good idea of how the service works, let's dig on the template
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
 
 These are the parameters on the template, most of them already have values inserted, the ones that you need to inform are: **bcMemberName** and **memberPassword**.
 
@@ -74,7 +74,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
+For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -86,7 +86,7 @@ You will be redirected to the Azure Portal in your web browser where you can ins
 
 After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -94,7 +94,7 @@ To set the right subscription, type following command:
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/quickstarts/microsoft.cognitiveservices/cognitive-services-Computer-vision-API/GettingStarted.md
+++ b/quickstarts/microsoft.cognitiveservices/cognitive-services-Computer-vision-API/GettingStarted.md
@@ -2,7 +2,7 @@
 
 The purpose of this ARM Template is **deploy an Azure AI Vision resource**.
 
-Let's understand a bit better how all this work.
+Let's understand a bit better how all this works.
 
 ## Overview
 
@@ -16,7 +16,7 @@ Before processing to the deployment of the template, we need to perform the foll
 
 Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template. Some of them are already with the values, the ones that you need to inform are **aiServicesName** and the **SKU** in case that need a powerful service.
+Those are the parameters on the template. Some of them are already filled with values, the ones that you need to inform are **aiServicesName** and the **SKU** in case that need a powerful service.
 
 Parameter         | Suggested value     | Description
 :--------------- |:-------------      |:---------------------
@@ -30,7 +30,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://learn.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://learn.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://learn.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
+For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
 
 ### Using Azure CLI with Visual Code
 
@@ -40,9 +40,9 @@ Type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -70,7 +70,7 @@ Let's check the resource on the [Azure Portal](https://portal.azure.com).
 
 On the portal, go to resource groups. In this blade, you can see the resource group that you created.
 
-Click on the resource group and there it's the resources
+Click on the resource group and there are the resources
 
 ![Screen](./images/portal-resource.png)
 

--- a/quickstarts/microsoft.cognitiveservices/cognitive-services-translate/GettingStarted.md
+++ b/quickstarts/microsoft.cognitiveservices/cognitive-services-translate/GettingStarted.md
@@ -2,7 +2,7 @@
 
 The purpose of this ARM Template is **deploy an Azure AI Translator resource**.
 
-Let's understand a bit better how all this work.
+Let's understand a bit better how all this works.
 
 ## Overview
 Azure AI services help developers and organizations rapidly create intelligent, cutting-edge, market-ready, and responsible applications with out-of-the-box and prebuilt and customizable APIs and models. Example applications include natural language processing for conversations, search, monitoring, translation, speech, vision, and decision-making.
@@ -16,7 +16,7 @@ Before processing to the deployment of the template, we need to perform the foll
 
 Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template. Some of them are already with the values, the ones that you need to inform are **aiServicesName** and the **SKU** in case that need a powerful service.
+Those are the parameters on the template. Some of them are already filled with values, the ones that you need to inform are **aiServicesName** and the **SKU** in case that need a powerful service.
 
 Parameter         | Suggested value     | Description
 :--------------- |:-------------      |:---------------------
@@ -30,7 +30,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://learn.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://learn.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://learn.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
+For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
 
 ### Using Azure CLI with Visual Code
 
@@ -40,9 +40,9 @@ Type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -70,7 +70,7 @@ Let's check the resource on the [Azure Portal](https://portal.azure.com).
 
 On the portal, go to resource groups. In this blade, you can see the resource group that you created.
 
-Click on the resource group and there it's the resources
+Click on the resource group and there are the resources
 
 ![Screen](./images/portal-resource.png)
 

--- a/quickstarts/microsoft.compute/vm-simple-windows-visualstudio2019/GettingStarted-wsvs.md
+++ b/quickstarts/microsoft.compute/vm-simple-windows-visualstudio2019/GettingStarted-wsvs.md
@@ -4,7 +4,7 @@ The purpose of this ARM Template is **simple Windows Server 2019 Datacenter** wi
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
 
 These are the parameters on the template, most of them already have values inserted, the ones that you need to inform are: **adminUsername**, **adminPassword**, **vmName**  and **resourceGroup**.
 
@@ -27,7 +27,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
+For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -39,7 +39,7 @@ You will be redirected to the Azure Portal in your web browser where you can ins
 
 After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -47,7 +47,7 @@ To set the right subscription, type following command:
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/quickstarts/microsoft.devices/iot-iothub-edgeemulator-vm/GettingStarted-Iot-EdgeEmulator.md
+++ b/quickstarts/microsoft.devices/iot-iothub-edgeemulator-vm/GettingStarted-Iot-EdgeEmulator.md
@@ -71,9 +71,9 @@ Log in to Azure:
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -101,7 +101,7 @@ Now we can look at the template file:
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
 These are the parameters on the template, most of them already have values inserted, the ones that you need to inform are: **adminUsername**, **adminPassword**, **resourceGroup** and the size of your Virtual Machine.
 
@@ -134,7 +134,7 @@ For Azure CLI I'm the Visual Code with Azure CLI and PowerShell extensions. Chec
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 
@@ -167,7 +167,7 @@ On the portal, go to Resource Groups. On this blade, you can see the Resource Gr
 
 ![Screen](./images/azdeployportal.png)
 
-Click on the Resource Group and there it's the resources **Resources**:
+Click on the Resource Group and there are the resources **Resources**:
 
 - Virtual machine
 - Disk

--- a/quickstarts/microsoft.devices/iothub-with-consumergroup-create/GettingStarted.md
+++ b/quickstarts/microsoft.devices/iothub-with-consumergroup-create/GettingStarted.md
@@ -2,7 +2,7 @@
 
 The purpose of this ARM Template is **Deploy a IoT Hub and Device to Cloud Consumer Group**.
 
-Let's understand a bit better how all this work.
+Let's understand a bit better how all this works.
 
 ## Overview
 
@@ -14,9 +14,9 @@ Before processing to the deployment of the template, we need to perform the foll
 
 ### The template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template. Some of them are already with the values, the ones that you need to inform are **IOT Hub Name** and the **sku** in case that need a powerful service.
+Those are the parameters on the template. Some of them are already filled with values, the ones that you need to inform are **IOT Hub Name** and the **sku** in case that need a powerful service.
 
 Parameter         | Suggested value     | Description
 :--------------- |:-------------      |:---------------------
@@ -30,7 +30,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
+For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
 
 ### Using Azure CLI with Visual Code
 
@@ -40,15 +40,15 @@ Type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 
@@ -70,7 +70,7 @@ Let's check the resource on the [Azure Portal](https://portal.azure.com).
 
 On the portal, go to Resource Groups. In this blade, you can see the Resource Group that you created.
 
-Click on the Resource Group and there it's the resources
+Click on the Resource Group and there are the resources
 
 ![Screen](./images/portal-resource.png)
 

--- a/quickstarts/microsoft.solutions/managed-application-with-metrics-and-alerts/README.md
+++ b/quickstarts/microsoft.solutions/managed-application-with-metrics-and-alerts/README.md
@@ -27,7 +27,7 @@ If this is your first time learning about Azure managed applications, please vis
 
 + [**Deploying your first managed application**](https://github.com/Azure/azure-quickstart-templates/tree/master/101-managed-application).
 
-This sample shows how you can author a service catalog managed application definition that will allow to deploy a managed application with defined metrics and alerts.
+This sample shows how you can author a service catalog managed application definition that will allow you to deploy a managed application with defined metrics and alerts.
 This managed application will contain single storage account as a resource, expose application metrics for the storage account including availability, success E2E latency, transactions; as well as alerts based on storage account availability and activity log alerts based on regenerating storage account keys.
 
 This sample template combines two steps:

--- a/quickstarts/microsoft.web/app-function/GettingStarted-FuncApp.md
+++ b/quickstarts/microsoft.web/app-function/GettingStarted-FuncApp.md
@@ -23,7 +23,7 @@ Azure Functions has two kinds of pricing plans. Choose the one that best fits yo
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
 
 These are the parameters on the template, they already have values inserted, so you don't need to worry about change them.
 
@@ -39,7 +39,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
+For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -51,7 +51,7 @@ You will be redirected to the Azure Portal in your web browser where you can ins
 
 After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -59,7 +59,7 @@ To set the right subscription, type following command:
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/quickstarts/microsoft.web/web-app-github-deploy/GettingStarted-WebGit.md
+++ b/quickstarts/microsoft.web/web-app-github-deploy/GettingStarted-WebGit.md
@@ -46,7 +46,7 @@ Copy this address, you will need it to inform as a parameter during the deployme
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
 
 These are the parameters on the template, most of them already have values inserted, the ones that you need to inform are: **webAppName** , **repoURL**  and **branch**.
 
@@ -67,7 +67,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
+For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -79,7 +79,7 @@ You will be redirected to the Azure Portal in your web browser where you can ins
 
 After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -87,7 +87,7 @@ To set the right subscription, type following command:
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 
@@ -191,7 +191,7 @@ On the portal, open your Resource Group, if you will not use the Web App anymore
 
 ![Screen](./images/off1.png)
 
-You can also just stop the Web App in case you gonna need the resource. Open the resource and click on Stop.
+You can also just stop the Web App in case you're going to need the resource. Open the resource and click on Stop.
 
 ![Screen](./images/off.png)
 

--- a/quickstarts/microsoft.web/web-app-java-tomcat/gettingstarted.md
+++ b/quickstarts/microsoft.web/web-app-java-tomcat/gettingstarted.md
@@ -2,7 +2,7 @@
 
 The purpose of this ARM Template is **deploy a web app with TomCat and Java** using a **web app**.
 
-But let's understand a bit better how all this work.
+But let's understand a bit better how all this works.
 
 ## Overview
 
@@ -14,9 +14,9 @@ Before proceeding to the deployment of the template, we need to perform the foll
 
 ### The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template. Most of them are already with the values, the ones that you need to inform are **web app name** and **location**.
+Those are the parameters on the template. Most of them are already filled with values, the ones that you need to inform are **web app name** and **location**.
 
 Parameter         | Suggested value     | Description
 :--------------- |:-------------      |:---------------------
@@ -29,7 +29,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
+For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
 
 ### Using Azure CLI with Visual Code
 
@@ -39,15 +39,15 @@ Type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 
@@ -74,11 +74,11 @@ And there we go, your deployment is Succeeded. Let's check the resource on the [
 
 On the portal, go to Resource Groups. In this blade, you can see the Resource Group that you created.
 
-Click on the Resource Group and there it's the resources
+Click on the Resource Group and there are the resources
 
 ![Screen](./images/portal-resource.png)
 
-Congratulations! You have deployed the template successfully. We can see our web visiting an URL like that:
+Congratulations! You have deployed the template successfully. We can see our web visiting a URL like that:
 
 #### webAppName.azurewebsites.net
 
@@ -96,7 +96,7 @@ On ARM Template, replace the contents of the template with your template, and cl
 
 ![Screen](./images/aztemplate3.png)
 
-Click on the refresh button and you will find your template. Click on it and the click in [Deploy].
+Click on the refresh button and you will find your template. Click on it and then click on [Deploy].
 
 ![Screen](./images/azportaldeploy.png)
 
@@ -145,7 +145,7 @@ It is because when we deploy our App Service, it needs to find the instance of t
 We use the property "--debug" to see that all is going well on the deployment.
 Congratulations, now you have deployed your node app in azure.
 
-You can also just stop the Web App in case you gonna need the resource. Open the resource and click on Stop.
+You can also just stop the Web App in case you're going to need the resource. Open the resource and click on Stop.
 
 ![Screen](./images/stop-rsc.png)
 

--- a/quickstarts/microsoft.web/web-app-python/gettingstarted.md
+++ b/quickstarts/microsoft.web/web-app-python/gettingstarted.md
@@ -2,7 +2,7 @@
 
 The purpose of this ARM Template is **deploy a web app with Python** using a **web app**.
 
-But let's understand a bit better how all this work.
+But let's understand a bit better how all this works.
 
 ## Overview
 
@@ -14,9 +14,9 @@ Before proceeding to the deployment of the template, we need to perform the foll
 
 ### The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template. Most of them are already with the values, the ones that you need to inform are **web app name** and **location**.
+Those are the parameters on the template. Most of them are already filled with values, the ones that you need to inform are **web app name** and **location**.
 
 Parameter         | Suggested value     | Description
 :--------------- |:-------------      |:---------------------
@@ -29,7 +29,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
+For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
 
 ### Using Azure CLI with Visual Code
 
@@ -39,15 +39,15 @@ Type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 
@@ -74,11 +74,11 @@ And there we go, your deployment is Succeeded. Let's check the resource on the [
 
 On the portal, go to Resource Groups. In this blade, you can see the Resource Group that you created.
 
-Click on the Resource Group and there it's the resources
+Click on the Resource Group and there are the resources
 
 ![Screen](./images/portal-resource.png)
 
-Congratulations! You have deployed the template successfully. We can see our web visiting an URL like that:
+Congratulations! You have deployed the template successfully. We can see our web visiting a URL like that:
 
 #### webAppName.azurewebsites.net
 
@@ -96,7 +96,7 @@ On ARM Template, replace the contents of the template with your template, and cl
 
 ![Screen](./images/aztemplate3.png)
 
-Click on the refresh button and you will find your template. Click on it and the click in [Deploy].
+Click on the refresh button and you will find your template. Click on it and then click on [Deploy].
 
 ![Screen](./images/azportaldeploy.png)
 
@@ -153,7 +153,7 @@ On the portal, open your Resource Group, if you will not use the Web App anymore
 
 ![Screen](./images/delete-rsc.png)
 
-You can also just stop the Web App in case you gonna need the resource. Open the resource and click on Stop.
+You can also just stop the Web App in case you're going to need the resource. Open the resource and click on Stop.
 
 ![Screen](./images/stop-rsc.png)
 

--- a/quickstarts/microsoft.web/webapp-linux-django/GettingStarted.md
+++ b/quickstarts/microsoft.web/webapp-linux-django/GettingStarted.md
@@ -2,7 +2,7 @@
 
 The purpose of this ARM Template is **deploy a web app with Django** using a **web app**.
 
-But let's understand a bit better how all this work.
+But let's understand a bit better how all this works.
 
 ## Overview
 
@@ -16,7 +16,7 @@ Before proceeding to the deployment of the template, we need to perform the foll
 
 Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template. Most of them are already with the values, the ones that you need to inform are **web app name** and **location**.
+Those are the parameters on the template. Most of them are already filled with values, the ones that you need to inform are **web app name** and **location**.
 
 Parameter         | Suggested value     | Description
 :--------------- |:-------------      |:---------------------
@@ -29,7 +29,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
+For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
 
 ### Using Azure CLI with Visual Code
 
@@ -39,15 +39,15 @@ Type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 
@@ -74,11 +74,11 @@ And there we go, your deployment is Succeeded. Let's check the resource on the [
 
 On the portal, go to Resource Groups. In this blade, you can see the Resource Group that you created.
 
-Click on the Resource Group and there it's the resources
+Click on the Resource Group and there are the resources
 
 ![Screen](./images/portal-resource.png)
 
-Congratulations! You have deployed the template successfully. We can see our web visiting an URL like that:
+Congratulations! You have deployed the template successfully. We can see our web visiting a URL like that:
 
 #### webAppName.azurewebsites.net
 
@@ -96,7 +96,7 @@ On ARM Template, replace the contents of the template with your template, and cl
 
 ![Screen](./images/aztemplate3.PNG)
 
-Click on the refresh button and you will find your template. Click on it and the click in [Deploy].
+Click on the refresh button and you will find your template. Click on it and then click on [Deploy].
 
 ![Screen](./images/azportaldeploy.PNG)
 
@@ -154,7 +154,7 @@ On the portal, open your Resource Group, if you will not use the Web App anymore
 
 ![Screen](./images/delete-rsc.png)
 
-You can also just stop the Web App in case you gonna need the resource. Open the resource and click on Stop.
+You can also just stop the Web App in case you're going to need the resource. Open the resource and click on Stop.
 
 ![Screen](./images/stop-rsc.png)
 

--- a/quickstarts/microsoft.web/webapp-linux-flask/GettingStarted.md
+++ b/quickstarts/microsoft.web/webapp-linux-flask/GettingStarted.md
@@ -2,7 +2,7 @@
 
 The purpose of this ARM Template is **deploy a web app with Flask** using a **web app**.
 
-But let's understand a bit better how all this work.
+But let's understand a bit better how all this works.
 
 ## Overview
 
@@ -14,9 +14,9 @@ Before proceeding to the deployment of the template, we need to perform the foll
 
 ### The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template. Most of them are already with the values, the ones that you need to inform are **web app name** and **location**.
+Those are the parameters on the template. Most of them are already filled with values, the ones that you need to inform are **web app name** and **location**.
 
 Parameter         | Suggested value     | Description
 :--------------- |:-------------      |:---------------------
@@ -29,7 +29,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
+For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
 
 ### Using Azure CLI with Visual Code
 
@@ -39,15 +39,15 @@ Type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 
@@ -74,11 +74,11 @@ And there we go, your deployment is Succeeded. Let's check the resource on the [
 
 On the portal, go to Resource Groups. In this blade, you can see the Resource Group that you created.
 
-Click on the Resource Group and there it's the resources
+Click on the Resource Group and there are the resources
 
 ![Screen](./images/portal-resource.png)
 
-Congratulations! You have deployed the template successfully. We can see our web visiting an URL like that:
+Congratulations! You have deployed the template successfully. We can see our web visiting a URL like that:
 
 #### webAppName.azurewebsites.net
 
@@ -96,7 +96,7 @@ On ARM Template, replace the contents of the template with your template, and cl
 
 ![Screen](./images/aztemplate3.png)
 
-Click on the refresh button and you will find your template. Click on it and the click in [Deploy].
+Click on the refresh button and you will find your template. Click on it and then click on [Deploy].
 
 ![Screen](./images/azportaldeploy.png)
 
@@ -153,7 +153,7 @@ On the portal, open your Resource Group, if you will not use the Web App anymore
 
 ![Screen](./images/delete-rsc.png)
 
-You can also just stop the Web App in case you gonna need the resource. Open the resource and click on Stop.
+You can also just stop the Web App in case you're going to need the resource. Open the resource and click on Stop.
 
 ![Screen](./images/stop-rsc.png)
 

--- a/quickstarts/microsoft.web/webapp-linux-managed-mysql/GettingStarted-WebAppMySQL.md
+++ b/quickstarts/microsoft.web/webapp-linux-managed-mysql/GettingStarted-WebAppMySQL.md
@@ -16,7 +16,7 @@ For more information about Web Apps on Linux, click [here](https://docs.microsof
 
 ## The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how much easier your life will be deploying resources to Azure.
 
 These are the parameters on the template, most of them already have values inserted, the ones that you need to inform are: **administratorLogin** and **administratorLoginPassword**.
 
@@ -41,7 +41,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
+For Azure CLI I'm using the Visual Code with Azure CLI extensions. If you would like you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code app, you can stick with the always present **Command Line** on Windows or the Linux **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -53,7 +53,7 @@ You will be redirected to the Azure Portal in your web browser where you can ins
 
 After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
@@ -61,7 +61,7 @@ To set the right subscription, type following command:
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't already created a Resource Group, you can do it now. If you are new to Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying: it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 

--- a/quickstarts/microsoft.web/webapp-linux-node/GettingStarted.md
+++ b/quickstarts/microsoft.web/webapp-linux-node/GettingStarted.md
@@ -2,7 +2,7 @@
 
 The purpose of this ARM Template is **deploy a web app with Node** using a **web app**.
 
-But let's understand a bit better how all this work.
+But let's understand a bit better how all this works.
 
 ## Overview
 
@@ -14,9 +14,9 @@ Before proceeding to the deployment of the template, we need to perform the foll
 
 ### The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template. Most of them are already with the values, the ones that you need to inform are **web app name** and **location**.
+Those are the parameters on the template. Most of them are already filled with values, the ones that you need to inform are **web app name** and **location**.
 
 Parameter         | Suggested value     | Description
 :--------------- |:-------------      |:---------------------
@@ -29,7 +29,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
+For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**
 
 ### Using Azure CLI with Visual Code
 
@@ -39,15 +39,15 @@ Type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 
@@ -74,11 +74,11 @@ And there we go, your deployment is Succeeded. Let's check the resource on the [
 
 On the portal, go to Resource Groups. In this blade, you can see the Resource Group that you created.
 
-Click on the Resource Group and there it's the resources
+Click on the Resource Group and there are the resources
 
 ![Screen](./images/portal-resource.png)
 
-Congratulations! You have deployed the template successfully. We can see our web visiting an URL like that:
+Congratulations! You have deployed the template successfully. We can see our web visiting a URL like that:
 
 #### webAppName.azurewebsites.net
 
@@ -96,7 +96,7 @@ On ARM Template, replace the contents of the template with your template, and cl
 
 ![Screen](./images/aztemplate3.png)
 
-Click on the refresh button and you will find your template. Click on it and the click in [Deploy].
+Click on the refresh button and you will find your template. Click on it and then click on [Deploy].
 
 ![Screen](./images/azportaldeploy.png)
 
@@ -152,7 +152,7 @@ On the portal, open your Resource Group, if you will not use the Web App anymore
 
 ![Screen](./images/delete-rsc.png)
 
-You can also just stop the Web App in case you gonna need the resource. Open the resource and click on Stop.
+You can also just stop the Web App in case you're going to need the resource. Open the resource and click on Stop.
 
 ![Screen](./images/stop-rsc.png)
 

--- a/quickstarts/microsoft.web/webapp-windows-aspnet/GettingStarted.md
+++ b/quickstarts/microsoft.web/webapp-windows-aspnet/GettingStarted.md
@@ -2,7 +2,7 @@
 
 The purpose of this ARM Template is **deploy a web app with ASP.NET** using a **web app**.
 
-But let's understand a bit better how all this work.
+But let's understand a bit better how all this works.
 
 ## Overview
 
@@ -14,9 +14,9 @@ Before proceeding to the deployment of the template, we need to perform the foll
 
 ### The Template
 
-Don't let the size of the template scares you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
+Don't let the size of the template scare you. The structure is very intuitive and once that you get the gist of it, you will see how easier your life will be regarding deploying resources to Azure.
 
-Those are the parameters on the template. Most of them are already with the values, the ones that you need to inform are **web app name** and **location**.
+Those are the parameters on the template. Most of them are already filled with values, the ones that you need to inform are **web app name** and **location**.
 
 Parameter         | Suggested value     | Description
 :--------------- |:-------------      |:---------------------
@@ -29,7 +29,7 @@ Parameter         | Suggested value     | Description
 There are a few ways to deploy this template.
 You can use [PowerShell](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy), [Azure CLI](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-cli), [Azure Portal](https://docs.microsoft.com/azure/azure-resource-manager/resource-group-template-deploy-portal) or your favorite SDK.
 
-For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bare in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**.
+For Azure CLI I'm using the Visual Code with Azure CLI extensions, if you like, you can find more information [here](https://code.visualstudio.com/docs/azure/extensions). But bear in mind that you don't need to use the Visual Code, you can stick with the old good always present **Command Line** on Windows or any **bash terminal**.
 
 ### Using Azure CLI with Visual Code
 
@@ -39,15 +39,15 @@ Type on the terminal window: **az login**
 
 You will be redirected to the Azure Portal where you can insert your credentials and log in.
 
-After logged in, you will see your credentials on the terminal.
+After logging in, you will see your credentials on the terminal.
 
-To set the right subscription, type following command:
+To set the right subscription, type the following command:
 
 #### az account set --subscription "your subscription id"
 
 ### Resource Group
 
-Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bare with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
+Now you need a Resource Group for our deployment. If you haven't yet created a Resource Group, you can do it now. If you are new on Azure and wonder what is a Resource Group? Bear with me! A Resource Group is a container that holds related resources for an Azure solution. The resource group includes those resources that you want to manage as a group. Simply saying, it's like a folder that contains files. Simple as that.
 
 To create a Resource Group, you need a name and a location for your Resource Group.
 
@@ -74,11 +74,11 @@ And there we go, your deployment is Succeeded. Let's check the resource on the [
 
 On the portal, go to Resource Groups. In this blade, you can see the Resource Group that you created.
 
-Click on the Resource Group and there it's the resources
+Click on the Resource Group and there are the resources
 
 ![Screen](./images/portal-resource.png)
 
-Congratulations! You have deployed the template successfully. We can see our web visiting an URL like that:
+Congratulations! You have deployed the template successfully. We can see our web visiting a URL like that:
 
 #### webAppName.azurewebsites.net
 
@@ -96,7 +96,7 @@ On ARM Template, replace the contents of the template with your template, and cl
 
 ![Screen](./images/aztemplate3.PNG)
 
-Click on the refresh button and you will find your template. Click on it and the click in [Deploy].
+Click on the refresh button and you will find your template. Click on it and then click on [Deploy].
 
 ![Screen](./images/azportaldepoy.PNG)
 
@@ -139,7 +139,7 @@ On the portal, open your Resource Group, if you will not use the Web App anymore
 
 ![Screen](./images/delete-rsc.png)
 
-You can also just stop the Web App in case you gonna need the resource. Open the resource and click on Stop.
+You can also just stop the Web App in case you're going to need the resource. Open the resource and click on Stop.
 
 ![Screen](./images/stop-rsc.png)
 


### PR DESCRIPTION
## Summary

Fix typos in 21 GettingStarted template files and 3 READMEs:

- bare/Bare → bear/Bear (in mind, with me)
- scares → scare
- the click → then click
- an URL → a URL
- this work → this works
- type following → type the following
- you gonna → you're going to
- After logged in → After logging in
- Fix grammar in managed-application README (allow to deploy → allow you to deploy)
- Fix possessive in mongodb README (VM's → VMs)
- Fix comma splice in azmgmt-demo README

No functional changes — documentation only.